### PR TITLE
fix: prevent Reports related issue when using wp-cli

### DIFF
--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -178,10 +178,8 @@ abstract class Endpoint {
 
 	/**
 	 * Get our sample schema for a report
-	 *
-	 * @param WP_REST_Request $request Current request.
 	 */
-	public function get_report_schema( $request ) {
+	public function get_report_schema() {
 
 		if ( $this->schema ) {
 			// Since WordPress 5.3, the schema can be cached in the $schema property.


### PR DESCRIPTION
## Description
This PR resolves issue #4592. In the original issue, a Fatal Error was thrown when accessing a site through wp-cli with Give installed because get_report_shema() received too few arguments. In this PR, the $request parameter is no longer expected by the get_report_schema() fn, solving the issue.

## How Has This Been Tested?
Tested locally, passed PHPUnit tests. Functional when using wp-cli.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.