### PR TITLE
feature: add average donation report endpoint

### DIFF
--- a/src/API/API.php
+++ b/src/API/API.php
@@ -55,6 +55,10 @@ class API {
 		// Load recent donations endpoint
 		$recentDonations = new Endpoints\Reports\RecentDonations();
 		$recentDonations->init();
+
+		// Load income endpoint
+		$income = new Endpoints\Reports\Income();
+		$income->init();
 	}
 
 }

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -25,6 +25,7 @@ class API {
 		Reports\TopDonors::class,
 		Reports\RecentDonations::class,
 		Reports\Income::class,
+		Reports\AverageDonation::class,
 	];
 
 	/**

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -59,6 +59,10 @@ class API {
 		// Load income endpoint
 		$income = new Endpoints\Reports\Income();
 		$income->init();
+
+		// Load average donation endpoint
+		$averageDonation = new Endpoints\Reports\AverageDonation();
+		$averageDonation->init();
 	}
 
 }

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -16,16 +16,16 @@ class AverageDonation extends Endpoint {
 
 	public function get_report( $request ) {
 
-		// // Check if a cached version exists
-		// $cached_report = $this->get_cached_report( $request );
-		// if ( $cached_report !== false ) {
-		// Bail and return the cached version
-		// return new \WP_REST_Response(
-		// [
-		// 'data' => $cached_report,
-		// ]
-		// );
-		// }
+		// Check if a cached version exists
+		$cached_report = $this->get_cached_report( $request );
+		if ( $cached_report !== false ) {
+			// Bail and return the cached version
+			return new \WP_REST_Response(
+				[
+					'data' => $cached_report,
+				]
+			);
+		}
 
 		$start = date_create( $request['start'] );
 		$end   = date_create( $request['end'] );

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Income over time endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class AverageDonation extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'average-donation';
+	}
+
+	public function get_report( $request ) {
+
+		// // Check if a cached version exists
+		// $cached_report = $this->get_cached_report( $request );
+		// if ( $cached_report !== false ) {
+		// Bail and return the cached version
+		// return new \WP_REST_Response(
+		// [
+		// 'data' => $cached_report,
+		// ]
+		// );
+		// }
+
+		$start = date_create( $request['start'] );
+		$end   = date_create( $request['end'] );
+		$diff  = date_diff( $start, $end );
+
+		$data = [];
+
+		switch ( true ) {
+			case ( $diff->days > 900 ):
+				$data = $this->get_data( $start, $end, 'P1Y', 'Y' );
+				break;
+			case ( $diff->days > 700 ):
+				$data = $this->get_data( $start, $end, 'P6M', 'F Y' );
+				break;
+			case ( $diff->days > 400 ):
+				$data = $this->get_data( $start, $end, 'P3M', 'F Y' );
+				break;
+			case ( $diff->days > 120 ):
+				$data = $this->get_data( $start, $end, 'P1M', 'M Y' );
+				break;
+			case ( $diff->days > 30 ):
+				$data = $this->get_data( $start, $end, 'P7D', 'M jS' );
+				break;
+			case ( $diff->days > 10 ):
+				$data = $this->get_data( $start, $end, 'P3D', 'M jS' );
+				break;
+			case ( $diff->days > 4 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'l' );
+				break;
+			case ( $diff->days > 1 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'D ga' );
+				break;
+			case ( $diff->days >= 0 ):
+				$data = $this->get_data( $start, $end, 'PT1H', 'D ga' );
+				break;
+		}
+
+		// Cache the report data
+		$result = $this->cache_report( $request, $data );
+
+		return new \WP_REST_Response(
+			[
+				'data' => $data,
+			]
+		);
+	}
+
+	public function get_data( $start, $end, $interval, $format ) {
+
+		$stats = new \Give_Payment_Stats();
+
+		$startStr = $start->format( 'Y-m-d H:i:s' );
+		$endStr   = $end->format( 'Y-m-d H:i:s' );
+
+		// Determine the start date of the previous period (used to calculate trend)
+		$prev    = date_sub( date_create( $startStr ), date_diff( $start, $end ) );
+		$prevStr = $prev->format( 'Y-m-d H:i:s' );
+
+		$labels = [];
+		$income = [];
+
+		$dateInterval = new \DateInterval( $interval );
+		while ( $start < $end ) {
+
+			$periodStart = $start->format( 'Y-m-d H:i:s' );
+
+			// Add interval to get period end
+			$periodEnd = clone $start;
+			date_add( $periodEnd, $dateInterval );
+
+			$label     = $periodEnd->format( $format );
+			$periodEnd = $periodEnd->format( 'Y-m-d H:i:s' );
+
+			$incomeForPeriod        = $stats->get_earnings( 0, $periodStart, $periodEnd );
+			$paymentsForPeriod      = $stats->get_sales( 0, $periodStart, $periodEnd );
+			$averageIncomeForPeriod = $paymentsForPeriod > 0 ? $incomeForPeriod / $paymentsForPeriod : 0;
+
+			$income[] = $averageIncomeForPeriod;
+			$labels[] = $label;
+
+			date_add( $start, $dateInterval );
+		}
+
+		$averageForPeriod = array_sum( $income ) / count( $income );
+
+		// Calculate the income trend by comparing average earnings in the
+		// previous period to average earnings in the current period
+		$prevIncome   = $stats->get_earnings( 0, $prevStr, $startStr );
+		$prevPayments = $stats->get_sales( 0, $prevStr, $startStr );
+		$prevAverage  = $prevPayments > 0 ? $prevIncome / $prevPayments : 0;
+
+		$currentIncome   = $stats->get_earnings( 0, $startStr, $endStr );
+		$currentPayments = $stats->get_sales( 0, $startStr, $endStr );
+		$currentAverage  = $currentPayments > 0 ? $currentIncome / $currentPayments : 0;
+
+		$trend = $prevAverage > 0 ? round( ( ( $currentAverage - $prevAverage ) / $prevAverage ) * 100 ) : 'NaN';
+
+		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		$data = [
+			'labels'   => $labels,
+			'datasets' => [
+				[
+					'label'     => 'Income',
+					'data'      => $income,
+					'trend'     => $trend,
+					'highlight' => give_currency_filter( give_format_amount( $averageForPeriod ), [ 'decode_currency' => true ] ),
+				],
+			],
+		];
+
+		return $data;
+
+	}
+}

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -99,9 +99,7 @@ class AverageDonation extends Endpoint {
 			$label     = $periodEnd->format( $format );
 			$periodEnd = $periodEnd->format( 'Y-m-d H:i:s' );
 
-			$incomeForPeriod        = $stats->get_earnings( 0, $periodStart, $periodEnd );
-			$paymentsForPeriod      = $stats->get_sales( 0, $periodStart, $periodEnd );
-			$averageIncomeForPeriod = $paymentsForPeriod > 0 ? $incomeForPeriod / $paymentsForPeriod : 0;
+			$averageIncomeForPeriod = $this->get_average_donation( $periodStart, $periodEnd );
 
 			$income[] = $averageIncomeForPeriod;
 			$labels[] = $label;
@@ -113,13 +111,8 @@ class AverageDonation extends Endpoint {
 
 		// Calculate the income trend by comparing average earnings in the
 		// previous period to average earnings in the current period
-		$prevIncome   = $stats->get_earnings( 0, $prevStr, $startStr );
-		$prevPayments = $stats->get_sales( 0, $prevStr, $startStr );
-		$prevAverage  = $prevPayments > 0 ? $prevIncome / $prevPayments : 0;
-
-		$currentIncome   = $stats->get_earnings( 0, $startStr, $endStr );
-		$currentPayments = $stats->get_sales( 0, $startStr, $endStr );
-		$currentAverage  = $currentPayments > 0 ? $currentIncome / $currentPayments : 0;
+		$prevAverage    = $this->get_average_donation( $prevStr, $startStr );
+		$currentAverage = $this->get_average_donation( $startStr, $endStr );
 
 		$trend = $prevAverage > 0 ? round( ( ( $currentAverage - $prevAverage ) / $prevAverage ) * 100 ) : 'NaN';
 
@@ -137,6 +130,18 @@ class AverageDonation extends Endpoint {
 		];
 
 		return $data;
+
+	}
+
+	public function get_average_donation( $start, $end ) {
+
+		$stats = new \Give_Payment_Stats();
+
+		$income   = $stats->get_earnings( 0, $start, $end );
+		$payments = $stats->get_sales( 0, $start, $end );
+		$average  = $payments > 0 ? $income / $payments : 0;
+
+		return $average;
 
 	}
 }

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -133,6 +133,12 @@ class AverageDonation extends Endpoint {
 
 	}
 
+	/**
+	 * Calculate the average donation for a given period
+	 *
+	 * @param  $start string|bool  The starting date for which we'd like to filter our sale stats. If false, we'll use the default start date of `this_month`
+	 * @param  $end  string|bool  The end date for which we'd like to filter our sale stats. If false, we'll use the default end date of `this_month`
+	 */
 	public function get_average_donation( $start, $end ) {
 
 		$stats = new \Give_Payment_Stats();

--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -150,4 +150,43 @@ abstract class Endpoint {
 		return $status;
 
 	}
+
+	/**
+	 * Get cached report
+	 *
+	 * @param WP_REST_Request $request Current request.
+	 */
+	public function get_cached_report( $request ) {
+
+		$query_args = [
+			'start' => $request['start'],
+			'end'   => $request['end'],
+		];
+
+		$cache_key = \Give_Cache::get_key( 'api_get_report', $query_args );
+
+		$cached = \Give_Cache::get( $cache_key, false, $query_args );
+
+		return \Give_Cache::get( $cache_key, false, $query_args );
+	}
+
+	/**
+	 * Cache report
+	 *
+	 * @param WP_REST_Request $request Current request.
+	 */
+	public function cache_report( $request, $report ) {
+
+		$query_args = [
+			'start' => $request['start'],
+			'end'   => $request['end'],
+		];
+
+		$cache_key = \Give_Cache::get_key( 'api_get_report', $query_args );
+
+		$result = \Give_Cache::set( $cache_key, $report, HOUR_IN_SECONDS, false, $query_args );
+
+		return $result;
+
+	}
 }

