### PR TITLE
fix: fix alignment of admin .give-money-field inputs and their preceding currency symbols

### DIFF
--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -55,6 +55,7 @@ Forms CPT
 		width: 75px;
 		margin-right: 0;
 		margin-left: 0;
+		vertical-align: baseline;
 	}
 
 	.give-money-symbol {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11359,9 +11359,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
     "jquery-chosen": {
       "version": "1.1.0",
@@ -18520,9 +18520,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
     },
     "unherit": {
       "version": "1.1.3",


### PR DESCRIPTION
## Description

In the wp-admin, many text inputs inherit this style from the wp-admin core styles:
```
.meta-box-sortables input {
    vertical-align: middle;
}
```

There's often no issue, but with `.give-money-field` inputs (like the "donation amount" field in the Donation Form post type editor metabox), this creates an alignment issue with the money field's input and the currency symbol element that immediately precedes it.

**Changes:** By setting this input's `vertical-align` to `baseline`, we override that core style on this class of field specifically, which gets the input and its preceding currency symbol more pleasingly aligned

## Affects
- Text inputs of class `.give-money-field` in the wp-admin
- Example: "donation amount" field in the Donation Form post type editor metabox

## What to test
- "Donation amount" field on Donation Form post type editor in wp-admin, on stack of supported browser/operating system/WP Version/viewport size combinations

## Screenshots

### Before

| Chrome 80.0.3987.163 | Firefox 75.0 | Safari 13.1  |
| --- | --- | --- |
| ![chrome before](https://cldup.com/iy8aNtyeGv-3000x3000.png) | ![firefox before](https://cldup.com/pBQYBjvDX_-3000x3000.png) | ![safari before](https://cldup.com/lC28BO5KZk-3000x3000.png) |

**AFTER**
| Chrome 80.0.3987.163 | Firefox 75.0 | Safari 13.1  |
| --- | --- | --- |
| ![chrome after](https://cldup.com/nvsmaFqM2g-3000x3000.png) | ![firefox after](https://cldup.com/Fn44mPx523-3000x3000.png) | ![safari after](https://cldup.com/7GubGr0YYl-3000x3000.png) |

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
