### PR TITLE
fix: Sequoia template now displays proper spacing above the advance button when goal/image are disabled

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -313,6 +313,8 @@ p {
 	}
 
 	.description + .advance-btn {
+		margin-top: 6px !important;
+
 		@media screen and (max-width: $break-phone) {
 			margin-top: 10px !important;
 		}


### PR DESCRIPTION
## Description
Resolves #4674 
Previously, when a form weas setup without an image or goal, the advance button had too great a top margin. This PR resolves this error, but introducing a sibling selector rule, so that when the advance button immediately follows a description, it has a smaller top margin. This purely css solution was decided on because it required the smallest change to the codebase, and touched the least number of files. It is also the most performant for server and client.

## Affects
This PR only impacts the Sequoia assets, specifically the CSS file.

## What to test
Try enabling or disabling goals and featured image, as well as image in the template options area. Does the advance button's top spacing seem appropriate in all these different contexts?

## Screenshots:
<img width="578" alt="Screen Shot 2020-04-30 at 1 11 28 PM" src="https://user-images.githubusercontent.com/5186078/80739275-29ff5f80-8ae4-11ea-963c-27ef28a3861d.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
