### PR TITLE
feature: add overview page component 4342

### DIFF
--- a/assets/src/js/admin/reports/components/routes/index.js
+++ b/assets/src/js/admin/reports/components/routes/index.js
@@ -1,8 +1,7 @@
 import { Switch, Route } from 'react-router-dom'
 import OverviewPage from '../../pages/overview-page'
 
-const Routes = (props) => {
-    
+const Routes = () => {
     return (
         <Switch>
             <Route exact path='/'>

--- a/assets/src/js/admin/reports/components/routes/index.js
+++ b/assets/src/js/admin/reports/components/routes/index.js
@@ -1,3 +1,6 @@
+// Handles display of different page components depending on location path
+// Page components are found in app/pages
+
 import { Switch, Route } from 'react-router-dom'
 import OverviewPage from '../../pages/overview-page'
 

--- a/assets/src/js/admin/reports/components/routes/index.js
+++ b/assets/src/js/admin/reports/components/routes/index.js
@@ -1,11 +1,12 @@
 import { Switch, Route } from 'react-router-dom'
+import OverviewPage from '../../pages/overview-page'
 
 const Routes = (props) => {
     
     return (
         <Switch>
             <Route exact path='/'>
-                <h1>Overview Page</h1>
+                <OverviewPage />
             </Route>
         </Switch>
     )

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -1,8 +1,12 @@
+import Grid from '../../components/grid'
+
 const OverviewPage = () => {
     return (
-        <div>
-            <h1>Overview Page!</h1>
-        </div>
+        <Grid>
+            <div>
+                Child Component
+            </div>
+        </Grid>
     )
 }
 export default OverviewPage

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -1,3 +1,7 @@
+// Overview Page component
+// Pages use the Grid component to establish a
+// 12 column grid for content to exist in
+
 import Grid from '../../components/grid'
 
 const OverviewPage = () => {

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -1,0 +1,8 @@
+const OverviewPage = () => {
+    return (
+        <div>
+            <h1>Overview Page!</h1>
+        </div>
+    )
+}
+export default OverviewPage


### PR DESCRIPTION
## Description
Resolves #4342 
Added an OverviewPage component (found in reports/pages/overview-page/index.js) to be ultimately used to contain all presentational components of the Overview page. Added this new OverviewPage component to appropriate route in Router.

## How Has This Been Tested?
Served locally and tested in browser without logging errors.

## Screenshots (jpeg or gifs if applicable):
New overview page component loaded with Grid as child component
<img width="473" alt="Screen Shot 2019-12-13 at 4 12 14 PM" src="https://user-images.githubusercontent.com/5186078/70832585-795a2300-1dc3-11ea-9148-0574b3de117b.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.