### PR TITLE
Updated give_donation_total_of_user to use fallbacks

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -270,9 +270,19 @@ function give_count_donations_of_donor( $user = null ) {
  */
 function give_donation_total_of_user( $user = null ) {
 
-	$stats = give_get_donation_stats_by_user( $user );
+    // Logged in?
+    if ( empty( $user ) ) {
+        $user = get_current_user_id();
+    }
 
-	return $stats['total_spent'];
+    // Email access?
+    if ( empty( $user ) && Give()->email_access->token_email ) {
+        $user = Give()->email_access->token_email;
+    }
+
+    $stats = ! empty( $user ) ? give_get_donation_stats_by_user( $user ) : false;
+
+    return isset( $stats['total_spent'] ) ? $stats['total_spent'] : 0;
 }
 
 


### PR DESCRIPTION
## Description
Changed give_donation_total_of_user to act much like give_count_donations_of_donor where if the user ID or email is not provided it will fall back to the logged-in user or by the email token.

## How Has This Been Tested?
Tested with and without user-id provided, logged in and not.

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.