### PR TITLE
feature: add recent donations endpoint

### DIFF
--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -177,7 +177,7 @@ const OverviewPage = () => {
 					/>
 				</List>
 			</Card>
-			<Card title={ __( 'Donation List', 'give' ) } width={ 4 }>
+			<Card title={ __( 'Recent Donations', 'give' ) } width={ 4 }>
 				<RESTList endpoint="recent-donations" />
 			</Card>
 		</Grid>

--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -9,7 +9,6 @@ import MiniChart from '../../../components/mini-chart';
 import List from '../../../components/list';
 import RESTList from '../../../components/rest-list';
 import LocationItem from '../../../components/location-item';
-import DonationItem from '../../../components/donation-item';
 const { __ } = wp.i18n;
 
 const OverviewPage = () => {
@@ -179,50 +178,7 @@ const OverviewPage = () => {
 				</List>
 			</Card>
 			<Card title={ __( 'Donation List', 'give' ) } width={ 4 }>
-				<List>
-					<DonationItem
-						status="completed"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-					<DonationItem
-						status="completed"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-					<DonationItem
-						status="abandoned"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-					<DonationItem
-						status="refunded"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-					<DonationItem
-						status="completed"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-					<DonationItem
-						status="completed"
-						amount="$50.00"
-						time="2013-02-08 09:30"
-						donor={ { name: 'Test Name', id: 456 } }
-						source="Save the Whales"
-					/>
-				</List>
+				<RESTList endpoint="recent-donations" />
 			</Card>
 		</Grid>
 	);

--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -2,231 +2,229 @@
 // Pages use the Grid component to establish a
 // 12 column grid for content to exist in
 
-import Grid from '../../../components/grid'
-import Card from '../../../components/card'
-import Chart from '../../../components/chart'
-import RESTChart from '../../../components/rest-chart'
-import MiniChart from '../../../components/mini-chart'
-import List from '../../../components/list'
-import RESTList from '../../../components/rest-list'
-import LocationItem from '../../../components/location-item'
-import DonationItem from '../../../components/donation-item'
-import DonorItem from '../../../components/donor-item'
+import Grid from '../../../components/grid';
+import Card from '../../../components/card';
+import RESTChart from '../../../components/rest-chart';
+import MiniChart from '../../../components/mini-chart';
+import List from '../../../components/list';
+import RESTList from '../../../components/rest-list';
+import LocationItem from '../../../components/location-item';
+import DonationItem from '../../../components/donation-item';
 const { __ } = wp.i18n;
 
 const OverviewPage = () => {
-    return (
-        <Grid>
-			<Card title={__('Donations vs Income', 'give')} width={12}>
+	return (
+		<Grid>
+			<Card title={ __( 'Donations vs Income', 'give' ) } width={ 12 }>
 				<RESTChart
-                    type='line'
-                    aspectRatio={0.4}
-                    endpoint='donations-vs-income'
-                    showLegend={false}
-                />
-            </Card>
-            <Card width={3}>
-                <MiniChart
-                    title='Mini Doughnut'
-                    type='doughnut'
-                    data={{
-                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
-                        datasets: [
-                            {
-                                label: 'Donations',
-                                data: [400.00, 532.00, 333.00, 72.56, 300.00, 422.22]
-                            }
-                        ]
-                    }}
-                />
-            </Card>
-            <Card width={3}>
-                <MiniChart
-                    title='Mini Line'
-                    type='line'
-                    data={{
-                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
-                        datasets: [
-                            {
-                                label: 'Donations',
-                                data: [400.00, 532.00, 333.00, 72.56, 390.23, 350.00]
-                            }
-                        ]
-                    }}
-                />
-            </Card>
-            <Card width={3}>
-                <MiniChart
-                    title='Mini Pie'
-                    type='pie'
-                    data={{
-                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
-                        datasets: [
-                            {
-                                label: 'Donations',
-                                data: [400.00, 532.00, 333.00, 72.56, 300.00, 450.30]
-                            }
-                        ]
-                    }}
-                />
-            </Card>
-            <Card width={3}>
-                <MiniChart
-                    title='Mini Bar'
-                    type='bar'
-                    data={{
-                        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul'],
-                        datasets: [
-                            {
-                                label: 'Donations',
-                                data: [400.00, 532.00, 333.00, 72.56, 300.00, 450.00]
-                            }
-                        ]
-                    }}
-                />
-            </Card>
-            <Card title={__('Payment Methods', 'give')} width={4}>
+					type="line"
+					aspectRatio={ 0.4 }
+					endpoint="donations-vs-income"
+					showLegend={ false }
+				/>
+			</Card>
+			<Card width={ 3 }>
+				<MiniChart
+					title="Mini Doughnut"
+					type="doughnut"
+					data={ {
+						labels: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul' ],
+						datasets: [
+							{
+								label: 'Donations',
+								data: [ 400.00, 532.00, 333.00, 72.56, 300.00, 422.22 ],
+							},
+						],
+					} }
+				/>
+			</Card>
+			<Card width={ 3 }>
+				<MiniChart
+					title="Mini Line"
+					type="line"
+					data={ {
+						labels: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul' ],
+						datasets: [
+							{
+								label: 'Donations',
+								data: [ 400.00, 532.00, 333.00, 72.56, 390.23, 350.00 ],
+							},
+						],
+					} }
+				/>
+			</Card>
+			<Card width={ 3 }>
+				<MiniChart
+					title="Mini Pie"
+					type="pie"
+					data={ {
+						labels: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul' ],
+						datasets: [
+							{
+								label: 'Donations',
+								data: [ 400.00, 532.00, 333.00, 72.56, 300.00, 450.30 ],
+							},
+						],
+					} }
+				/>
+			</Card>
+			<Card width={ 3 }>
+				<MiniChart
+					title="Mini Bar"
+					type="bar"
+					data={ {
+						labels: [ 'Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul' ],
+						datasets: [
+							{
+								label: 'Donations',
+								data: [ 400.00, 532.00, 333.00, 72.56, 300.00, 450.00 ],
+							},
+						],
+					} }
+				/>
+			</Card>
+			<Card title={ __( 'Payment Methods', 'give' ) } width={ 4 }>
 				<RESTChart
-                    type='doughnut'
-                    aspectRatio={0.6}
-                    endpoint='payment-methods'
-                    showLegend={true}
-                />
-            </Card>
-            <Card title={__('Payment Statuses', 'give')} width={4}>
+					type="doughnut"
+					aspectRatio={ 0.6 }
+					endpoint="payment-methods"
+					showLegend={ true }
+				/>
+			</Card>
+			<Card title={ __( 'Payment Statuses', 'give' ) } width={ 4 }>
 				<RESTChart
-                    type='bar'
-                    aspectRatio={1.2}
-                    endpoint='payment-statuses'
-                    showLegend={false}
-                />
-            </Card>
-            <Card title={__('Form Performance (All Time)', 'give')} width={4}>
-                <RESTChart
-                    type='pie'
-                    aspectRatio={0.6}
-                    endpoint='form-performance'
-                    showLegend={true}
-                />
-            </Card>
-            <Card title={__('Donor List', 'give')} width={4}>
-				<RESTList endpoint='top-donors' />
-            </Card>
-            <Card title={__('Location List', 'give')} width={4}>
-                <List onScrollEnd={() => alert('reached end!')}>
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                    <LocationItem
-                        city='Anacorts'
-                        state='Washington'
-                        country='United States'
-                        flag='flag.png'
-                        count='4 Donations'
-                        total='$345.00'
-                    />
-                 </List>
-            </Card>
-            <Card title={__('Donation List', 'give')} width={4}>
-                <List onScrollEnd={() => alert('reached end of list!')}>
-                    <DonationItem
-                        status='completed'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                    <DonationItem
-                        status='completed'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                    <DonationItem
-                        status='abandoned'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                    <DonationItem
-                        status='refunded'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                    <DonationItem
-                        status='completed'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                    <DonationItem
-                        status='completed'
-                        amount='$50.00'
-                        time='2013-02-08 09:30'
-                        donor={{name: 'Test Name', id: 456}}
-                        source='Save the Whales'
-                    />
-                </List>
-            </Card>
-        </Grid>
-    )
-}
-export default OverviewPage
+					type="bar"
+					aspectRatio={ 1.2 }
+					endpoint="payment-statuses"
+					showLegend={ false }
+				/>
+			</Card>
+			<Card title={ __( 'Form Performance (All Time)', 'give' ) } width={ 4 }>
+				<RESTChart
+					type="pie"
+					aspectRatio={ 0.6 }
+					endpoint="form-performance"
+					showLegend={ true }
+				/>
+			</Card>
+			<Card title={ __( 'Top Donors', 'give' ) } width={ 4 }>
+				<RESTList endpoint="top-donors" />
+			</Card>
+			<Card title={ __( 'Location List', 'give' ) } width={ 4 }>
+				<List>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+					<LocationItem
+						city="Anacorts"
+						state="Washington"
+						country="United States"
+						flag="flag.png"
+						count="4 Donations"
+						total="$345.00"
+					/>
+				</List>
+			</Card>
+			<Card title={ __( 'Donation List', 'give' ) } width={ 4 }>
+				<List>
+					<DonationItem
+						status="completed"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+					<DonationItem
+						status="completed"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+					<DonationItem
+						status="abandoned"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+					<DonationItem
+						status="refunded"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+					<DonationItem
+						status="completed"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+					<DonationItem
+						status="completed"
+						amount="$50.00"
+						time="2013-02-08 09:30"
+						donor={ { name: 'Test Name', id: 456 } }
+						source="Save the Whales"
+					/>
+				</List>
+			</Card>
+		</Grid>
+	);
+};
+export default OverviewPage;

--- a/assets/src/js/admin/reports/components/donation-item/utils/index.js
+++ b/assets/src/js/admin/reports/components/donation-item/utils/index.js
@@ -1,41 +1,43 @@
-export function getIcon (status) {
-    switch (status) {
-        case 'completed':
-            return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <g opacity="0.5">
-                <path opacity="0.3" d="M17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5Z" fill="black"/>
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black"/>
-                </g>
-            </svg>
-            break
-        case 'abandoned':
-            return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <g opacity="0.5">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black"/>
-                </g>
-            </svg>
-            break
-        case 'refunded':
-            return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <g opacity="0.5">
-            <path opacity="0.3" fill-rule="evenodd" clip-rule="evenodd" d="M19.5 19.5902H5.5V5.41016H19.5V19.5902ZM18.5 7.50016H6.5V9.50016H18.5V7.50016ZM6.5 11.5002H18.5V13.5002H6.5V11.5002ZM18.5 15.5002H6.5V17.5002H18.5V15.5002Z" fill="black"/>
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M20 4L18.5 2.5L17 4L15.5 2.5L14 4L12.5 2.5L11 4L9.5 2.5L8 4L6.5 2.5L5 4L3.5 2.5V22.5L5 21L6.5 22.5L8 21L9.5 22.5L11 21L12.5 22.5L14 21L15.5 22.5L17 21L18.5 22.5L20 21L21.5 22.5V2.5L20 4ZM5.5 19.59V5.41H19.5V19.59H5.5ZM18.5 17.5V15.5H6.5V17.5H18.5ZM18.5 11.5V13.5H6.5V11.5H18.5ZM18.5 9.5V7.5H6.5V9.5H18.5Z" fill="black"/>
-            </g>
-            </svg>
-            break
-    }
+export function getIcon( status ) {
+	switch ( status ) {
+		case 'completed':
+			return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<g opacity="0.5">
+					<path opacity="0.3" d="M17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5Z" fill="black" />
+					<path fillRule="evenodd" clipRule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black" />
+				</g>
+			</svg>;
+		case 'abandoned':
+			return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<g opacity="0.5">
+					<path fillRule="evenodd" clipRule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black" />
+				</g>
+			</svg>;
+		case 'cancelled':
+			return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<g opacity="0.5">
+					<path fillRule="evenodd" clipRule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black" />
+				</g>
+			</svg>;
+		case 'refunded':
+			return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<g opacity="0.5">
+					<path opacity="0.3" fillRule="evenodd" clipRule="evenodd" d="M19.5 19.5902H5.5V5.41016H19.5V19.5902ZM18.5 7.50016H6.5V9.50016H18.5V7.50016ZM6.5 11.5002H18.5V13.5002H6.5V11.5002ZM18.5 15.5002H6.5V17.5002H18.5V15.5002Z" fill="black" />
+					<path fillRule="evenodd" clipRule="evenodd" d="M20 4L18.5 2.5L17 4L15.5 2.5L14 4L12.5 2.5L11 4L9.5 2.5L8 4L6.5 2.5L5 4L3.5 2.5V22.5L5 21L6.5 22.5L8 21L9.5 22.5L11 21L12.5 22.5L14 21L15.5 22.5L17 21L18.5 22.5L20 21L21.5 22.5V2.5L20 4ZM5.5 19.59V5.41H19.5V19.59H5.5ZM18.5 17.5V15.5H6.5V17.5H18.5ZM18.5 11.5V13.5H6.5V11.5H18.5ZM18.5 9.5V7.5H6.5V9.5H18.5Z" fill="black" />
+				</g>
+			</svg>;
+	}
 }
 
-export function getColor (status) {
-    switch (status) {
-        case 'completed':
-            return '#69B868'
-            break;
-        case 'abandoned':
-            return '#D75A4B'
-            break;
-        case 'refunded':
-            return '#D75A4B'
-            break;
-    }
+export function getColor( status ) {
+	switch ( status ) {
+		case 'completed':
+			return '#69B868';
+		case 'abandoned':
+			return '#D75A4B';
+		case 'cancelled':
+			return '#D75A4B';
+		case 'refunded':
+			return '#D75A4B';
+	}
 }

--- a/assets/src/js/admin/reports/components/donation-item/utils/index.js
+++ b/assets/src/js/admin/reports/components/donation-item/utils/index.js
@@ -26,6 +26,12 @@ export function getIcon( status ) {
 					<path fillRule="evenodd" clipRule="evenodd" d="M20 4L18.5 2.5L17 4L15.5 2.5L14 4L12.5 2.5L11 4L9.5 2.5L8 4L6.5 2.5L5 4L3.5 2.5V22.5L5 21L6.5 22.5L8 21L9.5 22.5L11 21L12.5 22.5L14 21L15.5 22.5L17 21L18.5 22.5L20 21L21.5 22.5V2.5L20 4ZM5.5 19.59V5.41H19.5V19.59H5.5ZM18.5 17.5V15.5H6.5V17.5H18.5ZM18.5 11.5V13.5H6.5V11.5H18.5ZM18.5 9.5V7.5H6.5V9.5H18.5Z" fill="black" />
 				</g>
 			</svg>;
+		default:
+			return <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+				<g opacity="0.5">
+					<path fillRule="evenodd" clipRule="evenodd" d="M12.5 5.59C13.59 4.31 15.26 3.5 17 3.5C20.08 3.5 22.5 5.92 22.5 9C22.5 12.7769 19.1056 15.8549 13.9627 20.5185L13.95 20.53L12.5 21.85L11.05 20.54L11.0105 20.5041C5.88263 15.8442 2.5 12.7703 2.5 9C2.5 5.92 4.92 3.5 8 3.5C9.74 3.5 11.41 4.31 12.5 5.59ZM12.5 19.15L12.6 19.05C17.36 14.74 20.5 11.89 20.5 9C20.5 7 19 5.5 17 5.5C15.46 5.5 13.96 6.49 13.44 7.86H11.57C11.04 6.49 9.54 5.5 8 5.5C6 5.5 4.5 7 4.5 9C4.5 11.89 7.64 14.74 12.4 19.05L12.5 19.15Z" fill="black" />
+				</g>
+			</svg>;
 	}
 }
 
@@ -38,6 +44,8 @@ export function getColor( status ) {
 		case 'cancelled':
 			return '#D75A4B';
 		case 'refunded':
+			return '#D75A4B';
+		default:
 			return '#D75A4B';
 	}
 }

--- a/assets/src/js/admin/reports/components/donor-item/index.js
+++ b/assets/src/js/admin/reports/components/donor-item/index.js
@@ -1,44 +1,48 @@
-import PropTypes from 'prop-types'
-import './style.scss'
-import { getBGColor, getInitials } from './utils'
+import PropTypes from 'prop-types';
+import './style.scss';
+import { getBGColor, getInitials } from './utils';
 
-const DonorItem = ({image, name, email, count, total}) => {
-
-    const profile = image ? <img src={image} /> : <div className='donor-initials' style={{backgroundColor: getBGColor()}}>{getInitials(name)}</div>
-    return (
-        <div className='donor-item'>
-            {profile}
-            <div className='donor-info'>
-                <p><strong>{name}</strong></p>
-                <p>{email}</p>
-            </div>
-            <div className='donor-totals'>
-                <p>{count}</p>
-                <p>{total}</p>
-            </div>
-        </div>
-    )
-}
+const DonorItem = ( { image, name, email, count, total, url } ) => {
+	const profile = image ? <img src={ image } /> : <div className="donor-initials" style={ { backgroundColor: getBGColor() } }>{ getInitials( name ) }</div>;
+	return (
+		<a className="donor-link" href={ url }>
+			<div className="donor-item">
+				{ profile }
+				<div className="donor-info">
+					<p><strong>{ name }</strong></p>
+					<p>{ email }</p>
+				</div>
+				<div className="donor-totals">
+					<p>{ count }</p>
+					<p>{ total }</p>
+				</div>
+			</div>
+		</a>
+	);
+};
 
 DonorItem.propTypes = {
-    // Source URL for donor image
-    image: PropTypes.string,
-    // Donor name
-    name: PropTypes.string,
-    // Donor email
-    email: PropTypes.string,
-    // Internationalized count of donations attributed to donor (ex: "2 Donations")
-    count: PropTypes.string.isRequired,
-    // Internationalized total amount of donations attributed to donor (ex: "$100.00")
-    total: PropTypes.string.isRequired
-}
+	// Source URL for donor image
+	image: PropTypes.string,
+	// Donor name
+	name: PropTypes.string,
+	// Donor email
+	email: PropTypes.string,
+	// Internationalized count of donations attributed to donor (ex: "2 Donations")
+	count: PropTypes.string.isRequired,
+	// Internationalized total amount of donations attributed to donor (ex: "$100.00")
+	total: PropTypes.string.isRequired,
+	// Donor Overview URL
+	url: PropTypes.string.isRequired,
+};
 
 DonorItem.defaultProps = {
-    image: null,
-    name: 'Anonymous',
-    email: null,
-    count: null,
-    total: null
-}
+	image: null,
+	name: 'Anonymous',
+	email: null,
+	count: null,
+	total: null,
+	url: null,
+};
 
