### PR TITLE
feature: when a single gateway is enabled, Sequoia renders that gateway without radio selectors

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -232,6 +232,7 @@
 
 	navigator.init();
 
+	// Check if only a single gateway is enabled
 	if ( $( '#give-payment-mode-select' ).css( 'display' ) !== 'none' ) {
 		// Move payment information section when document load.
 		moveFieldsUnderPaymentGateway( true );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -232,19 +232,21 @@
 
 	navigator.init();
 
-	// Move payment information section when document load.
-	moveFieldsUnderPaymentGateway( true );
-
-	// Move payment information section when gateway updated.
-	$( document ).on( 'give_gateway_loaded', function() {
+	if ( $( '#give-payment-mode-select' ).css( 'display' ) !== 'none' ) {
+		// Move payment information section when document load.
 		moveFieldsUnderPaymentGateway( true );
-	} );
-	$( document ).on( 'Give:onPreGatewayLoad', function() {
-		moveFieldsUnderPaymentGateway( false );
-	} );
 
-	// Refresh payment information section.
-	$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
+		// Move payment information section when gateway updated.
+		$( document ).on( 'give_gateway_loaded', function() {
+			moveFieldsUnderPaymentGateway( true );
+		} );
+		$( document ).on( 'Give:onPreGatewayLoad', function() {
+			moveFieldsUnderPaymentGateway( false );
+		} );
+
+		// Refresh payment information section.
+		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
+	}
 
 	/**
 	 * Move form field under payment gateway


### PR DESCRIPTION
## Description
Resolves: #4684 
Pervasively, when only one gateway was enabled, the gateway would not appear in the Sequoia form template. Now, when only one gateway is enabled, it is rendered by itself, and not as part of any radio selection.

The solve this problem I made sure that the moveFieldsUnderPaymentGateway function was only called when multiple gateways are enabled, so that it would not be moved into the radio selection (which is set to display none when only a single gateway is enabled). 

## Affects
This fix only impacts Sequoia template frontend assets, specifically JS.

## What to test
Try enabling multiple payment gateways, then test enabling only one payment gateway. Do gateways appear as expected? When only one is enabled, does it load by itself rather than in a radio selection interface?

## Screenshots:
<img width="584" alt="Screen Shot 2020-04-30 at 1 55 56 PM" src="https://user-images.githubusercontent.com/5186078/80743618-3fc45300-8aeb-11ea-8d5e-fa160d833faf.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
