### PR TITLE
feature: add link to legacy reports page

### DIFF
--- a/assets/src/js/admin/reports/components/tab/index.js
+++ b/assets/src/js/admin/reports/components/tab/index.js
@@ -1,3 +1,4 @@
+// Dependencies
 import { Link, useRouteMatch } from 'react-router-dom'
 import PropTypes from 'prop-types'
 

--- a/assets/src/js/admin/reports/components/tab/index.js
+++ b/assets/src/js/admin/reports/components/tab/index.js
@@ -16,4 +16,11 @@ const Tab = ({to, children}) => {
 
 }
 
+Tab.propTypes = {
+    // Route that is passed to react-router Link component
+    to: PropTypes.string.isRequired,
+    // Link children (typically text)
+    children: PropTypes.node.isRequired
+}
+
 export default Tab

--- a/assets/src/js/admin/reports/components/tab/index.js
+++ b/assets/src/js/admin/reports/components/tab/index.js
@@ -1,14 +1,13 @@
 import { Link, useRouteMatch } from 'react-router-dom'
 
-const Tab = (props) => {
+const Tab = ({to, exact, children}) => {
     const match = useRouteMatch({
-        path: props.to,
+        path: to,
         exact: true
     })
-    console.log('match!', match);
     const classList = match ? 'nav-tab nav-tab-active' : 'nav-tab'
     return (
-        <Link to={props.to} exact={props.exact} className={classList}>{props.children}</Link>
+        <Link to={to} exact={exact} className={classList}>{children}</Link>
     )
 }
 export default Tab

--- a/assets/src/js/admin/reports/components/tab/index.js
+++ b/assets/src/js/admin/reports/components/tab/index.js
@@ -23,4 +23,9 @@ Tab.propTypes = {
     children: PropTypes.node.isRequired
 }
 
+Tab.defaultProps = {
+    to: null,
+    children: null
+}
+
 export default Tab

--- a/assets/src/js/admin/reports/components/tab/index.js
+++ b/assets/src/js/admin/reports/components/tab/index.js
@@ -1,13 +1,19 @@
 import { Link, useRouteMatch } from 'react-router-dom'
+import PropTypes from 'prop-types'
 
-const Tab = ({to, exact, children}) => {
+const Tab = ({to, children}) => {
+
     const match = useRouteMatch({
         path: to,
         exact: true
     })
+
     const classList = match ? 'nav-tab nav-tab-active' : 'nav-tab'
+
     return (
-        <Link to={to} exact={exact} className={classList}>{children}</Link>
+        <Link to={to} className={classList}>{children}</Link>
     )
+
 }
+
 export default Tab

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -1,4 +1,5 @@
 import Tab from '../tab'
+const { __ } = wp.i18n
 
 const Tabs = (props) => {
     return (
@@ -6,7 +7,7 @@ const Tabs = (props) => {
             <Tab to='/'>
                 Overview
             </Tab>
-            <a className='nav-tab' href={giveReportsData.legacyReportsUrl}>Legacy Reports Page</a>
+    <a className='nav-tab' href={giveReportsData.legacyReportsUrl}>{__('Legacy Reports Page', 'give')}</a>
         </div>
     )
 }

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -6,6 +6,9 @@ const Tabs = (props) => {
             <Tab to='/'>
                 Overview
             </Tab>
+            <Tab to='/edit.php?post_type=give_forms&page=give-reports'>
+                Legacy Reports Page
+            </Tab>
         </div>
     )
 }

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -1,13 +1,16 @@
-import Tab from '../tab'
+// Dependencies
 const { __ } = wp.i18n
 
-const Tabs = (props) => {
+// Components
+import Tab from '../tab'
+
+const Tabs = () => {
     return (
         <div className='nav-tab-wrapper give-nav-tab-wrapper'>
             <Tab to='/'>
                 Overview
             </Tab>
-    <a className='nav-tab' href={giveReportsData.legacyReportsUrl}>{__('Legacy Reports Page', 'give')}</a>
+            <a className='nav-tab' href={giveReportsData.legacyReportsUrl}>{__('Legacy Reports Page', 'give')}</a>
         </div>
     )
 }

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -6,9 +6,7 @@ const Tabs = (props) => {
             <Tab to='/'>
                 Overview
             </Tab>
-            <Tab directTo='/edit.php?post_type=give_forms&page=give-reports'>
-                Legacy Reports Page
-            </Tab>
+            <a className='nav-tab' href='/wp-admin/edit.php?post_type=give_forms&page=give-reports'>Legacy Reports Page</a>
         </div>
     )
 }

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -6,7 +6,7 @@ const Tabs = (props) => {
             <Tab to='/'>
                 Overview
             </Tab>
-            <Tab to='/edit.php?post_type=give_forms&page=give-reports'>
+            <Tab directTo='/edit.php?post_type=give_forms&page=give-reports'>
                 Legacy Reports Page
             </Tab>
         </div>

--- a/assets/src/js/admin/reports/components/tabs/index.js
+++ b/assets/src/js/admin/reports/components/tabs/index.js
@@ -6,7 +6,7 @@ const Tabs = (props) => {
             <Tab to='/'>
                 Overview
             </Tab>
-            <a className='nav-tab' href='/wp-admin/edit.php?post_type=give_forms&page=give-reports'>Legacy Reports Page</a>
+            <a className='nav-tab' href={giveReportsData.legacyReportsUrl}>Legacy Reports Page</a>
         </div>
     )
 }

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -52,11 +52,11 @@ function give_add_options_links() {
 		'give_donors_page'
 	);
 
-	//Reports
+	//Legacy reports
 	$give_reports_page = add_submenu_page(
-		'edit.php?post_type=give_forms',
+		null,
 		esc_html__( 'Donation Reports', 'give' ),
-		esc_html__( 'Reports', 'give' ),
+		esc_html__( 'Legacy Reports', 'give' ),
 		'view_give_reports',
 		'give-reports',
 		array(

--- a/includes/admin/reports/reports.php
+++ b/includes/admin/reports/reports.php
@@ -49,7 +49,7 @@ function give_reports_page() {
 					'tab'              => 'export',
 					'settings-updated' => false,
 				), $current_page ) ); ?>" class="nav-tab <?php echo 'export' === $active_tab ? esc_attr( 'nav-tab-active' ) : ''; ?>"><?php esc_html_e( 'Export', 'give' ); ?></a>
-			<?php } ?>
+			<?php }
 			/**
 			 * Fires in the report tabs.
 			 *

--- a/includes/admin/reports/reports.php
+++ b/includes/admin/reports/reports.php
@@ -38,6 +38,7 @@ function give_reports_page() {
 		<h1 class="screen-reader-text"><?php echo get_admin_page_title(); ?></h1>
 
 		<h2 class="nav-tab-wrapper">
+		<a href="#" class="nav-tab">testingg</a>
 			<?php foreach ( $views as $tab => $label ) { ?>
 				<a href="<?php echo esc_url( add_query_arg( array(
 					'tab'              => $tab,
@@ -49,7 +50,7 @@ function give_reports_page() {
 					'tab'              => 'export',
 					'settings-updated' => false,
 				), $current_page ) ); ?>" class="nav-tab <?php echo 'export' === $active_tab ? esc_attr( 'nav-tab-active' ) : ''; ?>"><?php esc_html_e( 'Export', 'give' ); ?></a>
-			<?php }
+			<?php } ?>
 			/**
 			 * Fires in the report tabs.
 			 *

--- a/includes/admin/reports/reports.php
+++ b/includes/admin/reports/reports.php
@@ -38,7 +38,6 @@ function give_reports_page() {
 		<h1 class="screen-reader-text"><?php echo get_admin_page_title(); ?></h1>
 
 		<h2 class="nav-tab-wrapper">
-		<a href="#" class="nav-tab">testingg</a>
 			<?php foreach ( $views as $tab => $label ) { ?>
 				<a href="<?php echo esc_url( add_query_arg( array(
 					'tab'              => $tab,

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -83,7 +83,11 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 				 * @since 1.8
 				 */
 				do_action( self::$setting_filter_prefix . '_tabs' );
