### PR TITLE
fix: Error in form when using Stripe Checkout and Recurring Donations. #4566

### DIFF
--- a/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
@@ -41,7 +41,7 @@ class Give_Stripe_Checkout_Session {
 			$args = apply_filters( 'give_stripe_create_checkout_session_args', $args );
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( ! defined( 'GIVE_STRIPE_VERSION' ) ) {
+			if ( ! defined( 'GIVE_STRIPE_VERSION' ) && isset( $args['payment_intent_data'] ) ) {
 				$args['payment_intent_data']['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['line_items'][0]['amount'] );
 			}
 


### PR DESCRIPTION
## Description
This PR resolve #4566 

This issue can be reproduced for donor processing recurring donations using Stripe Checkout 2.0 without Stripe Premium active.

## How Has This Been Tested?
Please check the acceptance criteria on the issue description.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.