### PR TITLE
Added styling to the Stripe connect banner

### DIFF
--- a/assets/src/css/admin/stripe-admin.scss
+++ b/assets/src/css/admin/stripe-admin.scss
@@ -10,6 +10,32 @@
     font-size: 15px;
 }
 
+#give-stripe-connect-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  p {
+    font-size: 16px;
+    flex: 1 0 0;
+  }
+
+  #give-stripe-connect {
+    margin-left: 10px;
+  }
+}
+
+@media (max-width: 782px) {
+  #give-stripe-connect-banner {
+    flex-direction: column;
+    align-items: flex-start;
+
+    #give-stripe-connect {
+      margin-left: 0;
+      margin-top: 10px;
+    }
+  }
+}
 #give-stripe-connect-banner p {
 	font-size: 16px;
 }
@@ -193,3 +219,4 @@ only screen and (min-device-pixel-ratio: 1.5) {
     }
 
 }
+

--- a/includes/gateways/stripe/includes/admin/admin-actions.php
+++ b/includes/gateways/stripe/includes/admin/admin-actions.php
@@ -293,7 +293,7 @@ function give_stripe_show_connect_banner() {
 
 	$message = sprintf(
 		/* translators: 1. Main Text, 2. Connect Link */
-		__( '<strong>Stripe Connect:</strong> %1$s %2$s', 'give' ),
+        __( '<p><strong>Stripe Connect:</strong> %1$s </p>%2$s', 'give' ),
 		$main_text,
 		$connect_link
 	);


### PR DESCRIPTION
## Description
I added styles to the Stripe Connect Banner presented to the user before they set up Stripe.

## How Has This Been Tested?
I have tested this on Chrome, Safari, and Firefox at many screen sizes.

## Screenshots (jpeg or gifs if applicable):
<img width="1265" alt="Donation_Forms_‹_Give_test_—_WordPress" src="https://user-images.githubusercontent.com/5809840/66018347-87222c80-e493-11e9-8f4c-0d50213953ae.png">

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.