### PR TITLE
fix: style card to pad title not content

### DIFF
--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -15,8 +15,11 @@ const Card = ({width, title, children}) => {
 }
 
 Card.propTypes = {
+    // Number of grid columns for Card to span, out of 12
     width: PropTypes.number,
+    // Title of card
     title: PropTypes.string.isRequired,
+    // Elements to displayed in content area of card (eg: Chart, List)
     children: PropTypes.node.isRequired
 }
 

--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -2,7 +2,7 @@ import './style.scss'
 
 const Card = (props) => {
     return (
-        <div className='card' style={{gridColumn: 'span ' + props.width}}>
+        <div className='givewp-card' style={{gridColumn: 'span ' + props.width}}>
             <div className='title'>
                 {props.title}
             </div>

--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -1,31 +1,12 @@
+import './style.scss'
+
 const Card = (props) => {
-
-    //To do: swap with scss
-    const cardStyle = {
-        background: '#fff',
-        borderRadius: '5px',
-        boxShadow: '0px 3px 6px rgba(68, 68, 68, 0.05), 0px 3px 6px rgba(68, 68, 68, 0.05)',
-        gridColumn: 'span ' + props.width,
-        display: 'flex',
-        flexDirection: 'column',
-    }
-
-    const titleStyle = {
-        fontWeight: 'bold',
-        padding: '22px 15px 15px 15px',
-        fontSize: '15px',
-    }
-
-    const contentStyle = {
-        padding: ' 0 15px 15px 15px'
-    }
-
     return (
-        <div style={cardStyle}>
-            <div style={titleStyle}>
+        <div className='card' style={{gridColumn: 'span ' + props.width}}>
+            <div className='title'>
                 {props.title}
             </div>
-            <div style={contentStyle}>
+            <div className='content'>
                 {props.children}
             </div>
         </div>

--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -20,4 +20,10 @@ Card.propTypes = {
     children: PropTypes.node.isRequired
 }
 
+Card.defaultProps = {
+    width: 4,
+    title: null,
+    children: null
+}
+
 export default Card

--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import './style.scss'
 
 const Card = ({width, title, children}) => {
@@ -12,4 +13,11 @@ const Card = ({width, title, children}) => {
         </div>
     )
 }
+
+Card.propTypes = {
+    width: PropTypes.number,
+    title: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired
+}
+
 export default Card

--- a/assets/src/js/admin/reports/components/card/index.js
+++ b/assets/src/js/admin/reports/components/card/index.js
@@ -1,13 +1,13 @@
 import './style.scss'
 
-const Card = (props) => {
+const Card = ({width, title, children}) => {
     return (
-        <div className='givewp-card' style={{gridColumn: 'span ' + props.width}}>
+        <div className='givewp-card' style={{gridColumn: 'span ' + width}}>
             <div className='title'>
-                {props.title}
+                {title}
             </div>
             <div className='content'>
-                {props.children}
+                {children}
             </div>
         </div>
     )

--- a/assets/src/js/admin/reports/components/card/style.scss
+++ b/assets/src/js/admin/reports/components/card/style.scss
@@ -1,0 +1,17 @@
+.card {
+    background: #fff;
+    border-radius: 5px;
+    box-shadow: 0px 3px 6px rgba(68, 68, 68, 0.05), 0px 3px 6px rgba(68, 68, 68, 0.05);
+    display: flex;
+    flex-direction: column;
+
+    > .title {
+        font-weight: bold;
+        padding: 22px 15px 15px 15px;
+        font-size: 15px;
+    }
+
+    > .content {
+        padding: 0 15px 15px 15px;
+    }
+}

--- a/assets/src/js/admin/reports/components/card/style.scss
+++ b/assets/src/js/admin/reports/components/card/style.scss
@@ -4,10 +4,11 @@
     box-shadow: 0px 3px 6px rgba(68, 68, 68, 0.05), 0px 3px 6px rgba(68, 68, 68, 0.05);
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 
     > .title {
         font-weight: bold;
-        padding: 22px 15px 15px 15px;
+        padding: 16px;
         font-size: 15px;
     }
 

--- a/assets/src/js/admin/reports/components/card/style.scss
+++ b/assets/src/js/admin/reports/components/card/style.scss
@@ -1,4 +1,4 @@
-.card {
+.givewp-card {
     background: #fff;
     border-radius: 5px;
     box-shadow: 0px 3px 6px rgba(68, 68, 68, 0.05), 0px 3px 6px rgba(68, 68, 68, 0.05);
@@ -12,6 +12,6 @@
     }
 
     > .content {
-        padding: 0 15px 15px 15px;
+        padding: 0;
     }
 }


### PR DESCRIPTION
## Description
Resolves #4358 
Refactored Card styles into style.scss file, and addressed issue with padding so that content is not padded, but title is. Also destructure Card component props, defined prop types and added default props.

## How Has This Been Tested?
Tested locally and throws no errors in browser console.

## Screenshots (jpeg or gifs if applicable):
<img width="272" alt="Screen Shot 2019-12-20 at 12 14 15 PM" src="https://user-images.githubusercontent.com/5186078/71289583-54653300-2322-11ea-8979-e99b7898c028.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.