--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -163,7 +163,7 @@ abstract class Endpoint {
 			'end'   => $request['end'],
 		];
 
-		$cache_key = \Give_Cache::get_key( 'api_get_report', $query_args );
+		$cache_key = \Give_Cache::get_key( "api_get_report_{$this->endpoint}", $query_args );
 
 		$cached = \Give_Cache::get( $cache_key, false, $query_args );
 
@@ -182,7 +182,7 @@ abstract class Endpoint {
 			'end'   => $request['end'],
 		];
 
-		$cache_key = \Give_Cache::get_key( 'api_get_report', $query_args );
+		$cache_key = \Give_Cache::get_key( "api_get_report_{$this->endpoint}", $query_args );
 
 		$result = \Give_Cache::set( $cache_key, $report, HOUR_IN_SECONDS, false, $query_args );
 

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Income over time endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class Income extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'income';
+	}
+
+	public function get_report( $request ) {
+
+		$start = date_create( $request['start'] );
+		$end   = date_create( $request['end'] );
+		$diff  = date_diff( $start, $end );
+
+		$data = [];
+
+		switch ( true ) {
+			case ( $diff->days > 900 ):
+				$data = $this->get_data( $start, $end, 'P1Y', 'Y' );
+				break;
+			case ( $diff->days > 700 ):
+				$data = $this->get_data( $start, $end, 'P6M', 'F Y' );
+				break;
+			case ( $diff->days > 400 ):
+				$data = $this->get_data( $start, $end, 'P3M', 'F Y' );
+				break;
+			case ( $diff->days > 120 ):
+				$data = $this->get_data( $start, $end, 'P1M', 'M Y' );
+				break;
+			case ( $diff->days > 30 ):
+				$data = $this->get_data( $start, $end, 'P7D', 'M jS' );
+				break;
+			case ( $diff->days > 10 ):
+				$data = $this->get_data( $start, $end, 'P3D', 'M jS' );
+				break;
+			case ( $diff->days > 4 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'l' );
+				break;
+			case ( $diff->days > 1 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'D ga' );
+				break;
+			case ( $diff->days >= 0 ):
+				$data = $this->get_data( $start, $end, 'PT1H', 'D ga' );
+				break;
+		}
+
+		return new \WP_REST_Response(
+			[
+				'data' => $data,
+			]
+		);
+	}
+
+	public function get_data( $start, $end, $interval, $format ) {
+
+		$stats = new \Give_Payment_Stats();
+
+		$labels = [];
+		$income = [];
+
+		$dateInterval = new \DateInterval( $interval );
+		while ( $start < $end ) {
+
+			$periodStart = $start->format( 'Y-m-d H:i:s' );
+
+			// Add interval to get period end
+			$periodEnd = clone $start;
+			date_add( $periodEnd, $dateInterval );
+
+			$label     = $periodEnd->format( $format );
+			$periodEnd = $periodEnd->format( 'Y-m-d H:i:s' );
+
+			$incomeForPeriod = $stats->get_earnings( 0, $periodStart, $periodEnd );
+
+			array_push( $income, $incomeForPeriod );
+			array_push( $labels, $label );
+
+			date_add( $start, $dateInterval );
+		}
+
+		$total = array_sum( $income );
+
+		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		$data = [
+			'labels'   => $labels,
+			'datasets' => [
+				[
+					'label'     => 'Income',
+					'data'      => $income,
+					'trend'     => '-15',
+					'highlight' => give_currency_filter( give_format_amount( $total ), [ 'decode_currency' => true ] ),
+				],
+			],
+		];
+
+		return $data;
+
+	}
+}

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -16,8 +16,10 @@ class Income extends Endpoint {
 
 	public function get_report( $request ) {
 
+		// Check if a cached version exists
 		$cached_report = $this->get_cached_report( $request );
 		if ( $cached_report !== false ) {
+			// Bail and return the cached version
 			return new \WP_REST_Response(
 				[
 					'data' => $cached_report,
@@ -61,6 +63,7 @@ class Income extends Endpoint {
 				break;
 		}
 
+		// Cache the report data
 		$result = $this->cache_report( $request, $data );
 
 		return new \WP_REST_Response(
@@ -77,6 +80,7 @@ class Income extends Endpoint {
 		$startStr = $start->format( 'Y-m-d H:i:s' );
 		$endStr   = $end->format( 'Y-m-d H:i:s' );
 
+		// Determine the start date of the previous period (used to calculate trend)
 		$prev    = date_sub( date_create( $startStr ), date_diff( $start, $end ) );
 		$prevStr = $prev->format( 'Y-m-d H:i:s' );
 
@@ -105,6 +109,8 @@ class Income extends Endpoint {
 
 		$totalForPeriod = array_sum( $income );
 
+		// Calculate the income trend by comparing total earnings in the
+		// previous period to earnings in the current period
 		$prevTotal    = $stats->get_earnings( 0, $prevStr, $startStr );
 		$currentTotal = $stats->get_earnings( 0, $startStr, $endStr );
 		$trend        = $prevTotal > 0 ? round( ( ( $currentTotal - $prevTotal ) / $prevTotal ) * 100 ) : 'NaN';

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -52,6 +52,9 @@ class Income extends Endpoint {
 				break;
 		}
 
+		$data['start'] = $request['start'];
+		$data['end']   = $request['end'];
+
 		return new \WP_REST_Response(
 			[
 				'data' => $data,
@@ -62,6 +65,12 @@ class Income extends Endpoint {
 	public function get_data( $start, $end, $interval, $format ) {
 
 		$stats = new \Give_Payment_Stats();
+
+		$startStr = $start->format( 'Y-m-d H:i:s' );
+		$endStr   = $end->format( 'Y-m-d H:i:s' );
+
+		$prev    = date_sub( date_create( $startStr ), date_diff( $start, $end ) );
+		$prevStr = $prev->format( 'Y-m-d H:i:s' );
 
 		$labels = [];
 		$income = [];
@@ -88,10 +97,9 @@ class Income extends Endpoint {
 
 		$totalForPeriod = array_sum( $income );
 
-		$beginning    = '2000-01-01';
-		$totalAtStart = $stats->get_earnings( 0, $beginning, $start->format( 'Y-m-d H:i:s' ) );
-		$totalAtEnd   = $stats->get_earnings( 0, $beginning, $end->format( 'Y-m-d H:i:s' ) );
-		$trend        = $totalAtStart > 0 ? ( ( $totalAtEnd - $totalAtStart ) / $totalAtStart ) * 100 : 'NaN';
+		$prevTotal    = $stats->get_earnings( 0, $prevStr, $startStr );
+		$currentTotal = $stats->get_earnings( 0, $startStr, $endStr );
+		$trend        = $prevTotal > 0 ? round( ( ( $currentTotal - $prevTotal ) / $prevTotal ) * 100 ) : 'NaN';
 
 		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
 		$data = [

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -89,8 +89,8 @@ class Income extends Endpoint {
 
 			$incomeForPeriod = $stats->get_earnings( 0, $periodStart, $periodEnd );
 
-			array_push( $income, $incomeForPeriod );
-			array_push( $labels, $label );
+			$income[] = $incomeForPeriod;
+			$labels[] = $label;
 
 			date_add( $start, $dateInterval );
 		}

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -16,6 +16,15 @@ class Income extends Endpoint {
 
 	public function get_report( $request ) {
 
+		$cached_report = $this->get_cached_report( $request );
+		if ( $cached_report !== false ) {
+			return new \WP_REST_Response(
+				[
+					'data' => $cached_report,
+				]
+			);
+		}
+
 		$start = date_create( $request['start'] );
 		$end   = date_create( $request['end'] );
 		$diff  = date_diff( $start, $end );
@@ -52,8 +61,7 @@ class Income extends Endpoint {
 				break;
 		}
 
-		$data['start'] = $request['start'];
-		$data['end']   = $request['end'];
+		$result = $this->cache_report( $request, $data );
 
 		return new \WP_REST_Response(
 			[

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -86,7 +86,12 @@ class Income extends Endpoint {
 			date_add( $start, $dateInterval );
 		}
 
-		$total = array_sum( $income );
+		$totalForPeriod = array_sum( $income );
+
+		$beginning    = '2000-01-01';
+		$totalAtStart = $stats->get_earnings( 0, $beginning, $start->format( 'Y-m-d H:i:s' ) );
+		$totalAtEnd   = $stats->get_earnings( 0, $beginning, $end->format( 'Y-m-d H:i:s' ) );
+		$trend        = $totalAtStart > 0 ? ( ( $totalAtEnd - $totalAtStart ) / $totalAtStart ) * 100 : 'NaN';
 
 		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
 		$data = [
@@ -95,8 +100,8 @@ class Income extends Endpoint {
 				[
 					'label'     => 'Income',
 					'data'      => $income,
-					'trend'     => '-15',
-					'highlight' => give_currency_filter( give_format_amount( $total ), [ 'decode_currency' => true ] ),
+					'trend'     => $trend,
+					'highlight' => give_currency_filter( give_format_amount( $totalForPeriod ), [ 'decode_currency' => true ] ),
 				],
 			],
 		];


### PR DESCRIPTION
## Description
Resolves #4425 
This PR adds the 'average donation' endpoint which calculates average donation over time and returns a data object appropriate shaped to be used in the RESTMiniChart component. The endpoint calculates average donation for the entire given period, as well as the trend in average donation from the previous period. 

## How Has This Been Tested?
Tested locally and throws no errors in browser console. Passed PHPUnit tests.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.