### PR TITLE
fix: allow G pay and Apple pay ability to update payment information without error #433

### DIFF
--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -1,12 +1,11 @@
 /**
  * Give - Stripe Gateway Add-on JS
  */
-
 let stripe = Stripe( give_stripe_vars.publishable_key );
 
 if ( give_stripe_vars.stripe_account_id ) {
 	stripe = Stripe( give_stripe_vars.publishable_key, {
-		stripeAccount: give_stripe_vars.stripe_account_id
+		stripeAccount: give_stripe_vars.stripe_account_id,
 	} );
 }
 
@@ -71,11 +70,10 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 
 		// Mount and Un-Mount Stripe CC Fields on gateway load.
 		jQuery( document ).on( 'give_gateway_loaded', function( event, xhr, settings ) {
-
 			// Un-mount card elements when stripe is not the selected gateway.
 			giveStripeUnmountCardElements( globalCardElements[ idPrefix ] );
 
-			if ( form_element.querySelector( '.give-gateway-option-selected .give-gateway').value === 'stripe' ) {
+			if ( form_element.querySelector( '.give-gateway-option-selected .give-gateway' ).value === 'stripe' ) {
 				// Mount card elements when stripe is the selected gateway.
 				giveStripeMountCardElements( idPrefix, globalCardElements[ idPrefix ] );
 			}
@@ -85,7 +83,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		} );
 
 		// Mount Card Elements, if default gateway is stripe.
-		if ( 'stripe' === defaultGateway ) {
+		if ( 'stripe' === defaultGateway || give_stripe_vars.stripe_card_update ) {
 			// Disabled the donate button of the form.
 			donateButton.setAttribute( 'disabled', 'disabled' );
 

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1121,3 +1121,26 @@ function give_stripe_prepare_metadata( $donation_id = 0 ) {
 	return $args;
 }
 
+/**
+ * This helper function is used to determine whether the screen is update payment method screen or not.
+ *
+ * @since 2.5.14
+ *
+ * @return bool
+ */
+function give_stripe_is_update_payment_method_screen() {
+
+	$get_data         = give_clean( filter_input_array( INPUT_GET ) );
+	$is_update_screen = false;
+
+	if (
+		isset( $get_data['action'] ) &&
+		'update' === $get_data['action'] &&
+		isset( $get_data['subscription_id'] ) &&
+		is_numeric( $get_data['subscription_id'] )
+	) {
+		$is_update_screen = true;
+	}
+
+	return $is_update_screen;
+}

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -194,7 +194,7 @@ function give_stripe_get_element_font_styles() {
 
 	if ( 'custom_fonts' === $stripe_fonts ) {
 		$custom_fonts_attributes = give_get_option( 'stripe_custom_fonts' );
-		$font_styles = json_decode( $custom_fonts_attributes );
+		$font_styles             = json_decode( $custom_fonts_attributes );
 	} else {
 		$font_styles = array(
 			'cssSrc' => give_get_option( 'stripe_google_fonts_url' ),
@@ -456,7 +456,7 @@ function give_stripe_get_custom_ffm_fields( $form_id, $donation_id = 0 ) {
 				continue;
 			}
 
-			$input_field_value = ! empty( $_POST[$field['name']] ) ? give_clean( $_POST[$field['name']] ) : '';
+			$input_field_value = ! empty( $_POST[ $field['name'] ] ) ? give_clean( $_POST[ $field['name'] ] ) : '';
 
 			if ( $donation_id > 0 ) {
 				$field_value = give_get_meta( $donation_id, $field['name'], true );
@@ -533,8 +533,6 @@ function give_stripe_set_app_info() {
 			esc_url_raw( 'https://givewp.com' ),
 			'pp_partner_DKj75W1QYBxBLK' // Partner ID.
 		);
-	} catch ( \Stripe\Error\Base $e ) {
-		Give_Stripe_Logger::log_error( $e, $this->id );
 	} catch ( Exception $e ) {
 
 		give_record_gateway_error(
@@ -619,18 +617,13 @@ function give_stripe_get_donation_id_by( $id, $type ) {
  */
 function give_stripe_set_api_key() {
 
-    try {
+	try {
 
 		// Fetch secret key.
-        $secret_key = give_stripe_get_secret_key();
+		$secret_key = give_stripe_get_secret_key();
 
-        // Set secret key.
+		// Set secret key.
 		\Stripe\Stripe::setApiKey( $secret_key );
-
-	} catch ( \Stripe\Error\Base $e ) {
-
-		// Log Error.
-		$this->log_error( $e );
 
 	} catch ( Exception $e ) {
 
@@ -638,7 +631,7 @@ function give_stripe_set_api_key() {
 		give_record_gateway_error(
 			__( 'Stripe Error', 'give' ),
 			sprintf(
-			/* translators: %s Exception Message Body */
+				/* translators: %s Exception Message Body */
 				__( 'Unable to set Stripe API Key. Details: %s', 'give' ),
 				$e->getMessage()
 			)
@@ -675,7 +668,7 @@ function give_stripe_get_webhook_key() {
  */
 function give_stripe_get_webhook_id() {
 
-    $key = give_stripe_get_webhook_key();
+	$key = give_stripe_get_webhook_key();
 
 	return trim( give_get_option( $key ) );
 }
@@ -689,7 +682,7 @@ function give_stripe_get_webhook_id() {
  */
 function give_stripe_delete_webhook_id() {
 
-    $key = give_stripe_get_webhook_key();
+	$key = give_stripe_get_webhook_key();
 
 	return trim( give_delete_option( $key ) );
 }
@@ -703,13 +696,13 @@ function give_stripe_delete_webhook_id() {
  */
 function give_stripe_get_payment_mode() {
 
-    $mode = 'live';
+	$mode = 'live';
 
-    if ( give_is_test_mode() ) {
-        $mode = 'test';
-    }
+	if ( give_is_test_mode() ) {
+		$mode = 'test';
+	}
 
-    return $mode;
+	return $mode;
 }
 
 /**
@@ -902,7 +895,6 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 
 			// Save donation summary to donation.
 			give_update_meta( $donation_id, '_give_stripe_donation_summary', $donation_summary );
-
 
 			if ( give_stripe_is_checkout_enabled() ) {
 

--- a/includes/gateways/stripe/includes/give-stripe-scripts.php
+++ b/includes/gateways/stripe/includes/give-stripe-scripts.php
@@ -30,16 +30,7 @@ function give_stripe_frontend_scripts() {
 	$zip_option      = give_is_setting_enabled( give_get_option( 'stripe_checkout_zip_verify' ) );
 	$remember_option = give_is_setting_enabled( give_get_option( 'stripe_checkout_remember_me' ) );
 
-	$stripe_card_update = false;
-	$get_data           = give_clean( filter_input_array( INPUT_GET ) );
-
-	if ( isset( $get_data['action'] ) &&
-		'update' === $get_data['action'] &&
-		isset( $get_data['subscription_id'] ) &&
-		is_numeric( $get_data['subscription_id'] )
-	) {
-		$stripe_card_update = true;
-	}
+	$stripe_card_update = give_stripe_is_update_payment_method_screen();
 
 	// Set vars for AJAX.
 	$stripe_vars = array(
@@ -62,9 +53,11 @@ function give_stripe_frontend_scripts() {
 		'element_complete_styles'      => give_stripe_get_element_complete_styles(),
 		'element_empty_styles'         => give_stripe_get_element_empty_styles(),
 		'element_invalid_styles'       => give_stripe_get_element_invalid_styles(),
-		'float_labels'                 => give_is_float_labels_enabled( array(
-			'form_id' => get_the_ID(),
-		) ),
+		'float_labels'                 => give_is_float_labels_enabled(
+			array(
+				'form_id' => get_the_ID(),
+			)
+		),
 		'base_country'                 => give_get_option( 'base_country' ),
 		'stripe_card_update'           => $stripe_card_update,
 		'stripe_account_id'            => give_stripe_is_connected() ? give_get_option( 'give_stripe_user_id' ) : false,
@@ -98,7 +91,7 @@ function give_stripe_frontend_scripts() {
 	}
 
 	// Load Stripe onpage credit card JS when Stripe credit card payment method is active.
-	if ( give_is_gateway_active( 'stripe' ) ) {
+	if ( give_is_gateway_active( 'stripe' ) || $stripe_card_update ) {
 		Give_Scripts::register_script( 'give-stripe-onpage-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-stripe.js', array( 'give-stripe-js' ), GIVE_VERSION );
 		wp_enqueue_script( 'give-stripe-onpage-js' );
 	}


### PR DESCRIPTION
## Description
This PR resolves https://github.com/impress-org/give-stripe/issues/433

## How Has This Been Tested?
I've tested this PR with the following scenarios:
- [x] Processing recurring donation via Stripe Checkout and updating the payment method
- [x] Processing recurring donation via Stripe Google Pay and updating the payment method
- [x] Processing recurring donation via Apple Pay and updating the payment method

**Video Link:** https://www.loom.com/share/33c65901d98e4b68a0e77811520c74de

@DevinWalker I need your help to process Apple Pay recurring donations and then try updating the payment method. Please pull below PR as well before testing:
- https://github.com/impress-org/give-stripe/pull/434
- https://github.com/impress-org/give-recurring/pull/925

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.