### PR TITLE
fix: when clicking modal popup button don't hide "donate now" button

### DIFF
--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -421,11 +421,7 @@ form[id*='give-form'] {
 
 }
 
-.give-display-button-only > *:not(form) {
-	display: none;
-}
-
-.give-display-button-only form[id*=give-form] > *:not(.give-btn-modal) {
+.give-display-button-only > *:not(.give-btn-modal) {
 	display: none;
 }
 

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -248,7 +248,7 @@ window.give_open_form_modal = function ($form_wrap, $form) {
 
 					// Hide .give-hidden and .give-btn-modal if admin only wants to show the button.
 					if ($form_wrap.hasClass( 'give-display-button-only' )) {
-						children = $form.children().not( '.give-btn-modal' );
+						children = $form.children();
 					}
 
 					// Hide all form elements besides the ones required for payment

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -691,8 +691,11 @@ function give_display_checkout_button( $form_id, $args ) {
 		: give_get_meta( $form_id, '_give_payment_display', true );
 
 	if ( 'button' === $display_option ) {
-		$display_option = 'modal';
-	} elseif ( $display_option === 'onpage' ) {
+		add_action( 'give_post_form', 'give_add_button_open_form', 10, 2 );
+		return '';
+	}
+
+	if ( $display_option === 'onpage' ) {
 		return '';
 	}
 
@@ -701,10 +704,34 @@ function give_display_checkout_button( $form_id, $args ) {
 
 	$output = '<button type="button" class="give-btn give-btn-' . $display_option . '">' . $display_label . '</button>';
 
-	echo apply_filters( 'give_display_checkout_button', $output );
+	echo apply_filters( 'give_display_checkout_button', $output, $form_id, $args );
 }
 
 add_action( 'give_after_donation_levels', 'give_display_checkout_button', 10, 2 );
+
+/**
+ * Display MagnificPopup Button.
+ *
+ * @since 2.5.11
+ *
+ * @param $form_id
+ * @param $args
+ *
+ * @return string
+ */
+function give_add_button_open_form( $form_id, $args ){
+	$display_label_field = give_get_meta( $form_id, '_give_reveal_label', true );
+	$display_label       = ! empty( $args['continue_button_title'] )
+		? $args['continue_button_title']
+		: ( ! empty( $display_label_field ) ? $display_label_field : esc_html__( 'Donate Now', 'give' ) );
+
+	$output = sprintf(
+		'<button type="button" class="give-btn give-btn-modal">%1$s</button>',
+		$display_label
+	);
+
+	echo apply_filters( 'give_display_checkout_button', $output, $form_id, $args );
+}
 
 /**
  * Shows the User Info fields in the Personal Info box, more fields can be added via the hooks provided.

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -704,6 +704,13 @@ function give_display_checkout_button( $form_id, $args ) {
 
 	$output = '<button type="button" class="give-btn give-btn-' . $display_option . '">' . $display_label . '</button>';
 
+	/**
+	 * filter the button html
+	 *
+	 * @param string $output Button HTML.
+	 * @param int $form_id Form ID.
+	 * @param array $args Shortcode argument
+	 */
 	echo apply_filters( 'give_display_checkout_button', $output, $form_id, $args );
 }
 
@@ -730,6 +737,13 @@ function give_add_button_open_form( $form_id, $args ){
 		$display_label
 	);
 
+	/**
+	 * filter the button html
+	 *
+	 * @param string $output Button HTML.
+	 * @param int $form_id Form ID.
+	 * @param array $args Shortcode argument
+	 */
 	echo apply_filters( 'give_display_checkout_button', $output, $form_id, $args );
 }
 


### PR DESCRIPTION
## Description
This PR will resolve #4352.

**Note: This solution can possibly break button style on the website when donation form display style setting to `Button` but the feature will not break. Check the video for the explanation.**

## How Has This Been Tested?
https://www.loom.com/share/0e99c2865bb94b3295b5a28d3bbc827c## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
Dom element location Change
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.