### PR TITLE
fix: increase Sequoia form wrapper width

### DIFF
--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -335,10 +335,9 @@ p {
 
 .choose-amount {
 	.content {
-		max-width: 80%;
 		text-align: center;
-		margin-top: 30px;
-		margin-bottom: 25px;
+		margin: 24px 30px 22px 30px;
+		font-size: 15px;
 	}
 
 	// Amount Total
@@ -352,15 +351,15 @@ p {
 
 		.give-donation-amount {
 			@include before-after-content-none;
-			width: 45%;
 			display: flex;
+			width: 207px;
 			align-items: center;
 			background-color: #fff;
 			box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.22);
 			border: 1px solid #979797;
 			border-radius: 4px !important;
 			overflow: hidden;
-			padding: 15px;
+			padding: 18px 24px;
 			margin: 0;
 
 			input {
@@ -391,10 +390,10 @@ p {
 	// Amount Buttons
 	.give-donation-levels-wrap {
 		@include before-after-content-none;
-		grid-gap: 8px;
+		grid-gap: 10px;
 		grid-template-columns: repeat(3, 1fr);
 		padding: 0;
-		margin: 15px 20px !important;
+		margin: 24px 30px 0 30px !important;
 
 		li {
 			margin: 0 !important;
@@ -410,19 +409,19 @@ p {
 			line-height: 1;
 			text-align: center;
 			color: #fff;
-			padding-top: 18px;
-			padding-bottom: 18px;
+			padding-top: 24px;
+			padding-bottom: 24px;
 
 			> .currency {
 				font-size: 14px;
-				margin: 0 4px 11px 0;
+				margin: 0 6px 11px 0;
 			}
 
 			&.give-btn-level-custom {
 				height: 100%;
 				font-size: 18px;
 				line-height: 1.2;
-				padding: 0;
+				padding: 10px;
 			}
 
 			&.give-default-level {

--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -101,7 +101,6 @@ p {
 .give_error,
 .give_success,
 .give_warning {
-	display: none !important;
 	@include before-after-content-none;
 	position: relative;
 	margin: 20px 20px 0 20px;

--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -252,7 +252,7 @@ p {
 	.headline {
 		max-width: 75%;
 		margin-bottom: 20px;
-		margin-top: 28px;
+		margin-top: 30px;
 	}
 
 	.seperator {

--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -81,17 +81,17 @@ p {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 18px 26px !important;
+	padding: 20px 28px !important;
 	border-radius: 4px;
 	border: none;
 	font-size: 22px;
 	line-height: 20px;
-	margin-top: 30px;
-	margin-bottom: 15px;
+	margin-top: 48px;
+	margin-bottom: 16px;
 	min-width: 236px;
 
 	> i {
-		font-size: 13px;
+		font-size: 15px;
 		margin-left: 15px;
 	}
 }
@@ -131,7 +131,7 @@ p {
 	height: auto;
 	position: relative;
 	overflow: hidden;
-	padding: 56.24% 0 0 0;
+	padding: 55.4% 0 0 0;
 	margin: 0;
 
 	img {
@@ -217,7 +217,7 @@ p {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		height: 45px;
+		height: 60px;
 		justify-content: center;
 		background: #fbfbfb;
 		border-top: 1px solid #f2f2f2;
@@ -225,7 +225,7 @@ p {
 
 		> i {
 			padding: 8px;
-			font-size: 10px;
+			font-size: 12px;
 		}
 	}
 }
@@ -251,7 +251,7 @@ p {
 
 	.headline {
 		max-width: 75%;
-		margin-bottom: 20px;
+		margin-bottom: 18px;
 		margin-top: 30px;
 	}
 
@@ -263,9 +263,9 @@ p {
 	}
 
 	.description {
-		max-width: 66%;
-		margin-bottom: 26px;
-		margin-top: 16px;
+		font-size: 16px;
+		font-weight: 500;
+		margin: 18px 70px 29px 70px;
 	}
 
 	.income-stats {

--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -101,6 +101,7 @@ p {
 .give_error,
 .give_success,
 .give_warning {
+	display: none !important;
 	@include before-after-content-none;
 	position: relative;
 	margin: 20px 20px 0 20px;
@@ -436,35 +437,30 @@ p {
 // Payment Section
 
 .payment {
-	padding: 0 20px;
-
+	padding: 0 30px;
 	.heading {
-		padding: 30px 0 3px 0;
-		font-size: 18px;
+		padding: 39px 3px 0;
+		font-size: 16px;
 		font-weight: 500;
 		color: #6b6b6b;
 		text-align: center;
 	}
-
 	.subheading {
-		padding: 3px 0 30px 0;
+		padding: 5px 0 34px 0;
 		font-style: italic;
-		font-size: 15px;
+		font-size: 12px;
 		color: #767676;
 		text-align: center;
 	}
-
 	#give_checkout_user_info {
 		legend {
 			display: none;
 		}
 	}
-
 	#give-payment-mode-select {
 		legend {
 			display: none;
 		}
-
 		ul {
 			@include before-after-content-none;
 			display: grid;
@@ -495,7 +491,6 @@ p {
 			}
 		}
 	}
-
 	#give_purchase_submit {
 		display: flex;
 		flex-direction: column;
@@ -526,8 +521,8 @@ fieldset {
 	}
 	i {
 		position: absolute;
-		top: 14px;
-		left: 13px;
+		top: 18px;
+		left: 16px;
 		font-size: 12px;
 		color: #989898;
 	}
@@ -538,6 +533,7 @@ fieldset {
 }
 
 .give-input {
+	font-family: 'Montserrat', sans-serif;
 	background: #fff;
 	border: 1px solid #b8b8b8;
 	box-sizing: border-box;
@@ -547,10 +543,11 @@ fieldset {
 	font-size: 14px;
 	line-height: 1;
 	color: #8d8e8e;
-	padding: 10px !important;
+	padding: 14px !important;
 }
 
 .give-select {
+	font-family: 'Montserrat', sans-serif;
 	font-size: 14px;
 	font-weight: 400;
 	color: #333;

--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -44,7 +44,7 @@ p {
 // Container
 
 .give-embed-form {
-	max-width: 480px;
+	max-width: 552px;
 	margin: auto;
 	border-radius: 6px;
 	color: #696969;


### PR DESCRIPTION
## Description
Resolves #4609 

This PR resolves a visual bug pointed out in issue #4609, where the Sequoia form wrapper width did not match the width of forms in the Figma design.

This PR also corrects other margins that had been incorrectly adjusted to fit within the wrong wrapper width. Now, margins match the Figma designs pixel for pixel and the form wrapper width is correct.

## Affects
This PR only impacts the css of the Sequoia form template, found in Sequoia's assets directory.

## What to test
Check that each step accurately reflects the spacings/margins found in the Figma designs. See Figma designs for reference: https://www.figma.com/file/jaVXDA4wjQD9OqTi0l9KQe/Form-Themes?node-id=1882%3A44&viewport=-259%2C1586%2C0.5

## Screenshots:
<img width="576" alt="Screen Shot 2020-04-02 at 1 06 09 PM" src="https://user-images.githubusercontent.com/5186078/78278110-8f5f3100-74e3-11ea-9d5d-fd7177ef1d39.png">

<img width="566" alt="Screen Shot 2020-04-02 at 1 06 22 PM" src="https://user-images.githubusercontent.com/5186078/78278118-925a2180-74e3-11ea-88b1-cee180cac6ed.png">

<img width="570" alt="Screen Shot 2020-04-02 at 1 07 13 PM" src="https://user-images.githubusercontent.com/5186078/78278133-96863f00-74e3-11ea-83c6-4cf990976789.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