-export default DonorItem
+export default DonorItem;

--- a/assets/src/js/admin/reports/components/donor-item/style.scss
+++ b/assets/src/js/admin/reports/components/donor-item/style.scss
@@ -1,39 +1,49 @@
+.donor-link {
+	display: contents;
+	text-decoration: inherit;
+	color: inherit;
+
+	&:hover {
+		color: rgb(90, 90, 90);
+	}
+}
+
 .donor-item {
-    display: flex;
-    align-items: center;
-    height: 72px;
-    padding: 0 16px;
+	display: flex;
+	align-items: center;
+	height: 72px;
+	padding: 0 16px;
 
-    > img {
-        object-fit: cover;
-        height: 36px;
-        width: 36px;
-        border-radius: 50%;
-        overflow: hidden;
-    }
+	> img {
+		object-fit: cover;
+		height: 36px;
+		width: 36px;
+		border-radius: 50%;
+		overflow: hidden;
+	}
 
-    > .donor-initials {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 36px;
-        width: 36px;
-        border-radius: 50%;
-        overflow: hidden;
-        color: #FFFFFF;
-        background: #D75A4B;
-    }
+	> .donor-initials {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 36px;
+		width: 36px;
+		border-radius: 50%;
+		overflow: hidden;
+		color: #fff;
+		background: #d75a4b;
+	}
 
-    > .donor-info {
-        flex: 1;
-        margin-left: 16px;
-    }
+	> .donor-info {
+		flex: 1;
+		margin-left: 16px;
+	}
 
-    > .donor-totals {
-        text-align: right;
-    }
+	> .donor-totals {
+		text-align: right;
+	}
 
-    p {
-        margin: 0;
-    }
+	p {
+		margin: 0;
+	}
 }

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -37,7 +37,7 @@ const RESTList = ( { endpoint } ) => {
 		}
 	}, [ period, endpoint ] );
 
