### PR TITLE
Fix give_send_back_to_checkout redirect

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -195,41 +195,15 @@ function give_send_back_to_checkout( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	// Merge URL query with $args to maintain third-party URL parameters after redirect.
-	$url_data = wp_parse_url( $url );
+	$redirect = add_query_arg( $args, $url );
 
-	// Check if an array to prevent notices before parsing.
-	if ( isset( $url_data['query'] ) && ! empty( $url_data['query'] ) ) {
-		parse_str( $url_data['query'], $query );
-
-		// Precaution: don't allow any CC info.
-		unset( $query['card_number'] );
-		unset( $query['card_cvc'] );
-
-	} else {
-		// No $url_data so pass empty array.
-		$query = array();
-	}
-
-	$new_query        = array_merge( $args, $query );
-	$new_query_string = http_build_query( $new_query );
-
-	$path = $url_data['path'];
-
-	if( is_multisite() && ! is_subdomain_install() ) {
-		/* @var  WP_Site $site_info */
-		$site_info = get_site();
-		$path = 0 === strpos( $path, $site_info->path )
-			? str_replace( untrailingslashit( $site_info->path ), '', $path )
-			: $path ;
-	}
-
-	// Assemble URL parts.
-	$redirect = home_url( '/' . $path . '?' . $new_query_string . '#give-form-' . $form_id . '-wrap' );
+	// Precaution: don't allow any CC info.
+	$redirect = remove_query_arg( [ 'card_number', 'card_cvc' ], $redirect );
 
 	// Redirect them.
+	$redirect .= '#give-form-' . $form_id . '-wrap';
 	wp_safe_redirect( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) );
 	give_die();
-
 }
 
 /**


### PR DESCRIPTION
## Description
Instead of build a url, I recommend just update the query arguments using `add_query_arg` and `remove_query_arg`. Your current way don't works with wordpress installed in a subdirectory.

## Types of changes
Bug fix: redirect correctly when the wordpress is installed in a subdirectory

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.