### PR TITLE
fix: save group type form template setting correctly.

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -1080,6 +1080,9 @@ class Give_MetaBox_Form_Data {
 					continue;
 				}
 
+				// Initialize $value for every field to prevent value type conflict.
+				$value = null;
+
 				switch ( $field->type ) {
 					case 'textarea':
 					case 'wysiwyg':
@@ -1091,6 +1094,7 @@ class Give_MetaBox_Form_Data {
 						break;
 
 					case 'group':
+						/* @var \Give\FormAPI\Form\Group $field */
 						foreach ( $options[ $group->id ][ $field->id ] as $index => $subFields ) {
 
 							// Do not save template input field values.
@@ -1101,7 +1105,7 @@ class Give_MetaBox_Form_Data {
 							$group_of_values = array();
 
 							foreach ( $subFields as $field_id => $field_value ) {
-								switch ( $field->getFormMetaboxFieldArguments()['fields'][ $field_id ]['type'] ) {
+								switch ( $field->getFieldArguments( $field_id )['type'] ) {
 									case 'wysiwyg':
 										$group_of_values[ $field_id ] = wp_kses_post( $field_value );
 										break;
@@ -1117,7 +1121,7 @@ class Give_MetaBox_Form_Data {
 						}
 
 						// Arrange repeater field keys in order.
-						$value = array_values( $value );
+						$value = $value ? array_values( $value ) : [];
 						break;
 
 					default:

--- a/src/FormAPI/Fields.php
+++ b/src/FormAPI/Fields.php
@@ -86,7 +86,7 @@ class Fields {
 		$array    = array_filter( $array ); // Remove empty values.
 
 		if ( array_diff( $required, array_keys( $array ) ) ) {
-			throw new InvalidArgumentException( __( 'To create a TextField object, please provide valid id, name and type.', 'give' ) );
+			throw new InvalidArgumentException( __( 'To create a Field object, please provide valid id, name and type.', 'give' ) );
 		}
 	}
 }

--- a/src/FormAPI/Fields.php
+++ b/src/FormAPI/Fields.php
@@ -9,6 +9,7 @@ use Give\FormAPI\Form\Radio;
 use Give\FormAPI\Form\Text;
 use Give\FormAPI\Form\Textarea;
 use Give\FormAPI\Form\Wysiwyg;
+use Give\FormAPI\Form\Group;
 
 class Fields {
 	/**
@@ -25,6 +26,7 @@ class Fields {
 		'radio'       => Radio::class,
 		'wysiwyg'     => Wysiwyg::class,
 		'colorpicker' => Colorpicker::class,
+		'group'       => Group::class,
 	];
 
 	/**

--- a/src/FormAPI/Form/Group.php
+++ b/src/FormAPI/Form/Group.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Give\FormAPI\Form;
+
+use http\Exception\InvalidArgumentException;
+
+class Group extends Field {
+	/**
+	 * Field options.
+	 * Note: Allow to update repeater aka group field frontend output.
+	 *
+	 * @since 2.7.0
+	 * @var array
+	 */
+	public $options = [];
+
+	/**
+	 * Sub fields
+	 *
+	 * Note: Allow developer to add sub fields to group.
+	 *
+	 * @since 2.7.0
+	 * @var array
+	 */
+	public $fields = [];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function parse( $array ) {
+		parent::parse( $array );
+
+		$defaultOptions = [
+			'header_title'    => esc_attr__( 'Group', 'give' ),
+			'add_button'      => esc_html__( 'Add Row', 'give' ),
+			'group_numbering' => 0,
+			'close_tabs'      => 0,
+		];
+
+		$this->options = isset( $array['options'] ) ?
+			array_merge( $defaultOptions, $array['options'] ) :
+			$defaultOptions;
+
+		$this->fields = isset( $array['fields'] ) ?
+			$array['fields'] :
+			[];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function toArray() {
+		return array_merge(
+			parent::toArray(),
+			[
+				'options' => $this->options,
+				'fields'  => $this->fields,
+			]
+		);
+	}
+
+
+	/**
+	 * Get sub fields.
+	 *
+	 * @since 2.7.0
+	 * @param string $fieldId
+	 * @return array
+	 */
+	public function getFieldArguments( $fieldId ) {
+		$field = current(
+			array_filter(
+				$this->fields,
+				static function( $field ) use ( $fieldId ) {
+					return $fieldId === $field['id'];
+				}
+			)
+		);
+
+		// Validate field.
+		if ( ! $field ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					__( 'Field with %1$s Id does not exist in group.', 'give' ),
+					$fieldId
+				)
+			);
+		}
+
+		return $field;
+	}
+}

--- a/src/FormAPI/Group.php
+++ b/src/FormAPI/Group.php
@@ -82,7 +82,7 @@ class Group {
 		$required = [ 'id', 'name', 'fields' ];
 
 		if ( array_diff( $required, array_keys( $array ) ) ) {
-			throw new InvalidArgumentException( __( 'To create a group object, please provide id, name and fields.', 'give' ) );
+			throw new InvalidArgumentException( __( 'To create a Group object, please provide id, name and fields.', 'give' ) );
 		}
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This patch will add a `Group` type field and fix logic to save the `group` type form template setting.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This PR will affect the form template saving logic.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
you can add a `group` type setting for form template which contains few fields. Save setting and review if it reflects in group settings or not.

```
[
				'id'            =>  'custom_setting',
				'name'          =>  'Custom Setting',
				'type'          => 'group',
				'options'       => array(
					'add_button'    => __( 'Add Level', 'give' ),
					'header_title'  => __( 'Donation Level', 'give' ),
					'remove_button' => '<span class="dashicons dashicons-no"></span>',
				),
				// Fields array works the same, except id's only need to be unique for this group.
				// Prefix is not needed.
				'fields'        => array(
					array(
						'name'       => __( 'Text', 'give' ),
						'id'         =>  'text',
						'type'       => 'text',
						'attributes' => array(
							'placeholder' => __( 'Donation Level', 'give' ),
							'class' => 'give-multilevel-text-field',
						),
					),
					array(
						'name' => __( 'Default', 'give' ),
						'id'   => 'default',
						'type' => 'radio_inline',
						'default' => 'disabled',
						'options' => [
							'enabled' => 'Enabled',
							'disabled' => 'Disabled'
						]
					),
					array(
						'name' => __( 'Select', 'give' ),
						'id'   => 'select',
						'type' => 'select',
						'default' => 'disabled',
						'options' => [
							'enabled' => 'Enabled',
							'disabled' => 'Disabled'
						]
					),
				)
			],
```

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
