### PR TITLE
feat: add form template view skin generator

### DIFF
--- a/src/TemplateSkinManager.php
+++ b/src/TemplateSkinManager.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Handle form template view skin.
+ *
+ * @package Give
+ */
+
+namespace Give;
+
+/**
+ * Class TemplateSkinManager
+ *
+ * @since 2.7.0
+ * @package Give
+ */
+class TemplateSkinManager {
+	/**
+	 * Document page title.
+	 *
+	 * This will be use to setup title tag.
+	 *
+	 * @since 2.7.0
+	 * @var string
+	 */
+	protected $title;
+
+	/**
+	 * Document page body.
+	 *
+	 * This will be use to setup content of body tag.
+	 *
+	 * @since 2.7.0
+	 * @var string
+	 */
+	protected $body;
+
+	/**
+	 * Body classes.
+	 *
+	 * This will be use to setup body tag classes.
+	 *
+	 * @since 2.7.0
+	 * @var array
+	 */
+	protected $bodyClasses = [ 'give-form-templates' ];
+
+	/**
+	 * Set document page title.
+	 *
+	 * @param string $title
+	 *
+	 * @return TemplateSkinManager $this
+	 */
+	public function setTitle( $title ) {
+		$this->title = $title;
+
+		return $this;
+	}
+
+	/**
+	 * Set document page title.
+	 *
+	 * @param string $body
+	 *
+	 * @return TemplateSkinManager $this
+	 */
+	public function setBody( $body ) {
+		$this->body = $body;
+
+		return $this;
+	}
+
+	/**
+	 * Set document page title.
+	 *
+	 * @param array $classes
+	 *
+	 * @return TemplateSkinManager $this
+	 */
+	public function setBodyClasses( $classes ) {
+		$this->bodyClasses = array_merge( $this->bodyClasses, (array) $classes );
+
+		return $this;
+	}
+
+
+	/**
+	 * Render view
+	 *
+	 * @since 2.7.0
+	 */
+	public function render() {
+		?>
+		<!DOCTYPE html>
+		<html <?php language_attributes(); ?>>
+			<head>
+				<meta charset="utf-8">
+				<title><?php echo apply_filters( 'the_title', $this->title ); ?></title>
+				<?php
+				/**
+				 * Fire the action hook in header
+				 */
+				do_action( 'give_embed_head' );
+				?>
+			</head>
+			<body class="<?php echo implode( ' ', $this->bodyClasses ); ?>">
+				<?php
+				echo $this->body;
+
+				/**
+				 * Fire the action hook in footer
+				 */
+				do_action( 'give_embed_footer' );
+				?>
+			</body>
+		</html>
+		<?php
+	}
+}

--- a/src/TemplateSkinManager.php
+++ b/src/TemplateSkinManager.php
@@ -85,7 +85,10 @@ class TemplateSkinManager {
 
 
 	/**
-	 * Render view
+	 * Render view.
+	 *
+	 * Note: if you want to overwrite this function then do not forget to add action hook in footer and header.
+	 * We use these hooks to manipulated donation form related actions.
 	 *
 	 * @since 2.7.0
 	 */

--- a/src/Views/Form/defaultFormDonationProcessing.php
+++ b/src/Views/Form/defaultFormDonationProcessing.php
@@ -4,9 +4,9 @@
  *
  * @since 2.7.0
  */
-use Give\TemplateSkinManager;
+use Give\IframeView;
 
-$tm = new TemplateSkinManager();
+$tm = new IframeView();
 
 $tm->setTitle( __( 'Donation Processing', 'give' ) )
 	->setBody( apply_filters( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ), '' ) )

--- a/src/Views/Form/defaultFormDonationProcessing.php
+++ b/src/Views/Form/defaultFormDonationProcessing.php
@@ -1,23 +1,13 @@
-<!DOCTYPE html>
-<html <?php language_attributes(); ?>  style="margin-top: 0 !important;">
-	<head>
-		<meta charset="utf-8">
-		<title><?php _e( 'Donation Processing', 'give' ); ?></title>
-		<?php
-		/**
-		 * Fire the action hook in header
-		 */
-		do_action( 'give_embed_head' );
-		?>
-	</head>
-	<body class="give-form-templates">
-		<?php
-		echo apply_filters( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ), '' );
+<?php
+/**
+ * Payment confirmation view.
+ *
+ * @since 2.7.0
+ */
+use Give\TemplateSkinManager;
 
-		/**
-		 * Fire the action hook in footer
-		 */
-		do_action( 'give_embed_footer' );
-		?>
-	</body>
-</html>
+$tm = new TemplateSkinManager();
+
+$tm->setTitle( __( 'Donation Processing', 'give' ) )
+	->setBody( apply_filters( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ), '' ) )
+	->render();

--- a/src/Views/Form/defaultFormDonationProcessing.php
+++ b/src/Views/Form/defaultFormDonationProcessing.php
@@ -4,10 +4,10 @@
  *
  * @since 2.7.0
  */
