### PR TITLE
fix: sort form grid by title when Form Name is selected

### DIFF
--- a/blocks/donation-form-grid/data/options.js
+++ b/blocks/donation-form-grid/data/options.js
@@ -11,7 +11,7 @@ const giveFormOptions = {};
 // Form Order By
 giveFormOptions.orderBy = [
 	{value: 'date', label: __('Date Created')},
-	{value: 'name', label: __('Form Name')},
+	{value: 'title', label: __('Form Name')},
 	{value: 'amount_donated', label: __('Amount Donated')},
 	{value: 'number_donations', label: __('Number of Donations')},
 	{value: 'menu_order', label: __('Menu Order')},

--- a/includes/admin/shortcodes/shortcode-give-donation-grid.php
+++ b/includes/admin/shortcodes/shortcode-give-donation-grid.php
@@ -61,7 +61,7 @@ class Give_Shortcode_Donation_Grid extends Give_Shortcode_Generator {
 				'label'       => esc_attr__( 'Order By:', 'give' ),
 				'tooltip'     => esc_attr__( 'Different parameter to set the order for the forms display in the form grid.', 'give' ),
 				'options'     => array(
-					'name'             => esc_html__( 'Form Name', 'give' ),
+					'title'             => esc_html__( 'Form Name', 'give' ),
 					'amount_donated'   => esc_html__( 'Amount Donated', 'give' ),
 					'number_donations' => esc_html__( 'Number of Donations', 'give' ),
 					'menu_order'       => esc_html__( 'Menu Order', 'give' ),


### PR DESCRIPTION
## Description
Resolves #4392 
Fixes issue with Donation Form Grid shortcode sorting by 'name' rather than 'title' when user chooses to sort forms by 'Form Name'. To resolve the issue, I updated the value associated with the 'Form Name' option to be 'title' in both the block editor inspector and the shortcode generator. This value is used to build a WP_Query when rendering theDonation Form Grid shortcode. **To avoid surprises to users: currently, this fix does not impact existing shortcodes, or blocks already added. To enable the fix, they need to regenerate the shortcode, or manually set the block to sort by Form Name. _Open to suggestions on this!_**

## How Has This Been Tested?
Tested block editor and shortcode generator by creating forms titled 'Test A', 'Test B', and 'Test C', then renaming the form's slugs to 'California', 'Boise', 'Alabama'. When sorted by Form Name, the forms displayed in alphabetical order according to the form title. No errors are thrown in the browser console, and PHPUnit tests passed.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.