### PR TITLE
feature: add test for give verify minimum price

### DIFF
--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -407,18 +407,40 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		//Verify that $_POST object represents minimum possible donation
 		$verified_min = give_verify_minimum_price('minimum');
 
+		// Test less-than minimum donation
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = '5';
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$unverified_min = give_verify_minimum_price('minimum');
+
 		// Test maximum donation
 		//Set post superglobal keys to values match maximum possible donation
 		$_POST['give-form-id'] = $this->_multi_form->ID;
-		$_POST['give-amount'] = '10';
-		$_POST['give-price-id'] = '1';
+		$_POST['give-amount'] = '100';
+		$_POST['give-price-id'] = '4';
 
 		//Verify that $_POST object represents maximum possible donation
 		$verified_max = give_verify_minimum_price('maximum');
 
+		// Test greater-than maximum donation
+		//Set post superglobal keys to values match maximum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = '150';
+		$_POST['give-price-id'] = '4';
+
+		//Verify that $_POST object represents maximum possible donation
+		$unverified_max = give_verify_minimum_price('maximum');
+
 		// Check verified status
 		$this->assertTrue($verified_min);
 		$this->assertTrue($verified_max);
+
+		// Check unverified status
+		$this->assertFalse($unverified_min);
+		$this->assertFalse($unverified_max);
 
 	}
 }

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -4,12 +4,28 @@
  * @group formatting
  */
 class Tests_MISC_Functions extends Give_Unit_Test_Case {
+
+	/**
+	 * @since  1.0
+	 * @access protected
+	 * @var Give_Donate_Form
+	 */
+	protected $_multi_form;
+
 	public function setUp() {
 		parent::setUp();
+
+		// Create multilevel donation form.
+		$this->_multi_form  = Give_Helper_Form::create_multilevel_form();
+
 	}
 
 	public function tearDown() {
 		parent::tearDown();
+
+		//Delete forms.
+		Give_Helper_Form::delete_form( $this->_simple_form->ID );
+		Give_Helper_Form::delete_form( $this->_multi_form->ID );
 	}
 
 
@@ -370,5 +386,49 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 			'/<a href=".+?\?donation_id=/',
 			$receipt_link_url
 		);
+	}
+
+	/**
+	 * Check if the give_verify_minimum_price() returns verified status, amount range and form ID.
+	 * Function handles verification of either maximum or minimum status, so test for both.
+	 *
+	 * @since  2.5.11
+	 * @access public
+	 *
+	 * @cover give_verify_minimum_price()
+	 */
+	public function test_give_verify_minimum_price() {
+
+		// Test minimum donation
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $_multi_form->ID;
+		$_POST['give-amount'] = '10';
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_min = give_verify_minimum_price('minimum');
+
+		// Test maximum donation
+		//Set post superglobal keys to values match maximum possible donation
+		$_POST['give-form-id'] = $_multi_form->ID;
+		$_POST['give-amount'] = '10';
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents maximum possible donation
+		$verified_max = give_verify_minimum_price('maximum');
+
+		// Check return values
+		// Check verified status
+		$this->assertTrue($verified_min->verified_stat);
+		$this->assertTrue($verified_max->verified_stat);
+
+		// Check amount range
+		$this->assertEquals($verified_max->amount_range, 'maximum');
+		$this->assertEquals($verified_min->amount_range, 'minimum');
+
+		// Check form id
+		$this->assertEquals($verified_max->form_id, $_multi_form->ID);
+		$this->assertEquals($verified_min->form_id, $_multi_form->ID);
+
 	}
 }

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -438,6 +438,8 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		give_update_meta( $this->_multi_form->ID, '_give_custom_amount', 'enabled' );
 		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_range_minimum', 5 );
 		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_minimum', 5 );
+		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_range_maximum', 150 );
+		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_maximum', 150 );
 
 		//Set post superglobal keys to values match minimum possible donation
 		$_POST['give-form-id'] = $this->_multi_form->ID;
@@ -445,7 +447,31 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		$_POST['give-price-id'] = '1';
 
 		//Verify that $_POST object represents minimum possible donation
