### PR TITLE
Add missing customization hook

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -615,7 +615,7 @@ function give_get_price_option_name( $form_id = 0, $price_id = 0, $payment_id = 
 
 		if ( intval( $price['_give_id']['level_id'] ) === intval( $price_id ) ) {
 
-			$price_text     = isset( $price['_give_text'] ) ? $price['_give_text'] : '';
+			$price_text = apply_filters( 'give_form_level_text', isset( $price['_give_text'] ) ? $price['_give_text'] : '', $form_id, $price );
 			$price_fallback = $use_fallback ?
 				give_currency_filter(
 					give_format_amount(


### PR DESCRIPTION
## Description

In `forms/template.php`, the price level text is usually run through the `give_form_level_text` filter. In `forms/functions.php`, this was missing, which meant that customization of the level text didn't work in the donation detail view. So I added the missing `apply_filters` call

## How Has This Been Tested?

I've made a dummy filter function like this:

```php
function my_form_level_text($price_text, $form_id, $price) {
    return 'XXX';
}
add_filter('give_form_level_text', 'my_form_level_text', 10, 3);
```

Then I visited the donation detail page (`/?donation_id=1234`) and checked that `XXX` was rendered in the details table

## Screenshots (jpeg or gifs if applicable):

![Bildschirmfoto 2020-02-01 um 10 45 36](https://user-images.githubusercontent.com/425166/73590202-06764a00-44e0-11ea-868f-9800a9db1eba.png)


## Types of changes

Makes Give more easily customizable (or rather: It allows me to customize without changing Give Core)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.