### PR TITLE
WPML: Registring the emails sent to donors for translation

### DIFF
--- a/includes/admin/emails/class-email-notification-util.php
+++ b/includes/admin/emails/class-email-notification-util.php
@@ -285,6 +285,12 @@ class Give_Email_Notification_Util {
 			? str_replace( '_give_', '', $option_name )
 			: $option_name );
 		$option_value       = give_get_option( $global_option_name, $default );
+		
+		//Emails sent to donors cannot be translated using WPML.
+		//Regiserting only the emails sent to the donors.
+		if (defined('ICL_SITEPRESS_VERSION') && !is_array($option_value)) {
+			$option_value = apply_filters('wpml_translate_single_string', $option_value, 'admin_texts_give_settings', '[give_settings]' . $global_option_name);
+		}
 
 		if (
 			! empty( $form_id )

--- a/includes/admin/emails/class-email-notification-util.php
+++ b/includes/admin/emails/class-email-notification-util.php
@@ -285,11 +285,11 @@ class Give_Email_Notification_Util {
 			? str_replace( '_give_', '', $option_name )
 			: $option_name );
 		$option_value       = give_get_option( $global_option_name, $default );
-		
-		//Emails sent to donors cannot be translated using WPML.
-		//Regiserting only the emails sent to the donors.
-		if (defined('ICL_SITEPRESS_VERSION') && !is_array($option_value)) {
-			$option_value = apply_filters('wpml_translate_single_string', $option_value, 'admin_texts_give_settings', '[give_settings]' . $global_option_name);
+
+		// Ensure that emails sent to donors can be translated using WPML
+		// Registering only the emails sent to the donors.
+		if ( defined( 'ICL_SITEPRESS_VERSION' ) && ! is_array( $option_value ) ) {
+			$option_value = apply_filters( 'wpml_translate_single_string', $option_value, 'admin_texts_give_settings', '[give_settings]' . $global_option_name );
 		}
 
 		if (

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -21,6 +21,18 @@
       <key name="subscription_receipt_message"/>
       <key name="subscription_cancelled_subject"/>
       <key name="subscription_cancelled_message"/>
+      <key name="donation-receipt_email_message"/>
+      <key name="donation-receipt_email_subject"/>
+      <key name="donation-receipt_email_header"/>
+      <key name="offline-donation-instruction_email_header"/>
+      <key name="offline-donation-instruction_email_subject"/>
+      <key name="offline-donation-instruction_email_message"/>
+      <key name="donor-register_email_subject"/>
+      <key name="donor-register_email_header"/>
+      <key name="donor-register_email_message"/>
+      <key name="donor-note_email_subject"/>
+      <key name="donor-note_email_header"/>
+      <key name="donor-note_email_message"/>
     </key>
   </admin-texts>
 </wpml-config>


### PR DESCRIPTION
## Description
The emails sent to donors cannot be translated using WPML even after registering them in the `wpml-config.xml` file.

## Affects
Only one change needed in PHP `/includes/admin/emails/class-email-notification-util.php` and some settings in `wpml-config.xml` file

## What to test
Add the emails sent to donors, for example, Donations -> Settings -> Emails -> Donor Emails and try to translate is using WPML.



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
