### PR TITLE
fix: resolve stripe payment intent error

### DIFF
--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		 * @since  2.5.0
 		 * @access public
 		 *
-		 * @return \Stripe\PaymentIntent
+		 * @return bool|\Stripe\PaymentIntent
 		 */
 		public function create( $args ) {
 
@@ -65,6 +65,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 				);
 
 				give_set_error( 'stripe_payment_intent_error', __( 'Error creating payment intent with Stripe. Please try again.', 'give' ) );
+				return false;
 			} // End try().
 		}
 

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -266,9 +266,13 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 					// Process additional steps for SCA or 3D secure.
 					give_stripe_process_additional_authentication( $donation_id, $intent );
 
-					// Send them to success page.
-					give_send_to_success_page();
-
+					if ( ! empty( $intent ) && 'succeeded' === $intent ) {
+						// Process to success page, only if intent is successful.
+						give_send_to_success_page();
+					} else {
+						// Show error message instead of confirmation page.
+						give_send_back_to_checkout( '?payment-mode=' . give_clean( $_GET['payment-mode'] ) );
+					}
 				} else {
 
 					// No customer, failed.

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -156,7 +156,11 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 
 			// Send donor back to checkout page, if no payment method id exists.
 			if ( empty( $payment_method_id ) ) {
-				give_set_error( 'no-payment-method-id', __( 'Unable to generate Payment Method ID. Please try again.', 'give' ) );
+				give_record_gateway_error(
+					__( 'Stripe Payment Method Error', 'give' ),
+					__( 'The payment method failed to generate during a donation. This is usually caused by a JavaScript error on the page preventing Stripe’s JavaScript from running correctly. Reach out to GiveWP support for assistance.', 'give' )
+				);
+				give_set_error( 'no-payment-method-id', __( 'Unable to generate Payment Method ID. Please contact a site administrator for assistance.', 'give' ) );
 				give_send_back_to_checkout( '?payment-mode=' . give_clean( $_GET['payment-mode'] ) );
 			}
 

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -152,7 +152,13 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 
 			$payment_method_id = ! empty( $donation_data['post_data']['give_stripe_payment_method'] )
 				? $donation_data['post_data']['give_stripe_payment_method']
-				: $this->check_for_source( $donation_data );
+				: false;
+
+			// Send donor back to checkout page, if no payment method id exists.
+			if ( empty( $payment_method_id ) ) {
+				give_set_error( 'no-payment-method-id', __( 'Unable to generate Payment Method ID. Please try again.', 'give' ) );
+				give_send_back_to_checkout( '?payment-mode=' . give_clean( $_GET['payment-mode'] ) );
+			}
 
 			// Any errors?
 			$errors = give_get_errors();


### PR DESCRIPTION
## Description
This PR is related to a Stripe Payment Intent issue which was not getting caught 😞 

But, after the call with @Benunc today, and checking some of the customer's site (staging as well as production), we were able to find out that the issue happens when there is JS conflict on the customer website. So, the JS conflict is restricting our JS to generate payment method ID and due to which the error happens.

## What are the areas improved in this PR and How has this been tested?
1. While processing a donation, if payment intent is throwing an error then we are sending the donor to the donation form with the error message instead of sending the donor to the donation confirmation page with `pending` status.
2. When a donor clicks on the "Donate" button and somehow the payment method ID is not generated then we are immediately sending the donor to the donation form with the error and logging the error in the admin as well.

Also, asked @Benunc to create a documentation issue so that we can add this issue to common troubleshooting points for customer reference.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.