### PR TITLE
fix: Sequoia no longer shows tooltips for unlabeled amounts

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -733,7 +733,13 @@ fieldset {
 		word-wrap: normal;
 		white-space: normal;
 		width: fit-content;
-		max-width: 120px;
+		max-width: 136px;
+	}
+
+	&.wide {
+		&::after {
+			width: 136px;
+		}
 	}
 }
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -719,17 +719,20 @@ fieldset {
 	margin: 0 !important;
 
 	&::after {
+		display: block;
+		padding: 12px 18px;
 		background: #383838;
 		color: #fff;
-		padding: 12px 18px;
 		font-size: 16px;
 		font-family: 'Montserrat', sans-serif;
 		border-radius: 4px;
-		line-height: 12px;
+		line-height: 1.2;
 		text-align: center;
-		white-space: nowrap;
 		text-shadow: 0 -1px 0 #000;
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+		word-wrap: normal;
+		white-space: normal;
+		max-width: 120px;
 	}
 }
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -732,6 +732,7 @@ fieldset {
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
 		word-wrap: normal;
 		white-space: normal;
+		width: fit-content;
 		max-width: 120px;
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -146,8 +146,10 @@
 					const symbol = window.give_global_vars.currency_sign;
 					const position = window.give_global_vars.currency_pos;
 
-					const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;
-					$( this ).html( html );
+					if ( value !== 'custom' ) {
+						const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;
+						$( this ).html( html );
+					}
 
 					// Setup string to check tooltip label against
 					const compare = position === 'before' ? symbol + value : value + symbol;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -155,7 +155,7 @@
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
-						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
+						const wrap = `<span class="give-tooltip hint--top hint--bounce ${ text.length > 50 ? 'wide' : '' }" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -143,8 +143,8 @@
 
 					const value = $( this ).attr( 'value' );
 					const text = $( this ).text();
-					const symbol = $( '.give-currency-symbol' ).text();
-					const position = $( '.give-currency-symbol' ).hasClass( 'give-currency-position-before' ) ? 'before' : 'after';
+					const symbol = window.give_global_vars.currency_sign;
+					const position = window.give_global_vars.currency_pos;
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					if ( value !== 'custom' && text !== compare ) {
 						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text }" rel="tooltip"></span>`;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -145,7 +145,11 @@
 					const text = $( this ).text();
 					const symbol = window.give_global_vars.currency_sign;
 					const position = window.give_global_vars.currency_pos;
+
+					// Setup string to check tooltip label against
 					const compare = position === 'before' ? symbol + value : value + symbol;
+
+					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
 						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text }" rel="tooltip"></span>`;
 						const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -143,10 +143,11 @@
 
 					const value = $( this ).attr( 'value' );
 					const text = $( this ).text();
-					if ( value !== 'custom' ) {
+					const symbol = $( '.give-currency-symbol' ).text();
+					const position = $( '.give-currency-symbol' ).hasClass( 'give-currency-position-before' ) ? 'before' : 'after';
+					const compare = position === 'before' ? symbol + value : value + symbol;
+					if ( value !== 'custom' && text !== compare ) {
 						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text }" rel="tooltip"></span>`;
-						const symbol = $( '.give-currency-symbol' ).text();
-						const position = $( '.give-currency-symbol' ).hasClass( 'give-currency-position-before' ) ? 'before' : 'after';
 						const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;
 						$( this ).html( html );
 						$( this ).wrap( wrap );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -155,7 +155,7 @@
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
-						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text }" rel="tooltip"></span>`;
+						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -155,7 +155,7 @@
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
-						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
+						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -146,14 +146,14 @@
 					const symbol = window.give_global_vars.currency_sign;
 					const position = window.give_global_vars.currency_pos;
 
+					const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;
+					$( this ).html( html );
+
 					// Setup string to check tooltip label against
 					const compare = position === 'before' ? symbol + value : value + symbol;
-
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
 						const wrap = `<span class="give-tooltip hint--top hint--bounce" style="width: 100%" aria-label="${ text }" rel="tooltip"></span>`;
-						const html = position === 'before' ? `<div class="currency">${ symbol }</div>${ value }` : `${ value }<div class="currency">${ symbol }</div>`;
-						$( this ).html( html );
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}


### PR DESCRIPTION
## Description
Resolves #4685 
This PR resolves an issue that caused amounts without labels to display tooltips in the Sequoia form template. Previously, when a user added an amount without a label, a tooltip would appearing over the amount button that simply displayed the amount again (eg: When a $25 level button was hovered, the tooltip also ready $25). The issue is caused by the way that GiveWP core renders multilevel amount donation forms, where a donation level left blank would simply render with the donation amount. 

This behavior makes sense in the context of legacy forms, but with Sequoia we are hacking the frontend to display the level's amount, and this "label" as a tooltip. With this in mind, I reached for a frontend solution that would be unique to Sequoia, that doesn't touch core logic, keeping in line with how we have handled transforming these amount buttons previously. Touching only frontend scripts, this PR checks if the provided label matches the amounts value, and if so, refrains from setting up a tooltip. 

## Affects
This PR only affects the frontend JS of the Sequoia template.

## What to test
Do tooltips appear above donation levels without labels? Are tooltips impacted by changing the currency sign or position? Do tooltips render correctly when a label is provided?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/80640536-86557700-8a31-11ea-97f5-e7c13908ec35.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
