### PR TITLE
fix: add donation check to get all time start

### DIFF
--- a/src/Views/Admin/DashboardWidgets/Reports.php
+++ b/src/Views/Admin/DashboardWidgets/Reports.php
@@ -95,8 +95,6 @@ class Reports {
 		$donations = new \Give_Payments_Query( $args );
 		$donations = $donations->get_payments();
 
-		$earliest = isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
-
-		return $earliest;
+		return isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
 	}
 }

--- a/src/Views/Admin/DashboardWidgets/Reports.php
+++ b/src/Views/Admin/DashboardWidgets/Reports.php
@@ -95,7 +95,7 @@ class Reports {
 		$donations = new \Give_Payments_Query( $args );
 		$donations = $donations->get_payments();
 
-		$earliest = $donations[0]->date;
+		$earliest = isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
 
 		return $earliest;
 	}

--- a/src/Views/Admin/Pages/Reports.php
+++ b/src/Views/Admin/Pages/Reports.php
@@ -114,7 +114,7 @@ class Reports {
 		$donations = new \Give_Payments_Query( $args );
 		$donations = $donations->get_payments();
 
-		$earliest = $donations[0]->date;
+		$earliest = isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
 
 		return $earliest;
 	}

--- a/src/Views/Admin/Pages/Reports.php
+++ b/src/Views/Admin/Pages/Reports.php
@@ -114,8 +114,6 @@ class Reports {
 		$donations = new \Give_Payments_Query( $args );
 		$donations = $donations->get_payments();
 
-		$earliest = isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
-
-		return $earliest;
+		return isset( $donations[0] ) ? $donations[0]->date : $start->format( 'Y-m-d H:i:s' );
 	}
 }


### PR DESCRIPTION
## Description
Resolves #4538 
This PR introduces a check in the get_all_time_start() fn to ensure that donations have been found before attempting to retrieve the date of the earliest donation.

## How Has This Been Tested?
Tested locally and throws no errors in the browser console. Passed PHPUnit tests. No PHP notices appeared in debugging.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.