### PR TITLE
feature: Sequoia social sharing links now prompt users to share

### DIFF
--- a/assets/src/js/frontend/give.js
+++ b/assets/src/js/frontend/give.js
@@ -20,6 +20,6 @@ import './give-donor-wall';
 import iFrameResizer from '../plugins/form-template/iframe-content';
 import '../plugins/form-template/parent-page';
 
-const { init, fn, form, notice, cache, donor, util } = GiveAPI;
-window.Give = { init, fn, form, notice, cache, donor, util, initializeIframeResize };
+const { init, fn, form, notice, cache, donor, util, share } = GiveAPI;
+window.Give = { init, fn, form, notice, cache, donor, util, share, initializeIframeResize };
 window.iFrameResizer = iFrameResizer;

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -335,17 +335,17 @@ const Give = {
 
 Give.share = {
 	fn: {
-		twitter: function twitter (url, text) {
+		twitter: function twitter( url, text ) {
 			const targetWindow = parent.window ? parent.window : window;
 			// Calculate new window position, based on parent window height/width
 			const top = targetWindow.innerHeight / 2 - 126;
 			const left = targetWindow.innerWidth / 2 - 280;
 			// Open new window with prompt for Twitter sharing
-			targetWindow.open(`https://twitter.com/intent/tweet?url=${url}&text=${text}`, 'newwindow', `width=560,height=253,top=${top},left=${left}`); 
+			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
 			return false;
-		}
-	}
-}
+		},
+	},
+};
 
 Give.notice = GiveNotice;
 Give.form = GiveForm;

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -333,6 +333,20 @@ const Give = {
 	cache: {},
 };
 
+Give.share = {
+	fn: {
+		twitter: function twitter (url, text) {
+			const targetWindow = parent.window ? parent.window : window;
+			// Calculate new window position, based on parent window height/width
+			const top = targetWindow.innerHeight / 2 - 126;
+			const left = targetWindow.innerWidth / 2 - 280;
+			// Open new window with prompt for Twitter sharing
+			targetWindow.open(`https://twitter.com/intent/tweet?url=${url}&text=${text}`, 'newwindow', `width=560,height=253,top=${top},left=${left}`); 
+			return false;
+		}
+	}
+}
+
 Give.notice = GiveNotice;
 Give.form = GiveForm;
 Give.donor = GiveDonor;

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -3,6 +3,7 @@ import GiveNotice from './notice';
 import GiveForm from './form';
 import GiveDonor from './donor';
 import GiveUtil from './util';
