### PR TITLE
fix: prevent fatal error on upgrade #4272

### DIFF
--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 									'id'          => 'give-recurring-fatal-error',
 									'type'        => 'error',
 									'description' => sprintf(
-										__( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing any issues please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'),
+										__( '<strong>Action Needed:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing any issues please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'),
 										'https://wordpress.org/plugins/wp-rollback/',
 										'https://givewp.com/support/'
 									),

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -88,6 +88,13 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 						isset( $recurring_plugin_data['Version'] ) &&
 						version_compare( '1.9.3', $recurring_plugin_data['Version'], '>=' )
 					) {
+
+						// Load Stripe SDK.
+						give_stripe_load_stripe_sdk();
+
+						// Include frontend files.
+						$this->include_frontend_files();
+
 						add_action('admin_notices', function() {
 
 							// Register error notice.
@@ -104,12 +111,6 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 								)
 							);
 						});
-
-						// Deactivate recurring addon to avoid fatal error.
-						deactivate_plugins( $recurring_plugin_basename );
-						if ( isset( $_GET['activate'] ) ) {
-							unset( $_GET['activate'] );
-						}
 					}
 				}
 

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 									'id'          => 'give-recurring-fatal-error',
 									'type'        => 'error',
 									'description' => sprintf(
-										__( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing this issue please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'),
+										__( '<strong>Activation Error:</strong> Please update the Recurring Donations add-on to version <strong>1.9.4+</strong> in order to be compatible with GiveWP <strong>2.5.5+</strong>. If you are experiencing any issues please rollback GiveWP to 2.5.4 or below using the <a href="%s" target="_blank">WP Rollback</a> plugin and <a href="%s" target="_blank">contact support</a> for prompt assistance.', 'give'),
 										'https://wordpress.org/plugins/wp-rollback/',
 										'https://givewp.com/support/'
 									),


### PR DESCRIPTION
## Description
This PR resolves #4272 

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue description.

Find the below-detailed testing scenario, I've handled for Give + Recurring when Stripe gateway is disabled:
> When a customer have Give 2.5.4 or lower and Recurring 1.9.3 or lower, then updating to Give 2.5.8 which usually resulted in a fatal error and then on additional refresh deactivates the recurring add-on to get rid of a fatal error.
- I've improved this scenario. So, now when customer upgrades to Give 2.5.8 having Recurring 1.9.3 or lower, then the recurring add-on is not deactivated and there will be no fatal error. Donations will also process smoothly. But, still, we have a notice in place to let customer update recurring to 1.9.4+ to ensure that any edge case doesn't affect donation processing.

Let me know, if you have any questions related to the testing scenarios.

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.