### PR TITLE
resolve unexpected behaviour created by orphaned license keys 

### DIFF
--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -269,6 +269,17 @@ function give_get_license_info_handler() {
 	$check_license_res['site_count']       = $activate_license_res['site_count'];
 	$check_license_res['activations_left'] = $activate_license_res['activations_left'];
 
+	// Remove single license which is part of all access pass or already existed all access pass key because admin can only one active.
+	// @see https://github.com/impress-org/givewp/issues/4669
+	if ( ! empty( $check_license_res['is_all_access_pass'] ) ) {
+		$addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense( $check_license_res );
+		foreach ( $licenses as $license_key => $data ) {
+			if ( in_array( $data['plugin_slug'], $addonSlugs, true ) || ! empty( $check_license_res['is_all_access_pass'] ) ) {
+				unset( $licenses[ $license_key ] );
+			}
+		}
+	}
+
 	$licenses[ $check_license_res['license_key'] ] = $check_license_res;
 	update_option( 'give_licenses', $licenses );
 

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -274,7 +274,7 @@ function give_get_license_info_handler() {
 	if ( ! empty( $check_license_res['is_all_access_pass'] ) ) {
 		$addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense( $check_license_res );
 		foreach ( $licenses as $license_key => $data ) {
-			if ( in_array( $data['plugin_slug'], $addonSlugs, true ) || ! empty( $check_license_res['is_all_access_pass'] ) ) {
+			if ( in_array( $data['plugin_slug'], $addonSlugs, true ) || ! empty( $data['is_all_access_pass'] ) ) {
 				unset( $licenses[ $license_key ] );
 			}
 		}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -3608,11 +3608,16 @@ function give_v262_upgrades() {
 
 	if ( $licenses ) {
 		foreach ( $licenses as $license ) {
-			// Remove single license which is part of all access pass.
-			// @see https://github.com/impress-org/givewp/issues/4669
 			if ( ! empty( $license['is_all_access_pass'] ) ) {
+				// Remove single license which is part of all access pass.
+				// @see https://github.com/impress-org/givewp/issues/4669
 				$addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense( $license );
 				foreach ( $licenses as $license_key => $data ) {
+					// Skip bundle plan license key.
+					if ( ! empty( $data['is_all_access_pass'] ) ) {
+						continue;
+					}
+
 					if ( in_array( $data['plugin_slug'], $addonSlugs, true ) ) {
 						unset( $licenses[ $license_key ] );
 					}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -142,6 +142,10 @@ function give_do_automatic_upgrades() {
 		case version_compare( $give_version, '2.5.11', '<' ):
 			give_v2511_upgrades();
 			$did_upgrade = true;
+
+		case version_compare( $give_version, '2.6.3', '<' ):
+			give_v262_upgrades();
+			$did_upgrade = true;
 	}
 
 	if ( $did_upgrade || version_compare( $give_version, GIVE_VERSION, '<' ) ) {
@@ -2375,12 +2379,12 @@ function give_v201_upgrades_payment_metadata_callback() {
 		"
 			SELECT ID FROM $wpdb->posts
 			WHERE 1=1
-			AND ( 
+			AND (
   				$wpdb->posts.post_date >= '2018-01-08 00:00:00'
 			)
 			AND $wpdb->posts.post_type = 'give_payment'
 			AND {$wpdb->posts}.post_status IN ('" . implode( "','", array_keys( give_get_payment_statuses() ) ) . "')
-			ORDER BY $wpdb->posts.post_date ASC 
+			ORDER BY $wpdb->posts.post_date ASC
 			LIMIT 100
 			OFFSET " . $give_updates->get_offset( 100 )
 	);
@@ -2466,11 +2470,11 @@ function give_v201_move_metadata_into_new_table_callback() {
 
 	$payments = $wpdb->get_col(
 		"
-			SELECT ID FROM $wpdb->posts 
+			SELECT ID FROM $wpdb->posts
 			WHERE 1=1
 			AND ( $wpdb->posts.post_type = 'give_payment' OR $wpdb->posts.post_type = 'give_forms' )
 			AND {$wpdb->posts}.post_status IN ('" . implode( "','", array_keys( give_get_payment_statuses() ) ) . "')
-			ORDER BY $wpdb->posts.post_date ASC 
+			ORDER BY $wpdb->posts.post_date ASC
 			LIMIT 100
 			OFFSET " . $give_updates->get_offset( 100 )
 	);
@@ -2552,11 +2556,11 @@ function give_v201_logs_upgrades_callback() {
 
 	$logs = $wpdb->get_col(
 		"
-			SELECT ID FROM $wpdb->posts 
+			SELECT ID FROM $wpdb->posts
 			WHERE 1=1
 			AND $wpdb->posts.post_type = 'give_log'
 			AND {$wpdb->posts}.post_status IN ('" . implode( "','", array_keys( give_get_payment_statuses() ) ) . "')
-			ORDER BY $wpdb->posts.post_date ASC 
+			ORDER BY $wpdb->posts.post_date ASC
 			LIMIT 100
 			OFFSET " . $give_updates->get_offset( 100 )
 	);
@@ -3593,3 +3597,30 @@ function give_v2511_upgrades() {
 		$wp_roles->remove_cap( $role, 'read_give_payment' );
 	}
 }
+
+/**
+ * Upgrade for version 2.6.3
+ *
+ * @since 2.6.3
+ */
+function give_v262_upgrades() {
+	$licenses = get_option( 'give_licenses', [] );
+
+	if ( $licenses ) {
+		foreach ( $licenses as $license ) {
+			// Remove single license which is part of all access pass.
+			// @see https://github.com/impress-org/givewp/issues/4669
+			if ( ! empty( $license['is_all_access_pass'] ) ) {
+				$addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense( $license );
+				foreach ( $licenses as $license_key => $data ) {
+					if ( in_array( $data['plugin_slug'], $addonSlugs, true ) ) {
+						unset( $licenses[ $license_key ] );
+					}
+				}
+			}
+		}
+
+		update_option( 'give_licenses', $licenses );
+	}
+}
+

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -144,7 +144,7 @@ function give_do_automatic_upgrades() {
 			$did_upgrade = true;
 
 		case version_compare( $give_version, '2.6.3', '<' ):
-			give_v262_upgrades();
+			give_v263_upgrades();
 			$did_upgrade = true;
 	}
 
@@ -3603,7 +3603,7 @@ function give_v2511_upgrades() {
  *
  * @since 2.6.3
  */
-function give_v262_upgrades() {
+function give_v263_upgrades() {
 	$licenses = get_option( 'give_licenses', [] );
 
 	if ( $licenses ) {

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -954,7 +954,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 		 * @param array $license All access pass license data
 		 *
 		 * @return string[]
-		 * @since 2.7.0
+		 * @since 2.6.3
 		 */
 		public static function getAddonSlugsFromAllAccessPassLicense( $license ) {
 			$result = [];

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -780,7 +780,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 								<?php
 								echo sprintf(
 									'<p class="give-license-renewal-date"><span class="dashicons dashicons-calendar-alt"></span> <strong>%1$s</strong> %2$s</p>',
-									$is_license_expired ? __( 'Expired:' ) : __( 'Renews:' ),
+									$is_license_expired ? __( 'Expired:', 'give' ) : __( 'Renews:', 'give' ),
 									date( give_date_format(), $expires_timestamp )
 								);
 								?>
@@ -884,7 +884,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 						<?php echo $plugin['Name']; ?>
 					</span>
 					<span class="give-addon-version">
-						<?php echo sprintf( '%1$s %2$s', __( 'Version' ), $plugin['Version'] ); ?>
+						<?php echo sprintf( '%1$s %2$s', __( 'Version', 'give' ), $plugin['Version'] ); ?>
 					</span>
 				</div>
 
@@ -901,7 +901,7 @@ if ( ! class_exists( 'Give_License' ) ) :
 							)
 						),
 						__( 'View Changelog', 'give' ),
-						__( 'Changelog of' ) . " {$plugin['Name']}"
+						__( 'Changelog of', 'give' ) . " {$plugin['Name']}"
 					);
 					?>
 
@@ -945,6 +945,25 @@ if ( ! class_exists( 'Give_License' ) ) :
 					'count'   => 0,
 				)
 			);
+		}
+
+		/**
+		 * Get all download slugs from all access pass key.
+		 * Note: only for internal use and will be refactored in the  future.
+		 *
+		 * @param array $license All access pass license data
+		 *
+		 * @return string[]
+		 * @since 2.7.0
+		 */
+		public static function getAddonSlugsFromAllAccessPassLicense( $license ) {
+			$result = [];
+
+			foreach ( $license['download'] as $download ) {
+				$result[] = $download['plugin_slug'];
+			}
+
+			return $result;
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4669 

You can see a list of unexpected behaviors here: https://github.com/impress-org/givewp/issues/4669#issuecomment-622260708

To resolve the issue we will do following things when activating bundle plan license key:
1. Remove a single addon license key if part of the bundle plan.
2. Remove the existing bundle plan license key. Admin can only activate one bundle plan key.

Note: an automatic upgrade also added and it will only remove single addon license keys if part of an active bundle license key.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This patch adds logic to remove single license keys and bundle plan license keys when activating the bundle plan license key. Similar logic will run on when updating the core.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Activate multiple bundle plan license key from low to high add-on count when any of must-have add-on installed for example REcurring addon.

If you want to review automatic updates then first switch to `develop` branch. Activate the single license key (recurring, pdf receipt) and bundle plan (basic) license key. Switch to `hotfix/remove-old-single-license-key-4669`. Go to `Downloads -> Settings ->  Licenses`. Check if recurring addon still listed as licensed or not because it is not part of the basic bundle plan that why only license key for `pdf receipt` addon will be removed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
