### PR TITLE
fix: remove space in link to Stripe webhooks documentation #4266

### DIFF
--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -664,7 +664,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							echo sprintf(
 								/* translators: 1. Documentation on webhook setup. */
 								__( 'See our <a href="%1$s" target="_blank">documentation</a> for more information.', 'give' ),
-								esc_url_raw( 'http://docs.givewp.com/stripe-webhooks ' )
+								esc_url_raw( 'http://docs.givewp.com/stripe-webhooks' )
 							);
 							?>
 						</p>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Removed a space from URL to Stripe Webhooks documentation that was causing the user to see a blank page.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Navigated to the `documentation` link under Settings > Payment Gateways > Stripe > Stripe Webhooks

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.