-				?>
+
+				$isReports = isset($_GET['page']) && $_GET['page'] === 'give-reports' ? true : false;
+				if ($isReports === true) { ?>
+				<a href="<?php echo admin_url('edit.php?post_type=give_forms&page=give-reports-v3') ?>" class="nav-tab"><?php esc_html_e( 'New Reports Page', 'give' ); ?></a>
+				<?php } ?>
 				<div class="give-sub-nav-tab-wrapper">
 					<a href="#" id="give-show-sub-nav" class="nav-tab give-not-tab" title="<?php esc_html_e( 'View remaining setting tabs', 'give' ); ?>">
 						<span class="dashicons dashicons-arrow-down-alt2"></span>

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -84,10 +84,12 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 				 */
 				do_action( self::$setting_filter_prefix . '_tabs' );
 
+				// Show link to New Reports page
 				$isReports = isset($_GET['page']) && $_GET['page'] === 'give-reports' ? true : false;
 				if ($isReports === true) { ?>
 				<a href="<?php echo admin_url('edit.php?post_type=give_forms&page=give-reports-v3') ?>" class="nav-tab"><?php esc_html_e( 'New Reports Page', 'give' ); ?></a>
 				<?php } ?>
+
 				<div class="give-sub-nav-tab-wrapper">
 					<a href="#" id="give-show-sub-nav" class="nav-tab give-not-tab" title="<?php esc_html_e( 'View remaining setting tabs', 'give' ); ?>">
 						<span class="dashicons dashicons-arrow-down-alt2"></span>

