### PR TITLE
fix: avoid errors when recurring addon is not installed with Give 2.5.6

### DIFF
--- a/give.php
+++ b/give.php
@@ -5,7 +5,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.5.6
+ * Version: 2.5.7
  * Text Domain: give
  * Domain Path: /languages
  *
@@ -439,7 +439,7 @@ if ( ! class_exists( 'Give' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'GIVE_VERSION' ) ) {
-				define( 'GIVE_VERSION', '2.5.6' );
+				define( 'GIVE_VERSION', '2.5.7' );
 			}
 
 			// Plugin Root File.

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -69,37 +69,43 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			// Bailout, if any of the Stripe gateways are not active.
 			if ( ! give_stripe_is_any_payment_method_active() ) {
 
-				// If `get_plugin_data` fn not exists then include the file.
-				if ( ! function_exists( 'get_plugin_data' ) ) {
-					require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-				}
-
 				// Hardcoded recurring plugin basename to show notice even when recurring addon is deactivated.
 				$recurring_plugin_basename = 'give-recurring/give-recurring.php';
-				$recurring_plugin_data     = get_plugin_data( WP_CONTENT_DIR . '/plugins/' . $recurring_plugin_basename );
+				$recurring_file_path       = WP_CONTENT_DIR . '/plugins/' . $recurring_plugin_basename;
 
-				// Avoid fatal error for smooth update for customers.
-				if (
-					isset( $recurring_plugin_data['Version'] ) &&
-					version_compare( '1.9.3', $recurring_plugin_data['Version'], '>=' )
-				) {
-					add_action( 'admin_notices', function() {
+				// If recurring donations add-on exists.
+				if ( file_exists( $recurring_file_path ) ) {
 
-						// Register error notice.
-						Give()->notices->register_notice(
-							array(
-								'id'          => 'give-recurring-fatal-error',
-								'type'        => 'error',
-								'description' => sprintf(__( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing this issue please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give' ), 'https://wordpress.org/plugins/wp-rollback/', 'https://givewp.com/support/'),
-								'show'        => true,
-							)
-						);
-					});
+					// If `get_plugin_data` fn not exists then include the file.
+					if ( ! function_exists( 'get_plugin_data' ) ) {
+						require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+					}
 
-					// Deactivate recurring addon to avoid fatal error.
-					deactivate_plugins( $recurring_plugin_basename );
-					if ( isset( $_GET['activate'] ) ) {
-						unset( $_GET['activate'] );
+					$recurring_plugin_data = get_plugin_data($recurring_file_path);
+
+					// Avoid fatal error for smooth update for customers.
+					if (
+						isset( $recurring_plugin_data['Version'] ) &&
+						version_compare( '1.9.3', $recurring_plugin_data['Version'], '>=' )
+					) {
+						add_action('admin_notices', function() {
+
+							// Register error notice.
+							Give()->notices->register_notice(
+								array(
+									'id'          => 'give-recurring-fatal-error',
+									'type'        => 'error',
+									'description' => sprintf(__('<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing this issue please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'), 'https://wordpress.org/plugins/wp-rollback/', 'https://givewp.com/support/'),
+									'show'        => true,
+								)
+							);
+						});
+
+						// Deactivate recurring addon to avoid fatal error.
+						deactivate_plugins( $recurring_plugin_basename );
+						if ( isset( $_GET['activate'] ) ) {
+							unset( $_GET['activate'] );
+						}
 					}
 				}
 

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -95,7 +95,11 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 								array(
 									'id'          => 'give-recurring-fatal-error',
 									'type'        => 'error',
-									'description' => sprintf(__('<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing this issue please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'), 'https://wordpress.org/plugins/wp-rollback/', 'https://givewp.com/support/'),
+									'description' => sprintf(
+										__( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing this issue please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'),
+										'https://wordpress.org/plugins/wp-rollback/',
+										'https://givewp.com/support/'
+									),
 									'show'        => true,
 								)
 							);

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donations, donation plugin, wordpress donation plugin, givewp, g
 Requires at least: 4.8
 Tested up to: 5.2
 Requires PHP: 5.6
-Stable tag: 2.5.6
+Stable tag: 2.5.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
## Description
This PR resolves the issue which arises when any customer is using GiveWP core `2.5.6` and has not installed recurring donations.

## How Has This Been Tested?
**Please check the testing video:** https://www.loom.com/share/1a99b1614a7e4290817ef83cd3ab6073

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.