### PR TITLE
fix: resolve top donors endpoint issues

### DIFF
--- a/assets/src/js/admin/reports/components/donor-item/index.js
+++ b/assets/src/js/admin/reports/components/donor-item/index.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import './style.scss';
 import { getBGColor, getInitials } from './utils';
+const { __ } = wp.i18n;
 
 const DonorItem = ( { image, name, email, count, total, url } ) => {
 	const profile = image ? <img src={ image } /> : <div className="donor-initials" style={ { backgroundColor: getBGColor() } }>{ getInitials( name ) }</div>;
@@ -38,7 +39,7 @@ DonorItem.propTypes = {
 
 DonorItem.defaultProps = {
 	image: null,
-	name: 'Anonymous',
+	name: __( 'Anonymous', 'give' ),
 	email: null,
 	count: null,
 	total: null,

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -37,7 +37,7 @@ class TopDonors extends Endpoint {
 			$avatar     = give_validate_gravatar( $donor->email ) ? get_avatar( $donor->email, 60 ) : null;
 			$total      = give_currency_filter( give_format_amount( $donor->purchase_value, array( 'sanitize' => false ) ), [ 'decode_currency' => true ] );
 			$url        = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . absint( $donor->id ) );
-			$countLabel = $donor->purchase_count > 1 ? esc_html__( 'Donations', 'give' ) : esc_html__( 'Donation', 'give' );
+			$countLabel = _n( 'Donation', 'Donations', $donor->purchase_count, 'give' )
 
 			$list[] = [
 				'type'  => 'donor',

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -39,7 +39,7 @@ class TopDonors extends Endpoint {
 			$url        = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . absint( $donor->id ) );
 			$countLabel = $donor->purchase_count > 1 ? esc_html__( 'Donations', 'give' ) : esc_html__( 'Donation', 'give' );
 
-			$item = [
+			$list[] = [
 				'type'  => 'donor',
 				'name'  => $donor->name,
 				'url'   => $url,
@@ -48,7 +48,6 @@ class TopDonors extends Endpoint {
 				'image' => $avatar,
 				'email' => $donor->email,
 			];
-			array_push( $list, $item );
 		}
 
 		// Return $list of donors for RESTList component


### PR DESCRIPTION
## Description
Resolves #4428 
This PR resolves issues raised by @ravinderk regarding the implementation of the top donors endpoint. Notably, it localizes the default donor name string, implements the _n() function in place of a ternary operator to handle plural localization, and remove an array_push call.

## How Has This Been Tested?
This has been tested locally and throws no errors in the browser. Passed PHPUnit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.