### PR TITLE
fix: allow to cache donation form page

### DIFF
--- a/includes/class-give-cache.php
+++ b/includes/class-give-cache.php
@@ -114,10 +114,14 @@ class Give_Cache {
 			)
 		);
 
-		if (
-			is_page( $page_ids )
-			|| is_singular( 'give_forms' )
-		) {
+		/**
+		 * Use this filter to prevent
+		 *
+		 * @since 2.6.3
+		 */
+		$canCache = apply_filters( 'give_can_cache_page', is_page( $page_ids ) );
+
+		if ( $canCache ) {
 			self::set_nocache_constants();
 			nocache_headers();
 		}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4546

This patch allows to cache the donation page. I also added a filter `give_can_cache_page` which others can use to set up there own logic for Give default pages.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
It will affect Give core page caching login in `Give_Cache`.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Confirm in the source that WP Rocket's comment is present in the footer and you can process donation without any issue as a guest, email accessed do not, and logged-in donor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
