### PR TITLE
fix: avoid locale issue with multiple languages same as legacy checkout #4290

### DIFF
--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -220,8 +220,13 @@ function give_stripe_get_preferred_locale() {
 
 	$language_code = substr( get_locale(), 0, 2 ); // Get the lowercase language code. For Example, en, es, de.
 
-	// Return "no" as accepted parameter for norwegian language code "nb" && "nn".
-	$language_code = in_array( $language_code, array( 'nb', 'nn' ), true ) ? 'no' : $language_code;
+	if ( 'modal' === give_stripe_get_checkout_type() ) {
+		// For Legacy Checkout, Return "no" as accepted parameter for norwegian language code "nb" && "nn".
+		$language_code = in_array( $language_code, array( 'nb', 'nn' ), true ) ? 'no' : $language_code;
+	} else {
+		// For Checkout 2.0, Return "nb" as accepted parameter for norwegian language code "no" && "nn".
+		$language_code = in_array( $language_code, array( 'no', 'nn' ), true ) ? 'nb' : $language_code;
+	}
 
 	return apply_filters( 'give_stripe_elements_preferred_locale', $language_code );
 }

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-checkout.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-checkout.php
@@ -284,6 +284,7 @@ if ( ! class_exists( 'Give_Stripe_Checkout' ) ) {
 				'submit_type'                => 'donate',
 				'success_url'                => give_get_success_page_uri(),
 				'cancel_url'                 => give_get_failed_transaction_uri(),
+				'locale'                     => give_stripe_get_preferred_locale(),
 			);
 
 			// If featured image exists, then add it to checkout session.


### PR DESCRIPTION
## Description
This PR resolves #4290 

## How Has This Been Tested?
I've tested this PR with the Norwegian language for which an issue came up for legacy checkout in the past.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.