+import GiveShare from './share';
 
 /**
  *  This API is under development.
@@ -333,30 +334,10 @@ const Give = {
 	cache: {},
 };
 
-Give.share = {
-	fn: {
-		twitter: function twitter( url, text ) {
-			const targetWindow = parent.window ? parent.window : window;
-			// Calculate new window position, based on parent window height/width
-			const top = targetWindow.innerHeight / 2 - 126;
-			const left = targetWindow.innerWidth / 2 - 280;
-			// Open new window with prompt for Twitter sharing
-			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
-		},
-		facebook: function facebook( url ) {
-			const targetWindow = parent.window ? parent.window : window;
-			// Calculate new window position, based on parent window height/width
-			const top = targetWindow.innerHeight / 2 - 365;
-			const left = targetWindow.innerWidth / 2 - 280;
-			// Open new window with prompt for Facebook sharing
-			window.open( `https://www.facebook.com/sharer/sharer.php?u=${ url }`, 'newwindow', `width=560,height=730,top=${ top },left=${ left }` );
-		},
-	},
-};
-
 Give.notice = GiveNotice;
 Give.form = GiveForm;
 Give.donor = GiveDonor;
 Give.util = GiveUtil;
+Give.share = GiveShare;
 
 export default Give;

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -342,8 +342,15 @@ Give.share = {
 			const left = targetWindow.innerWidth / 2 - 280;
 			// Open new window with prompt for Twitter sharing
 			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
-			return false;
 		},
+		facebook: function facebook( url ) {
+			const targetWindow = parent.window ? parent.window : window;
+			// Calculate new window position, based on parent window height/width
+			const top = targetWindow.innerHeight / 2 - 365;
+			const left = targetWindow.innerWidth / 2 - 280;
+			// Open new window with prompt for Facebook sharing
+			window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 'newwindow', `width=560,height=730,top=${top},left=${left}`); 
+		}
 	},
 };
 

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -349,8 +349,8 @@ Give.share = {
 			const top = targetWindow.innerHeight / 2 - 365;
 			const left = targetWindow.innerWidth / 2 - 280;
 			// Open new window with prompt for Facebook sharing
-			window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 'newwindow', `width=560,height=730,top=${top},left=${left}`); 
-		}
+			window.open( `https://www.facebook.com/sharer/sharer.php?u=${ url }`, 'newwindow', `width=560,height=730,top=${ top },left=${ left }` );
+		},
 	},
 };
 

--- a/assets/src/js/plugins/give-api/share.js
+++ b/assets/src/js/plugins/give-api/share.js
@@ -1,0 +1,20 @@
+export default {
+	fn: {
+		twitter: function twitter( url, text ) {
+			const targetWindow = parent.window ? parent.window : window;
+			// Calculate new window position, based on parent window height/width
+			const top = targetWindow.innerHeight / 2 - 126;
+			const left = targetWindow.innerWidth / 2 - 280;
+			// Open new window with prompt for Twitter sharing
+			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
+		},
+		facebook: function facebook( url ) {
+			const targetWindow = parent.window ? parent.window : window;
+			// Calculate new window position, based on parent window height/width
+			const top = targetWindow.innerHeight / 2 - 365;
+			const left = targetWindow.innerWidth / 2 - 280;
+			// Open new window with prompt for Facebook sharing
+			window.open( `https://www.facebook.com/sharer/sharer.php?u=${ url }`, 'newwindow', `width=560,height=730,top=${ top },left=${ left }` );
+		},
+	},
+};

--- a/assets/src/js/plugins/give-api/share.js
+++ b/assets/src/js/plugins/give-api/share.js
@@ -1,5 +1,12 @@
 export default {
 	fn: {
+
+		/**
+		 * Open a new window prompting user to Tweet
+		 * The tweet is pre-populated with supplied text, and url to share
+		 *
+		 * @since 2.7.0
+		 */
 		twitter: function twitter( url, text ) {
 			const targetWindow = parent.window ? parent.window : window;
 			// Calculate new window position, based on parent window height/width
@@ -8,6 +15,13 @@ export default {
 			// Open new window with prompt for Twitter sharing
 			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
 		},
+
+		/**
+		 * Open a new window prompting user to share on Facebook
+		 * The post is pre-populated with supplied url
+		 *
+		 * @since 2.7.0
+		 */
 		facebook: function facebook( url ) {
 			const targetWindow = parent.window ? parent.window : window;
 			// Calculate new window position, based on parent window height/width

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -188,7 +188,7 @@ return [
 				'id'         => 'sharing_instruction',
 				'name'       => __( 'Sharing Instruction', 'give' ),
 				'desc'       => __( 'Do you want to customize the sharing instructions for this form? The instruction note displays above the social sharing buttons. We recommend keeping it to 1-2 short sentences.', 'give' ),
-				'type'       => 'textarea',
+				'type'       => 'text',
 				'attributes' => [
 					'placeholder' => __( 'Tell the world about your generosity and help spread the word!', 'give' ),
 				],

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -194,6 +194,16 @@ return [
 				],
 				'default'    => __( 'Tell the world about your generosity and help spread the word!', 'give' ),
 			],
+			[
+				'id'         => 'twitter_message',
+				'name'       => __( 'Twitter Message', 'give' ),
+				'desc'       => __( 'Do you want to customize the default tweet? This text pre-fills a user\'s tweet when they choose to share to Twitter. We recommend keeping it to 1-2 short sentences.', 'give' ),
+				'type'       => 'text',
+				'attributes' => [
+					'placeholder' => __( 'Help me raise money for this great cause!', 'give' ),
+				],
+				'default'    => __( 'Help me raise money for this great cause!', 'give' ),
+			],
 		],
 	],
 ];

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -41,9 +41,11 @@ ob_start();
 					<button class="give-btn social-btn facebook-btn"
 						onclick="
 							const url = parent.window.location;
+							const top = parent.window.innerHeight / 2 - 365;
+							const left = parent.window.innerWidth / 2 - 280;
 							window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 
 							'newwindow', 