-	const items = fetched ? fetched.map( ( item, index ) => {
+	const items = Array.isArray( fetched ) && fetched.length ? fetched.map( ( item, index ) => {
 		switch ( item.type ) {
 			case 'donor':
 				return <DonorItem

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -24,8 +24,8 @@ const RESTList = ( { endpoint } ) => {
 		if ( period.startDate && period.endDate ) {
 			axios.get( wpApiSettings.root + 'give-api/v2/reports/' + endpoint, {
 				params: {
-					start: period.startDate.format( 'YYYY-MM-DD' ),
-					end: period.startDate.format( 'YYYY-MM-DD' ),
+					start: period.startDate.format( 'YYYY-MM-DD-HH' ),
+					end: period.endDate.format( 'YYYY-MM-DD-HH' ),
 				},
 				headers: {
 					'X-WP-Nonce': wpApiSettings.nonce,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3921,13 +3921,20 @@
       }
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "is-regexp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+          "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+          "dev": true
+        }
       }
     },
     "clone-response": {
@@ -5893,12 +5900,12 @@
       }
     },
     "execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       }
     },
     "executable": {
@@ -7896,9 +7903,9 @@
       "dev": true
     },
     "html-tags": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
     },
     "htmlparser2": {
@@ -7922,9 +7929,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8957,12 +8964,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
-    },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-svg": {
@@ -11555,9 +11556,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.11.0.tgz",
-      "integrity": "sha512-bEZlJzXo5V/ApNNa5z375mJC6Nrz4vG43UgcSCrg2OHC+yuB6j0iDSrY7RQ/+PRofFB03wNIIt9iXIVLr4wc7w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.16.0.tgz",
+      "integrity": "sha512-0g5vDDPvNnQk7WM/aE92dTDxXJoOE0biiIcUb3qkn/F6h/ZQZPlZIbE2XSXH2vFPfphkgCxuR2vH6HHnobEOaQ==",
       "dev": true
     },
     "last-call-webpack-plugin": {
@@ -13998,9 +13999,9 @@
       }
     },
     "postcss-jsx": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
-      "integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.4.tgz",
+      "integrity": "sha512-jwO/7qWUvYuWYnpOb0+4bIIgJt7003pgU3P6nETBLaOyBXuTD55ho21xnals5nBrlpTIFodyd3/jBi6UO3dHvA==",
       "dev": true,
       "requires": {
         "@babel/core": ">=7.2.2"
@@ -14502,13 +14503,13 @@
       }
     },
     "postcss-sass": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
