### PR TITLE
feat: add support for becs direct debit payments for australia #4590

### DIFF
--- a/assets/src/js/admin/stripe-admin.js
+++ b/assets/src/js/admin/stripe-admin.js
@@ -23,6 +23,10 @@ window.addEventListener( 'DOMContentLoaded', function() {
 	const iconStyleElement = document.querySelector( '.stripe-icon-style' );
 	const hideMandateElements = Array.from( document.querySelectorAll( ' input[name="stripe_mandate_acceptance_option"]' ) );
 	const mandateElement = document.querySelector( '.stripe-mandate-acceptance-text' );
+	const hideBecsIconElements = Array.from( document.querySelectorAll( 'input[name="stripe_becs_hide_icon"]' ) );
+	const becsIconStyleElement = document.querySelector( '.stripe-becs-icon-style' );
+	const hideBecsMandateElements = Array.from( document.querySelectorAll( ' input[name="stripe_becs_mandate_acceptance_option"]' ) );
+	const mandateBecsElement = document.querySelector( '.stripe-becs-mandate-acceptance-text' );
 
 	giveStripeJsonFormattedTextarea( stripeStylesBase );
 	giveStripeJsonFormattedTextarea( stripeStylesEmpty );
@@ -53,6 +57,30 @@ window.addEventListener( 'DOMContentLoaded', function() {
 		} );
 	}
 
+	// For BECS Direct Debit.
+	if ( null !== hideBecsIconElements ) {
+		hideBecsIconElements.forEach( ( hideIconElement ) => {
+			hideIconElement.addEventListener( 'change', ( e ) => {
+				if ( 'enabled' === e.target.value ) {
+					becsIconStyleElement.classList.remove( 'give-hidden' );
+				} else {
+					becsIconStyleElement.classList.add( 'give-hidden' );
+				}
+			} );
+		} );
+	}
+	if ( null !== hideBecsMandateElements ) {
+		hideBecsMandateElements.forEach( ( hideIconElement ) => {
+			hideIconElement.addEventListener( 'change', ( e ) => {
+				if ( 'enabled' === e.target.value ) {
+					mandateBecsElement.classList.remove( 'give-hidden' );
+				} else {
+					mandateBecsElement.classList.add( 'give-hidden' );
+				}
+			} );
+		} );
+	}
+
 	if ( null !== stripeConnectedElement ) {
 		const stripeStatus = stripeConnectedElement.getAttribute( 'data-status' );
 		const redirectUrl = stripeConnectedElement.getAttribute( 'data-redirect-url' );
@@ -68,7 +96,7 @@ window.addEventListener( 'DOMContentLoaded', function() {
 					type: 'confirm',
 					modalContent: {
 						title: modalTitle,
-						desc: `<span>${modalFirstDetail}</span><span class="give-field-description">${modalSecondDetail}</span>`,
+						desc: `<span>${ modalFirstDetail }</span><span class="give-field-description">${ modalSecondDetail }</span>`,
 					},
 					successConfirm: function( args ) {
 						window.location.href = redirectUrl;

--- a/assets/src/js/frontend/give-stripe-becs.js
+++ b/assets/src/js/frontend/give-stripe-becs.js
@@ -184,8 +184,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			const iconStyle = becsElement.getAttribute( 'data-icon_style' );
 
 			bankAccountCreateArgs.iconStyle = iconStyle;
-			bankAccountCreateArgs.hideIcon = ( 'disabled' !== hideIcon );
-
+			bankAccountCreateArgs.hideIcon = ( 'disabled' === hideIcon );
 		}
 
 		const bankAccountElement = elements.create(

--- a/assets/src/js/frontend/give-stripe-becs.js
+++ b/assets/src/js/frontend/give-stripe-becs.js
@@ -1,0 +1,291 @@
+/**
+ * Give - Stripe Gateway Add-on JS
+ */
+let stripe = Stripe( give_stripe_vars.publishable_key );
+
+if ( give_stripe_vars.stripe_account_id ) {
+	stripe = Stripe( give_stripe_vars.publishable_key, {
+		stripeAccount: give_stripe_vars.stripe_account_id,
+	} );
+}
+
+document.addEventListener( 'DOMContentLoaded', function( e ) {
+	// Register Variables.
+	let card = {};
+	let bankAccountElements = [];
+	let defaultGateway = '';
+	const globalIbanElements = [];
+	let bankAccountElementSelectors = [];
+	const fontStyles = [];
+	const preferredLocale = give_stripe_vars.preferred_locale;
+	const formWraps = document.querySelectorAll( '.give-form-wrap' );
+	const fontIterator = Object.entries( give_stripe_vars.element_font_styles );
+
+	// Loop through each font element to convert its object to array.
+	for ( const fontElement of fontIterator ) {
+		fontStyles[ fontElement[ 0 ] ] = fontElement[ 1 ];
+	}
+
+	// Loop through the number of forms on the page.
+	Array.prototype.forEach.call( formWraps, function( formWrap ) {
+		const formElement = formWrap.querySelector( '.give-form' );
+
+		let elements = stripe.elements( {
+			locale: preferredLocale,
+		} );
+
+		// Update fonts of Stripe Elements.
+		if ( fontStyles.length > 0 ) {
+			elements = stripe.elements( {
+				fonts: fontStyles,
+				locale: preferredLocale,
+			} );
+		}
+
+		if ( null !== formElement.querySelector( '.give-gateway:checked' ).value ) {
+			defaultGateway = formElement.querySelector( '.give-gateway:checked' ).value;
+		}
+
+		const idPrefix = formElement.getAttribute( 'data-id' );
+		const donateButton = formElement.querySelector( '.give-submit' );
+
+		// Create IBAN Elements for each form.
+		bankAccountElements = giveStripePrepareIbanElements( formElement, elements, idPrefix );
+
+		bankAccountElementSelectors = [ '#give-stripe-becs-fields-' ];
+
+		// Prepare Card Elements for each form on a single page.
+		globalIbanElements[ idPrefix ] = [];
+
+		Array.prototype.forEach.call( bankAccountElementSelectors, function( selector, index ) {
+			globalIbanElements[ idPrefix ][ index ] = [];
+			globalIbanElements[ idPrefix ][ index ].item = bankAccountElements[ index ];
+			globalIbanElements[ idPrefix ][ index ].selector = selector;
+			globalIbanElements[ idPrefix ][ index ].isCardMounted = false;
+		} );
+
+		// Mount and Un-Mount Stripe CC Fields on gateway load.
+		jQuery( document ).on( 'give_gateway_loaded', function( event, xhr, settings ) {
+			// Un-mount card elements when stripe is not the selected gateway.
+			giveStripeUnmountIbanElements( globalIbanElements[ idPrefix ] );
+
+			if ( formElement.querySelector( '.give-gateway-option-selected .give-gateway' ).value === 'stripe_becs' ) {
+				// Mount card elements when stripe is the selected gateway.
+				giveStripeMountIbanElements( idPrefix, globalIbanElements[ idPrefix ] );
+			}
+		} );
+
+		// Mount Card Elements, if default gateway is Stripe SEPA.
+		if ( 'stripe_becs' === defaultGateway ) {
+			// Disabled the donate button of the form.
+			donateButton.setAttribute( 'disabled', 'disabled' );
+
+			giveStripeMountIbanElements( idPrefix, globalIbanElements[ idPrefix ] );
+
+			// Enable the donate button of the form after successful mounting of CC fields.
+			donateButton.removeAttribute( 'disabled' );
+		} else {
+			giveStripeUnmountIbanElements( bankAccountElements );
+		}
+	} );
+
+	// Process Donation using Stripe Elements on form submission.
+	jQuery( 'body' ).on( 'submit', '.give-form', function( event ) {
+		const $form = jQuery( this );
+		const $idPrefix = $form.find( 'input[name="give-form-id-prefix"]' ).val();
+
+		if ( 'stripe_becs' === $form.find( 'input.give-gateway:checked' ).val() ) {
+			give_stripe_process_becs_bank_account( $form, globalIbanElements[ $idPrefix ][ 0 ].item );
+			event.preventDefault();
+		}
+	} );
+
+	/**
+	 * Mount Card Elements
+	 *
+	 * @param {string} idPrefix     ID Prefix.
+	 * @param {array}  bankAccountElements List of card elements to be mounted.
+	 *
+	 * @since 1.6
+	 */
+	function giveStripeMountIbanElements( idPrefix, bankAccountElements = [] ) {
+		const bankAccountElementsLength = Object.keys( bankAccountElements ).length;
+
+		// Assign any card element to variable to create source.
+		if ( bankAccountElementsLength > 0 ) {
+			card = bankAccountElements[ 0 ].item;
+		}
+
+		// Mount required card elements.
+		Array.prototype.forEach.call( bankAccountElements, function( value, index ) {
+			if ( false === value.isCardMounted ) {
+				value.item.mount( value.selector + idPrefix );
+				value.isCardMounted = true;
+			}
+		} );
+	}
+
+	/**
+	 * Un-mount Card Elements
+	 *
+	 * @param {array} bankAccountElements List of card elements to be unmounted.
+	 *
+	 * @since 1.6
+	 */
+	function giveStripeUnmountIbanElements( bankAccountElements = [] ) {
+		// Un-mount required card elements.
+		Array.prototype.forEach.call( bankAccountElements, function( value, index ) {
+			if ( true === value.isCardMounted ) {
+				value.item.unmount();
+				value.isCardMounted = false;
+			}
+		} );
+	}
+
+	/**
+	 * Create required card elements.
+	 *
+	 * @param {object} formElement Form Element.
+	 * @param {object} elements     Stripe Element.
+	 * @param {string} idPrefix     ID Prefix.
+	 *
+	 * @since 1.6
+	 *
+	 * @return {array} elements
+	 */
+	function giveStripePrepareIbanElements( formElement, elements, idPrefix ) {
+		const prepareCardElements = [];
+		const baseStyles = give_stripe_vars.element_base_styles;
+		const completeStyles = give_stripe_vars.element_complete_styles;
+		const emptyStyles = give_stripe_vars.element_empty_styles;
+		const invalidStyles = give_stripe_vars.element_invalid_styles;
+		const becsElement = formElement.querySelector( '#give-stripe-becs-fields-' + idPrefix );
+
+		const elementStyles = {
+			base: baseStyles,
+			complete: completeStyles,
+			empty: emptyStyles,
+			invalid: invalidStyles,
+		};
+
+		const elementClasses = {
+			focus: 'focus',
+			empty: 'empty',
+			invalid: 'invalid',
+		};
+
+		const bankAccountCreateArgs = {
+			style: elementStyles,
+			classes: elementClasses,
+		};
+
+		if ( 'stripe_becs' === defaultGateway ) {
+			const hideIcon = becsElement.getAttribute( 'data-hide_icon' );
+			const iconStyle = becsElement.getAttribute( 'data-icon_style' );
+
+			bankAccountCreateArgs.iconStyle = iconStyle;
+			bankAccountCreateArgs.hideIcon = ( 'disabled' !== hideIcon );
+
+		}
+
+		const bankAccountElement = elements.create(
+			'auBankAccount',
+			bankAccountCreateArgs
+		);
+
+		prepareCardElements.push( bankAccountElement );
+
+		return prepareCardElements;
+	}
+
+	/**
+	 * Stripe Response Handler
+	 *
+	 * @see https://stripe.com/docs/tutorials/forms
+	 *
+	 * @param {object} $form    Form Object.
+	 * @param {object} response Response Object containing source.
+	 */
+	function give_stripe_response_handler( $form, response ) {
+		// Add Source to hidden field for form submission.
+		$form.find( 'input[name="give_stripe_payment_method"]' ).val( response.id );
+
+		// Submit the form.
+		$form.get( 0 ).submit();
+	}
+
+	/**
+	 * Stripe Process CC
+	 *
+	 * @param {object} $form Form Object.
+	 * @param {object} $iban IBAN Object.
+	 *
+	 * @returns {boolean} True or False.
+	 */
+	function give_stripe_process_becs_bank_account( $form, $iban ) {
+		const additionalData = {
+			billing_details: {
+				name: '',
+				email: '',
+			},
+		};
+		const $form_id = $form.find( 'input[name="give-form-id"]' ).val();
+		const $firstName = $form.find( 'input[name="give_first"]' ).val();
+		const $lastName = $form.find( 'input[name="give_last"]' ).val();
+		const $email = $form.find( 'input[name="give_email"]' ).val();
+		const $form_submit_btn = $form.find( '[id^=give-purchase-button]' );
+
+		// Disable the submit button to prevent repeated clicks.
+		$form.find( '[id^=give-purchase-button]' ).attr( 'disabled', 'disabled' );
+
+		additionalData.billing_details.name = $firstName + ' ' + $lastName;
+		additionalData.billing_details.email = $email;
+
+		// Gather additional customer data we may have collected in our form.
+		if ( give_stripe_vars.checkout_address && ! give_stripe_vars.stripe_card_update ) {
+			const address1 = $form.find( '.card-address' ).val();
+			const address2 = $form.find( '.card-address-2' ).val();
+			const city = $form.find( '.card-city' ).val();
+			const state = $form.find( '.card_state' ).val();
+			const zip = $form.find( '.card-zip' ).val();
+			const country = $form.find( '.billing-country' ).val();
+
+			additionalData.billing_details.address = {
+				line1: address1 ? address1 : '',
+				line2: address2 ? address2 : '',
+				city: city ? city : '',
+				state: state ? state : '',
+				postal_code: zip ? zip : '',
+				country: country ? country : '',
+			};
+		}
+
+		// createPaymentMethod returns immediately - the supplied callback submits the form if there are no errors.
+		stripe.createPaymentMethod( 'au_becs_debit', $iban, additionalData ).then( function( result ) {
+			if ( result.error ) {
+				const error = '<div class="give_errors"><p class="give_error">' + result.error.message + '</p></div>';
+
+				// re-enable the submit button.
+				$form_submit_btn.attr( 'disabled', false );
+
+				// Hide the loading animation.
+				jQuery( '.give-loading-animation' ).fadeOut();
+
+				// Display Error on the form.
+				$form.find( '[id^=give-stripe-payment-errors-' + $form_id + ']' ).html( error );
+
+				// Reset Donate Button.
+				if ( give_global_vars.complete_purchase ) {
+					$form_submit_btn.val( give_global_vars.complete_purchase );
+				} else {
+					$form_submit_btn.val( $form_submit_btn.data( 'before-validation-label' ) );
+				}
+			} else {
+				// Send payment method to server for processing payment.
+				give_stripe_response_handler( $form, result.paymentMethod );
+			}
+		} );
+
+		return false; // Submit from callback.
+	}
+} );

--- a/assets/src/js/frontend/give-stripe-becs.js
+++ b/assets/src/js/frontend/give-stripe-becs.js
@@ -75,8 +75,8 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			}
 		} );
 
-		// Mount Card Elements, if default gateway is Stripe SEPA.
-		if ( 'stripe_becs' === defaultGateway ) {
+		// Mount Card Elements, if default gateway is Stripe BECS.
+		if ( 'stripe_becs' === defaultGateway || give_stripe_vars.stripe_card_update ) {
 			// Disabled the donate button of the form.
 			donateButton.setAttribute( 'disabled', 'disabled' );
 
@@ -94,7 +94,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		const $form = jQuery( this );
 		const $idPrefix = $form.find( 'input[name="give-form-id-prefix"]' ).val();
 
-		if ( 'stripe_becs' === $form.find( 'input.give-gateway:checked' ).val() ) {
+		if ( 'stripe_becs' === $form.find( 'input.give-gateway:checked' ).val() || give_stripe_vars.stripe_card_update  ) {
 			give_stripe_process_becs_bank_account( $form, globalIbanElements[ $idPrefix ][ 0 ].item );
 			event.preventDefault();
 		}

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -211,6 +211,12 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 				'checkout_label' => __( 'SEPA Direct Debit', 'give' ),
 			);
 
+			// Stripe - BECS Direct Debit.
+			$gateways['stripe_becs'] = array(
+				'admin_label'    => __( 'Stripe - BECS Direct Debit', 'give' ),
+				'checkout_label' => __( 'BECS Direct Debit', 'give' ),
+			);
+
 			return $gateways;
 		}
 	}

--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -175,6 +175,7 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/payment-methods/class-give-stripe-checkout.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/payment-methods/class-give-stripe-sepa.php';
+			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php';
 
 			// Deprecations.
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/deprecated/deprecated-functions.php';

--- a/includes/gateways/stripe/includes/admin/admin-actions.php
+++ b/includes/gateways/stripe/includes/admin/admin-actions.php
@@ -364,6 +364,27 @@ function give_stripe_show_currency_notice() {
 		);
 	}
 
+	// Show Currency notice when Stripe BECS Payment Gateway is selected.
+	if (
+		current_user_can( 'manage_give_settings' ) &&
+		give_is_gateway_active( 'stripe_becs' ) &&
+		'AUD' !== give_get_currency() &&
+		! class_exists( 'Give_Currency_Switcher' ) // Disable Notice, if Currency Switcher add-on is enabled.
+	) {
+		Give()->notices->register_notice(
+			array(
+				'id'          => 'give-stripe-currency-notice',
+				'type'        => 'error',
+				'dismissible' => false,
+				'description' => sprintf(
+					__( 'The currency must be set as "AUD (&dollar;)" within Give\'s <a href="%s">Currency Settings</a> in order to collect donations through the Stripe - BECS Direct Debit Payment Gateway.', 'give' ),
+					admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=general&section=currency-settings' )
+				),
+				'show'        => true,
+			)
+		);
+	}
+
 }
 
 add_action( 'admin_notices', 'give_stripe_show_currency_notice' );

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -31,6 +31,7 @@ function give_stripe_supported_payment_methods() {
 		'stripe_apple_pay',
 		'stripe_checkout',
 		'stripe_sepa',
+		'stripe_becs',
 	];
 }
 

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -515,7 +515,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						'name'          => __( 'Mandate Acceptance Text', 'give' ),
 						'desc'          => __( 'This text displays below the Bank Account fields and should provide clarity to your donors on how this payment option works.', 'give' ),
 						'id'            => 'stripe_becs_mandate_acceptance_text',