-							'width=560,height=730'); 
+							`width=560,height=730,top=${top},left=${left}`); 
 							return false;">
 						<?php _e( 'Share on Facebook', 'give' ); ?><i class="fab fa-facebook"></i>
 					</button>
@@ -51,9 +53,11 @@ ob_start();
 						class="give-btn social-btn twitter-btn"
 						onclick="
 							const url = parent.window.location;
+							const top = parent.window.innerHeight / 2 - 126;
+							const left = parent.window.innerWidth / 2 - 280;
 							window.open(`https://twitter.com/intent/tweet?url=${url}&text=<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`, 
 							'newwindow', 
-							'width=560,height=253'); 
+							`width=560,height=253,top=${top},left=${left}`); 
 							return false;">
 						<?php _e( 'Share on Twitter', 'give' ); ?><i class="fab fa-twitter"></i>
 					</a>

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -35,7 +35,7 @@ ob_start();
 		<?php if ( isset( $options['thank-you']['sharing'] ) && $options['thank-you']['sharing'] === 'enabled' ) : ?>
 			<div class="social-sharing">
 				<p class="instruction">
-					<?php __( 'Tell the world about your generosity and help spread the word!', 'give' ); ?>
+					<?php echo $options['thank-you']['sharing_instruction']; ?>
 				</p>
 				<div class="btn-row">
 					<button class="give-btn social-btn facebook-btn"

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -52,10 +52,9 @@ ob_start();
 							const top = parent.window.innerHeight / 2 - 365;
 							const left = parent.window.innerWidth / 2 - 280;
 							// Open new window with prompt for Facebook sharing
-							window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 
-							'newwindow', 
-							`width=560,height=730,top=${top},left=${left}`); 
-							return false;">
+							window.Give.share.fn.facebook(url);
+							return false;
+							">
 						<?php _e( 'Share on Facebook', 'give' ); ?><i class="fab fa-facebook"></i>
 					</button>
 					<!-- Use inline onclick listener to avoid popup blockers -->
@@ -70,7 +69,9 @@ ob_start();
 								url = window.Give.fn.removeURLParameter(url, 'payment-id');
 							}
 							const text = `<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`;
+							// Open new window with prompt for Twitter sharing
 							window.Give.share.fn.twitter(url, text);
+							return false;
 						">
 						<?php _e( 'Share on Twitter', 'give' ); ?><i class="fab fa-twitter"></i>
 					</a>

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -74,7 +74,7 @@ ob_start();
 							return false;
 						">
 						<?php _e( 'Share on Twitter', 'give' ); ?><i class="fab fa-twitter"></i>
-					</a>
+					</button>
 				</div>
 			</div>
 		<?php endif; ?>

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -44,7 +44,9 @@ ob_start();
 							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
 							if (window.Give.fn.getParameterByName('giveDonationAction', url)) {
-								url = url.replace('?giveDonationAction=showReceipt', '');
+								url = window.Give.fn.removeURLParameter(url, 'giveDonationAction');
+								url = window.Give.fn.removeURLParameter(url, 'payment-confirmation');
+								url = window.Give.fn.removeURLParameter(url, 'payment-id');
 							}
 							// Calculate new window position, based on parent window height/width
 							const top = parent.window.innerHeight / 2 - 365;
@@ -63,7 +65,9 @@ ob_start();
 							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
 							if (window.Give.fn.getParameterByName('giveDonationAction', url)) {
-								url = url.replace('?giveDonationAction=showReceipt', '');
+								url = window.Give.fn.removeURLParameter(url, 'giveDonationAction');
+								url = window.Give.fn.removeURLParameter(url, 'payment-confirmation');
+								url = window.Give.fn.removeURLParameter(url, 'payment-id');
 							}
 							// Calculate new window position, based on parent window height/width
 							const top = parent.window.innerHeight / 2 - 126;

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -40,12 +40,15 @@ ob_start();
 				<div class="btn-row">
 					<button class="give-btn social-btn facebook-btn"
 						onclick="
+							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
 							if (url.includes('?giveDonationAction=showReceipt')) {
 								url = url.replace('?giveDonationAction=showReceipt', '');
 							}
+							// Calculate new window position, based on parent window height/width
 							const top = parent.window.innerHeight / 2 - 365;
 							const left = parent.window.innerWidth / 2 - 280;
