### PR TITLE
feature: improved submit button loader

### DIFF
--- a/src/Views/Form/Themes/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Themes/Sequoia/assets/css/form.scss
@@ -506,10 +506,12 @@ p {
 			justify-content: center;
 			position: relative;
 
-			.give-loading-animation {
+			.sequoia-loader {
+				height: 30px;
+				width: 30px;
+				top: 64px;
 				position: absolute;
-				top: 0;
-				left: 50%;
+				font-size: 4px;
 			}
 		}
 	}
@@ -600,6 +602,29 @@ fieldset {
 		white-space: nowrap;
 		text-shadow: 0 -1px 0 #000;
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+	}
+}
+
+// Loader
+.sequoia-loader {
+	background-image: url("data:image/svg+xml;charset=utf8,%3C?xml version='1.0' encoding='utf-8'?%3E%3C!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0) --%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 349 348' style='enable-background:new 0 0 349 348;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0{fill:%23FFFFFF;} %3C/style%3E%3Cpath class='st0' d='M25.1,204.57c-13.38,0-24.47-10.6-24.97-24.08C0.04,178.09,0,175.97,0,174C0,77.78,78.28-0.5,174.5-0.5 c13.81,0,25,11.19,25,25s-11.19,25-25,25C105.85,49.5,50,105.35,50,174c0,1.37,0.03,2.85,0.1,4.65c0.51,13.8-10.27,25.39-24.07,25.9 C25.72,204.56,25.41,204.57,25.1,204.57z'/%3E%3Cpath class='st0' d='M174.5,348.5c-13.81,0-25-11.19-25-25c0-13.81,11.19-25,25-25c68.65,0,124.5-55.85,124.5-124.5 c0-1.38-0.03-2.85-0.1-4.65c-0.51-13.8,10.26-25.4,24.06-25.91c13.83-0.53,25.4,10.26,25.91,24.06c0.09,2.39,0.13,4.51,0.13,6.49 C349,270.22,270.72,348.5,174.5,348.5z'/%3E%3C/svg%3E");
+	pointer-events: none;
+	opacity: 0;
+
+	&.spinning {
+		opacity: 1;
+		transition: opacity 0.2s ease;
+		animation: load 0.6s linear infinite;
+	}
+}
+
+@keyframes load {
+	from {
+		transform: rotateZ(0deg);
+	}
+
+	to {
+		transform: rotateZ(180deg);
 	}
 }
 

--- a/src/Views/Form/Themes/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Themes/Sequoia/assets/js/form.js
@@ -141,6 +141,18 @@
 			showErrors: true,
 			setup: () => {
 				// Setup payment information screen
+
+				//Override submit loader with Sequoia loader
+				window.give_global_vars.purchase_loading = '';
+				$( '.give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
+
+				// Show Sequoia loader on click/touchend
+				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
+					$( 'form.give-form input[name="give-purchase"].give-submit' ).css( 'color', templateOptions.introduction.primary_color );
+					$( '.sequoia-loader' ).addClass( 'spinning' );
+				} );
+
+				//Setup input icons
 				setupInputIcon( '#give-first-name-wrap', 'user' );
 				setupInputIcon( '#give-email-wrap', 'envelope' );
 			},

--- a/src/Views/Form/Themes/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Themes/Sequoia/assets/js/form.js
@@ -148,7 +148,6 @@
 
 				// Show Sequoia loader on click/touchend
 				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
-					$( 'form.give-form input[name="give-purchase"].give-submit' ).css( 'color', templateOptions.introduction.primary_color );
 					$( '.sequoia-loader' ).addClass( 'spinning' );
 				} );
 

--- a/src/Views/Form/Themes/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Themes/Sequoia/assets/js/form.js
@@ -144,7 +144,7 @@
 
 				//Override submit loader with Sequoia loader
 				window.give_global_vars.purchase_loading = '';
-				$( '.give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
+				$( '.give-submit-button-wrap .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
 
 				// Show Sequoia loader on click/touchend
 				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {

--- a/src/Views/Form/Themes/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Themes/Sequoia/assets/js/form.js
@@ -142,13 +142,13 @@
 			setup: () => {
 				// Setup payment information screen
 
-				//Override submit loader with Sequoia loader
+				// Remove purchase_loading text
 				window.give_global_vars.purchase_loading = '';
-				$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
 
 				// Show Sequoia loader on click/touchend
 				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
-					$( '.sequoia-loader' ).addClass( 'spinning' );
+					//Override submit loader with Sequoia loader
+					$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader spinning' );
 				} );
 
 				//Setup input icons

--- a/src/Views/Form/Themes/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Themes/Sequoia/assets/js/form.js
@@ -144,7 +144,7 @@
 
 				//Override submit loader with Sequoia loader
 				window.give_global_vars.purchase_loading = '';
-				$( '.give-submit-button-wrap .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
+				$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
 
 				// Show Sequoia loader on click/touchend
 				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {


### PR DESCRIPTION
## Description
Resolves #4600 
This PR improved the submit button loading state by replacing the existing loading animation with a more modern, SVG rendered, in-button loader.

Previously, when the submit button was clicked, the button text would be replaced by "Please Wait", with a GIF spinner appearing next to the button. This PR replaces the GIF spinner with a modern looking SVG spinner that appears over the button (replacing the "Please Wait" text).

## Affects
The solution affects the Sequoia form assets (css and js) as it introduces the `sequoia-loader` css class, and defines specific styles for the sequoia loader within the submit wrapper. It also adds frontend scripting to override the existing Give loader, and prevent the "Please Wait" text from appearing.

## What to test
Test the payment information screen of the Sequoia form template. Does the new spinning loader appear in the appropriate place? Does the button text disappear under the spinner?

## Screenshots:
![SubmitLoaderGIF](https://user-images.githubusercontent.com/5186078/78818449-b06fc800-79a2-11ea-81d2-0c4fa4ebb39d.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