-		$verified_amount_range_min = give_verify_minimum_price('minimum');
+		$verified_custom_range_min = give_verify_minimum_price('minimum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 1;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_custom_range_min = give_verify_minimum_price('minimum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 150;
+		$_POST['give-price-id'] = '4';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_custom_range_max = give_verify_minimum_price('maximum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 250;
+		$_POST['give-price-id'] = '4';
+
+		//Verify that $_POST object represents minimum possible donation
+		$unverified_custom_range_max = give_verify_minimum_price('maximum');
 
 		//Set post superglobal keys to values match minimum possible donation
 		$_POST['give-form-id'] = $this->_multi_form->ID;
@@ -453,15 +479,45 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		$_POST['give-price-id'] = '1';
 
 		//Verify that $_POST object represents minimum possible donation
-		$verified_amount_min = give_verify_minimum_price('minimum');
+		$verified_custom_min = give_verify_minimum_price('minimum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 1;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$unverified_custom_min = give_verify_minimum_price('minimum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 150;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_custom_max = give_verify_minimum_price('maximum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 250;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$unverified_custom_max = give_verify_minimum_price('maximum');
 
 		// Check verified status
 		$this->assertTrue($verified_amount_range_min);
 		$this->assertTrue($verified_amount_min);
+		$this->assertTrue($verified_amount_range_max);
+		$this->assertTrue($verified_amount_max);
 		$this->assertTrue($verified_min);
 		$this->assertTrue($verified_max);
 
 		// Check unverified status
+		$this->assertTrue($unverified_custom_range_min);
+		$this->assertTrue($unverified_custom_min);
+		$this->assertTrue($unverified_custom_range_max);
+		$this->assertTrue($unverified_custom_max);
 		$this->assertFalse($unverified_min);
 		$this->assertFalse($unverified_max);
 

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -23,8 +23,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 	public function tearDown() {
 		parent::tearDown();
 
-		//Delete forms.
-		Give_Helper_Form::delete_form( $this->_simple_form->ID );
+		//Delete form.
 		Give_Helper_Form::delete_form( $this->_multi_form->ID );
 	}
 
@@ -389,7 +388,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * Check if the give_verify_minimum_price() returns verified status, amount range and form ID.
+	 * Check if the give_verify_minimum_price() returns verified status.
 	 * Function handles verification of either maximum or minimum status, so test for both.
 	 *
 	 * @since  2.5.11
@@ -401,7 +400,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 
 		// Test minimum donation
 		//Set post superglobal keys to values match minimum possible donation
-		$_POST['give-form-id'] = $_multi_form->ID;
+		$_POST['give-form-id'] = $this->_multi_form->ID;
 		$_POST['give-amount'] = '10';
 		$_POST['give-price-id'] = '1';
 
@@ -410,25 +409,16 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 
 		// Test maximum donation
 		//Set post superglobal keys to values match maximum possible donation
-		$_POST['give-form-id'] = $_multi_form->ID;
+		$_POST['give-form-id'] = $this->_multi_form->ID;
 		$_POST['give-amount'] = '10';
 		$_POST['give-price-id'] = '1';
 
 		//Verify that $_POST object represents maximum possible donation
 		$verified_max = give_verify_minimum_price('maximum');
 
-		// Check return values
 		// Check verified status
-		$this->assertTrue($verified_min->verified_stat);
-		$this->assertTrue($verified_max->verified_stat);
-
-		// Check amount range
-		$this->assertEquals($verified_max->amount_range, 'maximum');
-		$this->assertEquals($verified_min->amount_range, 'minimum');
-
-		// Check form id
-		$this->assertEquals($verified_max->form_id, $_multi_form->ID);
-		$this->assertEquals($verified_min->form_id, $_multi_form->ID);
+		$this->assertTrue($verified_min);
+		$this->assertTrue($verified_max);
 
 	}
 }

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -455,7 +455,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		$_POST['give-price-id'] = '1';
 
 		//Verify that $_POST object represents minimum possible donation
-		$verified_custom_range_min = give_verify_minimum_price('minimum');
+		$unverified_custom_range_min = give_verify_minimum_price('minimum');
 
 		//Set post superglobal keys to values match minimum possible donation
 		$_POST['give-form-id'] = $this->_multi_form->ID;
@@ -506,18 +506,18 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		$unverified_custom_max = give_verify_minimum_price('maximum');
 
 		// Check verified status
-		$this->assertTrue($verified_amount_range_min);
-		$this->assertTrue($verified_amount_min);
-		$this->assertTrue($verified_amount_range_max);
-		$this->assertTrue($verified_amount_max);
+		$this->assertTrue($verified_custom_range_min);
+		$this->assertTrue($verified_custom_min);
+		$this->assertTrue($verified_custom_range_max);
+		$this->assertTrue($verified_custom_max);
 		$this->assertTrue($verified_min);
 		$this->assertTrue($verified_max);
 
 		// Check unverified status
-		$this->assertTrue($unverified_custom_range_min);
-		$this->assertTrue($unverified_custom_min);
-		$this->assertTrue($unverified_custom_range_max);
-		$this->assertTrue($unverified_custom_max);
+		$this->assertFalse($unverified_custom_range_min);
+		$this->assertFalse($unverified_custom_min);
+		$this->assertFalse($unverified_custom_range_max);
+		$this->assertFalse($unverified_custom_max);
 		$this->assertFalse($unverified_min);
 		$this->assertFalse($unverified_max);
 

--- a/tests/unit-tests/tests-misc-functions.php
+++ b/tests/unit-tests/tests-misc-functions.php
@@ -434,7 +434,30 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 		//Verify that $_POST object represents maximum possible donation
 		$unverified_max = give_verify_minimum_price('maximum');
 
+		// Test and enable custom amounts
+		give_update_meta( $this->_multi_form->ID, '_give_custom_amount', 'enabled' );
+		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_range_minimum', 5 );
+		give_update_meta( $this->_multi_form->ID, '_give_custom_amount_minimum', 5 );
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 5;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_amount_range_min = give_verify_minimum_price('minimum');
+
+		//Set post superglobal keys to values match minimum possible donation
+		$_POST['give-form-id'] = $this->_multi_form->ID;
+		$_POST['give-amount'] = 5;
+		$_POST['give-price-id'] = '1';
+
+		//Verify that $_POST object represents minimum possible donation
+		$verified_amount_min = give_verify_minimum_price('minimum');
+
 		// Check verified status
+		$this->assertTrue($verified_amount_range_min);
+		$this->assertTrue($verified_amount_min);
 		$this->assertTrue($verified_min);
 		$this->assertTrue($verified_max);
 


### PR DESCRIPTION
## Description
Resolve #3232 
Added new test for give_verify_minimum_price() to tests-misc-functions.php. The test checks that both 'minimum' and 'maximum' prices can be verified, by setting up a sample multilevel donation form, then writing to the $_POST object to check how the function handles different donation levels.

## How Has This Been Tested?
Tested by running phpunit tests. First tested by itself, then tested alongside all phpunit tests, to ensure that directly writing to $_POST had no adverse impact on other tests. 

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.