### PR TITLE
feature: add RESTList HOC

### DIFF
--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -8,6 +8,7 @@ import Chart from '../../../components/chart'
 import RESTChart from '../../../components/rest-chart'
 import MiniChart from '../../../components/mini-chart'
 import List from '../../../components/list'
+import RESTList from '../../../components/rest-list'
 import LocationItem from '../../../components/location-item'
 import DonationItem from '../../../components/donation-item'
 import DonorItem from '../../../components/donor-item'
@@ -101,75 +102,7 @@ const OverviewPage = () => {
                 />
             </Card>
             <Card title={__('Donor List', 'give')} width={4}>
-                <List onScrollEnd={() => alert('Reached end!')} >
-                    <DonorItem
-                        image={null}
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        name='Test A Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        name='Test'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        name='Does This Work'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                    <DonorItem
-                        image='./default.png'
-                        name='Test Name'
-                        email='email@test.org'
-                        count='2 Donations'
-                        total='$200.00'
-                    />
-                </List>
+				<RESTList endpoint='top-donors' />
             </Card>
             <Card title={__('Location List', 'give')} width={4}>
                 <List onScrollEnd={() => alert('reached end!')}>

--- a/assets/src/js/admin/reports/components/donor-item/index.js
+++ b/assets/src/js/admin/reports/components/donor-item/index.js
@@ -3,7 +3,7 @@ import './style.scss'
 import { getBGColor, getInitials } from './utils'
 
 const DonorItem = ({image, name, email, count, total}) => {
-    
+
     const profile = image ? <img src={image} /> : <div className='donor-initials' style={{backgroundColor: getBGColor()}}>{getInitials(name)}</div>
     return (
         <div className='donor-item'>
@@ -24,9 +24,9 @@ DonorItem.propTypes = {
     // Source URL for donor image
     image: PropTypes.string,
     // Donor name
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     // Donor email
-    email: PropTypes.string.isRequired,
+    email: PropTypes.string,
     // Internationalized count of donations attributed to donor (ex: "2 Donations")
     count: PropTypes.string.isRequired,
     // Internationalized total amount of donations attributed to donor (ex: "$100.00")
@@ -35,7 +35,7 @@ DonorItem.propTypes = {
 
 DonorItem.defaultProps = {
     image: null,
-    name: null,
+    name: 'Anonymous',
     email: null,
     count: null,
     total: null

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -1,0 +1,80 @@
+// Vendor dependencies
+import axios from 'axios'
+import { useState, useEffect, Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+// Components
+import List from '../list'
+import DonorItem from '../donor-item'
+import LocationItem from '../location-item'
+import DonationItem from '../donation-item'
+
+// Store-related dependencies
+import { useStoreValue } from '../../app/store'
+
+const RESTList = ({endpoint}) => {
+
+	// Use period from store
+	const [{ period }, dispatch] = useStoreValue()
+
+	// Use state to hold data fetched from API
+	const [fetched, setFetched] = useState(null)
+
+	// Fetch new data and update Chart when period changes
+	useEffect(() => {
+		axios.get(wpApiSettings.root + 'give-api/v2/reports/' + endpoint, {
+			params: {
+				start: period.startDate.format('YYYY-MM-DD'),
+				end: period.startDate.format('YYYY-MM-DD')
+			},
+			headers: {
+				'X-WP-Nonce': wpApiSettings.nonce
+			}
+		})
+		.then(function (response) {
+			console.log(response)
+			setFetched(response.data.data)
+		})
+	}, [period, endpoint])
+
+	const items = fetched.map((item, index) => {
+		switch (item.type) {
+			case 'donor':
+				return <DonorItem name={item.name} />
+			case 'donation':
+				return <DonationItem name={item.name} />
+			case 'location':
+				return <LocationItem name={item.name} />
+		}
+	})
+
+	return (
+		<Fragment>
+			{fetched && (
+				<List>
+					{items}
+				</List>
+			)}
+		</Fragment>
+	)
+}
+
+RESTChart.propTypes = {
+	// Chart type (ex: line)
+	type: PropTypes.string.isRequired,
+	// Chart aspect ratio
+	aspectRatio: PropTypes.number,
+	// API endpoint where data is fetched (ex: 'payment-statuses')
+	endpoint: PropTypes.string.isRequired,
+	// Display Chart with Legend
+	showLegend: PropTypes.bool
+}
+
+RESTChart.defaultProps = {
+	type: null,
+	aspectRatio: 0.6,
+	endpoint: null,
+	showLegend: false
+}
+
+export default RESTChart

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -37,16 +37,35 @@ const RESTList = ({endpoint}) => {
 		})
 	}, [period, endpoint])
 
-	const items = fetched.map((item, index) => {
+	const items = fetched ? fetched.map((item, index) => {
 		switch (item.type) {
 			case 'donor':
-				return <DonorItem name={item.name} />
+				return <DonorItem
+							image={item.image}
+							name={item.name}
+							email={item.email}
+							count={item.count}
+							total={item.total}
+						/>
 			case 'donation':
-				return <DonationItem name={item.name} />
+				return <DonationItem
+							status={item.status}
+							amount={item.amount}
+							time={item.time}
+							donor={item.donor}
+							source={item.source}
+						/>
 			case 'location':
-				return <LocationItem name={item.name} />
+				return <LocationItem
+							city={item.city}
+							state={item.state}
+							country={item.country}
+							flag={item.flag}
+							count={item.count}
+							total={item.total}
+						/>
 		}
-	})
+	}) : null
 
 	return (
 		<Fragment>

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -46,6 +46,7 @@ const RESTList = ({endpoint}) => {
 							email={item.email}
 							count={item.count}
 							total={item.total}
+							key={index}
 						/>
 			case 'donation':
 				return <DonationItem
@@ -54,6 +55,7 @@ const RESTList = ({endpoint}) => {
 							time={item.time}
 							donor={item.donor}
 							source={item.source}
+							key={index}
 						/>
 			case 'location':
 				return <LocationItem
@@ -63,6 +65,7 @@ const RESTList = ({endpoint}) => {
 							flag={item.flag}
 							count={item.count}
 							total={item.total}
+							key={index}
 						/>
 		}
 	}) : null

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -20,7 +20,7 @@ const RESTList = ({endpoint}) => {
 	// Use state to hold data fetched from API
 	const [fetched, setFetched] = useState(null)
 
-	// Fetch new data and update Chart when period changes
+	// Fetch new data and update List when period changes
 	useEffect(() => {
 		axios.get(wpApiSettings.root + 'give-api/v2/reports/' + endpoint, {
 			params: {
@@ -59,22 +59,13 @@ const RESTList = ({endpoint}) => {
 	)
 }
 
-RESTChart.propTypes = {
-	// Chart type (ex: line)
-	type: PropTypes.string.isRequired,
-	// Chart aspect ratio
-	aspectRatio: PropTypes.number,
+RESTList.propTypes = {
 	// API endpoint where data is fetched (ex: 'payment-statuses')
-	endpoint: PropTypes.string.isRequired,
-	// Display Chart with Legend
-	showLegend: PropTypes.bool
+	endpoint: PropTypes.string.isRequired
 }
 
-RESTChart.defaultProps = {
-	type: null,
-	aspectRatio: 0.6,
+RESTList.defaultProps = {
 	endpoint: null,
-	showLegend: false
 }
 
-export default RESTChart
+export default RESTList

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -39,10 +39,14 @@ class API {
 		//Load payment methods endpoint
 		$paymentMethods = new Endpoints\Reports\PaymentMethods();
 		$paymentMethods->init();
-    
+
 		// Load form performance endpoint
 		$formPerformance = new Endpoints\Reports\FormPerformance();
 		$formPerformance->init();
+
+		// Load top donors endpoint
+		$topDonors = new Endpoints\Reports\TopDonors();
+		$topDonors->init();
 	}
 
 }

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Reports base endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class TopDonors extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'top-donors';
+	}
+
+	public function get_report($request) {
+
+		// Add caching logic here...
+
+		return new \WP_REST_Response([
+			'data' => [
+				[
+					'type' => 'donor',
+					'name' => 'Name',
+					'count' => '4 Donations',
+					'total' => '$50.00',
+					'image' => 'image.png',
+					'email' => 'test@email.com'
+				],
+			]
+		]);
+	}
+}


### PR DESCRIPTION
## Description
Resolves #4410 
This PR adds a higher order RESTList component that handles interaction with the Reports API endpoints, fetching data on page load and when the PeriodSelector is changed. For demonstrative purposes, the PR also introduces the 'top-donors' endpoint which returns dummy data for a donors list.

## How Has This Been Tested?
Tested locally and throws no errors in browser. Passed PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):
n/a

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.