-						'wrapper_class' => $is_hide_mandate ? 'stripe-mandate-acceptance-text' : 'stripe-mandate-acceptance-text give-hidden',
+						'wrapper_class' => $is_hide_mandate ? 'stripe-becs-mandate-acceptance-text' : 'stripe-becs-mandate-acceptance-text give-hidden',
 						'type'          => 'textarea',
 						'default'       => give_stripe_get_default_mandate_acceptance_text( 'becs' ),
 					);

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -112,6 +112,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 				'credit-card' => __( 'Credit Card On Site', 'give' ),
 				'checkout'    => __( 'Stripe Checkout', 'give' ),
 				'sepa'        => __( 'SEPA Direct Debit', 'give' ),
+				'becs'        => __( 'BECS Direct Debit', 'give' ),
 			);
 
 			return apply_filters( 'give_stripe_register_groups', $groups );
@@ -423,7 +424,6 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						),
 					);
 
-
 					$settings['sepa'][] = array(
 						'name'          => __( 'Display Mandate Acceptance', 'give' ),
 						'desc'          => __( 'The mandate acceptance text is meant to explain to your donors how the payment processing will work for their donation. The text will display below the IBAN field.', 'give' ),
@@ -459,6 +459,77 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 					// Stripe Admin Settings - Footer.
 					$settings['sepa'][] = array(
 						'id'   => 'give_title_stripe_sepa',
+						'type' => 'sectionend',
+					);
+
+					// BECS Direct Debit.
+					$settings['becs'][] = array(
+						'id'   => 'give_title_stripe_becs',
+						'type' => 'title',
+					);
+
+					$settings['becs'][] = array(
+						'name'          => __( 'Display Icon', 'give' ),
+						'desc'          => __( 'This option allows you to display a bank building icon within the bank account input field for BECS Direct Debit.', 'give' ),
+						'id'            => 'stripe_becs_hide_icon',
+						'wrapper_class' => 'stripe-becs-hide-icon',
+						'type'          => 'radio_inline',
+						'default'       => 'enabled',
+						'options'       => array(
+							'enabled'  => __( 'Enabled', 'give' ),
+							'disabled' => __( 'Disabled', 'give' ),
+						),
+					);
+
+					$is_becs_hide_icon = give_is_setting_enabled( give_get_option( 'stripe_becs_hide_icon', 'enabled' ) );
+
+					$settings['becs'][] = array(
+						'name'          => __( 'Icon Style', 'give' ),
+						'desc'          => __( 'This option allows you to select the icon style for the IBAN element of SEPA Direct Debit.', 'give' ),
+						'id'            => 'stripe_becs_icon_style',
+						'wrapper_class' => $is_becs_hide_icon ? 'stripe-becs-icon-style' : 'stripe-becs-icon-style give-hidden',
+						'type'          => 'radio_inline',
+						'default'       => 'default',
+						'options'       => array(
+							'default' => __( 'Default', 'give' ),
+							'solid'   => __( 'Solid', 'give' ),
+						),
+					);
+
+					$settings['becs'][] = array(
+						'name'          => __( 'Display Mandate Acceptance', 'give' ),
+						'desc'          => __( 'The mandate acceptance text is meant to explain to your donors how the payment processing will work for their donation. The text will display below the Bank Account fields.', 'give' ),
+						'id'            => 'stripe_becs_mandate_acceptance_option',
+						'wrapper_class' => 'stripe-becs-mandate-acceptance-option',
+						'type'          => 'radio_inline',
+						'default'       => 'enabled',
+						'options'       => array(
+							'enabled'  => __( 'Enabled', 'give' ),
+							'disabled' => __( 'Disabled', 'give' ),
+						),
+					);
+
+					$is_hide_mandate = give_is_setting_enabled( give_get_option( 'stripe_becs_mandate_acceptance_option', 'enabled' ) );
+
+					$settings['becs'][] = array(
+						'name'          => __( 'Mandate Acceptance Text', 'give' ),
+						'desc'          => __( 'This text displays below the Bank Account fields and should provide clarity to your donors on how this payment option works.', 'give' ),
+						'id'            => 'stripe_becs_mandate_acceptance_text',
+						'wrapper_class' => $is_hide_mandate ? 'stripe-mandate-acceptance-text' : 'stripe-mandate-acceptance-text give-hidden',
+						'type'          => 'textarea',
+						'default'       => give_stripe_get_default_mandate_acceptance_text( 'becs' ),
+					);
+
+					/**
+					 * This filter is used to add setting fields after BECS Direct Debit fields.
+					 *
+					 * @since 2.6.3
+					 */
+					$settings = apply_filters( 'give_stripe_after_becs_fields', $settings );
+
+					// Stripe Admin Settings - Footer.
+					$settings['becs'][] = array(
+						'id'   => 'give_title_stripe_becs',
 						'type' => 'sectionend',
 					);
 
@@ -648,7 +719,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							"<strong>{$site_url}?give-listener=stripe</strong>"
 						);
 						$modal_second_detail = __( 'Stripe webhooks are required so GiveWP can communicate properly with the payment gateway to confirm payment completion, renewals, and more.', 'give' );