-use Give\IframeView;
+use Give\Views\IframeView;
 
-$tm = new IframeView();
+$iframeView = new IframeView();
 
-$tm->setTitle( __( 'Donation Processing', 'give' ) )
+echo $iframeView->setTitle( __( 'Donation Processing', 'give' ) )
 	->setBody( apply_filters( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ), '' ) )
 	->render();

--- a/src/Views/Form/defaultFormReceiptTemplate.php
+++ b/src/Views/Form/defaultFormReceiptTemplate.php
@@ -5,10 +5,10 @@
  * @since 2.7.0
  */
 use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
-use Give\IframeView;
+use Give\Views\IframeView;
 
-$tm = new IframeView();
+$iframeView = new IframeView();
 
-$tm->setTitle( __( 'Donation Receipt', 'give' ) )
+echo $iframeView->setTitle( __( 'Donation Receipt', 'give' ) )
    ->setBody( do_shortcode( getReceiptShortcodeFromConfirmationPage() ) )
    ->render();

--- a/src/Views/Form/defaultFormReceiptTemplate.php
+++ b/src/Views/Form/defaultFormReceiptTemplate.php
@@ -5,9 +5,9 @@
  * @since 2.7.0
  */
 use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
-use Give\TemplateSkinManager;
+use Give\IframeView;
 
-$tm = new TemplateSkinManager();
+$tm = new IframeView();
 
 $tm->setTitle( __( 'Donation Receipt', 'give' ) )
    ->setBody( do_shortcode( getReceiptShortcodeFromConfirmationPage() ) )

--- a/src/Views/Form/defaultFormReceiptTemplate.php
+++ b/src/Views/Form/defaultFormReceiptTemplate.php
@@ -1,27 +1,14 @@
 <?php
-
+/**
+ * Payment receipt view.
+ *
+ * @since 2.7.0
+ */
 use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
-?>
-<!DOCTYPE html>
-<html <?php language_attributes(); ?>  style="margin-top: 0 !important;">
-	<head>
-		<meta charset="utf-8">
-		<title><?php _e( 'Donation Receipt', 'give' ); ?></title>
-		<?php
-		/**
-		 * Fire the action hook in header
-		 */
-		do_action( 'give_embed_head' );
-		?>
-	</head>
-	<body class="give-form-templates">
-		<?php
-		echo do_shortcode( getReceiptShortcodeFromConfirmationPage() );
+use Give\TemplateSkinManager;
 
-		/**
-		 * Fire the action hook in footer
-		 */
-		do_action( 'give_embed_footer' );
-		?>
-	</body>
-</html>
+$tm = new TemplateSkinManager();
+
+$tm->setTitle( __( 'Donation Receipt', 'give' ) )
+   ->setBody( do_shortcode( getReceiptShortcodeFromConfirmationPage() ) )
+   ->render();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -4,11 +4,11 @@
  *
  * @since 2.7.0
  */
-use Give\TemplateSkinManager;
+use Give\IframeView;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
 $formId = getFormId();
-$tm     = new TemplateSkinManager();
+$tm     = new IframeView();
 
 // Fetch the Give Form.
 ob_start();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -4,16 +4,16 @@
  *
  * @since 2.7.0
  */
-use Give\IframeView;
+use Give\Views\IframeView;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
-$formId = getFormId();
-$tm     = new IframeView();
+$formId     = getFormId();
+$iframeView = new IframeView();
 
 // Fetch the Give Form.
 ob_start();
 give_get_donation_form( [ 'id' => $formId ] );
 
-$tm->setTitle( get_post_field( 'post_title', $formId ) )
+echo $iframeView->setTitle( get_post_field( 'post_title', $formId ) )
    ->setBody( ob_get_clean() )
    ->render();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -1,30 +1,19 @@
 <?php
+/**
+ * Donation form view.
+ *
+ * @since 2.7.0
+ */
+use Give\TemplateSkinManager;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
 $formId = getFormId();
-?>
-<!DOCTYPE html>
-<html <?php language_attributes(); ?>  style="margin-top: 0 !important;">
-	<head>
-		<meta charset="utf-8">
-		<title><?php echo apply_filters( 'the_title', get_post_field( 'post_title', $formId ) ); ?></title>
-		<?php
-		/**
-		 * Fire the action hook in header
-		 */
-		do_action( 'give_embed_head' );
-		?>
-	</head>
-	<body class="give-form-templates">
-		<?php
+$tm     = new TemplateSkinManager();
 
-		// Fetch the Give Form.
-		give_get_donation_form( [ 'id' => $formId ] );
+// Fetch the Give Form.
+ob_start();
+give_get_donation_form( [ 'id' => $formId ] );
 
-		/**
-		 * Fire the action hook in footer
-		 */
-		do_action( 'give_embed_footer' );
-		?>
-	</body>
-</html>
+$tm->setTitle( get_post_field( 'post_title', $formId ) )
+   ->setBody( ob_get_clean() )
+   ->render();

