### PR TITLE
fix: replace wp.components with wp.serverSideRender

### DIFF
--- a/blocks/donation-form-grid/edit/block.js
+++ b/blocks/donation-form-grid/edit/block.js
@@ -7,7 +7,7 @@ const { __ } = wp.i18n;
  * WordPress dependencies
  */
 const { Fragment } = wp.element;
-const { ServerSideRender } = wp.components;
+const ServerSideRender = wp.serverSideRender;
 const { withSelect } = wp.data;
 
 /**

--- a/blocks/donation-form/edit/block.js
+++ b/blocks/donation-form/edit/block.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { ServerSideRender } = wp.components;
+const ServerSideRender = wp.serverSideRender;
 
 /**
  * Internal dependencies

--- a/blocks/donor-wall/edit/block.js
+++ b/blocks/donor-wall/edit/block.js
@@ -2,7 +2,7 @@
  * Wordpress dependencies
  */
 const { Fragment } = wp.element;
- const { ServerSideRender } = wp.components;
+ const ServerSideRender = wp.serverSideRender;
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description
Resolves #4402 
Replaces calls to deprecated wp.components.serverSideRender with wp.serverSideRender.

## How Has This Been Tested?
Tested locally and throws no errors in browser console, including deprecation warnings.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.