### PR TITLE
fix: modify setup_donation_form to return ID

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -381,7 +381,7 @@ class Give_Donate_Form {
 			$this->$key = $value;
 		}
 
-		return true;
+		return $donation_form->ID;
 
 	}
 


### PR DESCRIPTION
## Description
Modified setup_donation_form to return ID if setup is successful. This method is called by Give_Donate_Form->create(), which now returns an ID when creation is successful.

## How Has This Been Tested?
Ran PHPUnit tests, which passed. Also searched the codebase for references to Give_Donate_Form->create() and found only one reference, in give_import_get_form_data_from_csv(). Tested csv import functionality locally, and the does not appear to be any conflicts.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.