### PR TITLE
feat: redirect donor `Add Your Information` section if any error occurred during donation processing

### DIFF
--- a/assets/src/js/plugins/form-template/parent-page.js
+++ b/assets/src/js/plugins/form-template/parent-page.js
@@ -7,46 +7,6 @@ jQuery( function( $ ) {
 		return false;
 	}
 
-	// Check if all iframe loaded. if yes, then trigger custom action.
-	document.onreadystatechange = () => {
-		if ( document.readyState !== 'complete' ) {
-			return false;
-		}
-
-		document.dispatchEvent(
-			new CustomEvent(
-				'Give:iframesLoaded',
-				{
-					detail:
-						{
-							give:
-								{
-									iframes: document.querySelectorAll( 'iframe[name="give-embed-form"]:not([data-src])' ),
-								},
-						},
-				}
-			)
-		);
-	};
-
-	/**
-	 * Auto scroll to donor's donation form
-	 *
-	 * @since 2.7
-	 */
-	document.addEventListener( 'Give:iframesLoaded', function( e ) {
-		const { iframes } = e.detail.give;
-
-		Array.from( iframes ).forEach( function( iframe ) {
-			if ( '1' === iframe.getAttribute( 'data-autoScroll' ) && ! iframe.classList.contains( 'in-modal' ) ) {
-				$( 'html, body' ).animate( { scrollTop: iframe.offsetTop, scrollLeft: iframe.offsetLeft } );
-
-				// Exit function.
-				return false;
-			}
-		} );
-	} );
-
 	/**
 	 * Show hide iframe modal.
 	 *

--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -21,12 +21,30 @@ export const initializeIframeResize = function( iframe ) {
 				switch ( messageData.message ) {
 					case 'giveEmbedFormContentLoaded':
 						let parent = iframe.parentElement;
+						const iframeToAutoScroll = document.querySelector( 'iframe[name="give-embed-form"][data-autoscroll="1"]:not(.in-modal)' );
 						if ( iframe.parentElement.classList.contains( 'modal-content' ) ) {
 							parent = parent.parentElement.parentElement;
 						}
 
 						parent.classList.remove( 'give-loader-type-img' );
 						iframe.style.visibility = 'visible';
+
+						// Attribute to dom when iframe loaded.
+						iframe.setAttribute( 'data-contentLoaded', '1' );
+
+						// Is there any iframe to auto scroll?
+						if ( iframeToAutoScroll ) {
+							// Scroll to latest iframe only if all iframe loaded.
+							const allIframesCount = document.querySelectorAll( 'iframe[name="give-embed-form"]:not(.in-modal)' ).length,
+								  allILoadedIframesCount = document.querySelectorAll( 'iframe[name="give-embed-form"][data-contentloaded="1"]:not(.in-modal)' ).length;
+
+							if ( allIframesCount === allILoadedIframesCount ) {
+								jQuery( 'html, body' ).animate( {
+									scrollTop: iframeToAutoScroll.offsetTop,
+									scrollLeft: iframeToAutoScroll.offsetLeft,
+								} );
+							}
+						}
 
 						break;
 				}

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -251,7 +251,7 @@ class Form {
 		$url    = explode( '?', $redirect, 2 );
 		$url[0] = Give()->routeForm->getURL( get_post_field( 'post_name', absint( $_REQUEST['give-form-id'] ) ) );
 
-		return implode( '?', $url );
+		return implode( '?showDonationProcessingError=1', $url );
 	}
 
 	/**

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -85,9 +85,7 @@
 				$( '.form-footer' ).css( 'margin-top', `${ height }px` );
 			} );
 
-			const isDonorRedirectedOnDonationError = Give.fn.getParameterByName( 'showDonationProcessingError' ) || Give.fn.getParameterByName( 'showFailedDonationError' );
-
-			navigator.goToStep( isDonorRedirectedOnDonationError ? 2 : 0 );
+			navigator.goToStep( getInitialStep() );
 		},
 		back: () => {
 			const prevStep = navigator.currentStep !== 0 ? navigator.currentStep - 1 : 0;
@@ -278,5 +276,15 @@
 			window.requestAnimationFrame( checkHeightChange );
 		}
 		window.requestAnimationFrame( checkHeightChange );
+	}
+
+	/**
+	 * Get initial step to show donor.
+	 *
+	 * @since 2.7.0
+	 * @return {number}
+	 */
+	function getInitialStep() {
+		return Give.fn.getParameterByName( 'showDonationProcessingError' ) || Give.fn.getParameterByName( 'showFailedDonationError' ) ? 2 : 0;
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -84,7 +84,10 @@
 				}
 				$( '.form-footer' ).css( 'margin-top', `${ height }px` );
 			} );
-			navigator.goToStep( 0 );
+
+			const isDonorRedirectedOnDonationError = Give.fn.getParameterByName( 'showDonationProcessingError' ) || Give.fn.getParameterByName( 'showFailedDonationError' );
+
+			navigator.goToStep( isDonorRedirectedOnDonationError ? 2 : 0 );
 		},
 		back: () => {
 			const prevStep = navigator.currentStep !== 0 ? navigator.currentStep - 1 : 0;


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This patch adds logic to automatically redirect the donor to the third step of the Sequoia form template when a donor gets an error during donation processing.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Since this change is related to the `Sequoia` form template that's why this patch will only affect redirects for this theme. I add `showDonationProcessingError` query parameter to detect donor checkout redirect on donation error. 

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
I tested this patch by manually calling `give_send_back_to_checkout` after ajax validation which redirects donor to donation form view. I also test this with Paypal standard by returning from Paypal standard checkout page without completing the donation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
