### PR TITLE
fix: base state indicator display and field requirement on same logic

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -45,7 +45,8 @@ jQuery( function( $ ) {
 				success: function( response ) {
 					var new_state_field = '',
 						states_label = response.states_label,
-						$current_state_field = $form.find( 'input[name="card_state"], select[name="card_state"]' );
+						$current_state_field = $form.find( 'input[name="card_state"], select[name="card_state"]' ),
+						$city = $form.find( 'input[name="card_city"]' );
 
 					// Get response data from states query.
 					if (
@@ -75,8 +76,6 @@ jQuery( function( $ ) {
 							$current_state_field.closest( 'p' ).find( 'label .give-required-indicator' ).addClass( 'give-hidden' );
 						}
 
-						var $city = $form.find( 'input[name="card_city"]' );
-
 						// check if city fields is require or not
 						if ( 'undefined' !== typeof ( response.city_require ) && true === response.city_require ) {
 							$city.closest( 'p' ).find( 'label .give-required-indicator' ).removeClass( 'give-hidden' ).removeClass( 'required' );
@@ -98,8 +97,6 @@ jQuery( function( $ ) {
 							new_state_field.removeAttr( 'required' ).removeAttr( 'aria-required' ).removeClass('required');
 							$current_state_field.closest( 'p' ).find( '.give-fl-wrap' ).removeClass( 'give-fl-is-required' );
 						}
-
-						var $city = $form.find( 'input[name="card_city"]' );
 
 						// check if city fields is require or not
 						if ( 'undefined' !== typeof ( response.city_require ) && true === response.city_require ) {

--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -86,7 +86,29 @@ jQuery( function( $ ) {
 							$city.removeAttr( 'required' );
 						}
 					} else {
-						$current_state_field.closest( 'p' ).find( 'label' ).text( states_label );
+						//Had floating labels
+						if (
+							'undefined' !== typeof ( response.states_require )
+							&& true === response.states_require
+						) {
+							new_state_field.attr( 'required', 'required' ).attr( 'aria-required', 'true' ).addClass('required');
+							$current_state_field.closest( 'p' ).find( '.give-fl-wrap' ).addClass( 'give-fl-is-required' );
+
+						} else {
+							new_state_field.removeAttr( 'required' ).removeAttr( 'aria-required' ).removeClass('required');
+							$current_state_field.closest( 'p' ).find( '.give-fl-wrap' ).removeClass( 'give-fl-is-required' );
+						}
+
+						var $city = $form.find( 'input[name="card_city"]' );
+
+						// check if city fields is require or not
+						if ( 'undefined' !== typeof ( response.city_require ) && true === response.city_require ) {
+							$city.closest( 'p' ).find( '.give-fl-wrap' ).addClass( 'give-fl-is-required' );
+							$city.attr( 'required', true );
+						} else {
+							$city.closest( 'p' ).find( '.give-fl-wrap' ).removeClass( 'give-fl-is-required' );
+							$city.removeAttr( 'required' );
+						}
 					}
 
 					$current_state_field.closest( 'p' ).find( 'label .state-label-text' ).text( states_label );

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1229,6 +1229,7 @@ function give_default_cc_address_fields( $form_id ) {
 		$states_not_required_country_list = give_states_not_required_country_list();
 		// Used to determine if state is required.
 		$require_state = ! array_key_exists( $selected_country, $no_states_country ) && give_field_is_required( 'card_state', $form_id );
+		$validate_state = ! array_key_exists( $selected_country, $states_not_required_country_list ) && give_field_is_required( 'card_state', $form_id );
 
 		?>
 		<p id="give-card-state-wrap"
@@ -1236,7 +1237,7 @@ function give_default_cc_address_fields( $form_id ) {
 			<label for="card_state" class="give-label">
 				<span class="state-label-text"><?php echo $state_label; ?></span>
 				<span
-					class="give-required-indicator <?php echo array_key_exists( $selected_country, $states_not_required_country_list ) ? 'give-hidden' : ''; ?> ">*</span>
+					class="give-required-indicator <?php echo $validate_state ? '' : 'give-hidden'; ?> ">*</span>
 				<span class="give-tooltip give-icon give-icon-question"
 				      data-tooltip="<?php esc_attr_e( 'The state, province, or county for your billing address.', 'give' ); ?>"></span>
 			</label>
@@ -1248,8 +1249,8 @@ function give_default_cc_address_fields( $form_id ) {
 					name="card_state"
 					autocomplete="address-level1"
 					id="card_state"
-					class="card_state give-select<?php echo $require_state ? ' required' : ''; ?>"
-					<?php echo $require_state ? ' required aria-required="true" ' : ''; ?>>
+					class="card_state give-select<?php echo $validate_state ? ' required' : ''; ?>"
+					<?php echo $validate_state ? ' required aria-required="true" ' : ''; ?>>
 					<?php
 					foreach ( $states as $state_code => $state ) {
 						echo '<option value="' . $state_code . '"' . selected( $state_code, $selected_state, false ) . '>' . $state . '</option>';
@@ -1259,7 +1260,7 @@ function give_default_cc_address_fields( $form_id ) {
 			<?php else : ?>
 				<input type="text" size="6" name="card_state" id="card_state" class="card_state give-input"
 				       placeholder="<?php echo $state_label; ?>" value="<?php echo $selected_state; ?>"
-					<?php echo $require_state ? ' required aria-required="true" ' : ''; ?>
+					<?php echo $validate_state ? ' required aria-required="true" ' : ''; ?>
 				/>
 			<?php endif; ?>
 		</p>

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1229,6 +1229,7 @@ function give_default_cc_address_fields( $form_id ) {
 		$states_not_required_country_list = give_states_not_required_country_list();
 		// Used to determine if state is required.
 		$require_state = ! array_key_exists( $selected_country, $no_states_country ) && give_field_is_required( 'card_state', $form_id );
+		// Used to determine is state input should be marked as required.
 		$validate_state = ! array_key_exists( $selected_country, $states_not_required_country_list ) && give_field_is_required( 'card_state', $form_id );
 
 		?>


### PR DESCRIPTION
## Description
Resolves #4316 
Alters includes/form/template.php such that the "state" input's require attribute matches the field label's require indicator. Instead of using separate logic for each, they now both rely on a shared variable (based on existing logic for label indicator). 

## How Has This Been Tested?
Tested by checking demoing code against multiple different "base countries" as found in GiveWP settings. State fields now behave correctly, both for countries with required and optional state fields. Also tested with various payment gateways, behaves as expected.

Rather than touching logic of the $require_state variable, which might impact code in unforeseen ways, I opted to create new $validate_state variable that uses logic previously written for the field indicator to show whether the field is required/needs to be valid.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.