+							// Open new window with prompt for Facebook sharing
 							window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 
 							'newwindow', 
 							`width=560,height=730,top=${top},left=${left}`); 
@@ -55,12 +58,15 @@ ob_start();
 					<button
 						class="give-btn social-btn twitter-btn"
 						onclick="
+							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
 							if (url.includes('?giveDonationAction=showReceipt')) {
 								url = url.replace('?giveDonationAction=showReceipt', '');
 							}
+							// Calculate new window position, based on parent window height/width
 							const top = parent.window.innerHeight / 2 - 126;
 							const left = parent.window.innerWidth / 2 - 280;
+							// Open new window with prompt for Twitter sharing
 							window.open(`https://twitter.com/intent/tweet?url=${url}&text=<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`, 
 							'newwindow', 
 							`width=560,height=253,top=${top},left=${left}`); 

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -51,7 +51,7 @@ ob_start();
 						class="give-btn social-btn twitter-btn"
 						onclick="
 							const url = parent.window.location;
-							window.open(`https://twitter.com/intent/tweet?url=${url}&text=Hello%20world`, 
+							window.open(`https://twitter.com/intent/tweet?url=${url}&text=<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`, 
 							'newwindow', 
 							'width=560,height=253'); 
 							return false;">

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -43,7 +43,7 @@ ob_start();
 						onclick="
 							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
-							if (url.includes('?giveDonationAction=showReceipt')) {
+							if (window.Give.fn.getParameterByName('giveDonationAction', url)) {
 								url = url.replace('?giveDonationAction=showReceipt', '');
 							}
 							// Calculate new window position, based on parent window height/width
@@ -62,7 +62,7 @@ ob_start();
 						onclick="
 							// Retrieve and sanitize url to be shared
 							let url = parent.window.location.toString();
-							if (url.includes('?giveDonationAction=showReceipt')) {
+							if (window.Give.fn.getParameterByName('giveDonationAction', url)) {
 								url = url.replace('?giveDonationAction=showReceipt', '');
 							}
 							// Calculate new window position, based on parent window height/width

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -33,19 +33,15 @@ ob_start();
 			<?php echo formatContent( $options['thank-you']['description'], [ 'payment_id' => $payment->ID ] ); ?>
 		</p>
 		<?php if ( isset( $options['thank-you']['sharing'] ) && $options['thank-you']['sharing'] === 'enabled' ) : ?>
-			<?php
-			$facebookLink = 'https://www.facebook.com/sharer/sharer.php?u=https://givewp.com/donate';
-			$twitterLink  = 'https://twitter.com/intent/tweet?url=https://givewp.com/donate&text=Hello%20world';
-			?>
 			<div class="social-sharing">
 				<p class="instruction">
 					<?php __( 'Tell the world about your generosity and help spread the word!', 'give' ); ?>
 				</p>
 				<div class="btn-row">
-					<button 
-						class="give-btn social-btn facebook-btn"
+					<button class="give-btn social-btn facebook-btn"
 						onclick="
-							window.open('<?php echo $facebookLink; ?>', 
+							const url = parent.window.location;
+							window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 
 							'newwindow', 
 							'width=560,height=730'); 
 							return false;">
@@ -54,7 +50,8 @@ ob_start();
 					<button
 						class="give-btn social-btn twitter-btn"
 						onclick="
-							window.open('<?php echo $twitterLink; ?>', 
+							const url = parent.window.location;
+							window.open(`https://twitter.com/intent/tweet?url=${url}&text=Hello%20world`, 
 							'newwindow', 
 							'width=560,height=253'); 
 							return false;">

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -69,14 +69,9 @@ ob_start();
 								url = window.Give.fn.removeURLParameter(url, 'payment-confirmation');
 								url = window.Give.fn.removeURLParameter(url, 'payment-id');
 							}
-							// Calculate new window position, based on parent window height/width
-							const top = parent.window.innerHeight / 2 - 126;
-							const left = parent.window.innerWidth / 2 - 280;
-							// Open new window with prompt for Twitter sharing
-							window.open(`https://twitter.com/intent/tweet?url=${url}&text=<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`, 
-							'newwindow', 
-							`width=560,height=253,top=${top},left=${left}`); 
-							return false;">
+							const text = `<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`;
+							window.Give.share.fn.twitter(url, text);
+						">
 						<?php _e( 'Share on Twitter', 'give' ); ?><i class="fab fa-twitter"></i>
 					</a>
 				</div>

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -40,7 +40,10 @@ ob_start();
 				<div class="btn-row">
 					<button class="give-btn social-btn facebook-btn"
 						onclick="
-							const url = parent.window.location;
+							let url = parent.window.location.toString();
+							if (url.includes('?giveDonationAction=showReceipt')) {
+								url = url.replace('?giveDonationAction=showReceipt', '');
+							}
 							const top = parent.window.innerHeight / 2 - 365;
 							const left = parent.window.innerWidth / 2 - 280;
 							window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, 
@@ -52,7 +55,10 @@ ob_start();
 					<button
 						class="give-btn social-btn twitter-btn"
 						onclick="
-							const url = parent.window.location;
+							let url = parent.window.location.toString();
+							if (url.includes('?giveDonationAction=showReceipt')) {
+								url = url.replace('?giveDonationAction=showReceipt', '');
+							}
 							const top = parent.window.innerHeight / 2 - 126;
 							const left = parent.window.innerWidth / 2 - 280;
 							window.open(`https://twitter.com/intent/tweet?url=${url}&text=<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`, 

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -38,6 +38,7 @@ ob_start();
 					<?php echo $options['thank-you']['sharing_instruction']; ?>
 				</p>
 				<div class="btn-row">
+					<!-- Use inline onclick listener to avoid popup blockers -->
 					<button class="give-btn social-btn facebook-btn"
 						onclick="
 							// Retrieve and sanitize url to be shared
@@ -55,6 +56,7 @@ ob_start();
 							return false;">
 						<?php _e( 'Share on Facebook', 'give' ); ?><i class="fab fa-facebook"></i>
 					</button>
+					<!-- Use inline onclick listener to avoid popup blockers -->
 					<button
 						class="give-btn social-btn twitter-btn"
 						onclick="

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -33,17 +33,33 @@ ob_start();
 			<?php echo formatContent( $options['thank-you']['description'], [ 'payment_id' => $payment->ID ] ); ?>
 		</p>
 		<?php if ( isset( $options['thank-you']['sharing'] ) && $options['thank-you']['sharing'] === 'enabled' ) : ?>
+			<?php
+			$facebookLink = 'https://www.facebook.com/sharer/sharer.php?u=https://givewp.com/donate';
+			$twitterLink  = 'https://twitter.com/intent/tweet?url=https://givewp.com/donate&text=Hello%20world';
+			?>
 			<div class="social-sharing">
 				<p class="instruction">
 					<?php __( 'Tell the world about your generosity and help spread the word!', 'give' ); ?>
 				</p>
 				<div class="btn-row">
-					<button class="give-btn social-btn facebook-btn">
+					<button 
+						class="give-btn social-btn facebook-btn"
+						onclick="
+							window.open('<?php echo $facebookLink; ?>', 
+							'newwindow', 
+							'width=560,height=730'); 
+							return false;">
 						<?php _e( 'Share on Facebook', 'give' ); ?><i class="fab fa-facebook"></i>
 					</button>
-					<button class="give-btn social-btn twitter-btn">
+					<button
+						class="give-btn social-btn twitter-btn"
+						onclick="
+							window.open('<?php echo $twitterLink; ?>', 
+							'newwindow', 
+							'width=560,height=253'); 
+							return false;">
 						<?php _e( 'Share on Twitter', 'give' ); ?><i class="fab fa-twitter"></i>
-					</button>
+					</a>
 				</div>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
## Description
Resolves #4658 
This PR introduces functionality to the social sharing links found in the Sequoia template, and a new "Twitter Message" option for the template.

Now, when a user clicks share to Facebook, or share to Twitter, a new window opens prompting them to actually share the donation page to social media. The Twitter sharing link can have a custom message, which is set using the "Twitter Message" template option. 

## Affects
This PR impacts the Sequoia receipt view, and Sequoia template option config file.

## What to test
Can you enable/disable the social sharing section from template options? Are you able to update the default tweet from the template options panel? Does the share to facebook link open in a new window as expected, preloaded with a link to the page you made the donation on? Does the share to to twitter open a window to tweet prepopulated with the correct default tweet and link to the page you made a donation on?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/80027391-b04aee80-84b1-11ea-8eac-8fd95a055ff2.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
