### PR TITLE
fix: prevent redirect to new reports dashboard on legacy filtering

### DIFF
--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -809,7 +809,7 @@ function give_parse_report_dates( $data ) {
 	$tab  = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'earnings';
 	$id   = isset( $_GET['form-id'] ) ? $_GET['form-id'] : null;
 
-	wp_redirect( add_query_arg( $dates, admin_url( 'edit.php?post_type=give_forms&page=give-reports&tab=' . esc_attr( $tab ) . '&view=' . esc_attr( $view ) . '&form-id=' . absint( $id ) ) ) );
+	wp_redirect( add_query_arg( $dates, admin_url( 'edit.php?post_type=give_forms&page=give-reports&legacy=true&tab=' . esc_attr( $tab ) . '&view=' . esc_attr( $view ) . '&form-id=' . absint( $id ) ) ) );
 	give_die();
 }
 


### PR DESCRIPTION
## Description
Resolves #4644 
This PR introduces a patch for an issue first found in GiveWP 2.6.3. When a user attempted to filter data by time period on the legacy reports page, they were redirected to the new reports dashboard. This PR resolves this issue by adding the "legacy=true" URL parameter to the redirect performed in the give_parse_report_datas() function.

## Affects
This PR affects the legacy reports graphing logic, by ensuring that when filtering from the legacy reports page, the redirect is flagged with the "legacy=true" URL parameter.

## What to test
Try filtering by time periods on the legacy reports page. Are you redirected to the new reports dashboard? Are you presented with data from the expected time period?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/79271718-46599600-7e6e-11ea-8404-13b4b1d84286.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
