### PR TITLE
fix: avoid fatal error with recurring donation using GiveWP core patch

### DIFF
--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			// Load files which are necessary for front as well as admin end.
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/give-stripe-helpers.php';
 
-			// Bailout, if any of the Stripe gateway is not active.
+			// Bailout, if any of the Stripe gateways are not active.
 			if ( ! give_stripe_is_any_payment_method_active() ) {
 
 				// If `get_plugin_data` fn not exists then include the file.
@@ -90,7 +90,7 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 							array(
 								'id'          => 'give-recurring-fatal-error',
 								'type'        => 'error',
-								'description' => __( '<strong>Activation Error:</strong> You must have the Recurring Donations plugin updated to latest version <strong>1.9.4</strong> to make it work with GiveWP core <strong>2.5.5</strong>.', 'give' ),
+								'description' => __( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>.', 'give' ),
 								'show'        => true,
 							)
 						);

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -68,6 +68,41 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 
 			// Bailout, if any of the Stripe gateway is not active.
 			if ( ! give_stripe_is_any_payment_method_active() ) {
+
+				// If `get_plugin_data` fn not exists then include the file.
+				if ( ! function_exists( 'get_plugin_data' ) ) {
+					require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+				}
+
+				// Hardcoded recurring plugin basename to show notice even when recurring addon is deactivated.
+				$recurring_plugin_basename = 'give-recurring/give-recurring.php';
+				$recurring_plugin_data     = get_plugin_data( WP_CONTENT_DIR . '/plugins/' . $recurring_plugin_basename );
+
+				// Avoid fatal error for smooth update for customers.
+				if (
+					isset( $recurring_plugin_data['Version'] ) &&
+					version_compare( '1.9.3', $recurring_plugin_data['Version'], '>=' )
+				) {
+					add_action( 'admin_notices', function() {
+
+						// Register error notice.
+						Give()->notices->register_notice(
+							array(
+								'id'          => 'give-recurring-fatal-error',
+								'type'        => 'error',
+								'description' => __( '<strong>Activation Error:</strong> You must have the Recurring Donations plugin updated to latest version <strong>1.9.4</strong> to make it work with GiveWP core <strong>2.5.5</strong>.', 'give' ),
+								'show'        => true,
+							)
+						);
+					});
+
+					// Deactivate recurring addon to avoid fatal error.
+					deactivate_plugins( $recurring_plugin_basename );
+					if ( isset( $_GET['activate'] ) ) {
+						unset( $_GET['activate'] );
+					}
+				}
+
 				return;
 			}
 


### PR DESCRIPTION
## Description
This PR resolves the fatal error issue when Stripe is not enabled payment gateway in GiveWP core and recurring `1.9.3` is used.

## How Has This Been Tested?
**Please check the testing video:** https://www.loom.com/share/e65239b333124cd195e219a61afdcf70

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.