### PR TITLE
fix: form validation notices now appear above content

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -572,13 +572,18 @@ p {
 
 		.give-submit-button-wrap {
 			display: flex;
-			justify-content: center;
+			flex-direction: column;
+			align-items: center;
 			position: relative;
+
+			.give_notices + .give-submit {
+				margin-top: 0;
+			}
 
 			.sequoia-loader {
 				height: 30px;
 				width: 30px;
-				top: 64px;
+				bottom: 34px;
 				position: absolute;
 				font-size: 4px;
 			}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -474,6 +474,11 @@ p {
 // Payment Section
 
 .payment {
+	#give_error_invalid_donation_maximum,
+	#give_error_invalid_donation_amount {
+		cursor: pointer;
+	}
+
 	> .give_error {
 		margin-right: 20px;
 		margin-left: 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -106,7 +106,7 @@ p {
 .advance-btn:disabled,
 .give-submit:disabled,
 .download-btn:disabled {
-	filter: grayscale(0.6);
+	filter: grayscale(0.3);
 	opacity: 0.6;
 }
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -136,15 +136,13 @@ p {
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 	border-width: 0 0 0 5px;
 
-	> p {
-		font-weight: 400;
-		font-size: 16px;
-		line-height: 24px;
-		color: #555 !important;
+	font-weight: 400;
+	font-size: 16px;
+	line-height: 24px;
+	color: #555 !important;
 
-		> strong {
-			font-weight: 500 !important;
-		}
+	> strong {
+		font-weight: 500 !important;
 	}
 }
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -474,6 +474,10 @@ p {
 // Payment Section
 
 .payment {
+	> .give_error {
+		margin-right: 20px;
+		margin-left: 20px;
+	}
 	.heading {
 		padding: 39px 3px 0;
 		font-size: 16px;
@@ -482,6 +486,9 @@ p {
 		text-align: center;
 	}
 	.give_notices + .heading {
+		padding: 28px 3px 0;
+	}
+	.give_error + .heading {
 		padding: 28px 3px 0;
 	}
 	.subheading {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -481,6 +481,9 @@ p {
 		color: #6b6b6b;
 		text-align: center;
 	}
+	.give_notices + .heading {
+		padding: 28px 3px 0;
+	}
 	.subheading {
 		padding: 5px 0 34px 0;
 		font-style: italic;
@@ -585,10 +588,6 @@ p {
 			flex-direction: column;
 			align-items: center;
 			position: relative;
-
-			.give_notices + .give-submit {
-				margin-top: 0;
-			}
 
 			.sequoia-loader {
 				height: 30px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -495,6 +495,9 @@ p {
 		color: #6b6b6b;
 		text-align: center;
 	}
+	.give_notices {
+		width: 100%;
+	}
 	.give_notices + .heading {
 		padding: 28px 3px 0;
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -103,6 +103,13 @@ p {
 	}
 }
 
+.advance-btn:disabled,
+.give-submit:disabled,
+.download-btn:disabled {
+	filter: grayscale(0.6);
+	opacity: 0.6;
+}
+
 .download-btn {
 	font-size: 16px;
 	line-height: 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -361,6 +361,16 @@ p {
 // Choose Amount Styles
 
 .choose-amount {
+	> * {
+		order: 2;
+	}
+
+	> .give_error {
+		order: 1;
+		margin-right: 20px;
+		margin-left: 20px;
+	}
+
 	.content {
 		text-align: center;
 		margin: 24px 30px 22px 30px;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -128,6 +128,13 @@
 			label: templateOptions.payment_amount.next_label,
 			showErrors: false,
 			setup: () => {
+				$( '#give-amount' ).on( 'blur', function() {
+					if ( ! Give.form.fn.isValidDonationAmount( $( 'form' ) ) ) {
+						$( '.advance-btn' ).attr( 'disabled', true );
+					} else {
+						$( '.advance-btn' ).attr( 'disabled', false );
+					}
+				} );
 				$( '.give-donation-level-btn' ).each( function() {
 					const hasTooltip = $( this ).attr( 'has-tooltip' );
 					if ( hasTooltip ) {
@@ -168,7 +175,11 @@
 				$( 'body.give-form-templates' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
 					//Override submit loader with Sequoia loader
 					$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
-					$( '.sequoia-loader' ).addClass( 'spinning' );
+
+					// Only show spinner if form is valid
+					if ( $( 'form' ).get( 0 ).checkValidity() ) {
+						$( '.sequoia-loader' ).addClass( 'spinning' );
+					}
 				} );
 
 				// Go to choose amount step when donation maximum error is clicked
@@ -227,6 +238,11 @@
 	// Move payment information section when gateway updated.
 	$( document ).on( 'give_gateway_loaded', function() {
 		moveFieldsUnderPaymentGateway( true );
+
+		// Disable form if fields are still invalid
+		if ( $( '.give-invalid-maximum' ) || $( 'form' ).get( 0 ).checkValidity() ) {
+			Give.form.fn.disable( $( 'form' ), true );
+		}
 	} );
 	$( document ).on( 'Give:onPreGatewayLoad', function() {
 		moveFieldsUnderPaymentGateway( false );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -203,6 +203,7 @@
 								$( node ).clone().prependTo( '.give-section.payment' );
 								$( node ).remove();
 								$( '.sequoia-loader' ).removeClass( 'spinning' );
+								Give.form.fn.disable( $( 'form' ), true );
 							}
 						}
 					} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -169,7 +169,8 @@
 				// Show Sequoia loader on click/touchend
 				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
 					//Override submit loader with Sequoia loader
-					$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader spinning' );
+					$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
+					$( '.sequoia-loader' ).addClass( 'spinning' );
 				} );
 
 				//Setup input icons
@@ -191,6 +192,7 @@
 							if ( $( node ).parent().hasClass( 'give-submit-button-wrap' ) && $( node ).hasClass( 'give_errors' ) ) {
 								$( node ).clone().prependTo( '.give-section.payment' );
 								$( node ).remove();
+								$( '.sequoia-loader' ).removeClass( 'spinning' );
 							}
 						}
 					} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -240,7 +240,7 @@
 		moveFieldsUnderPaymentGateway( true );
 
 		// Disable form if fields are still invalid
-		if ( $( '.give-invalid-maximum' ).length > 0 || $( 'form' ).get( 0 ).checkValidity() === false ) {
+		if ( $( '.give-invalid-maximum' ).length > 0 ) {
 			Give.form.fn.disable( $( 'form' ), true );
 		}
 	} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -24,12 +24,6 @@
 				}, 200 );
 			}
 
-			if ( steps[ step ].showErrors === true ) {
-				$( '.give_error, .give_warning, .give_success', '.give-form-wrap' ).show();
-			} else {
-				$( '.give_error, .give_warning, .give_success', '.give-form-wrap' ).hide();
-			}
-
 			$( '.step-tracker' ).removeClass( 'current' );
 			$( '.step-tracker[data-step="' + step + '"]' ).addClass( 'current' );
 
@@ -165,6 +159,10 @@
 
 				// Remove purchase_loading text
 				window.give_global_vars.purchase_loading = '';
+
+				const testNotice = $( '#give_error_test_mode' );
+				$( testNotice ).clone().prependTo( '.give-section.payment' );
+				$( testNotice ).remove();
 
 				// Show Sequoia loader on click/touchend
 				$( 'body.give-form-templates' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -210,11 +210,11 @@
 						for ( let i = 0; i < mutation.addedNodes.length; i++ ) {
 							// do things to your newly added nodes here
 							const node = mutation.addedNodes[ i ];
+
 							if ( $( node ).parent().hasClass( 'give-submit-button-wrap' ) && $( node ).hasClass( 'give_errors' ) ) {
 								$( node ).clone().prependTo( '.give-section.payment' );
 								$( node ).remove();
 								$( '.sequoia-loader' ).removeClass( 'spinning' );
-								Give.form.fn.disable( $( 'form' ), true );
 							}
 						}
 					} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -178,6 +178,30 @@
 
 				// Setup gateway icons
 				setupGatewayIcons();
+
+				const observer = new window.MutationObserver( function( mutations ) {
+					mutations.forEach( function( mutation ) {
+						if ( ! mutation.addedNodes ) {
+							return;
+						}
+
+						for ( let i = 0; i < mutation.addedNodes.length; i++ ) {
+							// do things to your newly added nodes here
+							const node = mutation.addedNodes[ i ];
+							if ( $( node ).parent().hasClass( 'give-submit-button-wrap' ) && $( node ).hasClass( 'give_errors' ) ) {
+								$( node ).clone().prependTo( '.give-section.payment' );
+								$( node ).remove();
+							}
+						}
+					} );
+				} );
+
+				observer.observe( document.body, {
+					childList: true,
+					subtree: true,
+					attributes: false,
+					characterData: false,
+				} );
 			},
 		},
 	];

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -240,7 +240,7 @@
 		moveFieldsUnderPaymentGateway( true );
 
 		// Disable form if fields are still invalid
-		if ( $( '.give-invalid-maximum' ) || $( 'form' ).get( 0 ).checkValidity() ) {
+		if ( $( '.give-invalid-maximum' ) || $( 'form' ).get( 0 ).checkValidity() === false ) {
 			Give.form.fn.disable( $( 'form' ), true );
 		}
 	} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -167,10 +167,22 @@
 				window.give_global_vars.purchase_loading = '';
 
 				// Show Sequoia loader on click/touchend
-				$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
+				$( 'body.give-form-templates' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
 					//Override submit loader with Sequoia loader
 					$( '#give-purchase-button + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader' );
 					$( '.sequoia-loader' ).addClass( 'spinning' );
+				} );
+
+				// Go to choose amount step when donation maximum error is clicked
+				$( 'body.give-form-templates' ).on( 'click touchend', '#give_error_invalid_donation_maximum', function() {
+					// Go to choose amount step
+					navigator.goToStep( 1 );
+				} );
+
+				// Go to choose amount step when invalid donation error is clicked
+				$( 'body.give-form-templates' ).on( 'click touchend', '#give_error_invalid_donation_amount', function() {
+					// Go to choose amount step
+					navigator.goToStep( 1 );
 				} );
 
 				//Setup input icons

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -238,11 +238,6 @@
 	// Move payment information section when gateway updated.
 	$( document ).on( 'give_gateway_loaded', function() {
 		moveFieldsUnderPaymentGateway( true );
-
-		// Disable form if fields are still invalid
-		if ( $( '.give-invalid-maximum' ).length > 0 ) {
-			Give.form.fn.disable( $( 'form' ), true );
-		}
 	} );
 	$( document ).on( 'Give:onPreGatewayLoad', function() {
 		moveFieldsUnderPaymentGateway( false );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -240,7 +240,7 @@
 		moveFieldsUnderPaymentGateway( true );
 
 		// Disable form if fields are still invalid
-		if ( $( '.give-invalid-maximum' ) || $( 'form' ).get( 0 ).checkValidity() === false ) {
+		if ( $( '.give-invalid-maximum' ).length > 0 || $( 'form' ).get( 0 ).checkValidity() === false ) {
 			Give.form.fn.disable( $( 'form' ), true );
 		}
 	} );


### PR DESCRIPTION
## Description
Resolves #4666 
This PR improves the Sequoia form template so that validation error notices now appear at the top of the form. This PR resolves this issue as it appeared in the choose amount step and the payment information step.

The PR also introduces interactivity for error notices, so that when a notice is clicked you are directed to the relevant step of the form to make changes.

## Affects
This PR affects Sequoia form template assets. Specifically it touches some css, and introduces a MutationObserver to the frontend logic.

## What to test
When you input an invalid amount, does the error notice appear at the top of the choose amount screen? When you attempt to submit a donation with an invalid amount, does the submit loader disappear and error notices appear at the top of the payment information screen? When you click on a error notice, are you taken to the relevant step?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/80127721-bcdb4f80-8562-11ea-94b3-d9293420e231.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
