### PR TITLE
fix: Stripe payments don't work in form grid if grid [modal + has a closed form] #4467

### DIFF
--- a/assets/src/js/frontend/give-stripe-checkout.js
+++ b/assets/src/js/frontend/give-stripe-checkout.js
@@ -13,7 +13,7 @@ document.addEventListener( 'DOMContentLoaded', ( evt ) => {
 
 		// Bailout, if `form_element` is null.
 		if ( null === form_element ) {
-			return false;
+			return;
 		}
 
 		const formName = form_element.querySelector( 'input[name="give-form-title"]' ).value;

--- a/assets/src/js/frontend/give-stripe-checkout.js
+++ b/assets/src/js/frontend/give-stripe-checkout.js
@@ -10,6 +10,12 @@ document.addEventListener( 'DOMContentLoaded', ( evt ) => {
 	Array.prototype.forEach.call( formWraps, function( formWrap ) {
 		let tokenCreated = false;
 		const form_element = formWrap.querySelector( '.give-form' );
+
+		// Bailout, if `form_element` is null.
+		if ( null === form_element ) {
+			return false;
+		}
+
 		const formName = form_element.querySelector( 'input[name="give-form-title"]' ).value;
 		const idPrefix = form_element.querySelector( 'input[name="give-form-id-prefix"]' ).value;
 		const checkoutImage = ( give_stripe_vars.checkout_image.length > 0 ) ? give_stripe_vars.checkout_image : '';

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -30,6 +30,11 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	Array.prototype.forEach.call( formWraps, function( formWrap ) {
 		const form_element = formWrap.querySelector( '.give-form' );
 
+		// Bailout, if `form_element` is null.
+		if ( null === form_element ) {
+			return;
+		}
+
 		let elements = stripe.elements( {
 			locale: preferredLocale,
 		} );


### PR DESCRIPTION
## Description
This PR will resolves #4467 

## How Has This Been Tested?
I have tested this PR with the below-mentioned scenarios:
- [x] Tested a page having form grid with Stripe CC enabled
- [x] Tested a page having form grid with Stripe Checkout enabled

**Check another PR for Stripe Google/Apple Pay scenario:** https://github.com/impress-org/give-stripe/pull/435

## Screenshots

*Before*
<img width="1904" alt="error-before-fix" src="https://user-images.githubusercontent.com/1852711/76602137-56f5b400-6530-11ea-9976-f659a81ff73a.png">

*After*
<img width="1897" alt="no-error-after-update" src="https://user-images.githubusercontent.com/1852711/76602125-4fcea600-6530-11ea-8cd0-ae1432bb94ad.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.