### PR TITLE
fix: company field now includes a building icon

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -151,7 +151,7 @@
 						$( this ).html( html );
 					}
 
-					// Setup string to check tooltip label against
+					// Setup string to check tooltip label ga
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
@@ -204,6 +204,7 @@
 				//Setup input icons
 				setupInputIcon( '#give-first-name-wrap', 'user' );
 				setupInputIcon( '#give-email-wrap', 'envelope' );
+				setupInputIcon( '#give-company-wrap', 'briefcase' );
 
 				// Setup gateway icons
 				setupGatewayIcons();

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -204,7 +204,7 @@
 				//Setup input icons
 				setupInputIcon( '#give-first-name-wrap', 'user' );
 				setupInputIcon( '#give-email-wrap', 'envelope' );
-				setupInputIcon( '#give-company-wrap', 'briefcase' );
+				setupInputIcon( '#give-company-wrap', 'building' );
 
 				// Setup gateway icons
 				setupGatewayIcons();


### PR DESCRIPTION
## Description
Resolves #4686 
Previously, when the company field was enabled, it did not include any icon. This made it visually different from other fields in the row, and made it so that the company input was not vertically aligned with other inputs in the form (eg the name input). 

To resolve this issue, I used the setupInputIcon funciton to add a building icon to the company field.

## Affects
This PR only affects Sequoia template frontend assets, specifically JS.

## What to test
Enable the company field for a form using the Sequoia form template. Does the company field show a small building icon before the input?

## Screenshots:
<img width="572" alt="Screen Shot 2020-04-30 at 3 09 48 PM" src="https://user-images.githubusercontent.com/5186078/80749621-b580ec80-8af4-11ea-8772-5653e5a1bff6.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
