### PR TITLE
feat: handle form setting which moved to Legacy form template

### DIFF
--- a/src/Form/Theme.php
+++ b/src/Form/Theme.php
@@ -32,13 +32,13 @@ abstract class Theme {
 	public $openFailedPageInIframe = true;
 
 	/**
-	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:16 Check property desciption.
+	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:16 Check property description.
 	 * @var array $defaultSettings Form settings default values for form template.
 	 */
 	protected $defaultLegacySettingValues = [];
 
 	/**
-	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:18 Check property desciption.
+	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:18 Check property description.
 	 * @var array $mapToLegacySetting
 	 */
 	protected $mapToLegacySetting = [];

--- a/src/Form/Theme.php
+++ b/src/Form/Theme.php
@@ -130,7 +130,7 @@ abstract class Theme {
 	/**
 	 * Returns LegacyFormSettingCompatibility object.
 	 *
-	 * This will help to maintain backward compatibility with legacy form settings.
+	 * This function helps to maintain backward compatibility with legacy form settings.
 	 *
 	 * @since 2.7.0
 	 *

--- a/src/Form/Theme.php
+++ b/src/Form/Theme.php
@@ -9,6 +9,7 @@
 
 namespace Give\Form;
 
+use Give\Form\Theme\LegacyFormSettingCompatibility;
 use Give\Form\Theme\Options;
 use function Give\Helpers\Form\Utils\createFailedPageURL;
 
@@ -123,5 +124,19 @@ abstract class Theme {
 	 */
 	public function getFailedPageURL( $formId ) {
 		return createFailedPageURL( Give()->routeForm->getURL( get_post_field( 'post_name', $formId ) ) );
+	}
+
+
+	/**
+	 * Returns LegacyFormSettingCompatibility object.
+	 *
+	 * This will help to maintain backward compatibility with legacy form settings.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @return LegacyFormSettingCompatibility
+	 */
+	public function getLegacySettingHandler() {
+		return new LegacyFormSettingCompatibility();
 	}
 }

--- a/src/Form/Theme.php
+++ b/src/Form/Theme.php
@@ -32,6 +32,18 @@ abstract class Theme {
 	public $openFailedPageInIframe = true;
 
 	/**
+	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:16 Check property desciption.
+	 * @var array $defaultSettings Form settings default values for form template.
+	 */
+	protected $defaultLegacySettingValues = [];
+
+	/**
+	 * @see src/Form/Theme/LegacyFormSettingCompatibility.php:18 Check property desciption.
+	 * @var array $mapToLegacySetting
+	 */
+	protected $mapToLegacySetting = [];
+
+	/**
 	 * template vs file array
 	 *
 	 * @since 2.7.0
@@ -134,9 +146,11 @@ abstract class Theme {
 	 *
 	 * @since 2.7.0
 	 *
-	 * @return LegacyFormSettingCompatibility
+	 * @return LegacyFormSettingCompatibility|null
 	 */
 	public function getLegacySettingHandler() {
-		return new LegacyFormSettingCompatibility();
+		return $this->mapToLegacySetting || $this->defaultLegacySettingValues ?
+			new LegacyFormSettingCompatibility( $this->mapToLegacySetting, $this->defaultLegacySettingValues ) :
+			null;
 	}
 }

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -12,7 +12,7 @@ class LegacyFormSettingCompatibility {
 	 * @var array $defaultSettings Form settings default values for form template.
 	 */
 	private $defaultLegacySettingValues = [
-		'_give_display_style'        => 'button',
+		'_give_display_style'        => 'buttons',
 		'_give_payment_display'      => 'onpage',
 		'_give_form_floating_labels' => 'disabled',
 		'_give_display_content'      => 'disabled',

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -1,0 +1,71 @@
+<?php
+namespace Give\Form\Theme;
+
+/**
+ * Class LegacyFormSettingCompatibility
+ *
+ * @since 2.7.0
+ * @package Give\Form\Theme
+ */
+abstract class LegacyFormSettingCompatibility {
+	/**
+	 * @var array $defaultSettings Form settings default values for form template.
+	 */
+	private $defaultLegacySettingValues = [
+		'_give_display_style'        => 'button',
+		'_give_payment_display'      => 'onpage',
+		'_give_form_floating_labels' => 'disabled',
+		'_give_display_content'      => 'disabled',
+	];
+
+	/**
+	 * Map form template setting to form setting.
+	 *
+	 * Note: either this array will be empty of contain field id as key and legacy setting key as value grouped by group id.
+	 * For example:
+	 * [
+	 *    'introduction' => [
+	 *        'content' => '_give_display_content'
+	 *        ......
+	 *    ],
+	 *    .......
+	 * ]
+	 *
+	 * @var array $mapToLegacySetting
+	 */
+	private $mapToLegacySetting = [];
+
+
+	/**
+	 * Save legacy settings.
+	 *
+	 * Note: This function must be called when saving donation form in WP Backed.
+	 *
+	 * @param array $settings
+	 * @since 2.7.0
+	 */
+	public function saveLegacySettings( $settings ) {
+		$alreadySavedLegacySettings = [];
+		$formId                     = absint( $_GET['post_ID'] );
+
+		if ( $this->mapToLegacySetting ) {
+			foreach ( $this->mapToLegacySetting as $groupId => $group ) {
+				foreach ( $group as $fieldId => $legacySettingMetaKey ) {
+					// Continue if setting is not find.
+					if ( ! isset( $settings[ $groupId ][ $fieldId ] ) ) {
+						continue;
+					}
+
+					Give()->form_meta->update( $formId, $legacySettingMetaKey, $settings[ $groupId ][ $fieldId ] );
+					$alreadySavedLegacySettings[] = $legacySettingMetaKey;
+				}
+			}
+		}
+
+		if ( $remainingSettings = array_diff( array_keys( $this->defaultLegacySettingValues ), $alreadySavedLegacySettings ) ) {
+			foreach ( $remainingSettings as $metaKey => $metaValue ) {
+				Give()->form_meta->update( $formId, $metaKey, $metaKey );
+			}
+		}
+	}
+}

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -10,12 +10,18 @@ namespace Give\Form\Theme;
 class LegacyFormSettingCompatibility {
 	/**
 	 * @var array $defaultSettings Form settings default values for form template.
+	 *
+	 * These form setting is moved to Legacy form template but legacy form needs them to render donation form HTML.
 	 */
 	private $defaultLegacySettingValues = [
 		'_give_display_style'        => 'buttons',
 		'_give_payment_display'      => 'onpage',
 		'_give_form_floating_labels' => 'disabled',
+		'_give_reveal_label'         => '',
+		'_give_checkout_label'       => '',
 		'_give_display_content'      => 'disabled',
+		'_give_content_placement'    => 'give_pre_form',
+		'_give_form_content'         => '',
 	];
 
 	/**
@@ -44,6 +50,9 @@ class LegacyFormSettingCompatibility {
 	 * @since 2.7.0
 	 */
 	public function __construct( $mapToLegacySetting = [], $defaultLegacySettingValues = [] ) {
+		$this->defaultLegacySettingValues['_give_reveal_label']   = __( 'Donate Now', 'give' );
+		$this->defaultLegacySettingValues['_give_checkout_label'] = __( 'Donate Now', 'give' );
+
 		$this->mapToLegacySetting         = $mapToLegacySetting;
 		$this->defaultLegacySettingValues = array_merge( $this->defaultLegacySettingValues, $defaultLegacySettingValues );
 	}

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -41,12 +41,12 @@ abstract class LegacyFormSettingCompatibility {
 	 *
 	 * Note: This function must be called when saving donation form in WP Backed.
 	 *
+	 * @param int   $formId
 	 * @param array $settings
 	 * @since 2.7.0
 	 */
-	public function saveLegacySettings( $settings ) {
+	public function saveLegacySettings( $formId, $settings ) {
 		$alreadySavedLegacySettings = [];
-		$formId                     = absint( $_GET['post_ID'] );
 
 		if ( $this->mapToLegacySetting ) {
 			foreach ( $this->mapToLegacySetting as $groupId => $group ) {

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -11,7 +11,7 @@ class LegacyFormSettingCompatibility {
 	/**
 	 * @var array $defaultSettings Form settings default values for form template.
 	 *
-	 * These form setting is moved to Legacy form template but legacy form needs them to render donation form HTML.
+	 * These form settings moved to Legacy form template but legacy form needs them to render donation form HTML.
 	 */
 	private $defaultLegacySettingValues = [
 		'_give_display_style'        => 'buttons',
@@ -27,7 +27,7 @@ class LegacyFormSettingCompatibility {
 	/**
 	 * Map form template setting to form setting.
 	 *
-	 * Note: either this array will be empty of contain field id as key and legacy setting key as value grouped by group id.
+	 * Note: either this array will be empty or contain field id as key and legacy setting key as value grouped by group id.
 	 * For example:
 	 * [
 	 *    'introduction' => [
@@ -60,8 +60,9 @@ class LegacyFormSettingCompatibility {
 	/**
 	 * Save legacy settings.
 	 *
-	 * Note: This function must be called when saving donation form in WP Backed.
+	 * Note: we are using function internally to store legacy form settings when save form template setting.
 	 *
+	 * @see src/Helpers/Form/Theme/Theme.php:46  we are using this function in set function.
 	 * @param int   $formId
 	 * @param array $settings
 	 * @since 2.7.0

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -75,8 +75,8 @@ class LegacyFormSettingCompatibility {
 		}
 
 		if ( $remainingSettings = array_diff( array_keys( $this->defaultLegacySettingValues ), $alreadySavedLegacySettings ) ) {
-			foreach ( $remainingSettings as $metaKey => $metaValue ) {
-				Give()->form_meta->update( $formId, $metaKey, $metaKey );
+			foreach ( $remainingSettings as $metaKey ) {
+				Give()->form_meta->update_meta( $formId, $metaKey, $this->defaultLegacySettingValues[ $metaKey ] );
 			}
 		}
 	}

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -7,7 +7,7 @@ namespace Give\Form\Theme;
  * @since 2.7.0
  * @package Give\Form\Theme
  */
-abstract class LegacyFormSettingCompatibility {
+class LegacyFormSettingCompatibility {
 	/**
 	 * @var array $defaultSettings Form settings default values for form template.
 	 */
@@ -33,8 +33,20 @@ abstract class LegacyFormSettingCompatibility {
 	 *
 	 * @var array $mapToLegacySetting
 	 */
-	private $mapToLegacySetting = [];
+	private $mapToLegacySetting;
 
+	/**
+	 * LegacyFormSettingCompatibility constructor.
+	 *
+	 * @param array $mapToLegacySetting
+	 * @param array $defaultLegacySettingValues
+	 *
+	 * @since 2.7.0
+	 */
+	public function __construct( $mapToLegacySetting = [], $defaultLegacySettingValues = [] ) {
+		$this->mapToLegacySetting         = $mapToLegacySetting;
+		$this->defaultLegacySettingValues = array_merge( $this->defaultLegacySettingValues, $defaultLegacySettingValues );
+	}
 
 	/**
 	 * Save legacy settings.
@@ -45,7 +57,7 @@ abstract class LegacyFormSettingCompatibility {
 	 * @param array $settings
 	 * @since 2.7.0
 	 */
-	public function saveLegacySettings( $formId, $settings ) {
+	public function save( $formId, $settings ) {
 		$alreadySavedLegacySettings = [];
 
 		if ( $this->mapToLegacySetting ) {

--- a/src/Form/Theme/LegacyFormSettingCompatibility.php
+++ b/src/Form/Theme/LegacyFormSettingCompatibility.php
@@ -77,7 +77,7 @@ class LegacyFormSettingCompatibility {
 						continue;
 					}
 
-					Give()->form_meta->update( $formId, $legacySettingMetaKey, $settings[ $groupId ][ $fieldId ] );
+					Give()->form_meta->update_meta( $formId, $legacySettingMetaKey, $settings[ $groupId ][ $fieldId ] );
 					$alreadySavedLegacySettings[] = $legacySettingMetaKey;
 				}
 			}

--- a/src/Helpers/Form/Theme/Theme.php
+++ b/src/Helpers/Form/Theme/Theme.php
@@ -54,9 +54,10 @@ function set( $formId, $settings ) {
 	 *
 	 * Note: We can remove legacy setting compatibility by not extending LegacyFormSettingCompatibility class in Theme.
 	 */
-	/* @var Theme $themeObj */
-	if ( $isUpdated && ( ( $themeObj = Give()->themes->getTheme( $theme ) ) instanceof LegacyFormSettingCompatibility ) ) {
-		$themeObj->saveLegacySettings( $formId, $settings );
+	/* @var LegacyFormSettingCompatibility $legacySettingHandler */
+	$legacySettingHandler = Give()->themes->getTheme( $theme )->getLegacySettingHandler();
+	if ( $isUpdated && $legacySettingHandler instanceof LegacyFormSettingCompatibility ) {
+		$legacySettingHandler->save( $formId, $settings );
 	}
 
 	return $isUpdated;

--- a/src/Helpers/Form/Theme/Theme.php
+++ b/src/Helpers/Form/Theme/Theme.php
@@ -56,7 +56,7 @@ function set( $formId, $settings ) {
 	 */
 	/* @var LegacyFormSettingCompatibility $legacySettingHandler */
 	$legacySettingHandler = Give()->themes->getTheme( $theme )->getLegacySettingHandler();
-	if ( $isUpdated && $legacySettingHandler instanceof LegacyFormSettingCompatibility ) {
+	if ( $legacySettingHandler instanceof LegacyFormSettingCompatibility ) {
 		$legacySettingHandler->save( $formId, $settings );
 	}
 

--- a/src/Helpers/Form/Theme/Theme.php
+++ b/src/Helpers/Form/Theme/Theme.php
@@ -52,7 +52,7 @@ function set( $formId, $settings ) {
 	 * Below code save legacy setting which connected/mapped to form template setting.
 	 * Existing form render on basis of these settings if missed then required output will not generate from give_form_shortcode -> give_get_donation_form function.
 	 *
-	 * Note: We can remove legacy setting compatibility by not extending LegacyFormSettingCompatibility class in Theme.
+	 * Note: We can remove legacy setting compatibility by returning anything except LegacyFormSettingCompatibility class object.
 	 */
 	/* @var LegacyFormSettingCompatibility $legacySettingHandler */
 	$legacySettingHandler = Give()->themes->getTheme( $theme )->getLegacySettingHandler();

--- a/src/Views/Form/Themes/Legacy/Legacy.php
+++ b/src/Views/Form/Themes/Legacy/Legacy.php
@@ -4,6 +4,24 @@ namespace Give\Views\Form\Themes\Legacy;
 use Give\Form\Theme;
 
 class Legacy extends Theme {
+	/**
+	 * Map form template settings to legacy form settings.
+	 *
+	 * @since 2.7.0
+	 * @var array
+	 */
+	private $mapToLegacySetting = [
+		'display_settings' => [
+			'display_style'        => '_give_display_style',
+			'payment_display'      => '_give_payment_display',
+			'reveal_label'         => '_give_reveal_label',
+			'checkout_label'       => '_give_checkout_label',
+			'form_floating_labels' => '_give_form_floating_labels',
+			'display_content'      => '_give_display_content',
+			'content_placement'    => '_give_content_placement',
+			'form_content'         => '_give_form_content',
+		],
+	];
 
 	/**
 	 * @inheritDoc
@@ -31,5 +49,12 @@ class Legacy extends Theme {
 	 */
 	public function getOptionsConfig() {
 		return require 'optionConfig.php';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLegacySettingHandler() {
+		return new Theme\LegacyFormSettingCompatibility( $this->mapToLegacySetting );
 	}
 }

--- a/src/Views/Form/Themes/Legacy/Legacy.php
+++ b/src/Views/Form/Themes/Legacy/Legacy.php
@@ -5,12 +5,11 @@ use Give\Form\Theme;
 
 class Legacy extends Theme {
 	/**
-	 * Map form template settings to legacy form settings.
-	 *
+	 * @inheritDoc
 	 * @since 2.7.0
 	 * @var array
 	 */
-	private $mapToLegacySetting = [
+	protected $mapToLegacySetting = [
 		'display_settings' => [
 			'display_style'        => '_give_display_style',
 			'payment_display'      => '_give_payment_display',
@@ -49,12 +48,5 @@ class Legacy extends Theme {
 	 */
 	public function getOptionsConfig() {
 		return require 'optionConfig.php';
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getLegacySettingHandler() {
-		return new Theme\LegacyFormSettingCompatibility( $this->mapToLegacySetting );
 	}
 }

--- a/src/Views/Form/Themes/Sequoia/Actions.php
+++ b/src/Views/Form/Themes/Sequoia/Actions.php
@@ -41,7 +41,7 @@ class Actions {
 	}
 
 	/**
-	 * Hanlde cancel login and checkout register ajax request.
+	 * Handle cancel login and checkout register ajax request.
 	 *
 	 * @since 2.7.0
 	 * @return void

--- a/src/Views/Form/Themes/Sequoia/Actions.php
+++ b/src/Views/Form/Themes/Sequoia/Actions.php
@@ -47,7 +47,7 @@ class Actions {
 	 * @return void
 	 */
 	public function cancelLoginAjaxHanleder() {
-		//add_action( 'give_donation_form_before_personal_info', [ $this, 'getIntroductionSectionTextSubSection' ] );
+		// add_action( 'give_donation_form_before_personal_info', [ $this, 'getIntroductionSectionTextSubSection' ] );
 	}
 
 	/**
@@ -92,9 +92,6 @@ class Actions {
 
 		// Hide title.
 		add_filter( 'give_form_title', '__return_empty_string' );
-
-		// Override checkout button
-		add_filter( 'give_donation_form_submit_button', [ $this, 'getCheckoutButton' ] );
 	}
 
 	/**
@@ -143,24 +140,6 @@ class Actions {
 
 		printf(
 			'<div class="give-section"><button class="give-btn advance-btn">%1$s</button></div>',
-			$label
-		);
-	}
-
-	/**
-	 * Add checkout button
-	 *
-	 * @since 2.7.0
-	 */
-	public function getCheckoutButton() {
-
-		$label = isset( $this->themeOptions['payment_information']['checkout_label'] ) ? $this->themeOptions['payment_information']['checkout_label'] : __( 'Donate Now', 'give' );
-
-		return sprintf(
-			'<div class="give-submit-button-wrap give-clearfix">
-				<input type="submit" class="give-submit give-btn" id="give-purchase-button" name="give-purchase" value="%1$s" data-before-validation-label="Donate Now">
-				<span class="give-loading-animation"></span>
-			</div>',
 			$label
 		);
 	}

--- a/src/Views/Form/Themes/Sequoia/Sequoia.php
+++ b/src/Views/Form/Themes/Sequoia/Sequoia.php
@@ -18,7 +18,7 @@ class Sequoia extends Theme implements Hookable, Scriptable {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	private $mapToLegacySetting = [
+	protected $mapToLegacySetting = [
 		'payment_information' => [
 			'checkout_label' => '_give_checkout_label',
 		],
@@ -109,12 +109,5 @@ class Sequoia extends Theme implements Hookable, Scriptable {
 	 */
 	public function getOptionsConfig() {
 		return require 'optionConfig.php';
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getLegacySettingHandler() {
-		return new Theme\LegacyFormSettingCompatibility( $this->mapToLegacySetting );
 	}
 }

--- a/src/Views/Form/Themes/Sequoia/Sequoia.php
+++ b/src/Views/Form/Themes/Sequoia/Sequoia.php
@@ -12,6 +12,17 @@ use function Give\Helpers\Form\Theme\get as getThemeOptions;
  * @package Give\Form\Theme
  */
 class Sequoia extends Theme implements Hookable, Scriptable {
+	/**
+	 * Map form template settings to legacy form settings.
+	 *
+	 * @since 2.7.0
+	 * @var array
+	 */
+	private $mapToLegacySetting = [
+		'payment_information' => [
+			'checkout_label' => '_give_checkout_label',
+		],
+	];
 
 	/**
 	 * @inheritDoc
@@ -98,5 +109,12 @@ class Sequoia extends Theme implements Hookable, Scriptable {
 	 */
 	public function getOptionsConfig() {
 		return require 'optionConfig.php';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLegacySettingHandler() {
+		return new Theme\LegacyFormSettingCompatibility( $this->mapToLegacySetting );
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR will resolve #4608 

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr affect form setting saving functionality. As you know we move a few form display related settings to `Legacy` form template but these settings play a critical role in form rendering. That why we must need this setting.
As per the solution, I created a class `Give\Form\Theme\LegacyFormSettingCompatibility` which is accessible by any form template by `getLegacySettingHandler` function. This class responsible to store default setting values (depends upon form template setup) when update forms settings.
A developer can also map their settings to legacy form settings which means legacy form setting will change when value change for that specific form setting otherwise a default value will store.
We choose the default settings as per the `Sequoia` form template which can overwrite.

## What to test
Tests:
- Legacy Form Template: edit any `Form Display` will reflect in form.
- Sequoia Form Template: form renders as expected with defined default values of legacy form settings.  

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
