### PR TITLE
feature: add form performance report endpoint

### DIFF
--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -92,11 +92,11 @@ const OverviewPage = () => {
                     showLegend={false}
                 />
             </Card>
-            <Card title={__('Pie Chart', 'give')} width={4}>
+            <Card title={__('Form Performance', 'give')} width={4}>
                 <RESTChart
                     type='pie'
                     aspectRatio={0.6}
-                    endpoint='payment-statuses'
+                    endpoint='form-performance'
                     showLegend={true}
                 />
             </Card>

--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -92,7 +92,7 @@ const OverviewPage = () => {
                     showLegend={false}
                 />
             </Card>
-            <Card title={__('Form Performance', 'give')} width={4}>
+            <Card title={__('Form Performance (All Time)', 'give')} width={4}>
                 <RESTChart
                     type='pie'
                     aspectRatio={0.6}

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -35,6 +35,10 @@ class API {
 		// Load payment statuses endpoint
 		$paymentStatuses = new Endpoints\Reports\PaymentStatuses();
 		$paymentStatuses->init();
+
+		// Load form performance endpoint
+		$formPerformance = new Endpoints\Reports\FormPerformance();
+		$formPerformance->init();
 	}
 
 }

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -16,34 +16,28 @@ class FormPerformance extends Endpoint {
 
 	public function get_report($request) {
 
-		// Setup args for give_count_payments
-		$args = [
-			'start-date' => $request['start'],
-			'end-date' => $request['end']
-		];
+		$labels = [];
+		$data = [];
 
-		// Use give_count_payments logic to get payments
-		$payments = give_count_payments( $args );
+		$stats = new \Give_Payment_Stats;
+		$topForms = $stats->get_best_selling(5);
+
+		foreach ($topForms as $form) {
+			$title = get_the_title($form->form_id);
+			array_push($labels, $title);
+			array_push($data, $form->sales);
+		}
 
 		// Add caching logic here...
 
 		return new \WP_REST_Response([
 			'data' => [
-				'labels' => [
-					'Completed',
-					'Pending',
-					'Refunded',
-					'Abandoned'
-				],
+				'top' => $topForms,
+				'labels' => $labels,
 				'datasets' => [
 					[
-						'label' => 'Payments',
-						'data' => [
-							$payments->completed,
-							$payments->pending,
-							$payments->refunded,
-							$payments->abandoned
-						]
+						'label' => 'Sales',
+						'data' => $data
 					]
 				],
 			]

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Reports base endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class FormPerformance extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'form-performance';
+	}
+
+	public function get_report($request) {
+
+		// Setup args for give_count_payments
+		$args = [
+			'start-date' => $request['start'],
+			'end-date' => $request['end']
+		];
+
+		// Use give_count_payments logic to get payments
+		$payments = give_count_payments( $args );
+
+		// Add caching logic here...
+
+		return new \WP_REST_Response([
+			'data' => [
+				'labels' => [
+					'Completed',
+					'Pending',
+					'Refunded',
+					'Abandoned'
+				],
+				'datasets' => [
+					[
+						'label' => 'Payments',
+						'data' => [
+							$payments->completed,
+							$payments->pending,
+							$payments->refunded,
+							$payments->abandoned
+						]
+					]
+				],
+			]
+		]);
+	}
+}

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Reports base endpoint
+ * Form Performance endpoint
  *
  * @package Give
  */
@@ -19,9 +19,11 @@ class FormPerformance extends Endpoint {
 		$labels = [];
 		$data = [];
 
+		// Use Give Payment Stats class to get best selling forms
 		$stats = new \Give_Payment_Stats;
 		$topForms = $stats->get_best_selling(5);
 
+		// Populate data from top performing forms
 		foreach ($topForms as $form) {
 			$title = get_the_title($form->form_id);
 			array_push($labels, $title);

--- a/src/API/Endpoints/Reports/PaymentStatuses.php
+++ b/src/API/Endpoints/Reports/PaymentStatuses.php
@@ -39,7 +39,7 @@ class PaymentStatuses extends Endpoint {
 					[
 						'label' => 'Payments',
 						'data' => [
-							$payments->completed,
+							$payments->publish,
 							$payments->pending,
 							$payments->refunded,
 							$payments->abandoned


### PR DESCRIPTION
## Description
Resolves #4399 
Adds 'form-performance' endpoint to the Reports API. The endpoint uses existing logic from the Give Payment Stats class to return information about the top performing forms.

## How Has This Been Tested?
Tested locally without errors in the browser console. Passed PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.