### PR TITLE
fix: avoid retrieving cached data for recent periods

### DIFF
--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -155,6 +155,12 @@ abstract class Endpoint {
 	 */
 	public function get_cached_report( $request ) {
 
+		// Do not get cached report for period less than a week
+		$diff = date_diff( $request['start'], date_create() );
+		if ( $diff->days < 8 ) {
+			return null;
+		}
+
 		$query_args = [
 			'start' => $request['start'],
 			'end'   => $request['end'],

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -58,7 +58,7 @@ class FormPerformance extends Endpoint {
 			foreach ( $this->payments as $payment ) {
 				if ( $payment->status === 'publish' ) {
 					$forms[ $payment->form_id ]['income']    = isset( $forms[ $payment->form_id ]['income'] ) ? $forms[ $payment->form_id ]['income'] += $payment->total : $payment->total;
-					$forms[ $payment->form_id ]['donations'] = isset( $forms[ $payment->form_id ]['income'] ) ? $forms[ $payment->form_id ]['income'] += 1 : 1;
+					$forms[ $payment->form_id ]['donations'] = isset( $forms[ $payment->form_id ]['donations'] ) ? $forms[ $payment->form_id ]['donations'] += 1 : 1;
 					$forms[ $payment->form_id ]['title']     = $payment->form_title;
 				}
 			}

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -77,24 +77,24 @@ class Income extends Endpoint {
 		$periodEnd   = clone $start;
 
 		// Subtract interval to set up period start
-		date_sub( $periodStart, $interval );
+		if ( $intervalStr !== 'P1D' ) {
+			date_sub( $periodStart, $interval );
+		}
 
-		while ( $periodStart < $end ) {
+		while ( $periodStart <= $end ) {
 
 			$values          = $this->get_values( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
 			$incomeForPeriod = $values['earnings'];
 			$donorsForPeriod = $values['donor_count'];
+			$time            = $periodEnd->format( 'Y-m-d H:i:s' );
 
 			switch ( $intervalStr ) {
 				case 'P1D':
-					$periodLabel = $periodEnd->format( 'l' );
+					$time        = $periodStart->format( 'Y-m-d H:i:s' );
+					$periodLabel = $periodStart->format( 'l' );
 					break;
 				case 'PT12H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT3H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT1H':
 					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
 					break;
@@ -103,7 +103,7 @@ class Income extends Endpoint {
 			}
 
 			$income[] = [
-				'x' => $periodEnd->format( 'Y-m-d H:i:s' ),
+				'x' => $time,
 				'y' => $incomeForPeriod,
 			];
 


### PR DESCRIPTION
## Description
Resolves #4497 

This PR improves the Reports experience by presenting fresh data for recent periods, by avoid caching for periods under a week.

## How Has This Been Tested?
Tested locally and throws no errors in browser console. Passed PHPUnit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.