-      "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.2.tgz",
+      "integrity": "sha512-hcRgnd91OQ6Ot9R90PE/khUDCJHG8Uxxd3F7Y0+9VHjBiJgNv7sK5FxyHMCBtoLmmkzVbSj3M3OlqUfLJpq0CQ==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
+        "gonzales-pe": "^4.2.4",
+        "postcss": "^7.0.21"
       }
     },
     "postcss-scss": {
@@ -17046,65 +17047,75 @@
       }
     },
     "stylelint": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.10.1.tgz",
-      "integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-11.1.1.tgz",
+      "integrity": "sha512-Vx6TAJsxG6qksiFvxQTKriQhp1CqUWdpTDITEkAjTR+l+8Af7qNlvrUDXfpuFJgXh/ayF8xdMSKE+SstcsPmMA==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^9.0.0",
+        "autoprefixer": "^9.5.1",
         "balanced-match": "^1.0.0",
-        "chalk": "^2.4.1",
-        "cosmiconfig": "^5.0.0",
-        "debug": "^4.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^4.0.0",
-        "get-stdin": "^6.0.0",
+        "chalk": "^2.4.2",
+        "cosmiconfig": "^5.2.0",
+        "debug": "^4.1.1",
+        "execall": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^7.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^9.0.0",
+        "globby": "^9.2.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^5.0.4",
-        "import-lazy": "^3.1.0",
+        "html-tags": "^3.0.0",
+        "ignore": "^5.0.6",
+        "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.11.0",
-        "leven": "^2.1.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
+        "known-css-properties": "^0.16.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.14",
+        "log-symbols": "^3.0.0",
+        "mathml-tag-names": "^2.1.0",
         "meow": "^5.0.0",
