### PR TITLE
Fix title field required label displaying incorrectly

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -55,9 +55,7 @@ jQuery( function( $ ) {
 						new_state_field = `<input type="text" id="card_state" name="card_state" class="cart-state give-input required" placeholder="${ states_label }" value="${ response.default_state }" autocomplete="address-level4"/>`;
 						new_state_field = $( new_state_field );
 					}
-
-					console.log( new_state_field );
-
+					
 					// No float labels.
 					if ( false === $form.hasClass( 'float-labels-enabled' ) ) {
 						if (

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -785,7 +785,7 @@ function give_user_info_fields( $form_id ) {
 					<?php echo Give()->tooltips->render_help( __( 'Title is used to personalize your donation record..', 'give' ) ); ?>
 				</label>
 				<select
-					class="give-input required"
+					class="give-input"
 					type="text"
 					name="give_title"
 					id="give-title"


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This resolves the issue with the title field displaying incorrectly. The fix was removing the `required` class that was output regardless.

Note: this was an issue with both floating and non-floating labels. Essentially, a fix for all configurations.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Manually