### PR TITLE
feat: add stripe connect modal notice after connecting #4561

### DIFF
--- a/assets/src/css/admin/stripe-admin.scss
+++ b/assets/src/css/admin/stripe-admin.scss
@@ -208,6 +208,23 @@ a.give-stripe-connect-temp-dismiss:active {
     display: none;
 }
 
+/* Connected Modal Support */
+.give-stripe-connected-modal {
+	.give-modal__title {
+		font-weight: normal;
+	}
+
+	.give-modal__description {
+		span {
+			display: block;
+
+			&:first-child {
+				font-size: 14px;
+			}
+		}
+	}
+}
+
 /* Retina support */
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
 only screen and (min--moz-device-pixel-ratio: 1.5),

--- a/assets/src/js/admin/stripe-admin.js
+++ b/assets/src/js/admin/stripe-admin.js
@@ -28,23 +28,28 @@ window.addEventListener( 'DOMContentLoaded', function() {
 
 	if ( null !== stripeConnectedElement ) {
 		const stripeStatus = stripeConnectedElement.getAttribute( 'data-status' );
+		const redirectUrl = stripeConnectedElement.getAttribute( 'data-redirect-url' );
+		const canDisplay = stripeConnectedElement.getAttribute( 'data-display' );
 		const modalTitle = stripeConnectedElement.getAttribute( 'data-title' );
 		const modalFirstDetail = stripeConnectedElement.getAttribute( 'data-first-detail' );
 		const modalSecondDetail = stripeConnectedElement.getAttribute( 'data-second-detail' );
 
-		if ( 'connected' === stripeStatus ) {
+		if ( 'connected' === stripeStatus && '0' === canDisplay ) {
 			new GiveConfirmModal(
 				{
-					modalWrapper: 'give-stripe-connected-modal',
+					modalWrapper: 'give-stripe-connected-modal give-modal--success',
 					modalContent: {
 						title: modalTitle,
-						desc: modalFirstDetail +'<br/><span class="give-field-description">' + modalSecondDetail + '</span>',
+						desc: '<span>' + modalFirstDetail + '</span>' + '<span class="give-field-description">' + modalSecondDetail + '</span>',
 					},
 					successConfirm: function( args ) {
-
+						window.location.href = redirectUrl;
 					},
 				}
 			).render();
+
+			stripeConnectedElement.setAttribute( 'data-display', '1' );
+			history.pushState( { urlPath: redirectUrl }, '', redirectUrl );
 		}
 	}
 

--- a/assets/src/js/admin/stripe-admin.js
+++ b/assets/src/js/admin/stripe-admin.js
@@ -38,6 +38,7 @@ window.addEventListener( 'DOMContentLoaded', function() {
 			new GiveConfirmModal(
 				{
 					modalWrapper: 'give-stripe-connected-modal give-modal--success',
+					type: 'confirm',
 					modalContent: {
 						title: modalTitle,
 						desc: `<span>${modalFirstDetail}</span><span class="give-field-description">${modalSecondDetail}</span>`,

--- a/assets/src/js/admin/stripe-admin.js
+++ b/assets/src/js/admin/stripe-admin.js
@@ -3,6 +3,9 @@
  *
  * @since 2.5.0
  */
+
+import { GiveConfirmModal } from '../plugins/modal';
+
 window.addEventListener( 'DOMContentLoaded', function() {
 	const ccFormatSettings = document.querySelector( '.stripe-cc-field-format-settings' );
 	const stripeFonts = document.querySelectorAll( 'input[name="stripe_fonts"]' );
@@ -15,12 +18,35 @@ window.addEventListener( 'DOMContentLoaded', function() {
 	const stripeDisconnect = document.querySelector( '.give-stripe-disconnect' );
 	const checkoutTypes = document.querySelectorAll( 'input[name="stripe_checkout_type"]' );
 	const legacyCheckoutFields = Array.from( document.querySelectorAll( '.stripe-checkout-field' ) );
+	const stripeConnectedElement = document.getElementById( 'give-stripe-connect' );
 
 	giveStripeJsonFormattedTextarea( stripeStylesBase );
 	giveStripeJsonFormattedTextarea( stripeStylesEmpty );
 	giveStripeJsonFormattedTextarea( stripeStylesInvalid );
 	giveStripeJsonFormattedTextarea( stripeStylesComplete );
 	giveStripeJsonFormattedTextarea( stripeCustomFonts );
+
+	if ( null !== stripeConnectedElement ) {
+		const stripeStatus = stripeConnectedElement.getAttribute( 'data-status' );
+		const modalTitle = stripeConnectedElement.getAttribute( 'data-title' );
+		const modalFirstDetail = stripeConnectedElement.getAttribute( 'data-first-detail' );
+		const modalSecondDetail = stripeConnectedElement.getAttribute( 'data-second-detail' );
+
+		if ( 'connected' === stripeStatus ) {
+			new GiveConfirmModal(
+				{
+					modalWrapper: 'give-stripe-connected-modal',
+					modalContent: {
+						title: modalTitle,
+						desc: modalFirstDetail +'<br/><span class="give-field-description">' + modalSecondDetail + '</span>',
+					},
+					successConfirm: function( args ) {
+
+					},
+				}
+			).render();
+		}
+	}
 
 	if ( null !== checkoutTypes ) {
 		checkoutTypes.forEach( ( checkoutType ) => {

--- a/assets/src/js/admin/stripe-admin.js
+++ b/assets/src/js/admin/stripe-admin.js
@@ -40,7 +40,7 @@ window.addEventListener( 'DOMContentLoaded', function() {
 					modalWrapper: 'give-stripe-connected-modal give-modal--success',
 					modalContent: {
 						title: modalTitle,
-						desc: '<span>' + modalFirstDetail + '</span>' + '<span class="give-field-description">' + modalSecondDetail + '</span>',
+						desc: `<span>${modalFirstDetail}</span><span class="give-field-description">${modalSecondDetail}</span>`,
 					},
 					successConfirm: function( args ) {
 						window.location.href = redirectUrl;

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -565,12 +565,13 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 				<td class="give-forminp give-forminp-api_key">
 					<?php
 					if ( give_stripe_is_connected() ) :
+						$site_url            = get_site_url();
 						$stripe_user_id      = give_get_option( 'give_stripe_user_id' );
 						$modal_title         = __( 'Connected! <strong>Important: Now please configure the stripe webhook to finalize the setup.</strong>', 'give' );
 						$modal_first_detail  = sprintf(
 							'%1$s %2$s',
 							__( 'In order for Stripe to function properly, you must configure your Stripe webhooks. You can visit your Stripe Account Dashboard to add a new webhook endpoint for the following URL:', 'give' ),
-							'<strong>https://give.test/?give-listener=stripe</strong>'
+							"<strong>{$site_url}?give-listener=stripe</strong>"
 						);
 						$modal_second_detail = __( 'Stripe webhooks are important to setup so GiveWP can communicate properly with the payment gateway. It is not required to have the sandbox webhooks setup unless you are testing. Note: webhooks cannot be setup on localhost or websites in maintenance mode.', 'give' );
 						$can_display = ! empty( $_GET['stripe_access_token'] ) ? '0' : '1';
@@ -585,7 +586,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							data-display="<?php echo $can_display; ?>"
 							data-redirect-url="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=stripe-settings' ) ); ?>"
 						>
-							<span>Connected</span>
+							<span><?php echo __( 'Connected', 'give' ); ?></span>
 						</span>
 						<p class="give-field-description">
 							<span class="dashicons dashicons-yes" style="color:#25802d;"></span>

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -567,13 +567,13 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 					if ( give_stripe_is_connected() ) :
 						$site_url            = get_site_url();
 						$stripe_user_id      = give_get_option( 'give_stripe_user_id' );
-						$modal_title         = __( 'Connected! <strong>Important: Now please configure the stripe webhook to finalize the setup.</strong>', 'give' );
+						$modal_title         = __( '<strong>You are connected! Now this is important: Please now configure your Stripe webhook to finalize the setup.</strong>', 'give' );
 						$modal_first_detail  = sprintf(
 							'%1$s %2$s',
-							__( 'In order for Stripe to function properly, you must configure your Stripe webhooks. You can visit your Stripe Account Dashboard to add a new webhook endpoint for the following URL:', 'give' ),
+							__( 'In order for Stripe to function properly, you must add a new Stripe webhook endpoint. To do this please visit the <a href=\'https://dashboard.stripe.com/webhooks\' target=\'_blank\'>Webhooks Section of your Stripe Dashboard</a> and click the <strong>Add endpoint</strong> button and paste the following URL:', 'give' ),
 							"<strong>{$site_url}?give-listener=stripe</strong>"
 						);
-						$modal_second_detail = __( 'Stripe webhooks are important to setup so GiveWP can communicate properly with the payment gateway. It is not required to have the sandbox webhooks setup unless you are testing. Note: webhooks cannot be setup on localhost or websites in maintenance mode.', 'give' );
+						$modal_second_detail = __( 'Stripe webhooks are required so GiveWP can communicate properly with the payment gateway to confirm payment completion, renewals, and more.', 'give' );
 						$can_display = ! empty( $_GET['stripe_access_token'] ) ? '0' : '1';
 						?>
 						<span

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -570,9 +570,10 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						$modal_first_detail  = sprintf(
 							'%1$s %2$s',
 							__( 'In order for Stripe to function properly, you must configure your Stripe webhooks. You can visit your Stripe Account Dashboard to add a new webhook endpoint for the following URL:', 'give' ),
-							'https://give.test/?give-listener=stripe'
+							'<strong>https://give.test/?give-listener=stripe</strong>'
 						);
 						$modal_second_detail = __( 'Stripe webhooks are important to setup so GiveWP can communicate properly with the payment gateway. It is not required to have the sandbox webhooks setup unless you are testing. Note: webhooks cannot be setup on localhost or websites in maintenance mode.', 'give' );
+						$can_display = ! empty( $_GET['stripe_access_token'] ) ? '0' : '1';
 						?>
 						<span
 							id="give-stripe-connect"
@@ -581,6 +582,8 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							data-title="<?php echo $modal_title; ?>"
 							data-first-detail="<?php echo $modal_first_detail; ?>"
 							data-second-detail="<?php echo $modal_second_detail; ?>"
+							data-display="<?php echo $can_display; ?>"
+							data-redirect-url="<?php echo esc_url_raw( admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=stripe-settings' ) ); ?>"
 						>
 							<span>Connected</span>
 						</span>

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -565,9 +565,25 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 				<td class="give-forminp give-forminp-api_key">
 					<?php
 					if ( give_stripe_is_connected() ) :
-						$stripe_user_id = give_get_option( 'give_stripe_user_id' );
+						$stripe_user_id      = give_get_option( 'give_stripe_user_id' );
+						$modal_title         = __( 'Connected! <strong>Important: Now please configure the stripe webhook to finalize the setup.</strong>', 'give' );
+						$modal_first_detail  = sprintf(
+							'%1$s %2$s',
+							__( 'In order for Stripe to function properly, you must configure your Stripe webhooks. You can visit your Stripe Account Dashboard to add a new webhook endpoint for the following URL:', 'give' ),
+							'https://give.test/?give-listener=stripe'
+						);
+						$modal_second_detail = __( 'Stripe webhooks are important to setup so GiveWP can communicate properly with the payment gateway. It is not required to have the sandbox webhooks setup unless you are testing. Note: webhooks cannot be setup on localhost or websites in maintenance mode.', 'give' );
 						?>
-						<span id="give-stripe-connect" class="stripe-btn-disabled"><span>Connected</span></span>
+						<span
+							id="give-stripe-connect"
+							class="stripe-btn-disabled"
+							data-status="connected"
+							data-title="<?php echo $modal_title; ?>"
+							data-first-detail="<?php echo $modal_first_detail; ?>"
+							data-second-detail="<?php echo $modal_second_detail; ?>"
+						>
+							<span>Connected</span>
+						</span>
 						<p class="give-field-description">
 							<span class="dashicons dashicons-yes" style="color:#25802d;"></span>
 							<?php
@@ -653,7 +669,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							$date_time_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
 							?>
 							<p>
-								<strong><?php esc_html_e( 'Last webhook received on' ); ?></strong> <?php echo date_i18n( esc_html( $date_time_format ), $webhook_received_on ); ?>
+								<strong><?php esc_html_e( 'Last webhook received on', 'give' ); ?></strong> <?php echo date_i18n( esc_html( $date_time_format ), $webhook_received_on ); ?>
 							</p>
 							<?php
 						}


### PR DESCRIPTION
## Description
This PR resolves #4561 

## How Has This Been Tested?
I've tested this PR by connecting and disconnecting the Square account and refreshing the page multiple times after connected to see that the popup is displayed once.

## Screenshots (jpeg or gifs if applicable):
![image](https://user-images.githubusercontent.com/1852711/77610767-9fa66780-6f49-11ea-8a94-e7823f272d51.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [X] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.