### PR TITLE
feature: add refunds report endpoint

### DIFF
--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -42,8 +42,8 @@ const OverviewPage = () => {
 			</Card>
 			<Card width={ 3 }>
 				<RESTMiniChart
-					title={ __( 'Total Income', 'give' ) }
-					endpoint="income"
+					title={ __( 'Total Refunds', 'give' ) }
+					endpoint="refunds"
 				/>
 			</Card>
 			<Card title={ __( 'Payment Methods', 'give' ) } width={ 4 }>

--- a/src/API/API.php
+++ b/src/API/API.php
@@ -26,6 +26,7 @@ class API {
 		Reports\RecentDonations::class,
 		Reports\Income::class,
 		Reports\AverageDonation::class,
+		Reports\Refunds::class,
 	];
 
 	/**

--- a/src/API/Endpoints/Reports/Refunds.php
+++ b/src/API/Endpoints/Reports/Refunds.php
@@ -107,7 +107,7 @@ class Refunds extends Endpoint {
 			date_add( $start, $dateInterval );
 		}
 
-		$totalForPeriod = array_sum( $income );
+		$totalForPeriod = array_sum( $refunds );
 
 		// Calculate the refunds trend by comparing total refunds in the
 		// previous period to refunds in the current period

--- a/src/API/Endpoints/Reports/Refunds.php
+++ b/src/API/Endpoints/Reports/Refunds.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Refunds endpoint
+ *
+ * @package Give
+ */
+
+namespace Give\API\Endpoints\Reports;
+
+class Refunds extends Endpoint {
+
+	public function __construct() {
+		$this->endpoint = 'refunds';
+	}
+
+	public function get_report( $request ) {
+
+		// Check if a cached version exists
+		$cached_report = $this->get_cached_report( $request );
+		if ( $cached_report !== null ) {
+			// Bail and return the cached version
+			return new \WP_REST_Response(
+				[
+					'data' => $cached_report,
+				]
+			);
+		}
+
+		$start = date_create( $request['start'] );
+		$end   = date_create( $request['end'] );
+		$diff  = date_diff( $start, $end );
+
+		$data = [];
+
+		switch ( true ) {
+			case ( $diff->days > 900 ):
+				$data = $this->get_data( $start, $end, 'P1Y', 'Y' );
+				break;
+			case ( $diff->days > 700 ):
+				$data = $this->get_data( $start, $end, 'P6M', 'F Y' );
+				break;
+			case ( $diff->days > 400 ):
+				$data = $this->get_data( $start, $end, 'P3M', 'F Y' );
+				break;
+			case ( $diff->days > 120 ):
+				$data = $this->get_data( $start, $end, 'P1M', 'M Y' );
+				break;
+			case ( $diff->days > 30 ):
+				$data = $this->get_data( $start, $end, 'P7D', 'M jS' );
+				break;
+			case ( $diff->days > 10 ):
+				$data = $this->get_data( $start, $end, 'P3D', 'M jS' );
+				break;
+			case ( $diff->days > 4 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'l' );
+				break;
+			case ( $diff->days > 1 ):
+				$data = $this->get_data( $start, $end, 'P1D', 'D ga' );
+				break;
+			case ( $diff->days >= 0 ):
+				$data = $this->get_data( $start, $end, 'PT1H', 'D ga' );
+				break;
+		}
+
+		// Cache the report data
+		$result = $this->cache_report( $request, $data );
+
+		return new \WP_REST_Response(
+			[
+				'data' => $data,
+			]
+		);
+	}
+
+	public function get_data( $start, $end, $interval, $format ) {
+
+		$stats = new \Give_Payment_Stats();
+
+		$startStr = $start->format( 'Y-m-d H:i:s' );
+		$endStr   = $end->format( 'Y-m-d H:i:s' );
+
+		// Determine the start date of the previous period (used to calculate trend)
+		$prev    = date_sub( date_create( $startStr ), date_diff( $start, $end ) );
+		$prevStr = $prev->format( 'Y-m-d H:i:s' );
+
+		$labels  = [];
+		$refunds = [];
+
+		$dateInterval = new \DateInterval( $interval );
+		while ( $start < $end ) {
+
+			$periodStart = $start->format( 'Y-m-d H:i:s' );
+
+			// Add interval to get period end
+			$periodEnd = clone $start;
+			date_add( $periodEnd, $dateInterval );
+
+			$label     = $periodEnd->format( $format );
+			$periodEnd = $periodEnd->format( 'Y-m-d H:i:s' );
+
+			$refundsForPeriod = $stats->get_sales( 0, $periodStart, $periodEnd, 'refunded' );
+
+			$refunds[] = $refundsForPeriod;
+			$labels[]  = $label;
+
+			date_add( $start, $dateInterval );
+		}
+
+		$totalForPeriod = array_sum( $income );
+
+		// Calculate the refunds trend by comparing total refunds in the
+		// previous period to refunds in the current period
+		$prevTotal    = $stats->get_sales( 0, $prevStr, $startStr, 'refunded' );
+		$currentTotal = $stats->get_sales( 0, $startStr, $endStr, 'refunded' );
+		$trend        = $prevTotal > 0 ? round( ( ( $currentTotal - $prevTotal ) / $prevTotal ) * 100 ) : 'NaN';
+
+		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		$data = [
+			'labels'   => $labels,
+			'datasets' => [
+				[
+					'label'     => __( 'Refunds', 'give' ),
+					'data'      => $refunds,
+					'trend'     => $trend,
+					'highlight' => $totalForPeriod,
+				],
+			],
+		];
+
+		return $data;
+
+	}
+}

--- a/src/API/Endpoints/Reports/Refunds.php
+++ b/src/API/Endpoints/Reports/Refunds.php
@@ -115,7 +115,7 @@ class Refunds extends Endpoint {
 		$currentTotal = $stats->get_sales( 0, $startStr, $endStr, 'refunded' );
 		$trend        = $prevTotal > 0 ? round( ( ( $currentTotal - $prevTotal ) / $prevTotal ) * 100 ) : 'NaN';
 
-		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		// Create data objec to be returned, with total highlighted
 		$data = [
 			'labels'   => $labels,
 			'datasets' => [


### PR DESCRIPTION
## Description
Resolves #4426 
This PR adds the 'refunds' endpoint to the Reports API. It returns data reflecting the number of refunds given over the selected period of time. It also calculated the total number of refunds, and trend in refund count for the selected period of time.

## How Has This Been Tested?
Tested locally and throws no errors in the browser console. Passed PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):
<img width="271" alt="Screen Shot 2020-01-23 at 4 56 04 PM" src="https://user-images.githubusercontent.com/5186078/73027631-c89f6480-3e01-11ea-8168-816c8fd33742.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.