### PR TITLE
fix: prevent choppy iframe resizing

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -80,7 +80,7 @@
 				navigator.goToStep( parseInt( $( e.target ).attr( 'data-step' ) ) );
 			} );
 			setupHeightChangeCallback( function( height, diff ) {
-				if ( diff > 10 ) {
+				if ( diff > 4 ) {
 					$( '.form-footer' ).css( 'transition', 'margin-top 0.2s ease' );
 				} else {
 					$( '.form-footer' ).css( 'transition', '' );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -10,6 +10,9 @@
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
 		animating: false,
 		goToStep: ( step ) => {
+			const stepHeight = $( steps[ step ].selector ).outerHeight() + 123;
+			$( '.give-form-templates' ).css( 'min-height', `${ stepHeight }px` );
+
 			if ( steps[ step ].showErrors === true ) {
 				$( '.give_error, .give_warning, .give_success', '.give-form-wrap' ).show();
 			} else {
@@ -84,7 +87,6 @@
 				}
 				$( '.form-footer' ).css( 'margin-top', `${ height }px` );
 			} );
-
 			navigator.goToStep( getInitialStep() );
 		},
 		back: () => {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -10,8 +10,15 @@
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
 		animating: false,
 		goToStep: ( step ) => {
-			const stepHeight = $( steps[ step ].selector ).outerHeight() + 123;
-			$( '.give-form-templates' ).css( 'min-height', `${ stepHeight }px` );
+			const nextStepHeight = steps[ step ].title ? $( steps[ step ].selector ).height() + 50 : $( steps[ step ].selector ).height();
+			const currentStepHeight = steps[ navigator.currentStep ].title ? $( steps[ navigator.currentStep ].selector ).height() + 50 : $( steps[ navigator.currentStep ].selector ).height();
+			if ( nextStepHeight > currentStepHeight ) {
+				$( '.give-form-templates' ).css( 'min-height', `${ nextStepHeight + 123 }px` );
+			} else {
+				setTimeout( function() {
+					$( '.give-form-templates' ).css( 'min-height', `${ nextStepHeight + 123 }px` );
+				}, 200 );
+			}
 
 			if ( steps[ step ].showErrors === true ) {
 				$( '.give_error, .give_warning, .give_success', '.give-form-wrap' ).show();

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -10,11 +10,14 @@
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
 		animating: false,
 		goToStep: ( step ) => {
+			// Adjust body height before animating step, to prevent choppy iframe resizing
+			// Compare next step to current step, and increase body height if next step is taller.
 			const nextStepHeight = steps[ step ].title ? $( steps[ step ].selector ).height() + 50 : $( steps[ step ].selector ).height();
 			const currentStepHeight = steps[ navigator.currentStep ].title ? $( steps[ navigator.currentStep ].selector ).height() + 50 : $( steps[ navigator.currentStep ].selector ).height();
 			if ( nextStepHeight > currentStepHeight ) {
 				$( '.give-form-templates' ).css( 'min-height', `${ nextStepHeight + 123 }px` );
 			} else {
+				// Delay setting body height if next step is shorter than current step
 				setTimeout( function() {
 					$( '.give-form-templates' ).css( 'min-height', `${ nextStepHeight + 123 }px` );
 				}, 200 );


### PR DESCRIPTION
## Description
Resolves #4616 
This PR introduces frontend logic to the Sequoia template to ensure that transitions in height appear smooth, and iframe resizing does not appear choppy.

While researching the solution, it became apparent that iframe-resizer as a library would struggle to handle animation/transitions in height of the iframe's body element. With this in mind, the solution presented here simply compares the height of the current step to the next step, and if the height of the next step is greater, instantly increases the body min-height to accommodate the transition that accompanies the change in step height. If the next step is shorter, the body height is only adjusted after the transition is completed (200 milliseconds).

## Affects
This PR only touches the Sequoia frontend assets, specifically form.js. 

## What to test
Test the animation between steps 2 and 3 of the Sequoia template. Does the iframe change in height in a predictable way, allowing the form to transition in height smoothly? The choppiness that persists between steps 1 and 2 is related to a different issue (involving the navigator area/header) and is being dealt with in a different PR (see: https://github.com/impress-org/givewp/pull/4651).

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/79762708-189ea200-82f1-11ea-88ba-3a5c632d1013.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
