### PR TITLE
Bug: Multiple Donate buttons appearing when a button mode form also appears on the page

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -745,6 +745,10 @@ function give_add_button_open_form( $form_id, $args ){
 	 * @param array $args Shortcode argument
 	 */
 	echo apply_filters( 'give_display_checkout_button', $output, $form_id, $args );
+
+	// Remove action otherwise button will be added to coming form.
+	// @see https://github.com/impress-org/givewp/issues/4395
+	remove_action( 'give_post_form', 'give_add_button_open_form', 10 );
 }
 
 /**


### PR DESCRIPTION
## Description
This PR will resolve #4395

## How Has This Been Tested?
Output donation form with there shortcode where first contain `Button` style and other `All fields`.
Testing Video: https://www.loom.com/share/20686165b3114723baf25586b860f23c

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bugfix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.