### PR TITLE
fix: donation forms using Stripe do not redirect to success page #4605

### DIFF
--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -276,7 +276,7 @@ if ( ! class_exists( 'Give_Stripe_Card' ) ) {
 					// Process additional steps for SCA or 3D secure.
 					give_stripe_process_additional_authentication( $donation_id, $intent );
 
-					if ( ! empty( $intent ) && 'succeeded' === $intent ) {
+					if ( ! empty( $intent->status ) && 'succeeded' === $intent->status ) {
 						// Process to success page, only if intent is successful.
 						give_send_to_success_page();
 					} else {


### PR DESCRIPTION
## Description
This PR resolves #4605 

## Affects
- https://github.com/impress-org/givewp/blob/develop/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php#L279

## What to test
I have tested this PR by processing donation via Credit Card.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
