### PR TITLE
feature: add flexible chart component 4331

### DIFF
--- a/assets/src/js/admin/reports/components/chart/index.js
+++ b/assets/src/js/admin/reports/components/chart/index.js
@@ -6,7 +6,7 @@ const Chart = ({type, aspectRatio, data}) => {
 
     const canvas = createRef()
     const config = createConfig(type, data)
-    const height = calcHeight(aspectRatio)
+    const height = 100 * aspectRatio
 
     useEffect(() => {
 

--- a/assets/src/js/admin/reports/components/chart/index.js
+++ b/assets/src/js/admin/reports/components/chart/index.js
@@ -1,12 +1,12 @@
 import ChartJS from 'chart.js'
 import { useEffect, createRef } from 'react'
-import { createConfig, calcHeight } from './utils'
+import { createConfig } from './utils'
 
-const Chart = (props) => {
+const Chart = ({type, data}) => {
 
     const canvas = createRef()
-    const config = createConfig(props)
-    const height = calcHeight(props)
+    const config = createConfig(type, data)
+    let height = 100
 
     useEffect(() => {
 
@@ -16,7 +16,7 @@ const Chart = (props) => {
         return function cleanup() {
             chart.destroy()
         }
-        
+
     }, [])
 
     return (

--- a/assets/src/js/admin/reports/components/chart/index.js
+++ b/assets/src/js/admin/reports/components/chart/index.js
@@ -1,12 +1,12 @@
 import ChartJS from 'chart.js'
-import { useEffect, createRef } from 'react'
+import { useEffect, useLayoutEffect, useState, createRef } from 'react'
 import { createConfig } from './utils'
 
 const Chart = ({type, data}) => {
 
     const canvas = createRef()
     const config = createConfig(type, data)
-    let height = 100
+    const [height, setHeight] = useState(100)
 
     useEffect(() => {
 
@@ -15,6 +15,22 @@ const Chart = ({type, data}) => {
 
         return function cleanup() {
             chart.destroy()
+        }
+
+    }, [])
+
+    useLayoutEffect(() => {
+
+        function updateHeight (evt) {
+            console.log('update height!', canvas)
+            setHeight(80)
+        }
+
+        window.addEventListener('resize', updateHeight)
+        updateHeight()
+
+        return function cleanup() {
+            window.removeEventListener('resize', updateHeight)
         }
 
     }, [])

--- a/assets/src/js/admin/reports/components/chart/index.js
+++ b/assets/src/js/admin/reports/components/chart/index.js
@@ -1,12 +1,12 @@
 import ChartJS from 'chart.js'
-import { useEffect, useLayoutEffect, useState, createRef } from 'react'
-import { createConfig } from './utils'
+import { useEffect, createRef } from 'react'
+import { createConfig, calcHeight } from './utils'
 
-const Chart = ({type, data}) => {
+const Chart = ({type, aspectRatio, data}) => {
 
     const canvas = createRef()
     const config = createConfig(type, data)
-    const [height, setHeight] = useState(100)
+    const height = calcHeight(aspectRatio)
 
     useEffect(() => {
 
@@ -17,23 +17,7 @@ const Chart = ({type, data}) => {
             chart.destroy()
         }
 
-    }, [])
-
-    useLayoutEffect(() => {
-
-        function updateHeight (evt) {
-            console.log('update height!', canvas)
-            setHeight(80)
-        }
-
-        window.addEventListener('resize', updateHeight)
-        updateHeight()
-
-        return function cleanup() {
-            window.removeEventListener('resize', updateHeight)
-        }
-
-    }, [])
+    }, [height])
 
     return (
         <div>

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -32,17 +32,21 @@ function createStyles (type, data) {
         '#9EA3A8'
     ]
 
-    const area = ['#69B86844']
-    const line = ['#69B868']
-
-    const backgroundColor = type === 'line' ? area : palette
-    const borderColor = type === 'line' ? line : palette
-    const borderWidth = type === 'line' ? 3 : 0
-
     const styles = {
-        backgroundColor,
-        borderColor,
-        borderWidth
+        backgroundColor: palette,
+        borderColor: palette,
+        borderWidth: 0
+    }
+
+    switch (type) {
+        case 'line':
+            styles.backgroundColor = ['#69B86844']
+            styles.borderColor = ['#69B868']
+            styles.borderWidth = 3
+            break;
+        case 'doughnut':
+            styles.borderColor = ['#FFFFFF']
+            styles.borderWidth = 3
     }
 
     return styles
@@ -54,6 +58,9 @@ export function createConfig (type, data) {
         type: type,
         data: formattedData,
         options: {
+            legend: {
+                position: 'bottom',
+            },
             scales: {
                 yAxes: [{
                     ticks: {

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -50,7 +50,3 @@ export function createConfig (type, data) {
     }
     return config
 }
-
-export function calcHeight (aspectRatio) {
-    return 40
-}

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -1,15 +1,15 @@
-export function formatData (data) {
+export function formatData (type, data) {
 
     const formattedLabels = data.labels
 
     const formattedDatasets = data.datasets.map((dataset) => {
-        //const styles = createStyles(props)
+        const styles = createStyles(type, dataset.data)
         const formatted = {
             label: dataset.label,
             data: dataset.data,
-            backgroundColor: ['rgba(105, 184, 104, 0.21)'],
-            borderColor: ['rgba(105, 184, 104, 1)'],
-            borderWidth: 3
+            backgroundColor: styles.backgroundColor,
+            borderColor: styles.borderColor,
+            borderWidth: styles.borderWidth
         }
         return formatted
     })
@@ -22,18 +22,34 @@ export function formatData (data) {
     return formattedData
 }
 
-function createStyles (props) {
+function createStyles (type, data) {
+
+    const palette = [
+        '#69B868',
+        '#F49420',
+        '#D75A4B',
+        '#556E79',
+        '#9EA3A8'
+    ]
+
+    const area = ['#69B86844']
+    const line = ['#69B868']
+
+    const backgroundColor = type === 'line' ? area : palette
+    const borderColor = type === 'line' ? line : palette
+    const borderWidth = type === 'line' ? 3 : 0
+
     const styles = {
-        backgroundColor: ['rgba(105, 184, 104, 0.21)'],
-        borderColor: ['rgba(105, 184, 104, 1)'],
-        borderWidth: 3
+        backgroundColor,
+        borderColor,
+        borderWidth
     }
 
     return styles
 }
 
 export function createConfig (type, data) {
-    const formattedData = formatData(data)
+    const formattedData = formatData(type, data)
     const config = {
         type: type,
         data: formattedData,

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -3,7 +3,7 @@ export function formatData (data) {
     const formattedLabels = data.labels
 
     const formattedDatasets = data.datasets.map((dataset) => {
-        const styles = createStyles(props)
+        //const styles = createStyles(props)
         const formatted = {
             label: dataset.label,
             data: dataset.data,
@@ -51,17 +51,6 @@ export function createConfig (type, data) {
     return config
 }
 
-export function calcHeight (props) {
-    let ratio
-    switch (true) {
-        case props.cardWidth <= 3:
-            ratio = 1
-            break
-        case props.cardWidth <= 6:
-            ratio = 0.8
-            break
-        default:
-            ratio = 0.25
-    }
-    return 100 * ratio
+export function calcHeight (aspectRatio) {
+    return 40
 }

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -32,10 +32,10 @@ function createStyles (props) {
     return styles
 }
 
-export function createConfig (props) {
-    const formattedData = formatData(props.data)
+export function createConfig (type, data) {
+    const formattedData = formatData(data)
     const config = {
-        type: props.type,
+        type: type,
         data: formattedData,
         options: {
             scales: {

--- a/assets/src/js/admin/reports/components/chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/chart/utils/index.js
@@ -2,8 +2,8 @@ export function formatData (type, data) {
 
     const formattedLabels = data.labels
 
-    const formattedDatasets = data.datasets.map((dataset) => {
-        const styles = createStyles(type, dataset.data)
+    const formattedDatasets = data.datasets.map((dataset, index) => {
+        const styles = createStyles(type, dataset.data, index)
         const formatted = {
             label: dataset.label,
             data: dataset.data,
@@ -22,7 +22,7 @@ export function formatData (type, data) {
     return formattedData
 }
 
-function createStyles (type, data) {
+function createStyles (type, data, index) {
 
     const palette = [
         '#69B868',
@@ -40,8 +40,12 @@ function createStyles (type, data) {
 
     switch (type) {
         case 'line':
-            styles.backgroundColor = ['#69B86844']
-            styles.borderColor = ['#69B868']
+            styles.backgroundColor = [
+                palette[index] + '44'
+            ]
+            styles.borderColor = [
+                palette[index]
+            ]
             styles.borderWidth = 3
             break;
         case 'doughnut':

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -12,6 +12,7 @@ const OverviewPage = () => {
             <Card title="Sample Chart" width={12}>
                 <Chart
                     type='line'
+                    aspectRatio={0.4}
                     data={{
                         labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
                         datasets: [

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -5,11 +5,12 @@
 import Grid from '../../components/grid'
 import Card from '../../components/card'
 import Chart from '../../components/chart'
+const { __ } = wp.i18n;
 
 const OverviewPage = () => {
     return (
         <Grid>
-            <Card title="Doughnut Chart" width={4}>
+            <Card title={__('Dougnhut Chart', 'give')} width={4}>
                 <Chart
                     type='doughnut'
                     aspectRatio={0.7}
@@ -24,7 +25,7 @@ const OverviewPage = () => {
                     }}
                 />
             </Card>
-            <Card title="Bar Chart" width={4}>
+            <Card title={__('Bar Chart', 'give')} width={4}>
                 <Chart
                     type='bar'
                     aspectRatio={0.7}
@@ -39,7 +40,7 @@ const OverviewPage = () => {
                     }}
                 />
             </Card>
-            <Card title="Pie Chart" width={4}>
+            <Card title={__('Pie Chart', 'give')} width={4}>
                 <Chart
                     type='pie'
                     aspectRatio={0.7}
@@ -54,7 +55,7 @@ const OverviewPage = () => {
                     }}
                 />
             </Card>
-            <Card title="Line Chart" width={12}>
+            <Card title={__('Line Chart', 'give')} width={12}>
                 <Chart
                     type='line'
                     aspectRatio={0.4}

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -9,7 +9,7 @@ import Chart from '../../components/chart'
 const OverviewPage = () => {
     return (
         <Grid>
-            <Card title="Sample Chart" width={12}>
+            <Card title="Line Chart" width={12}>
                 <Chart
                     type='line'
                     aspectRatio={0.4}
@@ -17,6 +17,37 @@ const OverviewPage = () => {
                         labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
                         datasets: [
                             {
+                                label: 'Donations',
+                                data: [4, 5, 3, 7, 5, 6]
+                            }
+                        ]
+                    }}
+                />
+            </Card>
+            <Card title="Doughnut Chart" width={4}>
+                <Chart
+                    type='doughnut'
+                    aspectRatio={0.7}
+                    data={{
+                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
+                        datasets: [
+                            {
+                                label: 'Donations',
+                                data: [4, 5, 3, 7, 5, 6]
+                            }
+                        ]
+                    }}
+                />
+            </Card>
+            <Card title="Bar Chart" width={4}>
+                <Chart
+                    type='bar'
+                    aspectRatio={0.7}
+                    data={{
+                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
+                        datasets: [
+                            {
+                                label: 'Donations',
                                 data: [4, 5, 3, 7, 5, 6]
                             }
                         ]

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -19,6 +19,10 @@ const OverviewPage = () => {
                             {
                                 label: 'Donations',
                                 data: [4, 5, 3, 7, 5, 6]
+                            },
+                            {
+                                label: 'Refunds',
+                                data: [2, 4, 6, 4, 3, 4]
                             }
                         ]
                     }}
@@ -42,6 +46,21 @@ const OverviewPage = () => {
             <Card title="Bar Chart" width={4}>
                 <Chart
                     type='bar'
+                    aspectRatio={0.7}
+                    data={{
+                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
+                        datasets: [
+                            {
+                                label: 'Donations',
+                                data: [4, 5, 3, 7, 5, 6]
+                            }
+                        ]
+                    }}
+                />
+            </Card>
+            <Card title="Pie Chart" width={4}>
+                <Chart
+                    type='pie'
                     aspectRatio={0.7}
                     data={{
                         labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -9,9 +9,18 @@ import Chart from '../../components/chart'
 const OverviewPage = () => {
     return (
         <Grid>
-            <Card
-            title="Sample Chart">
-                <Chart/>
+            <Card title="Sample Chart" width={12}>
+                <Chart
+                    type='line'
+                    data={{
+                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
+                        datasets: [
+                            {
+                                data: [4, 5, 3, 7, 5, 6]
+                            }
+                        ]
+                    }}
+                />
             </Card>
         </Grid>
     )

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -3,13 +3,16 @@
 // 12 column grid for content to exist in
 
 import Grid from '../../components/grid'
+import Card from '../../components/card'
+import Chart from '../../components/chart'
 
 const OverviewPage = () => {
     return (
         <Grid>
-            <div>
-                Child Component
-            </div>
+            <Card
+            title="Sample Chart">
+                <Chart/>
+            </Card>
         </Grid>
     )
 }

--- a/assets/src/js/admin/reports/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/pages/overview-page/index.js
@@ -9,25 +9,6 @@ import Chart from '../../components/chart'
 const OverviewPage = () => {
     return (
         <Grid>
-            <Card title="Line Chart" width={12}>
-                <Chart
-                    type='line'
-                    aspectRatio={0.4}
-                    data={{
-                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
-                        datasets: [
-                            {
-                                label: 'Donations',
-                                data: [4, 5, 3, 7, 5, 6]
-                            },
-                            {
-                                label: 'Refunds',
-                                data: [2, 4, 6, 4, 3, 4]
-                            }
-                        ]
-                    }}
-                />
-            </Card>
             <Card title="Doughnut Chart" width={4}>
                 <Chart
                     type='doughnut'
@@ -69,6 +50,25 @@ const OverviewPage = () => {
                                 label: 'Donations',
                                 data: [4, 5, 3, 7, 5, 6]
                             }
+                        ]
+                    }}
+                />
+            </Card>
+            <Card title="Line Chart" width={12}>
+                <Chart
+                    type='line'
+                    aspectRatio={0.4}
+                    data={{
+                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
+                        datasets: [
+                            {
+                                label: 'Donations',
+                                data: [4, 5, 3, 7, 5, 6]
+                            },
+                            // {
+                            //     label: 'Refunds',
+                            //     data: [2, 4, 6, 4, 3, 4]
+                            // }
                         ]
                     }}
                 />

--- a/includes/reports/class-reports-admin.php
+++ b/includes/reports/class-reports-admin.php
@@ -35,7 +35,8 @@ class Reports_Admin {
 				['wp-element', 'wp-api'],
 				'0.0.1',
 				true
-			);
+            );
+            wp_set_script_translations( 'give-admin-reports-v3-js', 'give' );
 		}
 	}
 


### PR DESCRIPTION
## Description
Resolves #4331 
Added a flexible chart component for building charts using ChartJS. Accepts **type, aspectRatio and data** props.

**NOTE: ** Implementation of a proper legend for Charts should be explored in another PR, as this functionality might best be suited in a separate component.

## How Has This Been Tested?
Tested locally in browser and does not log errors.

## Screenshots (jpeg or gifs if applicable):
<img width="1072" alt="Screen Shot 2019-12-16 at 8 17 08 PM" src="https://user-images.githubusercontent.com/5186078/70964537-0eb61b00-2041-11ea-9fff-448b8cdb84ef.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.