### PR TITLE
feat: render selected form template on single donation page

### DIFF
--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -38,7 +38,7 @@ class Form {
 		add_action( 'init', [ $this, 'loadThemeOnAjaxRequest' ] );
 		add_action( 'init', [ $this, 'embedFormSuccessURIHandler' ], 1, 3 );
 		add_filter( 'give_send_back_to_checkout', [ $this, 'handlePrePaymentProcessingErrorRedirect' ] );
-		add_action( 'give_before_single_form_summary', [ $this, 'handleLegacyDonationFormTemplate' ], 0 );
+		add_action( 'give_before_single_form_summary', [ $this, 'handleSingleDonationFormPage' ], 0 );
 	}
 
 	/**
@@ -213,11 +213,11 @@ class Form {
 	}
 
 	/**
-	 * Handle legacy donation form sidebar
+	 * Handle single donation form page.
 	 *
 	 * @since 2.7.0
 	 */
-	public function handleLegacyDonationFormTemplate() {
+	public function handleSingleDonationFormPage() {
 		// Exit if current form is legacy
 		if ( isLegacyForm() ) {
 			return;

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -13,6 +13,7 @@ use Give\Form\LoadTheme;
 use WP_Post;
 use function Give\Helpers\Form\Theme\Utils\Frontend\getFormId;
 use function Give\Helpers\Form\Theme\Utils\Frontend\getShortcodeArgs;
+use function Give\Helpers\Form\Utils\isLegacyForm;
 use function Give\Helpers\Form\Utils\isProcessingForm;
 use function Give\Helpers\Form\Utils\isViewingForm;
 use function Give\Helpers\Form\Utils\isViewingFormFailedTransactionPage;
@@ -37,6 +38,7 @@ class Form {
 		add_action( 'init', array( $this, 'loadThemeOnAjaxRequest' ) );
 		add_action( 'init', array( $this, 'embedFormSuccessURIHandler' ), 1, 3 );
 		add_filter( 'give_send_back_to_checkout', array( $this, 'handlePrePaymentProcessingErrorRedirect' ) );
+		add_action( 'give_before_single_form', [ $this, 'handleLegacyDonationFormSidebar' ], 9 );
 	}
 
 	/**
@@ -208,5 +210,29 @@ class Form {
 		$url[0] = Give()->routeForm->getURL( absint( $_REQUEST['give-form-id'] ) );
 
 		return implode( '?', $url );
+	}
+
+	/**
+	 * Handle legacy donation form sidebar
+	 *
+	 * @since 2.7.0
+	 */
+	public function handleLegacyDonationFormSidebar() {
+		// Exit if current for is not legacy
+		if ( isLegacyForm() ) {
+			return;
+		}
+
+		add_action( 'give_get_option_form_sidebar', [ $this, 'disableLegacyDonationFormSidebar' ] );
+	}
+
+	/**
+	 * Return 'disabled' as donation form sidebar status.
+	 *
+	 * @since 2.7.0
+	 * @return string
+	 */
+	public function disableLegacyDonationFormSidebar() {
+		return 'disabled';
 	}
 }

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -218,7 +218,7 @@ class Form {
 	 * @since 2.7.0
 	 */
 	public function handleLegacyDonationFormTemplate() {
-		// Exit if current for is not legacy
+		// Exit if current form is legacy
 		if ( isLegacyForm() ) {
 			return;
 		}

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -38,7 +38,7 @@ class Form {
 		add_action( 'init', array( $this, 'loadThemeOnAjaxRequest' ) );
 		add_action( 'init', array( $this, 'embedFormSuccessURIHandler' ), 1, 3 );
 		add_filter( 'give_send_back_to_checkout', array( $this, 'handlePrePaymentProcessingErrorRedirect' ) );
-		add_action( 'give_before_single_form', [ $this, 'handleLegacyDonationFormSidebar' ], 9 );
+		add_action( 'give_before_single_form', [ $this, 'handleLegacyDonationFormTemplate' ], 9 );
 	}
 
 	/**
@@ -217,13 +217,22 @@ class Form {
 	 *
 	 * @since 2.7.0
 	 */
-	public function handleLegacyDonationFormSidebar() {
+	public function handleLegacyDonationFormTemplate() {
 		// Exit if current for is not legacy
 		if ( isLegacyForm() ) {
 			return;
 		}
 
+		// Disable sidebar.
 		add_action( 'give_get_option_form_sidebar', [ $this, 'disableLegacyDonationFormSidebar' ] );
+
+		// Remove title.
+		remove_action( 'give_single_form_summary', 'give_template_single_title', 5 );
+
+		// Remove donation form renderer.
+		remove_action( 'give_single_form_summary', 'give_get_donation_form', 10 );
+
+		add_action( 'give_single_form_summary', [ $this, 'renderFormOnSingleDonationFormPage' ], 10 );
 	}
 
 	/**
@@ -234,5 +243,17 @@ class Form {
 	 */
 	public function disableLegacyDonationFormSidebar() {
 		return 'disabled';
+	}
+
+
+	/**
+	 * This function handle donation form style for single donation page.
+	 *
+	 * Note: it will render style on basis on selected form template.
+	 *
+	 * @since 2.7.0
+	 */
+	public function renderFormOnSingleDonationFormPage() {
+		echo give_form_shortcode( [] );
 	}
 }

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -38,7 +38,7 @@ class Form {
 		add_action( 'init', [ $this, 'loadThemeOnAjaxRequest' ] );
 		add_action( 'init', [ $this, 'embedFormSuccessURIHandler' ], 1, 3 );
 		add_filter( 'give_send_back_to_checkout', [ $this, 'handlePrePaymentProcessingErrorRedirect' ] );
-		add_action( 'give_before_single_form', [ $this, 'handleLegacyDonationFormTemplate' ], 9 );
+		add_action( 'give_before_single_form_summary', [ $this, 'handleLegacyDonationFormTemplate' ], 0 );
 	}
 
 	/**

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -94,6 +94,8 @@ function getFailedTransactionPageURL( $args = array() ) {
  * @since 2.7.0
  */
 function isLegacyForm( $formID = null ) {
-	return 'legacy' === getActiveID( $formID );
+	$formTemplate = getActiveID( $formID );
+
+	return ! $formTemplate || 'legacy' === getActiveID( $formID );
 }
 

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -1,6 +1,8 @@
 <?php
 namespace Give\Helpers\Form\Utils;
 
+use function Give\Helpers\Form\Theme\getActiveID;
+
 /**
  * Get result if we are viewing embed form or not
  *
@@ -80,5 +82,18 @@ function getFailedTransactionPageURL( $args = array() ) {
 		array_merge( array( 'giveDonationAction' => 'failedDonation' ), $args ),
 		give_clean( $_REQUEST['give-current-url'] )
 	);
+}
+
+
+/**
+ * Returns whether or not the given form uses the legacy form template
+ *
+ * @param int|null $formID
+ *
+ * @return bool
+ * @since 2.7.0
+ */
+function isLegacyForm( $formID = null ) {
+	return 'legacy' === getActiveID( $formID );
 }
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will resolve #4585.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
As per scope we only have to test that on the single donation, whether or not form page form style changes on the basis of the selected form template. I find out that it works as expected.

## Visuals
Single donation form page with `Sequoia` and `Legacy` form template.


![image](https://user-images.githubusercontent.com/1784821/77678669-820fe700-6fb7-11ea-8efb-6deb692f5d9d.png)
![image](https://user-images.githubusercontent.com/1784821/77678763-a4096980-6fb7-11ea-8371-966842e7fb16.png)



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.