--- a/includes/reports/class-reports-admin.php
+++ b/includes/reports/class-reports-admin.php
@@ -53,7 +53,10 @@ class Reports_Admin {
 				'0.0.1',
 				true
             );
-            wp_set_script_translations( 'give-admin-reports-v3-js', 'give' );
+			wp_set_script_translations( 'give-admin-reports-v3-js', 'give' );
+			wp_localize_script('give-admin-reports-v3-js', 'giveReportsData', [
+				'legacyReportsUrl' => get_admin_url(null, '/edit.php?post_type=give_forms&page=give-reports')
+			]);
 		} else if ($base === 'index.php') {
 			wp_enqueue_style(
 				'give-admin-reports-widget-style',

--- a/includes/reports/class-reports-admin.php
+++ b/includes/reports/class-reports-admin.php
@@ -79,7 +79,7 @@ class Reports_Admin {
 		add_submenu_page(
 			'edit.php?post_type=give_forms',
 			esc_html__( 'Donation Reports', 'give' ),
-			esc_html__( 'Reports v3', 'give' ),
+			esc_html__( 'Reports', 'give' ),
 			'view_give_reports',
 			'give-reports-v3',
 			[$this, 'render_template']


### PR DESCRIPTION
## Description
Resolves #4372 
Added link to legacy reports page on new reports page, and a link to new reports page that appears on the legacy reports page. Also removed legacy reports page from the admin menu, and renamed the new reports page from 'Reports v3' to 'Reports'. For now, the new reports page uses 'give-reports-v3' as a slug, while the legacy reports page uses just 'give-reports'. The transition should be handled in a seperate issue because it has more to do with modifying existing routing logic than simply adding links to the pages.

## How Has This Been Tested?
Tested locally and throws no errors in browser or in PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):
<img width="361" alt="Screen Shot 2019-12-31 at 1 57 54 PM" src="https://user-images.githubusercontent.com/5186078/71635021-98372280-2bd5-11ea-966c-ccde138ca9ba.png">
<img width="600" alt="Screen Shot 2019-12-31 at 1 58 01 PM" src="https://user-images.githubusercontent.com/5186078/71635027-9cfbd680-2bd5-11ea-92a6-2b3030c6c2fc.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.