--- a/src/Views/Form/defaultRedirectHandlerTemplate.php
+++ b/src/Views/Form/defaultRedirectHandlerTemplate.php
@@ -4,7 +4,7 @@
  *
  * @since 2.7.0
  */
-use Give\IframeView;
+use Give\Views\IframeView;
 
 $bodyContent = sprintf(
 	'<p style="text-align: center">%1$s/p>
@@ -17,7 +17,7 @@ $bodyContent = sprintf(
 	esc_js( $location )
 );
 
-$tm = new IframeView();
-$tm->setTitle( __( 'Donation Processing...', 'give' ) )
+$iframeView = new IframeView();
+echo $iframeView->setTitle( __( 'Donation Processing...', 'give' ) )
    ->setBody( $bodyContent )
    ->render();

--- a/src/Views/Form/defaultRedirectHandlerTemplate.php
+++ b/src/Views/Form/defaultRedirectHandlerTemplate.php
@@ -4,7 +4,7 @@
  *
  * @since 2.7.0
  */
-use Give\TemplateSkinManager;
+use Give\IframeView;
 
 $bodyContent = sprintf(
 	'<p style="text-align: center">%1$s/p>
@@ -17,7 +17,7 @@ $bodyContent = sprintf(
 	esc_js( $location )
 );
 
-$tm = new TemplateSkinManager();
+$tm = new IframeView();
 $tm->setTitle( __( 'Donation Processing...', 'give' ) )
    ->setBody( $bodyContent )
    ->render();

--- a/src/Views/Form/defaultRedirectHandlerTemplate.php
+++ b/src/Views/Form/defaultRedirectHandlerTemplate.php
@@ -1,16 +1,23 @@
-<!doctype html>
-<html <?php language_attributes(); ?> >
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-		<meta http-equiv="X-UA-Compatible" content="ie=edge">
-		<title><?php _e( 'Donation Processing...', 'give' ); ?></title>
-	</head>
-	<body>
-		<p style="text-align: center"><?php _e( 'Processing...', 'give' ); ?></p>
-		<a style="font-size: 0" id="link" href="<?php echo esc_js( $location ); ?>" target="_parent"><?php _e( 'Link', 'give' ); ?></a>
+<?php
+/**
+ * Offsite payment gateway Iframe redirect handler view.
+ *
+ * @since 2.7.0
+ */
+use Give\TemplateSkinManager;
+
+$bodyContent = sprintf(
+	'<p style="text-align: center">%1$s/p>
+		<a style="font-size: 0" id="link" href="%3$s" target="_parent">%2$s</a>
 		<script>
-			document.getElementById( 'link' ).click();
-		</script>
-	</body>
-</html>
+			document.getElementById( \'link\' ).click();
+		</script>',
+	__( 'Processing...', 'give' ),
+	__( 'Link', 'give' ),
+	esc_js( $location )
+);
+
+$tm = new TemplateSkinManager();
+$tm->setTitle( __( 'Donation Processing...', 'give' ) )
+   ->setBody( $bodyContent )
+   ->render();

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -8,12 +8,12 @@
 namespace Give;
 
 /**
- * Class TemplateSkinManager
+ * Class IframeView
  *
  * @since 2.7.0
  * @package Give
  */
-class TemplateSkinManager {
+class IframeView {
 	/**
 	 * Document page title.
 	 *
@@ -49,7 +49,7 @@ class TemplateSkinManager {
 	 *
 	 * @param string $title
 	 *
-	 * @return TemplateSkinManager $this
+	 * @return IframeView $this
 	 */
 	public function setTitle( $title ) {
 		$this->title = $title;
@@ -62,7 +62,7 @@ class TemplateSkinManager {
 	 *
 	 * @param string $body
 	 *
-	 * @return TemplateSkinManager $this
+	 * @return IframeView $this
 	 */
 	public function setBody( $body ) {
 		$this->body = $body;
@@ -75,7 +75,7 @@ class TemplateSkinManager {
 	 *
 	 * @param array $classes
 	 *
-	 * @return TemplateSkinManager $this
+	 * @return IframeView $this
 	 */
 	public function setBodyClasses( $classes ) {
 		$this->bodyClasses = array_merge( $this->bodyClasses, (array) $classes );

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -5,7 +5,7 @@
  * @package Give
  */
 
-namespace Give;
+namespace Give\Views;
 
 /**
  * Class IframeView

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -93,6 +93,7 @@ class IframeView {
 	 * @since 2.7.0
 	 */
 	public function render() {
+		ob_start();
 		?>
 		<!DOCTYPE html>
 		<html <?php language_attributes(); ?>>
@@ -118,5 +119,6 @@ class IframeView {
 			</body>
 		</html>
 		<?php
+		return ob_get_clean();
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This patch does not fix any issue but renders provide a convenient way to generate a donation form view template and prevent code repetition. To solve it we added class `Give\TemplateSkinManager` with which you have set the necessary things on view and then render it.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This will require refactoring of existing default form template views.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
You can review donation form view like donation form view, receipt view, donation confirmation view, etc.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
