### PR TITLE
fix: show old receipt in legacy style  for styling consistency

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -15,6 +15,7 @@ use Give\Form\Template\Scriptable;
 use function Give\Helpers\Form\Template\getActiveID;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 use function Give\Helpers\Form\Utils\inIframe;
+use function Give\Helpers\Form\Utils\isLegacyForm;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -117,6 +118,11 @@ class LoadTemplate {
 	 * @since 2.7.0
 	 */
 	public function handleReceiptAjax() {
+		// Do not handle form template receipt for legacy form.
+		if ( isLegacyForm() ) {
+			return;
+		}
+
 		ob_start();
 		include_once $this->template->getReceiptView();
 		$data = ob_get_clean();

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -14,6 +14,7 @@ use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
 use function Give\Helpers\Form\Template\getActiveID;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use function Give\Helpers\Form\Utils\getSuccessPageURL;
 use function Give\Helpers\Form\Utils\inIframe;
 use function Give\Helpers\Form\Utils\isLegacyForm;
 
@@ -120,6 +121,11 @@ class LoadTemplate {
 	public function handleReceiptAjax() {
 		// Do not handle form template receipt for legacy form.
 		if ( isLegacyForm() ) {
+			return;
+		}
+
+		// Show new receipt view only on donation confirmation page.
+		if ( false === strpos( wp_get_referer(), untrailingslashit( getSuccessPageURL() ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves: #4673 

As s side effect new receipt view was loading when view old recept but as per discussion with @DevinWalker we decided to show a receipt in legacy style for styling consistency. As per logic, a donor can see receipt either on the donation confirmation page or on the history page.
To restrict the new receipt view to a donation confirmation page, I added logic to compare the referer.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
It will affect `wp_ajax_get_receipt` handler `LoadTemplate::handleReceiptAjax`.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Check receipt style on the donation confirmation page and history page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
