### PR TITLE
feature: do not render decimal places on 'choose amount' screen of Sequoia template

### DIFF
--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -46,9 +46,9 @@ function isProcessingForm() {
  * @return bool
  */
 function isProcessingGiveActionOnAjax() {
-	return isset( $_REQUEST['action'] ) &&
-		   wp_doing_ajax() &&
-		   0 === strpos( $_REQUEST['action'], 'give_' );
+	$action            = isset( $_REQUEST['action'] ) ? give_clean( $_REQUEST['action'] ) : '';
+	$whiteListedAction = [ 'get_receipt' ];
+	return $action && wp_doing_ajax() && ( 0 === strpos( $action, 'give_' ) || in_array( $action, $whiteListedAction, true ) );
 }
 
 

--- a/src/Views/Form/Themes/Sequoia/Actions.php
+++ b/src/Views/Form/Themes/Sequoia/Actions.php
@@ -28,6 +28,10 @@ class Actions {
 		// Get Theme options
 		$this->themeOptions = getTheme();
 
+		// Set zero number of decimal.
+		add_filter( 'give_sanitize_amount_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
+		add_filter( 'give_get_option_number_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
+
 		// Handle personal section html template.
 		add_action( 'wp_ajax_give_cancel_login', [ $this, 'cancelLoginAjaxHanleder' ], 9 );
 		add_action( 'wp_ajax_nopriv_give_cancel_login', [ $this, 'cancelLoginAjaxHanleder' ], 9 );
@@ -38,6 +42,19 @@ class Actions {
 
 		// Setup hooks.
 		add_action( 'give_pre_form_output', [ $this, 'loadHooks' ], 1, 3 );
+	}
+
+
+	/**
+	 * Return zero as number of decimals setting value or currency formatting value.
+	 *
+	 * As per design requirement we want to donation amount with zero decimal whether or not number of decimal admin setting set  to zero.
+	 *
+	 * @since 2.7.0
+	 * @return int
+	 */
+	public function setupZeroNumberOfDecimal() {
+		return 0;
 	}
 
 	/**

--- a/src/Views/Form/Themes/Sequoia/Actions.php
+++ b/src/Views/Form/Themes/Sequoia/Actions.php
@@ -29,7 +29,7 @@ class Actions {
 		$this->themeOptions = getTheme();
 
 		// Set zero number of decimal.
-		add_filter( 'give_sanitize_amount_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
+		add_filter( 'give_get_currency_formatting_settings', [ $this, 'setupZeroNumberOfDecimalInCurrencyFormattingSetting' ], 1 );
 		add_filter( 'give_get_option_number_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
 
 		// Handle personal section html template.
@@ -44,6 +44,20 @@ class Actions {
 		add_action( 'give_pre_form_output', [ $this, 'loadHooks' ], 1, 3 );
 	}
 
+	/**
+	 * Set zero as number of decimals in currency formatting setting.
+	 *
+	 * As per design requirement we want to donation amount with zero decimal whether or not number of decimal admin setting set  to zero.
+	 *
+	 * @since 2.7.0
+	 * @param array $currencyFormattingSettings
+	 * @return array
+	 */
+	public function setupZeroNumberOfDecimalInCurrencyFormattingSetting( $currencyFormattingSettings ) {
+		$currencyFormattingSettings['number_decimals'] = 0;
+		return $currencyFormattingSettings;
+	}
+
 
 	/**
 	 * Return zero as number of decimals setting value or currency formatting value.
@@ -51,7 +65,7 @@ class Actions {
 	 * As per design requirement we want to donation amount with zero decimal whether or not number of decimal admin setting set  to zero.
 	 *
 	 * @since 2.7.0
-	 * @return int
+	 * @return int|array
 	 */
 	public function setupZeroNumberOfDecimal() {
 		return 0;

--- a/src/Views/Form/Themes/Sequoia/Actions.php
+++ b/src/Views/Form/Themes/Sequoia/Actions.php
@@ -47,7 +47,7 @@ class Actions {
 	/**
 	 * Set zero as number of decimals in currency formatting setting.
 	 *
-	 * As per design requirement we want to donation amount with zero decimal whether or not number of decimal admin setting set  to zero.
+	 * As per design requirement we want to format donation amount with zero decimal whether or not number of decimal admin setting set to zero.
 	 *
 	 * @since 2.7.0
 	 * @param array $currencyFormattingSettings
@@ -62,7 +62,7 @@ class Actions {
 	/**
 	 * Return zero as number of decimals setting value or currency formatting value.
 	 *
-	 * As per design requirement we want to donation amount with zero decimal whether or not number of decimal admin setting set  to zero.
+	 * As per design requirement we want to format donation amount with zero decimal whether or not number of decimal admin setting set to zero.
 	 *
 	 * @since 2.7.0
 	 * @return int|array


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
As per design Sequoia form template requirement, we want o to impose zero number for decimal on the frontend. Following PR resolve issue by returning zero on filter hook of helper function which developers use in there an add-on to access number of decimal admin setting.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Change in PR will apply only to the frontend (because of template code loads in the frontend only) donation form only if it has a `Sequoia` form template or we are processing donation with this form or any ajax request on frontend related to this form.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
To test this PR, you can review a number of decimals apply to the amount in `Choose Amount` section on the donation form or amount on the receipt.
You can also test above mentioned item with `Fee Recovery` add-on.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/78402615-83c15680-7618-11ea-8747-3c074cdc61db.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
