### PR TITLE
fix: remove extra height from input field

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -603,3 +603,14 @@ Donations forms filter
 		}
 	}
 }
+
+
+/*
+Prevent currency icon height issue with input field
+ref: https://github.com/impress-org/givewp/pull/4315
+*/
+@-moz-document url-prefix() {
+	.give_options_panel .give-money-symbol {
+		padding: 8.5px 10px 8.5px;
+	}
+}


### PR DESCRIPTION
## Description
This Pr will resolve styling issue mentioned in https://github.com/impress-org/givewp/pull/4306#discussion_r350648893

## How Has This Been Tested?
Tested with WP 5.2 and 5.3

## Screenshots (jpeg or gifs if applicable):
**WP 5.2**
![image](https://user-images.githubusercontent.com/1784821/70058192-79f4fb80-1604-11ea-9803-eff631c29f59.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [x] Money input field looks fine on  WP 5.3 and older