### PR TITLE
refactor: improve `give_doing_it_wrong()` function

### DIFF
--- a/give.php
+++ b/give.php
@@ -411,7 +411,7 @@ if ( ! class_exists( 'Give' ) ) :
 		 */
 		public function __clone() {
 			// Cloning instances of the class is forbidden.
-			give_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'give' ), '1.0' );
+			give_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'give' ) );
 		}
 
 		/**
@@ -424,7 +424,7 @@ if ( ! class_exists( 'Give' ) ) :
 		 */
 		public function __wakeup() {
 			// Unserializing instances of the class is forbidden.
-			give_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'give' ), '1.0' );
+			give_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'give' ) );
 		}
 
 		/**

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -293,7 +293,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 				return false;
 			}
 
-			give_doing_it_wrong( __FUNCTION__, 'Use self::request_license_api instead', '2.5.0' );
+			give_doing_it_wrong( __FUNCTION__, 'Use self::request_license_api instead from GiveWP 2.5.0' );
 
 			// Data to send to the API.
 			$api_params = array(

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -609,7 +609,7 @@ class Give_Session {
 	public function use_php_sessions() {
 		$ret = false;
 
-		give_doing_it_wrong( __FUNCTION__, __( 'We are using database session logic instead of PHP session', 'give' ), '2.2.0' );
+		give_doing_it_wrong( __FUNCTION__, __( 'We are using database session logic instead of PHP session since GiveWP 2.2.0', 'give' ) );
 
 		return (bool) apply_filters( 'give_use_php_sessions', $ret );
 	}
@@ -629,7 +629,7 @@ class Give_Session {
 
 		$start_session = true;
 
-		give_doing_it_wrong( __FUNCTION__, __( 'We are using database session logic instead of PHP session', 'give' ), '2.2.0' );
+		give_doing_it_wrong( __FUNCTION__, __( 'We are using database session logic instead of PHP session since GiveWP 2.2.0', 'give' ) );
 
 
 		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {  // @codingStandardsIgnoreLine

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -239,7 +239,7 @@ function give_currency_filter( $price = '', $args = array() ) {
 			'form_id'         => isset( $func_args[3] ) ? $func_args[3] : '',
 		);
 
-		give_doing_it_wrong( __FUNCTION__, 'Pass second argument as Array.', GIVE_VERSION );
+		give_doing_it_wrong( __FUNCTION__, 'Pass second argument as Array.' );
 	}
 
 	// Set default values.

--- a/includes/emails/class-give-emails.php
+++ b/includes/emails/class-give-emails.php
@@ -337,7 +337,7 @@ class Give_Emails {
 	public function send( $to, $subject, $message, $attachments = '' ) {
 
 		if ( ! did_action( 'init' ) && ! did_action( 'admin_init' ) ) {
-			give_doing_it_wrong( __FUNCTION__, esc_html__( 'You cannot send email with Give_Emails until init/admin_init has been reached.', 'give' ), null );
+			give_doing_it_wrong( __FUNCTION__, esc_html__( 'You cannot send email with Give_Emails until init/admin_init has been reached.', 'give' ) );
 
 			return false;
 		}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1581,6 +1581,7 @@ function give_donation_history_table_end() {
  *
  * @return void
  * @since  1.8.18
+ * @since  2.5.13 Refactor function
  */
 function give_doing_it_wrong( $function, $message, $version = null  ) {
 	/**
@@ -1592,7 +1593,7 @@ function give_doing_it_wrong( $function, $message, $version = null  ) {
 	 * @param string $replacement Optional. The function that should have been called.
 	 * @param string $version     The plugin version that deprecated the function.
 	 *
-	 * @since 1.0
+	 * @since 2.5.13
 	 */
 	do_action( 'give_doing_it_wrong', $function, $message, $version );
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1577,15 +1577,32 @@ function give_donation_history_table_end() {
  *
  * @param string $function
  * @param string $message
- * @param string $version
+ * @param string $version deprecated
  *
  * @return void
  * @since  1.8.18
  */
-function give_doing_it_wrong( $function, $message, $version ) {
-	$message .= "\nBacktrace:" . wp_debug_backtrace_summary();
+function give_doing_it_wrong( $function, $message, $version = null  ) {
+	/**
+	 * Fires while calling function incorrectly.
+	 *
+	 * Allow you to hook to incorrect function call.
+	 *
+	 * @param string $function    The function that was called.
+	 * @param string $replacement Optional. The function that should have been called.
+	 * @param string $version     The plugin version that deprecated the function.
+	 *
+	 * @since 1.0
+	 */
+	do_action( 'give_doing_it_wrong', $function, $message, $version );
 
-	_doing_it_wrong( $function, $message, $version );
+	$show_errors = current_user_can( 'manage_options' );
+
+	// Allow plugin to filter the output error trigger.
+	if ( WP_DEBUG && apply_filters( 'give_doing_it_wrong_trigger_error', $show_errors ) ) {
+		trigger_error( sprintf( __( '%1$s was called <strong>incorrectly</strong>. %2$s', 'give' ), $function, $message ) );
+		trigger_error( print_r( wp_debug_backtrace_summary(), 1 ) );// Limited to previous 1028 characters, but since we only need to move back 1 in stack that should be fine.
+	}
 }
 
 

--- a/includes/payments/class-give-payment.php
+++ b/includes/payments/class-give-payment.php
@@ -763,7 +763,7 @@ final class Give_Payment {
 			);
 
 			if ( ! empty( $custom_payment_meta ) ) {
-				give_doing_it_wrong( '_give_payment_meta', __( 'This custom meta key has been deprecated for performance reasons. Your custom meta data will still be stored but we recommend updating your code to store meta keys individually.', 'give' ), '2.0.0' );
+				give_doing_it_wrong( '_give_payment_meta', __( 'This custom meta key has been deprecated for performance reasons. Your custom meta data will still be stored but we recommend updating your code to store meta keys individually from GiveWP 2.0.0.', 'give' ) );
 
 				$this->update_meta( '_give_payment_meta', array_map( 'maybe_unserialize', $custom_payment_meta ) );
 			}


### PR DESCRIPTION
## Description
This Pr will resolve #2572 

`give_doing_it_wrong ` and `_give_deprecated_function` serve different purpose. we can use `_give_deprecated_function` when deprecating a function while we can use `give_doing_it_wrong` when deprecating function parameter or suggestion for the developer when doing something wrong.

I refactored `give_doing_it_wrong ` to accept only two parameters `function name` and `message`. I deprecated the `version` because that can we part of `message`. Because it is a silent deprecation of the third parameter, so it will not throw any notice or warning when passing.

## How Has This Been Tested?
This PR tested by calling deprecated functions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.