### PR TITLE
fix: round avg donations to the 2nd decimal place

### DIFF
--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -174,6 +174,7 @@ class AverageDonation extends Endpoint {
 
 		$average = $paymentCount > 0 ? $earnings / $paymentCount : 0;
 
+		// Return rounded average (avoid displaying figures with many decimal places)
 		return round( $average, 2 );
 	}
 
@@ -186,6 +187,7 @@ class AverageDonation extends Endpoint {
 
 		$average = $sales > 0 ? $earnings / $sales : 0;
 
+		// Return rounded average (avoid displaying figures with many decimal places)
 		return round( $average, 2 );
 	}
 }

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -174,7 +174,7 @@ class AverageDonation extends Endpoint {
 
 		$average = $paymentCount > 0 ? $earnings / $paymentCount : 0;
 
-		return $average;
+		return round( $average, 2 );
 	}
 
 	public function get_prev_average_donation( $startStr, $endStr ) {
@@ -186,6 +186,6 @@ class AverageDonation extends Endpoint {
 
 		$average = $sales > 0 ? $earnings / $sales : 0;
 
-		return $average;
+		return round( $average, 2 );
 	}
 }


### PR DESCRIPTION
## Description
Resolves #4537 

This PR resolves the bug found by @rickalday, where figures with more than 3 decimal places are not properly handled by give_format_amount() or give_currency_filter() when the thousands separator is set to period. Because the get_average_donation() function often results in a number with many decimal places, the solution introduced in this PR is to round calculated average donations to the 2nd decimal place.

## How Has This Been Tested?
Tested locally and throws no console errors in the browser. Passed PHPUnit tests.

## Screenshots (jpeg or gifs if applicable):
<img width="1102" alt="Screen Shot 2020-03-18 at 2 52 42 PM" src="https://user-images.githubusercontent.com/5186078/76996586-2941ae00-6928-11ea-956b-2acd09ce4068.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.