### PR TITLE
refactor: remove duplicate code for retrieving donor address

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -478,22 +478,8 @@ function give_count_total_donors() {
  * @return array The donor's address, if any
  */
 function give_get_donor_address( $donor_id = null, $args = array() ) {
-	$default_args = array(
-		'by_user_id'   => false,
-		'address_type' => 'billing',
-	);
 
-	$default_address = array(
-		'line1'   => '',
-		'line2'   => '',
-		'city'    => '',
-		'state'   => '',
-		'country' => '',
-		'zip'     => '',
-	);
-
-	$address = array();
-	$args    = wp_parse_args( $args, $default_args );
+	$args['by_user_id'] = false;
 
 	// Set user id if donor is empty.
 	if ( empty( $donor_id ) ) {
@@ -501,35 +487,12 @@ function give_get_donor_address( $donor_id = null, $args = array() ) {
 		$args['by_user_id'] = true;
 	}
 
-	// Backward compatibility.
-	if ( ! give_has_upgrade_completed( 'v20_upgrades_user_address' ) && $by_user_id ) {
-		return wp_parse_args(
-			(array) get_user_meta( $donor_id, '_give_user_address', true ),
-			$default_address
-		);
-	}
-
 	$donor = new Give_Donor( $donor_id, (bool) $args['by_user_id'] );
 
-	if (
-		! $donor->id ||
-		empty( $donor->address ) ||
-		! array_key_exists( $args['address_type'], $donor->address )
-	) {
-		return $default_address;
-	}
-
-	switch ( true ) {
-		case is_string( end( $donor->address[ $args['address_type'] ] ) ):
-			$address = wp_parse_args( $donor->address[ $args['address_type'] ], $default_address );
-			break;
-
-		case is_array( end( $donor->address[ $args['address_type'] ] ) ):
-			$address = wp_parse_args( array_shift( $donor->address[ $args['address_type'] ] ), $default_address );
-			break;
-	}
+	$address = $donor->get_donor_address($args);
 
 	return $address;
+	
 }
 
 /**


### PR DESCRIPTION
## Description
Resolves #3253 
Removed duplicate code from give_get_donor_address() to instead rely on the Give_Donor class method get_donor_address. give_get_donor_address now uses creates a new Give_Donor class based on the donor_id passed to it (keeping existing logic for checking if now id is passed, and using get_current_user instead). Then returns the result of get_donor_address called on the new Donor object.

## How Has This Been Tested?
There is no existing unit test for give_get_donor_address, but I ran the unit test for Give_Donor::get_donor_address() and passed. I checked the return values of each on a local site and found them to behave identically and as expected.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.