-        "micromatch": "^3.1.10",
+        "micromatch": "^4.0.0",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.0",
-        "postcss": "^7.0.13",
+        "postcss": "^7.0.14",
         "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.0",
-        "postcss-less": "^3.1.0",
+        "postcss-jsx": "^0.36.3",
+        "postcss-less": "^3.1.4",
         "postcss-markdown": "^0.36.0",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.0",
+        "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.0",
-        "postcss-sass": "^0.3.5",
+        "postcss-safe-parser": "^4.0.1",
+        "postcss-sass": "^0.4.1",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
         "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
+        "postcss-value-parser": "^4.0.2",
+        "resolve-from": "^5.0.0",
         "signal-exit": "^3.0.2",
-        "slash": "^2.0.0",
+        "slash": "^3.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^3.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.2.0",
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.0.0"
+        "table": "^5.2.3",
+        "v8-compile-cache": "^2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
         },
         "camelcase-keys": {
           "version": "4.2.0",
@@ -17117,19 +17128,25 @@
             "quick-lru": "^1.0.0"
           }
         },
-        "file-entry-cache": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
-          "integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "flat-cache": "^2.0.1"
+            "to-regex-range": "^5.0.1"
           }
         },
         "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
           "dev": true
         },
         "global-modules": {
@@ -17173,6 +17190,12 @@
               "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
               "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
               "dev": true
+            },
+            "slash": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+              "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+              "dev": true
             }
           }
         },
