### PR TITLE
feat: enable form setting for quick setup

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -192,20 +192,19 @@ class Give_MetaBox_Form_Data {
 								),
 								'default'       => array(
 									array(
-										'_give_id'      =>
+										'_give_id'     =>
 											array(
 												'level_id' => 0,
 											),
-										'_give_amount'  => '10.000000',
-										'_give_text'    => '',
-										'_give_default' => 'default',
+										'_give_amount' => '10.000000',
+										'_give_text'   => '',
 									),
 									array(
 										'_give_id'     =>
 											array(
 												'level_id' => 1,
 											),
-										'_give_amount' => '20.000000',
+										'_give_amount' => '25.000000',
 										'_give_text'   => '',
 									),
 									array(
@@ -217,12 +216,13 @@ class Give_MetaBox_Form_Data {
 										'_give_text'   => '',
 									),
 									array(
-										'_give_id'     =>
+										'_give_id'      =>
 											array(
 												'level_id' => 3,
 											),
-										'_give_amount' => '100.000000',
-										'_give_text'   => '',
+										'_give_amount'  => '100.000000',
+										'_give_text'    => '',
+										'_give_default' => 'default',
 									),
 									array(
 										'_give_id'     =>

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -197,7 +197,6 @@ class Give_MetaBox_Form_Data {
 												'level_id' => 0,
 											),
 										'_give_amount' => '10.000000',
-										'_give_text'   => '',
 									),
 									array(
 										'_give_id'     =>
@@ -205,7 +204,6 @@ class Give_MetaBox_Form_Data {
 												'level_id' => 1,
 											),
 										'_give_amount' => '25.000000',
-										'_give_text'   => '',
 									),
 									array(
 										'_give_id'     =>
@@ -213,7 +211,6 @@ class Give_MetaBox_Form_Data {
 												'level_id' => 2,
 											),
 										'_give_amount' => '50.000000',
-										'_give_text'   => '',
 									),
 									array(
 										'_give_id'      =>
@@ -221,7 +218,6 @@ class Give_MetaBox_Form_Data {
 												'level_id' => 3,
 											),
 										'_give_amount'  => '100.000000',
-										'_give_text'    => '',
 										'_give_default' => 'default',
 									),
 									array(
@@ -230,7 +226,6 @@ class Give_MetaBox_Form_Data {
 												'level_id' => 5,
 											),
 										'_give_amount' => '250.000000',
-										'_give_text'   => '',
 									),
 								),
 								'wrapper_class' => 'give-hidden',

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -189,6 +189,49 @@ class Give_MetaBox_Form_Data {
 									'header_title'  => __( 'Donation Level', 'give' ),
 									'remove_button' => '<span class="dashicons dashicons-no"></span>',
 								),
+								'default'       => array(
+									array(
+										'_give_id'      =>
+											array(
+												'level_id' => 0,
+											),
+										'_give_amount'  => '10.000000',
+										'_give_text'    => '',
+										'_give_default' => 'default',
+									),
+									array(
+										'_give_id'     =>
+											array(
+												'level_id' => 1,
+											),
+										'_give_amount' => '20.000000',
+										'_give_text'   => '',
+									),
+									array(
+										'_give_id'     =>
+											array(
+												'level_id' => 2,
+											),
+										'_give_amount' => '50.000000',
+										'_give_text'   => '',
+									),
+									array(
+										'_give_id'     =>
+											array(
+												'level_id' => 3,
+											),
+										'_give_amount' => '100.000000',
+										'_give_text'   => '',
+									),
+									array(
+										'_give_id'     =>
+											array(
+												'level_id' => 5,
+											),
+										'_give_amount' => '250.000000',
+										'_give_text'   => '',
+									),
+								),
 								'wrapper_class' => 'give-hidden',
 								// Fields array works the same, except id's only need to be unique for this group.
 								// Prefix is not needed.

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -146,7 +146,7 @@ class Give_MetaBox_Form_Data {
 								'description' => __( 'Do you want the user to be able to input their own donation amount?', 'give' ),
 								'id'          => $prefix . 'custom_amount',
 								'type'        => 'radio_inline',
-								'default'     => 'disabled',
+								'default'     => 'enabled',
 								'options'     => array(
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -174,6 +174,7 @@ class Give_MetaBox_Form_Data {
 								'description'   => __( 'This text appears as a label below the custom amount field for set donation forms. For multi-level forms the text will appear as it\'s own level (ie button, radio, or select option).', 'give' ),
 								'id'            => $prefix . 'custom_amount_text',
 								'type'          => 'text_medium',
+								'default'       => __( 'Custom Amount', 'give' ),
 								'attributes'    => array(
 									'rows'        => 3,
 									'placeholder' => __( 'Give a Custom Amount', 'give' ),

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -176,8 +176,7 @@ class Give_MetaBox_Form_Data {
 								'type'          => 'text_medium',
 								'default'       => __( 'Custom Amount', 'give' ),
 								'attributes'    => array(
-									'rows'        => 3,
-									'placeholder' => __( 'Give a Custom Amount', 'give' ),
+									'rows' => 3,
 								),
 								'wrapper_class' => 'give-hidden',
 							),

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -1251,9 +1251,15 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 
 		<table class="give-repeatable-fields-section-wrapper" cellspacing="0">
 			<?php
+			// Get value.
 			$repeater_field_values = ! empty( $fields['attributes']['value'] )
 				? $fields['attributes']['value']
 				: give_get_meta( $thepostid, $fields['id'], true );
+
+			// Setup default value.
+			if ( empty( $repeater_field_values ) && ! empty( $fields['default'] ) ) {
+				$repeater_field_values = $fields['default'];
+			}
 
 			$header_title = isset( $fields['options']['header_title'] )
 				? $fields['options']['header_title']

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -181,7 +181,7 @@ function give_import_get_form_data_from_csv( $data, $import_setting = array() ) 
 		// If new form is created.
 		if ( ! empty( $new_form ) ) {
 			$new_form = array(
-				'_give_custom_amount_text'          => ( ! empty( $data['form_custom_amount_text'] ) ? $data['form_custom_amount_text'] : 'custom' ),
+				'_give_custom_amount_text'          => ( ! empty( $data['form_custom_amount_text'] ) ? $data['form_custom_amount_text'] : __( 'Custom Amount', 'give' ) ),
 				'_give_logged_in_only'              => 'enabled',
 				'_give_custom_amount'               => 'enabled',
 				'_give_payment_import'              => true,

--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -424,7 +424,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 							$custom_amount_text = give_get_meta( $payment->form_id, '_give_custom_amount_text', true );
 
 							if ( empty( $custom_amount_text ) ) {
-								$custom_amount_text = esc_html__( 'Custom', 'give' );
+								$custom_amount_text = esc_html__( 'Custom Amount', 'give' );
 							}
 							$data[ $i ]['form_level_title'] = $custom_amount_text;
 						} else {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -523,7 +523,7 @@ function give_output_levels( $form_id ) {
 	$custom_amount_text = give_get_meta( $form_id, '_give_custom_amount_text', true );
 
 	if ( empty( $custom_amount_text ) ) {
-		$custom_amount_text = esc_html__( 'Give a Custom Amount', 'give' );
+		$custom_amount_text = esc_html__( 'Custom Amount', 'give' );
 	}
 
 	$output = '';


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will resolve #4579.

As per previous experience, we found that we can set default value to common value which will help admin to quickly set up it.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Default Form settings.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Form settings default value (mentioned in issue `Acceptance Criteria` section )

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
