### PR TITLE
fix: include receipt_link_url in plain text emails #4284

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2183,7 +2183,7 @@ function give_get_view_receipt_link( $donation_id ) {
 
 	return sprintf(
 		'<a href="%1$s">%2$s</a>',
-		esc_url( give_get_view_receipt_url( $donation_id ) ),
+		give_get_view_receipt_url( $donation_id ),
 		esc_html__( 'View the receipt in your browser &raquo;', 'give' )
 	);
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2159,7 +2159,7 @@ function give_get_receipt_link( $donation_id ) {
  */
 function give_get_receipt_url( $donation_id ) {
 
-	$receipt_url = esc_url(
+	$receipt_url = esc_url_raw(
 		add_query_arg(
 			array(
 				'donation_id' => $donation_id,
@@ -2199,7 +2199,7 @@ function give_get_view_receipt_link( $donation_id ) {
  */
 function give_get_view_receipt_url( $donation_id ) {
 
-	$receipt_url = esc_url(
+	$receipt_url = esc_url_raw(
 		add_query_arg(
 			array(
 				'action'     => 'view_in_browser',


### PR DESCRIPTION
## Description
This PR resolves #4284 

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue description

## Screenshots (jpeg or gifs if applicable):
**Before:**
![image](https://user-images.githubusercontent.com/1852711/67360143-c4ee0e80-f582-11e9-9900-60a42ccaaaae.png)

**After:**
![image](https://user-images.githubusercontent.com/1852711/67360157-cf100d00-f582-11e9-96d8-09e8ee466a29.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.