### PR TITLE
style: fix block styles so they don't conflict with default gutes #4354

### DIFF
--- a/blocks/donation-form/style.scss
+++ b/blocks/donation-form/style.scss
@@ -1,23 +1,33 @@
 .float-right {
-	float: right ;
+  float: right;
 }
 
-.gutenberg__editor .give-blank-slate__image {
-	max-width: 96px;
-}
+.gutenberg__editor {
 
-.components-button {
-	margin: 15px 0 0 0;
-}
+  // Donation form block.
+  .give-blank-slate {
 
-.give-chosen-base-control {
-	a.chosen-single {
+	.give-chosen-base-control {
+	  margin: 0 auto 15px;
+	  max-width: 300px;
+
+	  a.chosen-single {
 		box-shadow: none !important;
-	}
+	  }
 
-	ul.chosen-results {
+	  ul.chosen-results {
 		margin: 0 !important;
 		text-align: left !important;
+	  }
+
 	}
+
+	.give-blank-slate__image {
+	  max-width: 96px;
+	}
+
+  }
+
 }
+
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Resolves #4354 by adjusting styles that were conflicting with the default Gutenberg editor.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually

## Screenshots (jpeg or gifs if applicable):

![2019-12-23_11-39-15](https://user-images.githubusercontent.com/1571635/71377191-dd75a780-2578-11ea-8f27-cc3822d2b0df.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Style bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.