### PR TITLE
fix: prevent shifting Gutenberg block menus

### DIFF
--- a/blocks/donation-form/style.scss
+++ b/blocks/donation-form/style.scss
@@ -1,13 +1,5 @@
-.float-right {
-	float: right ;
-}
-
 .gutenberg__editor .give-blank-slate__image {
 	max-width: 96px;
-}
-
-.components-button {
-	margin: 15px 0 0 0;
 }
 
 .give-chosen-base-control {
@@ -20,4 +12,3 @@
 		text-align: left !important;
 	}
 }
-


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This Pr will resolve #4577 

## How Has This Been Tested?
Locally by visiting the post edit screen.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1784821/77462063-8dcda300-6e29-11ea-82b2-df8b517e7c1e.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.