@@ -17182,16 +17205,28 @@
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         },
+        "import-lazy": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+          "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+          "dev": true
+        },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
-        "leven": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "load-json-file": {
@@ -17212,15 +17247,6 @@
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "dev": true
             }
-          }
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1"
           }
         },
         "map-obj": {
@@ -17244,6 +17270,16 @@
             "redent": "^2.0.0",
             "trim-newlines": "^2.0.0",
             "yargs-parser": "^10.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "parse-json": {
@@ -17284,12 +17320,6 @@
             "uniq": "^1.0.1"
           }
         },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -17322,26 +17352,37 @@
           }
         },
         "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
         "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
           }
         },
         "strip-ansi": {
@@ -17351,6 +17392,14 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
           }
         },
         "strip-bom": {
@@ -17365,10 +17414,25 @@
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
         "trim-newlines": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
           "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        },
+        "v8-compile-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+          "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
           "dev": true
         },
         "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "sass-loader": "^7.1.0",
         "script-loader": "^0.7.2",
         "style-loader": "^1.1.2",
-        "stylelint": "^9.10.1",
+        "stylelint": "^11.0.0",
         "stylelint-config-prettier": "^8.0.0",
         "stylelint-config-wordpress": "^13.1.0",
         "stylelint-prettier": "^1.1.2",

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -8,27 +8,27 @@
 
 namespace Give\API;
 
