### PR TITLE
fix: improve shortcode button styles

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -151,7 +151,7 @@ Shortcode Copy & Paste
 		font-size: 16px;
 		width: 16px;
 		vertical-align: middle;
-		color: #0071a1;
+		color: inherit;
 		margin-right: 2px;
 	}
 

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -158,9 +158,11 @@ Shortcode Copy & Paste
 }
 
 // Hide 'copy shortcode' text at certain resolutions
-@media only screen and (min-width: 782px) and (max-width: 1232px) {
-	.give-shortcode-button-text {
-		display: none;
+@media only screen and (min-width: 782px) and (max-width: 1260px) {
+	.js-give-shortcode-button {
+		.give-button-text {
+			display: none;
+		}
 	}
 }
 

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -158,7 +158,7 @@ Shortcode Copy & Paste
 }
 
 // Hide 'copy shortcode' text at certain resolutions
-@media only screen and (min-width: 782px) and (max-width: 1260px) {
+@media only screen and (min-width: 782px) and (max-width: 1480px) {
 	.js-give-shortcode-button {
 		.give-button-text {
 			display: none;

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -151,14 +151,17 @@ Shortcode Copy & Paste
 		font-size: 16px;
 		width: 16px;
 		vertical-align: middle;
-		color: #909090;
+		color: #0071a1;
 		margin-right: 2px;
 	}
 
-	&:hover .dashicons {
-		color: #555;
-	}
+}
 
+// Hide 'copy shortcode' text at certain resolutions
+@media only screen and (min-width: 782px) and (max-width: 1232px) {
+	.give-shortcode-button-text {
+		display: none;
+	}
 }
 
 //-------------------------------------

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -158,7 +158,7 @@ Shortcode Copy & Paste
 }
 
 // Hide 'copy shortcode' text at certain resolutions
-@media only screen and (min-width: 782px) and (max-width: 1480px) {
+@media only screen and (min-width: 782px) and (max-width: 1260px) {
 	.js-give-shortcode-button {
 		.give-button-text {
 			display: none;

--- a/assets/src/js/admin/button.js
+++ b/assets/src/js/admin/button.js
@@ -41,11 +41,9 @@ class GiveButton {
 	updateIcon( className, position = 'before' ) {
 		const icon = `<span class="${className}"></span>`;
 
-		if ( 'after' === position ) {
-			this.root.innerHTML = `${this._buttonTextWithWrapper} ${icon}`;
-		} else {
-			this.root.innerHTML = `${icon} ${this._buttonTextWithWrapper}`;
-		}
+		this.root.innerHTML = 'after' === position
+			? `${this._buttonTextWithWrapper} ${icon}`
+			: `${icon} ${this._buttonTextWithWrapper}`;
 
 		this.iconClassName = className;
 		this.iconPosition  = position;

--- a/assets/src/js/admin/button.js
+++ b/assets/src/js/admin/button.js
@@ -3,6 +3,7 @@ class GiveButton {
 		this.root          = element;
 		this.buttonText    = this.root.textContent.trim();
 		this.iconPosition  = 'before';
+		this.text = this.root.querySelector('.give-button-text') ? `<span class="give-button-text">${this.buttonText}</span>` : this.buttonText;
 
 		const icon = this.root.querySelector( '.dashicons' );
 
@@ -21,8 +22,7 @@ class GiveButton {
 
 	setBusyState() {
 		const busyIcon      = '<span class="dashicons dashicons-marker"></span>';
-		const text = this.root.querySelector('.give-button-text') ? `<span class="${this.buttonText}"></span>` : this.buttonText;
-		this.root.innerHTML = `${busyIcon} ${text}`;
+		this.root.innerHTML = `${busyIcon} ${this.text}`;
 		this.disable();
 	}
 
@@ -39,9 +39,9 @@ class GiveButton {
 		const text = this.root.querySelector('.give-button-text') ? `<span class="give-button-text">${this.buttonText}</span>` : this.buttonText;
 		
 		if ( 'after' === position ) {
-			this.root.innerHTML = `${text} ${icon}`;
+			this.root.innerHTML = `${this.text} ${icon}`;
 		} else {
-			this.root.innerHTML = `${icon} ${text}`;
+			this.root.innerHTML = `${icon} ${this.text}`;
 		}
 
 		this.iconClassName = className;

--- a/assets/src/js/admin/button.js
+++ b/assets/src/js/admin/button.js
@@ -3,7 +3,11 @@ class GiveButton {
 		this.root          = element;
 		this.buttonText    = this.root.textContent.trim();
 		this.iconPosition  = 'before';
-		this.text = this.root.querySelector('.give-button-text') ? `<span class="give-button-text">${this.buttonText}</span>` : this.buttonText;
+
+		// Note: this property is for internal use. It can be change in future.
+		this._buttonTextWithWrapper = this.root.querySelector('.give-button-text')
+			? `<span class="give-button-text">${this.buttonText}</span>`
+			: this.buttonText;
 
 		const icon = this.root.querySelector( '.dashicons' );
 
@@ -22,7 +26,7 @@ class GiveButton {
 
 	setBusyState() {
 		const busyIcon      = '<span class="dashicons dashicons-marker"></span>';
-		this.root.innerHTML = `${busyIcon} ${this.text}`;
+		this.root.innerHTML = `${busyIcon} ${this._buttonTextWithWrapper}`;
 		this.disable();
 	}
 
@@ -38,9 +42,9 @@ class GiveButton {
 		const icon = `<span class="${className}"></span>`;
 
 		if ( 'after' === position ) {
-			this.root.innerHTML = `${this.text} ${icon}`;
+			this.root.innerHTML = `${this._buttonTextWithWrapper} ${icon}`;
 		} else {
-			this.root.innerHTML = `${icon} ${this.text}`;
+			this.root.innerHTML = `${icon} ${this._buttonTextWithWrapper}`;
 		}
 
 		this.iconClassName = className;

--- a/assets/src/js/admin/button.js
+++ b/assets/src/js/admin/button.js
@@ -21,7 +21,8 @@ class GiveButton {
 
 	setBusyState() {
 		const busyIcon      = '<span class="dashicons dashicons-marker"></span>';
-		this.root.innerHTML = `${busyIcon} ${this.buttonText}`;
+		const text = this.root.querySelector('.give-button-text') ? `<span class="${this.buttonText}"></span>` : this.buttonText;
+		this.root.innerHTML = `${busyIcon} ${text}`;
 		this.disable();
 	}
 
@@ -35,11 +36,12 @@ class GiveButton {
 
 	updateIcon( className, position = 'before' ) {
 		const icon = `<span class="${className}"></span>`;
-
+		const text = this.root.querySelector('.give-button-text') ? `<span class="give-button-text">${this.buttonText}</span>` : this.buttonText;
+		
 		if ( 'after' === position ) {
-			this.root.innerHTML = `${this.buttonText} ${icon}`;
+			this.root.innerHTML = `${text} ${icon}`;
 		} else {
-			this.root.innerHTML = `${icon} ${this.buttonText}`;
+			this.root.innerHTML = `${icon} ${text}`;
 		}
 
 		this.iconClassName = className;

--- a/assets/src/js/admin/button.js
+++ b/assets/src/js/admin/button.js
@@ -36,8 +36,7 @@ class GiveButton {
 
 	updateIcon( className, position = 'before' ) {
 		const icon = `<span class="${className}"></span>`;
-		const text = this.root.querySelector('.give-button-text') ? `<span class="give-button-text">${this.buttonText}</span>` : this.buttonText;
-		
+
 		if ( 'after' === position ) {
 			this.root.innerHTML = `${this.text} ${icon}`;
 		} else {

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -125,7 +125,7 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'shortcode':
 				$shortcode = sprintf( '[give_form id="%s"]', absint( $post_id ) );
 				printf(
-					'<button type="button" class="button hint-tooltip hint--top js-give-shortcode-button" aria-label="%1$s" data-give-shortcode="%2$s"><span class="dashicons dashicons-admin-page"></span> %3$s</button>',
+					'<button type="button" class="button hint-tooltip hint--top js-give-shortcode-button" aria-label="%1$s" data-give-shortcode="%2$s"><span class="dashicons dashicons-admin-page"></span><span class="give-shortcode-button-text"> %3$s</span></button>',
 					esc_attr( $shortcode ),
 					esc_attr( $shortcode ),
 					esc_html__( 'Copy Shortcode', 'give' )

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -125,7 +125,14 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'shortcode':
 				$shortcode = sprintf( '[give_form id="%s"]', absint( $post_id ) );
 				printf(
-					'<button type="button" class="button hint-tooltip hint--top js-give-shortcode-button" aria-label="%1$s" data-give-shortcode="%2$s"><span class="dashicons dashicons-admin-page"></span><span class="give-button-text"> %3$s</span></button>',
+					'<button
+							type="button"
+							class="button hint-tooltip hint--top js-give-shortcode-button"
+							aria-label="%1$s"
+							data-give-shortcode="%2$s">
+						<span class="dashicons dashicons-admin-page"></span>
+						<span class="give-button-text"> %3$s</span>
+					</button>',
 					esc_attr( $shortcode ),
 					esc_attr( $shortcode ),
 					esc_html__( 'Copy Shortcode', 'give' )

--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -125,7 +125,7 @@ function give_render_form_columns( $column_name, $post_id ) {
 			case 'shortcode':
 				$shortcode = sprintf( '[give_form id="%s"]', absint( $post_id ) );
 				printf(
-					'<button type="button" class="button hint-tooltip hint--top js-give-shortcode-button" aria-label="%1$s" data-give-shortcode="%2$s"><span class="dashicons dashicons-admin-page"></span><span class="give-shortcode-button-text"> %3$s</span></button>',
+					'<button type="button" class="button hint-tooltip hint--top js-give-shortcode-button" aria-label="%1$s" data-give-shortcode="%2$s"><span class="dashicons dashicons-admin-page"></span><span class="give-button-text"> %3$s</span></button>',
 					esc_attr( $shortcode ),
 					esc_attr( $shortcode ),
 					esc_html__( 'Copy Shortcode', 'give' )


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

- surround shortcode button text with span of class "give-shortcode-button-text"
- create new style rule w/ media query in admin/forms.scss to hide button text at certain resolutions (prevents overlapping)
- update button icon style to inherit button text color

## How Has This Been Tested?
Tested locally with, and checked that the button text is hidden at appropriate breakpoints. Also tested button icon color by testing different WP admin color palettes, and the icon color matches button text color.

## Screenshots (jpeg or gifs if applicable):
[Button w text shown](https://drive.google.com/file/d/1OqRR6MGRxvXpSJB8H0IEEVaYT8e6bYmS/view?usp=sharing
)[Button w text hidden](https://drive.google.com/file/d/1l3W7CdLiUvuFpmpIrkI2j2e8wIK_f8uZ/view?usp=sharing)
[Button at smaller with, w text shown](https://drive.google.com/file/d/1B_-MN7dVV4nqJCSEORaiHfUFqJhLItbN/view?usp=sharing)
[Button styling with different admin color palette](https://drive.google.com/file/d/1XxHQFgGps562dKU966pjmheGNxasbnTb/view?usp=sharing)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.