### PR TITLE
fix: prevent blank space beneath initial step of Sequoia template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -176,6 +176,13 @@ p {
 	width: 100%;
 	position: absolute;
 	z-index: 99;
+	transition: transform 0.2s ease;
+	transform: translate3d(0, -50px, 0);
+
+	&.nav-visible {
+		transform: translate3d(0, 0, 0);
+		transition-delay: 0.15s;
+	}
 
 	> .back-btn {
 		padding: 0 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -62,6 +62,7 @@ p {
 	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
 	width: 100%;
 	overflow: hidden;
+	position: relative;
 }
 
 // Buttons
@@ -172,7 +173,9 @@ p {
 	background: #fbfbfb;
 	border-bottom: 1px solid #f2f2f2;
 	height: 50px;
-	position: relative;
+	width: 100%;
+	position: absolute;
+	z-index: 99;
 
 	> .back-btn {
 		padding: 0 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -31,8 +31,10 @@
 				}
 			} else if ( step === 0 ) {
 				$( '.give-form-navigator', $container ).hide();
+				$( steps[ step ].selector ).css( 'padding-top', '' );
 			} else {
 				$( '.give-form-navigator', $container ).show();
+				$( steps[ step ].selector ).css( 'padding-top', '50px' );
 			}
 
 			$navigatorTitle.text( steps[ step ].title );
@@ -76,7 +78,7 @@
 				navigator.goToStep( parseInt( $( e.target ).attr( 'data-step' ) ) );
 			} );
 			setupHeightChangeCallback( function( height, diff ) {
-				if ( diff > 10 ) {
+				if ( diff > 5 ) {
 					$( '.form-footer' ).css( 'transition', 'margin-top 0.2s ease' );
 				} else {
 					$( '.form-footer' ).css( 'transition', '' );
@@ -305,11 +307,11 @@
 		let lastHeight = 0;
 		function checkHeightChange() {
 			const selector = $( steps[ navigator.currentStep ].selector );
-			const changed = lastHeight !== $( selector ).height();
+			const changed = lastHeight !== $( selector ).outerHeight();
 			if ( changed ) {
-				const diff = lastHeight > $( selector ).height() ? lastHeight - $( selector ).height() : $( selector ).height() - lastHeight;
-				callback( $( selector ).height(), diff );
-				lastHeight = $( selector ).height();
+				const diff = lastHeight > $( selector ).outerHeight() ? lastHeight - $( selector ).outerHeight() : $( selector ).outerHeight() - lastHeight;
+				callback( $( selector ).outerHeight(), diff );
+				lastHeight = $( selector ).outerHeight();
 			}
 			window.requestAnimationFrame( checkHeightChange );
 		}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -5,6 +5,7 @@
 	const $advanceButton = $( '.advance-btn', $container );
 	const $backButton = $( '.back-btn' );
 	const $navigatorTitle = $( '.give-form-navigator .title' );
+	let gatewayAnimating = false;
 
 	const navigator = {
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
@@ -96,8 +97,8 @@
 				e.preventDefault();
 				navigator.goToStep( parseInt( $( e.target ).attr( 'data-step' ) ) );
 			} );
-			setupHeightChangeCallback( function( height, diff ) {
-				if ( diff > 4 ) {
+			setupHeightChangeCallback( function( height ) {
+				if ( gatewayAnimating === false ) {
 					$( '.form-footer' ).css( 'transition', 'margin-top 0.2s ease' );
 				} else {
 					$( '.form-footer' ).css( 'transition', '' );
@@ -241,11 +242,13 @@
 			// eslint-disable-next-line no-unused-expressions
 			setupInputIcon( '#give-card-country-wrap', 'globe-americas' );
 
-			// eslint-disable-next-line no-unused-expressions
-			showFields && jQuery( '.give_purchase_form_wrap-clone' ).slideDown( 300, function() {
-				const height = $( '.payment' ).height();
-				$( '.form-footer' ).css( 'margin-top', `${ height }px` );
-			} );
+			if ( showFields ) {
+				gatewayAnimating = true;
+				// eslint-disable-next-line no-unused-expressions
+				jQuery( '.give_purchase_form_wrap-clone' ).slideDown( 300, function() {
+					gatewayAnimating = false;
+				} );
+			}
 		} );
 	}
 
@@ -327,8 +330,7 @@
 			const selector = $( steps[ navigator.currentStep ].selector );
 			const changed = lastHeight !== $( selector ).outerHeight();
 			if ( changed ) {
-				const diff = lastHeight > $( selector ).outerHeight() ? lastHeight - $( selector ).outerHeight() : $( selector ).outerHeight() - lastHeight;
-				callback( $( selector ).outerHeight(), diff );
+				callback( $( selector ).outerHeight() );
 				lastHeight = $( selector ).outerHeight();
 			}
 			window.requestAnimationFrame( checkHeightChange );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -19,6 +19,10 @@
 			$( '.step-tracker' ).removeClass( 'current' );
 			$( '.step-tracker[data-step="' + step + '"]' ).addClass( 'current' );
 
+			if ( steps[ step ].title ) {
+				$navigatorTitle.text( steps[ step ].title );
+			}
+
 			if ( templateOptions.introduction.enabled === 'disabled' ) {
 				if ( $( '.step-tracker' ).length === 3 ) {
 					$( '.step-tracker:first-of-type' ).remove();
@@ -30,14 +34,12 @@
 					$( '.back-btn', $container ).show();
 				}
 			} else if ( step === 0 ) {
-				$( '.give-form-navigator', $container ).hide();
+				$( '.give-form-navigator', $container ).removeClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '' );
 			} else {
-				$( '.give-form-navigator', $container ).show();
+				$( '.give-form-navigator', $container ).addClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '50px' );
 			}
-
-			$navigatorTitle.text( steps[ step ].title );
 
 			const hide = steps.map( ( obj, index ) => {
 				if ( index === step || index === navigator.currentStep ) {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -53,8 +53,6 @@
 				const inDirection = navigator.currentStep < step ? 'right' : 'left';
 				$( steps[ navigator.currentStep ].selector ).removeClass( directionClasses ).addClass( `slide-out-${ outDirection }` );
 				$( steps[ step ].selector ).show().removeClass( directionClasses ).addClass( `slide-in-${ inDirection }` );
-			} else {
-				$( steps[ navigator.currentStep ].selector ).css( 'position', 'absolute' );
 			}
 			navigator.currentStep = step;
 		},
@@ -63,6 +61,7 @@
 				if ( step.setup !== undefined ) {
 					step.setup();
 				}
+				$( step.selector ).css( 'position', 'absolute' );
 			} );
 			$advanceButton.on( 'click', function( e ) {
 				e.preventDefault();

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -19,26 +19,30 @@
 			$( '.step-tracker' ).removeClass( 'current' );
 			$( '.step-tracker[data-step="' + step + '"]' ).addClass( 'current' );
 
-			if ( steps[ step ].title ) {
-				$navigatorTitle.text( steps[ step ].title );
-			}
-
 			if ( templateOptions.introduction.enabled === 'disabled' ) {
 				if ( $( '.step-tracker' ).length === 3 ) {
-					$( '.step-tracker:first-of-type' ).remove();
+					$( '.step-tracker' ).remove();
 				}
+
 				step = step > 0 ? step : 1;
 				if ( step === 1 ) {
 					$( '.back-btn', $container ).hide();
 				} else {
 					$( '.back-btn', $container ).show();
 				}
+
+				$( '.give-form-navigator', $container ).addClass( 'nav-visible' );
+				$( steps[ step ].selector ).css( 'padding-top', '50px' );
 			} else if ( step === 0 ) {
 				$( '.give-form-navigator', $container ).removeClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '' );
 			} else {
 				$( '.give-form-navigator', $container ).addClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '50px' );
+			}
+
+			if ( steps[ step ].title ) {
+				$navigatorTitle.text( steps[ step ].title );
 			}
 
 			const hide = steps.map( ( obj, index ) => {


### PR DESCRIPTION
## Description
Resolves #4648 
This PR resolves a long standing bug with the Sequoia template where the initial step would load with a large blank space beneath it (before the "Donate Now" button. This PR also introduces some other improvements to how the Sequoia template handles animating between steps (specifically around how the navigator/header area animates in/impacts other form elements).

## Affects
The impacts of this PR are limited to the Sequoia template assets.

## What to test
Try loading the Sequoia form template on the frontend, dos a large blank space appear beneath the initial step? Does the form animate from step to step smoothly, without quick jumps when the navigator/header section first appears? Does the navigator/header section slide in/out smoothly?

## Screenshots:
![PRDemoShort](https://user-images.githubusercontent.com/5186078/79602710-01756f80-80b9-11ea-9153-35674256b5a2.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