-						$can_display = ! empty( $_GET['stripe_access_token'] ) ? '0' : '1';
+						$can_display         = ! empty( $_GET['stripe_access_token'] ) ? '0' : '1';
 						?>
 						<span
 							id="give-stripe-connect"

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1216,3 +1216,35 @@ function give_stripe_get_iban_icon_style( $form_id ) {
 function give_stripe_get_iban_placeholder_country() {
 	return apply_filters( 'give_stripe_get_iban_placeholder_country', 'DE' );
 }
+
+/**
+ * This helper function is used get stored value of whether we need to hide icon for Bank Account element or not.
+ *
+ * @param int $form_id Donation Form ID.
+ *
+ * @since 2.6.1
+ *
+ * @return string
+ */
+function give_stripe_becs_hide_icon( $form_id ) {
+
+	$hide_icon = give_get_option( 'stripe_becs_hide_icon', 'enabled' );
+
+	return apply_filters( 'give_stripe_becs_hide_icon', $hide_icon, $form_id );
+}
+
+/**
+ * This helper function is used get IBAN element icon style.
+ *
+ * @param int $form_id Donation Form ID.
+ *
+ * @since 2.6.1
+ *
+ * @return string
+ */
+function give_stripe_get_becs_icon_style( $form_id ) {
+
+	$icon_style = give_get_option( 'stripe_becs_icon_style', 'default' );
+
+	return apply_filters( 'give_stripe_get_becs_icon_style', $icon_style, $form_id );
+}

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1177,14 +1177,21 @@ function give_stripe_get_default_mandate_acceptance_text( $method = 'sepa' ) {
 /**
  * This function is used to get mandate acceptance text which is saved in admin.
  *
+ * @param string $method Type of Direct Debit method.
+ *
  * @since 2.6.1
  *
  * @return string
  */
-function give_stripe_get_mandate_acceptance_text() {
+function give_stripe_get_mandate_acceptance_text( $method = 'sepa' ) {
 
 	$default_text = give_stripe_get_default_mandate_acceptance_text();
 	$text         = give_get_option( 'stripe_mandate_acceptance_text', $default_text );
+
+	if ( 'becs' === $method ) {
+		$default_text = give_stripe_get_default_mandate_acceptance_text( 'becs' );
+		$text         = give_get_option( 'stripe_becs_mandate_acceptance_text', $default_text );
+	}
 
 	return apply_filters( 'give_stripe_get_mandate_acceptance_text', $text );
 }

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1148,15 +1148,30 @@ function give_stripe_is_update_payment_method_screen() {
 /**
  * This function will return the default mandate acceptance text.
  *
+ * @param string $method Type of Direct Debit Method.
+ *
  * @since 2.6.1
  *
  * @return string
  */
-function give_stripe_get_default_mandate_acceptance_text() {
-	return sprintf(
+function give_stripe_get_default_mandate_acceptance_text( $method = 'sepa' ) {
+
+	// For SEPA Direct Debit.
+	$mandate_acceptance_text = sprintf(
 		__( 'By providing your IBAN and confirming this payment, you are authorizing %1$s and Stripe, our payment service provider, to send instructions to your bank to debit your account and your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.', 'give' ),
 		get_bloginfo( 'sitename' )
 	);
+
+	if ( 'becs' === $method ) {
+		// For BECS Direct Debit.
+		$mandate_acceptance_text = sprintf(
+			__( 'By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the <a href="%1$s" target="_blank">Direct Debit Request service agreement</a>, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of %2$s (the “Merchant”) for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.', 'give' ),
+			esc_url_raw( 'https://stripe.com/au-becs-dd-service-agreement/legal' ),
+			get_bloginfo( 'sitename' )
+		);
+	}
+
+	return $mandate_acceptance_text;
 }
 
 /**

--- a/includes/gateways/stripe/includes/give-stripe-scripts.php
+++ b/includes/gateways/stripe/includes/give-stripe-scripts.php
@@ -101,6 +101,12 @@ function give_stripe_frontend_scripts() {
 		Give_Scripts::register_script( 'give-stripe-sepa', GIVE_PLUGIN_URL . 'assets/dist/js/give-stripe-sepa.js', array( 'give-stripe-js' ), GIVE_VERSION );
 		wp_enqueue_script( 'give-stripe-sepa' );
 	}
+
+	// Load Stripe BECS Direct Debit JS when the gateway is active.
+	if ( give_is_gateway_active( 'stripe_becs' ) ) {
+		Give_Scripts::register_script( 'give-stripe-becs', GIVE_PLUGIN_URL . 'assets/dist/js/give-stripe-becs.js', array( 'give-stripe-js' ), GIVE_VERSION );
+		wp_enqueue_script( 'give-stripe-becs' );
+	}
 }
 
 add_action( 'wp_enqueue_scripts', 'give_stripe_frontend_scripts' );

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'Give_Stripe_Becs' ) ) {
 
 			<fieldset id="give_cc_fields" class="give-do-validate">
 				<legend>
-					<?php esc_attr_e( 'IBAN Info', 'give' ); ?>
+					<?php esc_attr_e( 'Bank Account Info', 'give' ); ?>
 				</legend>
 
 				<?php

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * Give - Stripe BECS Direct Debit
+ *
+ * @package    Give
+ * @subpackage Stripe Core
+ * @copyright  Copyright (c) 2019, GiveWP
+ * @license    https://opensource.org/licenses/gpl-license GNU Public License
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Check for Give_Stripe_Becs existence.
+ *
+ * @since 2.6.3
+ */
+if ( ! class_exists( 'Give_Stripe_Becs' ) ) {
+
+	/**
+	 * Class Give_Stripe_Becs.
+	 *
+	 * @since 2.6.3
+	 */
+	class Give_Stripe_Becs extends Give_Stripe_Gateway {
+
+
+		/**
+		 * Give_Stripe_Becs constructor.
+		 *
+		 * @since  2.6.3
+		 * @access public
+		 */
+		public function __construct() {
+
+			$this->id = 'stripe_becs';
+
+			parent::__construct();
+
+			// Remove CC fieldset.
+			add_action( 'give_stripe_becs_cc_form', '__return_false' );
+
+			add_action( 'give_stripe_becs_cc_form', [ $this, 'add_mandate_form' ], 10, 3 );
+		}
+
+
+		/**
+		 * Stripe BECS uses it's own mandate form.
+		 *
+		 * We don't want the name attributes to be present on the fields in order to
+		 * prevent them from getting posted to the server.
+		 *
+		 * @param int  $form_id Donation Form ID.
+		 * @param int  $args    Donation Form Arguments.
+		 * @param bool $echo    Status to display or not.
+		 *
+		 * @access public
+		 * @since  2.6.3
+		 *
+		 * @return string $form
+		 */
+		public function add_mandate_form( $form_id, $args, $echo = true ) {
+
+			$id_prefix       = ! empty( $args['id_prefix'] ) ? $args['id_prefix'] : '';
+			$publishable_key = give_stripe_get_publishable_key();
+			$secret_key      = give_stripe_get_secret_key();
+
+			ob_start();
+
+			do_action( 'give_before_cc_fields', $form_id ); ?>
+
+			<fieldset id="give_cc_fields" class="give-do-validate">
+				<legend>
+					<?php esc_attr_e( 'IBAN Info', 'give' ); ?>
+				</legend>
+
+				<?php
+				if ( is_ssl() ) {
+					?>
+					<div id="give_secure_site_wrapper">
+						<span class="give-icon padlock"></span>
+						<span><?php esc_attr_e( 'This is a secure SSL encrypted payment.', 'give' ); ?></span>
+					</div>
+					<?php
+				}
+
+				if (
+					! is_ssl() &&
+					! give_is_test_mode() &&
+					(
+						empty( $publishable_key ) ||
+						empty( $secret_key )
+					)
+				) {
+					Give()->notices->print_frontend_notice(
+						sprintf(
+							'<strong>%1$s</strong> %2$s',
+							esc_html__( 'Notice:', 'give' ),
+							esc_html__( 'Mandate form fields are disabled because Stripe is not connected and your site is not running securely over HTTPS.', 'give' )
+						)
+					);
+				} elseif (
+					empty( $publishable_key ) ||
+					empty( $secret_key )
+				) {
+					Give()->notices->print_frontend_notice(
+						sprintf(
+							'<strong>%1$s</strong> %2$s',
+							esc_html__( 'Notice:', 'give' ),
+							esc_html__( 'Mandate form fields are disabled because Stripe is not connected.', 'give' )
+						)
+					);
+				} elseif ( ! is_ssl() && ! give_is_test_mode() ) {
+					Give()->notices->print_frontend_notice(
+						sprintf(
+							'<strong>%1$s</strong> %2$s',
+							esc_html__( 'Notice:', 'give' ),
+							esc_html__( 'Mandate form fields are disabled because your site is not running securely over HTTPS.', 'give' )
+						)
+					);
+				} else {
+					?>
+					<div id="give-bank-account-number-wrap" class="form-row form-row-responsive give-stripe-cc-field-wrap">
+						<label for="give-bank-account-number-field-<?php echo $id_prefix; ?>" class="give-label">
+							<?php echo __( 'Bank Account', 'give' ); ?>
+							<span class="give-required-indicator">*</span>
+							<span class="give-tooltip give-icon give-icon-question" data-tooltip="The (typically) 16 digits on the front of your credit card."></span>
+						</label>
+						<div
+							id="give-stripe-becs-fields-<?php echo $id_prefix; ?>"
+							class="give-stripe-becs-bank-account-field give-stripe-cc-field"
+							data-hide_icon="<?php echo give_stripe_becs_hide_icon( $form_id ); ?>"
+							data-icon_style="<?php echo give_stripe_get_becs_icon_style( $form_id ); ?>"
+						></div>
+					</div>
+					<div class="form-row form-row-responsive give-stripe-sepa-mandate-acceptance-text">
+						<?php
+						if ( give_is_setting_enabled( give_get_option( 'stripe_mandate_acceptance_option', 'enabled' ) ) ) {
+							echo give_stripe_get_mandate_acceptance_text();
+						}
+						?>
+					</div>
+					<?php
+					/**
+					 * This action hook is used to display content after the Credit Card expiration field.
+					 *
+					 * Note: Kept this hook as it is.
+					 *
+					 * @param int   $form_id Donation Form ID.
+					 * @param array $args    List of additional arguments.
+					 *
+					 * @since 2.5.0
+					 */
+					do_action( 'give_after_cc_expiration', $form_id, $args );
+
+					/**
+					 * This action hook is used to display content after the Credit Card expiration field.
+					 *
+					 * @param int   $form_id Donation Form ID.
+					 * @param array $args    List of additional arguments.
+					 *
+					 * @since 2.5.0
+					 */
+					do_action( 'give_stripe_after_cc_expiration', $form_id, $args );
+				}
+				?>
+			</fieldset>
+			<?php
+			// Remove Address Fields if user has option enabled.
+			$billing_fields_enabled = give_get_option( 'stripe_collect_billing' );
+			if ( ! $billing_fields_enabled ) {
+				remove_action( 'give_after_cc_fields', 'give_default_cc_address_fields' );
+			}
+
+			do_action( 'give_after_cc_fields', $form_id, $args );
+
+			$form = ob_get_clean();
+
+			if ( false !== $echo ) {
+				echo $form;
+			}
+
+			return $form;
+		}
+
+		/**
+		 * This function will be used for donation processing.
+		 *
+		 * @param array $donation_data List of donation data.
+		 *
+		 * @return void
+		 * @since  2.6.3
+		 * @access public
+		 */
+		public function process_payment( $donation_data ) {
+
+			// Bailout, if the current gateway and the posted gateway mismatched.
+			if ( $this->id !== $donation_data['post_data']['give-gateway'] ) {
+				return;
+			}
+
+			// Make sure we don't have any left over errors present.
+			give_clear_errors();
+
+			// Any errors?
+			$errors = give_get_errors();
+
+			// No errors, proceed.
+			if ( ! $errors ) {
+
+				$form_id          = ! empty( $donation_data['post_data']['give-form-id'] ) ? intval( $donation_data['post_data']['give-form-id'] ) : 0;
+				$price_id         = ! empty( $donation_data['post_data']['give-price-id'] ) ? $donation_data['post_data']['give-price-id'] : 0;
+				$donor_email      = ! empty( $donation_data['post_data']['give_email'] ) ? $donation_data['post_data']['give_email'] : 0;
+				$payment_method   = ! empty( $donation_data['post_data']['give_stripe_payment_method'] ) ? $donation_data['post_data']['give_stripe_payment_method'] : 0;
+				$donation_summary = give_payment_gateway_donation_summary( $donation_data, false );
+
+				// Get an existing Stripe customer or create a new Stripe Customer and attach the source to customer.
+				$give_stripe_customer = new Give_Stripe_Customer( $donor_email, $payment_method );
+				$stripe_customer_id   = $give_stripe_customer->get_id();
+				$payment_method_id    = ! empty( $give_stripe_customer->attached_payment_method ) ?
+					$give_stripe_customer->attached_payment_method->id :
+					$payment_method;
+
+				// We have a Stripe customer, charge them.
+				if ( $stripe_customer_id ) {
+
+					// Setup the payment details.
+					$payment_data = array(
+						'price'           => $donation_data['price'],
+						'give_form_title' => $donation_data['post_data']['give-form-title'],
+						'give_form_id'    => $form_id,
+						'give_price_id'   => $price_id,
+						'date'            => $donation_data['date'],
+						'user_email'      => $donation_data['user_email'],
+						'purchase_key'    => $donation_data['purchase_key'],
+						'currency'        => give_get_currency( $form_id ),
+						'user_info'       => $donation_data['user_info'],
+						'status'          => 'pending',
+						'gateway'         => $this->id,
+					);
+
+					// Record the pending payment in Give.
+					$donation_id = give_insert_payment( $payment_data );
+
+					// Return error, if donation id doesn't exists.
+					if ( ! $donation_id ) {
+						give_record_gateway_error(
+							__( 'Donation creating error', 'give' ),
+							sprintf(
+								/* translators: %s Donation Data */
+								__( 'Unable to create a pending donation. Details: %s', 'give' ),
+								wp_json_encode( $donation_data )
+							)
+						);
+						give_set_error( 'stripe_error', __( 'The Stripe Gateway returned an error while creating a pending donation.', 'give' ) );
+						give_send_back_to_checkout( '?payment-mode=' . give_clean( $_GET['payment-mode'] ) );
+
+						return;
+					}
+
+					// Assign required data to array of donation data for future reference.
+					$donation_data['donation_id'] = $donation_id;
+					$donation_data['description'] = $donation_summary;
+					$donation_data['customer_id'] = $stripe_customer_id;
+					$donation_data['source_id']   = $payment_method;
+
+					// Save Stripe Customer ID to Donation note, Donor and Donation for future reference.
+					give_insert_payment_note( $donation_id, 'Stripe Customer ID: ' . $stripe_customer_id );
+					$this->save_stripe_customer_id( $stripe_customer_id, $donation_id );
+					give_update_meta( $donation_id, '_give_stripe_customer_id', $stripe_customer_id );
+
+					// Save Source ID to donation note and DB.
+					give_insert_payment_note( $donation_id, 'Stripe Source/Payment Method ID: ' . $payment_method_id );
+					give_update_meta( $donation_id, '_give_stripe_source_id', $payment_method_id );
+					give_update_meta( $donation_id, '_give_stripe_payment_method_id', $payment_method_id );
+
+					// Save donation summary to donation.
+					give_update_meta( $donation_id, '_give_stripe_donation_summary', $donation_summary );
+
+					/**
+					 * This filter hook is used to update the payment intent arguments.
+					 *
+					 * @since 2.5.0
+					 */
+					$intent_args = apply_filters(
+						'give_stripe_create_intent_args',
+						array(
+							'amount'               => $this->format_amount( $donation_data['price'] ),
+							'currency'             => give_get_currency( $form_id ),
+							'payment_method_types' => [ 'au_becs_debit' ],
+							'statement_descriptor' => give_stripe_get_statement_descriptor(),
+							'description'          => give_payment_gateway_donation_summary( $donation_data ),
+							'metadata'             => $this->prepare_metadata( $donation_id ),
+							'customer'             => $stripe_customer_id,
+							'payment_method'       => $payment_method_id,
+							'confirm'              => true,
+							'setup_future_usage'   => 'off_session',
+							'mandate_data'         => [
+								'customer_acceptance' => [
+									'type'   => 'online',
+									'online' => [
+										'ip_address' => give_get_ip(),
+										'user_agent' => give_get_user_agent(),
+									],
+								],
+							],
+							'return_url'           => give_get_success_page_uri(),
+						)
+					);
+
+					// Send Stripe Receipt emails when enabled.
+					if ( give_is_setting_enabled( give_get_option( 'stripe_receipt_emails' ) ) ) {
+						$intent_args['receipt_email'] = $donation_data['user_email'];
+					}
+
+					$intent = $this->payment_intent->create( $intent_args );
+
+					if ( ! empty( $intent->status ) && 'processing' === $intent->status ) {
+
+						// Save Payment Intent Client Secret to donation note and DB.
+						give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );
+						give_update_meta( $donation_id, '_give_stripe_payment_intent_client_secret', $intent->client_secret );
+
+						// Set Payment Intent ID as transaction ID for the donation.
+						give_set_payment_transaction_id( $donation_id, $intent->id );
+						give_insert_payment_note( $donation_id, 'Stripe Charge/Payment Intent ID: ' . $intent->id );
+
+						// Success. Send user to success page.
+						give_send_to_success_page();
+					} else {
+						give_send_back_to_checkout( '?payment-mode=' . give_clean( $_GET['payment-mode'] ) );
+
+						return;
+					}
+
+					// Don't execute code further.
+					give_die();
+				}
+			}
+
+		}
+	}
+}
+
+new Give_Stripe_Becs();

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
@@ -136,10 +136,10 @@ if ( ! class_exists( 'Give_Stripe_Becs' ) ) {
 							data-icon_style="<?php echo give_stripe_get_becs_icon_style( $form_id ); ?>"
 						></div>
 					</div>
-					<div class="form-row form-row-responsive give-stripe-sepa-mandate-acceptance-text">
+					<div class="form-row form-row-responsive give-stripe-becs-mandate-acceptance-text">
 						<?php
-						if ( give_is_setting_enabled( give_get_option( 'stripe_mandate_acceptance_option', 'enabled' ) ) ) {
-							echo give_stripe_get_mandate_acceptance_text();
+						if ( give_is_setting_enabled( give_get_option( 'stripe_becs_mandate_acceptance_option', 'enabled' ) ) ) {
+							echo give_stripe_get_mandate_acceptance_text( 'becs' );
 						}
 						?>
 					</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const config = {
 		'give-stripe': [ './assets/src/js/frontend/give-stripe.js' ],
 		'give-stripe-checkout': [ './assets/src/js/frontend/give-stripe-checkout.js' ],
 		'give-stripe-sepa': [ './assets/src/js/frontend/give-stripe-sepa.js' ],
+		'give-stripe-becs': [ './assets/src/js/frontend/give-stripe-becs.js' ],
 		admin: [ './assets/src/css/admin/give-admin.scss', './assets/src/js/admin/admin.js' ],
 		'admin-global': [ './assets/src/css/admin/give-admin-global.scss' ],
 		'babel-polyfill': '@babel/polyfill',


### PR DESCRIPTION
## Description
This PR resolves #4590 

## Affects
This PR adds a feature to accept donation via Stripe BECS Direct Debit for Australia

## What to test
I have tested this feature by processing donation with manual API Keys with a Stripe account enabled for BECS Direct Debit.

## Screenshots:
**Admin Settings**
![image](https://user-images.githubusercontent.com/1852711/78893314-c6f04f00-7a88-11ea-9ba5-9ec607736beb.png)

**List of Payment Gateways in admin**
![image](https://user-images.githubusercontent.com/1852711/78893356-dc657900-7a88-11ea-846d-0c83b681e5dd.png)

 **Update Payment Method Screen for Recurring Donations**
![image](https://user-images.githubusercontent.com/1852711/78893406-ef784900-7a88-11ea-9f1e-6f27faa12e66.png)

**Donation Form Screen**
![image](https://user-images.githubusercontent.com/1852711/78893470-07e86380-7a89-11ea-867c-7e23005a30ec.png)

**Details stored under Donation Notes**
![image](https://user-images.githubusercontent.com/1852711/78893537-2189ab00-7a89-11ea-882b-c88d17b80a76.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