-defined('ABSPATH') || exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Manages API Endpoints
  */
 class API {
 
-    /**
-     * Initialize Reports and Pages, register hooks
-     */
-    public function init() {
-        // To prevent conflict on we are loading autoload.php when need for now. In future we can loaded it globally.
-        require GIVE_PLUGIN_DIR . 'vendor/autoload.php';
+	/**
+	 * Initialize Reports and Pages, register hooks
+	 */
+	public function init() {
+		// To prevent conflict on we are loading autoload.php when need for now. In future we can loaded it globally.
+		require GIVE_PLUGIN_DIR . 'vendor/autoload.php';
 
-        // Load endpoints
-        $this->load_endpoints();
+		// Load endpoints
+		$this->load_endpoints();
 
-    }
+	}
 
-    public function __construct() {
-        //Do nothing
+	public function __construct() {
+		// Do nothing
 	}
 
 	public function load_endpoints() {
@@ -40,7 +40,7 @@ class API {
 		$donationsVsIncome = new Endpoints\Reports\DonationsVsIncome();
 		$donationsVsIncome->init();
 
-		//Load payment methods endpoint
+		// Load payment methods endpoint
 		$paymentMethods = new Endpoints\Reports\PaymentMethods();
 		$paymentMethods->init();
 
@@ -51,8 +51,12 @@ class API {
 		// Load top donors endpoint
 		$topDonors = new Endpoints\Reports\TopDonors();
 		$topDonors->init();
+
+		// Load recent donations endpoint
+		$recentDonations = new Endpoints\Reports\RecentDonations();
+		$recentDonations->init();
 	}
 
 }
-$api = new API;
+$api = new API();
 $api->init();

--- a/src/API/Endpoints/Reports/RecentDonations.php
+++ b/src/API/Endpoints/Reports/RecentDonations.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Recent Donations endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class RecentDonations extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'recent-donations';
+	}
+
+	public function get_report( $request ) {
+
+		// Setup donor query args (get sanitized start/end date from request)
+		$args = [
+			'number'     => 50,
+			'paged'      => 1,
+			'orderby'    => 'publish_date',
+			'order'      => 'DESC',
+			'start_date' => $request['start'],
+			'end_date'   => $request['end'],
+		];
+
+		// Get array of 50 recent donations
+		$donations = new \Give_Payments_Query( $args );
+		$donations = $donations->get_payments();
+
+		// Populate $list with arrays in correct shape for frontend RESTList component
+		$list = [];
+		foreach ( $donations as $donation ) {
+
+			$item = [
+				'type'   => 'donation',
+				'status' => 'completed',
+				'amount' => '$50.00',
+				'time'   => '2013-02-08 09:30',
+				'donor'  => [
+					'name' => 'Test Name',
+					'id'   => 456,
+				],
+				'source' => 'Save the Whales',
+			];
+			array_push( $list, $item );
+		}
+
+		// Return $list of donors for RESTList component
+		return new \WP_REST_Response(
+			[
+				'data' => $list,
+			]
+		);
+	}
+}

--- a/src/API/Endpoints/Reports/RecentDonations.php
+++ b/src/API/Endpoints/Reports/RecentDonations.php
@@ -34,16 +34,22 @@ class RecentDonations extends Endpoint {
 		$list = [];
 		foreach ( $donations as $donation ) {
 
+			$donation = new \Give_Payment( $donation->ID );
+
+			$amount = give_currency_symbol( $payment->currency, true ) . give_format_amount( $donation->total, array( 'sanitize' => false ) );
+			$status = $donation->status === 'publish' ? 'completed' : $donation->status;
+
 			$item = [
-				'type'   => 'donation',
-				'status' => 'completed',
-				'amount' => '$50.00',
-				'time'   => '2013-02-08 09:30',
-				'donor'  => [
-					'name' => 'Test Name',
-					'id'   => 456,
+				'type'     => 'donation',
+				'donation' => $donation,
+				'status'   => $status,
+				'amount'   => $amount,
+				'time'     => $donation->date,
+				'donor'    => [
+					'name' => "{$donation->first_name} {$donation->last_name}",
+					'id'   => $donation->donor_id,
 				],
-				'source' => 'Save the Whales',
+				'source'   => $donation->form_title,
 			];
 			array_push( $list, $item );
 		}

--- a/src/API/Endpoints/Reports/RecentDonations.php
+++ b/src/API/Endpoints/Reports/RecentDonations.php
@@ -16,7 +16,7 @@ class RecentDonations extends Endpoint {
 
 	public function get_report( $request ) {
 
-		// Setup donor query args (get sanitized start/end date from request)
+		// Setup donation query args (get sanitized start/end date from request)
 		$args = [
 			'number'     => 50,
 			'paged'      => 1,
@@ -54,7 +54,7 @@ class RecentDonations extends Endpoint {
 			array_push( $list, $item );
 		}
 
-		// Return $list of donors for RESTList component
+		// Return $list of donations for RESTList component
 		return new \WP_REST_Response(
 			[
 				'data' => $list,

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -33,12 +33,15 @@ class TopDonors extends Endpoint {
 		foreach ( $donors as $donor ) {
 
 			$avatar = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
+			$total  = give_currency_filter( give_format_amount( $donor->purchase_value, array( 'sanitize' => false ) ), [ 'decode_currency' => true ] );
+
+			$countLabel = $donor->purchase_count > 1 ? esc_html__( 'Donations', 'give' ) : esc_html__( 'Donation', 'give' );
 
 			$item = [
 				'type'  => 'donor',
 				'name'  => $donor->name,
-				'count' => $donor->purchase_count,
-				'total' => $donor->purchase_value,
+				'count' => "{$donor->purchase_count} {$countLabel}",
+				'total' => $total,
 				'image' => $avatar,
 				'email' => $donor->email,
 			];

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -31,12 +31,15 @@ class TopDonors extends Endpoint {
 		$list = [];
 
 		foreach ( $donors as $donor ) {
+
+			$avatar = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
+
 			$item = [
 				'type'  => 'donor',
 				'name'  => $donor->name,
 				'count' => $donor->purchase_count,
 				'total' => $donor->purchase_value,
-				'image' => 'image.png',
+				'image' => $avatar,
 				'email' => $donor->email,
 			];
 			array_push( $list, $item );
@@ -44,9 +47,8 @@ class TopDonors extends Endpoint {
 
 		return new \WP_REST_Response(
 			[
-				'start' => $startTime,
-				'end'   => $endTime,
-				'data'  => $list,
+				'donors' => $donors,
+				'data'   => $list,
 			]
 		);
 	}

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Reports base endpoint
+ * Top Donors endpoint
  *
  * @package Give
  */
@@ -16,6 +16,7 @@ class TopDonors extends Endpoint {
 
 	public function get_report( $request ) {
 
+		// Setup donor query args (get sanitized start/end date from request)
 		$args = [
 			'number'     => 25,
 			'paged'      => 1,
@@ -25,11 +26,12 @@ class TopDonors extends Endpoint {
 			'end_date'   => $request['end'],
 		];
 
+		// Get array of top 25 donors
 		$donors = new \Give_Donors_Query( $args );
 		$donors = $donors->get_donors();
 
+		// Populate $list with arrays in correct shape for frontend RESTList component
 		$list = [];
-
 		foreach ( $donors as $donor ) {
 
 			$avatar     = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
@@ -49,10 +51,10 @@ class TopDonors extends Endpoint {
 			array_push( $list, $item );
 		}
 
+		// Return $list of donors for RESTList component
 		return new \WP_REST_Response(
 			[
-				'donors' => $donors,
-				'data'   => $list,
+				'data' => $list,
 			]
 		);
 	}

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -17,7 +17,7 @@ class TopDonors extends Endpoint {
 	public function get_report( $request ) {
 
 		$args = [
-			'number'     => 10,
+			'number'     => 25,
 			'paged'      => 1,
 			'orderby'    => 'purchase_value',
 			'order'      => 'DESC',
@@ -32,14 +32,15 @@ class TopDonors extends Endpoint {
 
 		foreach ( $donors as $donor ) {
 
-			$avatar = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
-			$total  = give_currency_filter( give_format_amount( $donor->purchase_value, array( 'sanitize' => false ) ), [ 'decode_currency' => true ] );
-
+			$avatar     = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
+			$total      = give_currency_filter( give_format_amount( $donor->purchase_value, array( 'sanitize' => false ) ), [ 'decode_currency' => true ] );
+			$url        = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . absint( $donor->id ) );
 			$countLabel = $donor->purchase_count > 1 ? esc_html__( 'Donations', 'give' ) : esc_html__( 'Donation', 'give' );
 
 			$item = [
 				'type'  => 'donor',
 				'name'  => $donor->name,
+				'url'   => $url,
 				'count' => "{$donor->purchase_count} {$countLabel}",
 				'total' => $total,
 				'image' => $avatar,

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -17,10 +17,12 @@ class TopDonors extends Endpoint {
 	public function get_report( $request ) {
 
 		$args = [
-			'number'  => 10,
-			'paged'   => 1,
-			'orderby' => 'purchase_value',
-			'order'   => 'DESC',
+			'number'     => 10,
+			'paged'      => 1,
+			'orderby'    => 'purchase_value',
+			'order'      => 'DESC',
+			'start_date' => $request['start'],
+			'end_date'   => $request['end'],
 		];
 
 		$donors = new \Give_Donors_Query( $args );
@@ -42,7 +44,9 @@ class TopDonors extends Endpoint {
 
 		return new \WP_REST_Response(
 			[
-				'data' => $list,
+				'start' => $startTime,
+				'end'   => $endTime,
+				'data'  => $list,
 			]
 		);
 	}

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -14,21 +14,36 @@ class TopDonors extends Endpoint {
 		$this->endpoint = 'top-donors';
 	}
 
-	public function get_report($request) {
+	public function get_report( $request ) {
 
-		// Add caching logic here...
+		$args = [
+			'number'  => 10,
+			'paged'   => 1,
+			'orderby' => 'purchase_value',
+			'order'   => 'DESC',
+		];
 
-		return new \WP_REST_Response([
-			'data' => [
-				[
-					'type' => 'donor',
-					'name' => 'Name',
-					'count' => '4 Donations',
-					'total' => '$50.00',
-					'image' => 'image.png',
-					'email' => 'test@email.com'
-				],
+		$donors = new \Give_Donors_Query( $args );
+		$donors = $donors->get_donors();
+
+		$list = [];
+
+		foreach ( $donors as $donor ) {
+			$item = [
+				'type'  => 'donor',
+				'name'  => $donor->name,
+				'count' => $donor->purchase_count,
+				'total' => $donor->purchase_value,
+				'image' => 'image.png',
+				'email' => $donor->email,
+			];
+			array_push( $list, $item );
+		}
+
+		return new \WP_REST_Response(
+			[
+				'data' => $list,
 			]
-		]);
+		);
 	}
 }


### PR DESCRIPTION
## Description
Resolves #4416 
This PR adds the 'recent-donations' endpoint to the Reports API. The endpoint returns data on recent donations for a given period, gathered using the existing Give_Payments_Query and Give_Payment classes. The data is returned in the correct shape to be used in a RESTList component, populated by DonationItem components.

## How Has This Been Tested?
This has been tested locally and throws no errors in the browser console. Passed all PHPUnit tests.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.