### PR TITLE
fix: ensure that empty donation receipt emails are not triggered 

### DIFF
--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function give_trigger_donation_receipt( $payment_id ) {
 	// Make sure we don't send a receipt while editing a donation.
-	if ( isset( $_POST['give-action'] ) && 'edit_payment' == $_POST['give-action'] ) {
+	if ( ! current_user_can( 'edit_give_payments', $payment_id ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
This PR will resolve #4185 

## How Has This Been Tested?
Tested locally

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bugfix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.