### PR TITLE
Grouped simple helper functions in a class as static functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,6 @@
     "autoload": {
         "psr-4": {
             "Give\\": "src/"
-        },
-        "files": [
-            "src/Helpers/Form/Template/Template.php",
-            "src/Helpers/Form/Template/Utils/Admin.php",
-            "src/Helpers/Form/Template/Utils/Frontend.php",
-            "src/Helpers/Form/Utils.php",
-            "src/Helpers/Frontend/Shortcode.php",
-            "src/Helpers/Utils.php"
-        ]
+        }
     }
 }

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -14,8 +14,7 @@
 use Give\Form\Template;
 use Give\FormAPI\Fields;
 use Give\FormAPI\Group;
-use function Give\Helpers\Form\Template\get as getTemplateSettings;
-use function Give\Helpers\Form\Template\set as SaveTemplateSettings;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 
 /**
  * Give_Meta_Box_Form_Data Class.
@@ -1070,7 +1069,7 @@ class Give_MetaBox_Form_Data {
 
 		/* @var Template\Options $templateOptions */
 		$templateOptions = $template->getOptions();
-		$saveOptions     = getTemplateSettings( $formID );
+		$saveOptions     = FormTemplateUtils::getOptions( $formID );
 
 		/* @var Group $group */
 		foreach ( $templateOptions->groups as $group ) {
@@ -1132,7 +1131,7 @@ class Give_MetaBox_Form_Data {
 			}
 		}
 
-		SaveTemplateSettings( $formID, $saveOptions );
+		FormTemplateUtils::saveOptions( $formID, $saveOptions );
 	}
 
 

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -13,7 +13,7 @@
 
 use Give\Form\Template;
 use Give\FormAPI\Fields;
-use Give\FormAPI\Group;
+use Give\FormAPI\Section;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 
 /**
@@ -1071,8 +1071,8 @@ class Give_MetaBox_Form_Data {
 		$templateOptions = $template->getOptions();
 		$saveOptions     = FormTemplateUtils::getOptions( $formID );
 
-		/* @var Group $group */
-		foreach ( $templateOptions->groups as $group ) {
+		/* @var Section $group */
+		foreach ( $templateOptions->sections as $group ) {
 			/* @var Fields $field */
 			foreach ( $group->fields as $field ) {
 				if ( ! isset( $options[ $group->id ][ $field->id ] ) ) {

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -12,7 +12,7 @@
  */
 
 // Exit if accessed directly.
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -864,7 +864,7 @@ function give_get_form_template_id() {
 		wp_send_json_error();
 	}
 
-	$templateID = getActiveID( $formId );
+	$templateID = FormTemplateUtils::getActiveID( $formId );
 	$templateID = $templateID ?: 'legacy';
 
 	wp_send_json_success( $templateID );

--- a/includes/forms/widget.php
+++ b/includes/forms/widget.php
@@ -10,7 +10,7 @@
  */
 
 // Exit if accessed directly.
-use function Give\Helpers\Form\Utils\isLegacyForm;
+use Give\Helpers\Form\Utils as FormUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -116,7 +116,7 @@ class Give_Forms_Widget extends WP_Widget {
 		$form_id = (int) $instance['id'];
 
 		// Use alias setting to set display setting when form template other then Legacy.
-		if ( ! isLegacyForm( $form_id ) ) {
+		if ( ! FormUtils::isLegacyForm( $form_id ) ) {
 			$instance['display_style']         = $instance['tmp_display_style'];
 			$instance['continue_button_title'] = $instance['tmp_continue_button_title'];
 

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
 /**
@@ -32,7 +32,7 @@ use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
  * @return bool
  **/
 function give_manual_form_ouput() {
-	if ( getActiveId( getFormId() ) === 'legacy') {
+	if ( getActiveId( getFormId() ) === 'legacy' ) {
 		return false;
 	}
 
@@ -49,7 +49,7 @@ function give_manual_form_ouput() {
 							<rect width="83.75" height="67" fill="white"/>
 						</clipPath>
 					</defs>
-				</svg>			
+				</svg>
 			</div>
 			<p style="text-align: center;"><b>%1$s</b></p>
 			<p style="text-align: center;">

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 /**
  * Manual Gateway does not need a CC form, so remove it.
@@ -32,7 +32,7 @@ use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
  * @return bool
  **/
 function give_manual_form_ouput() {
-	if ( getActiveId( getFormId() ) === 'legacy' ) {
+	if ( FormTemplateUtils::getActiveId( FrontendFormTemplateUtils::getFormId() ) === 'legacy' ) {
 		return false;
 	}
 

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
 /**
@@ -32,7 +32,7 @@ function give_paypal_standard_billing_fields( $form_id ) {
 		return true;
 	}
 
-	if ( getActiveID( getFormId() ) === 'legacy' ) {
+	if ( FormTemplateUtils::getActiveID( getFormId() ) === 'legacy' ) {
 		return false;
 	}
 

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 /**
  * Toggle PayPal CC Billing Detail Fieldset.
@@ -32,7 +32,7 @@ function give_paypal_standard_billing_fields( $form_id ) {
 		return true;
 	}
 
-	if ( FormTemplateUtils::getActiveID( getFormId() ) === 'legacy' ) {
+	if ( FormTemplateUtils::getActiveID( FrontendFormTemplateUtils::getFormId() ) === 'legacy' ) {
 		return false;
 	}
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -13,7 +13,7 @@
 use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -144,7 +144,7 @@ function give_form_shortcode( $atts ) {
 	$atts['show_goal']  = filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN );
 
 	// Set form id.
-	$atts['id'] = $atts['id'] ?: getFormId();
+	$atts['id'] = $atts['id'] ?: FrontendFormTemplateUtils::getFormId();
 	$formId     = absint( $atts['id'] );
 
 	// Get active theme

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -13,10 +13,8 @@
 use function Give\Helpers\Form\Template\getActiveID;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 use function Give\Helpers\Form\Utils\getSuccessPageURL;
-use function Give\Helpers\Form\Utils\isViewingFormFailedPage;
 use function Give\Helpers\Form\Utils\isViewingFormReceipt;
 use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
-use function Give\Helpers\removeDonationAction;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -191,7 +189,7 @@ function give_form_shortcode( $atts ) {
 			trailingslashit( $url )
 		);
 
-		$iframe_url = removeDonationAction( $iframe_url );
+		$iframe_url = Utils::removeDonationAction( $iframe_url );
 
 		$uniqueId         = uniqid( 'give-' );
 		$buttonModeActive = 'button' === $atts['display_style'];

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -10,11 +10,11 @@
  */
 
 // Exit if accessed directly.
+use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
 use function Give\Helpers\Form\Template\getActiveID;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 use function Give\Helpers\Form\Utils\getSuccessPageURL;
 use function Give\Helpers\Form\Utils\isViewingFormReceipt;
-use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -65,7 +65,7 @@ function give_donation_history( $atts, $content = false ) {
 	) {
 		ob_start();
 
-		echo do_shortcode( getReceiptShortcodeFromConfirmationPage() );
+		echo do_shortcode( ShortcodeUtils::getReceiptShortcodeFromConfirmationPage() );
 
 		// Display donation history link only if Receipt Access Session is available.
 		if ( give_get_receipt_session() || is_user_logged_in() ) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -11,10 +11,9 @@
 
 // Exit if accessed directly.
 use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Utils as FormUtils;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
-use function Give\Helpers\Form\Utils\getSuccessPageURL;
-use function Give\Helpers\Form\Utils\isViewingFormReceipt;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -149,7 +148,7 @@ function give_form_shortcode( $atts ) {
 	$formId     = absint( $atts['id'] );
 
 	// Get active theme
-	$activeTheme = getActiveID( $atts['id'] );
+	$activeTheme = FormTemplateUtils::getActiveID( $atts['id'] );
 
 	// Fetch the Give Form.
 	ob_start();
@@ -176,8 +175,8 @@ function give_form_shortcode( $atts ) {
 		// Build iframe url.
 		$url = Give()->routeForm->getURL( get_post_field( 'post_name', $formId ) );
 
-		if ( ( $hasAction && 'showReceipt' === $query_string['giveDonationAction'] ) || isViewingFormReceipt() ) {
-			$url = getSuccessPageURL();
+		if ( ( $hasAction && 'showReceipt' === $query_string['giveDonationAction'] ) || FormUtils::isViewingFormReceipt() ) {
+			$url = FormUtils::getSuccessPageURL();
 
 		} elseif ( ( $hasAction && 'failedDonation' === $query_string['giveDonationAction'] ) ) {
 			$url                                     = Give()->templates->getTemplate( $activeTheme )->getFailedPageURL( $formId );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -12,6 +12,7 @@
 // Exit if accessed directly.
 use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
 use Give\Helpers\Form\Utils as FormUtils;
+use Give\Helpers\Utils as GlobalUtils;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
@@ -188,7 +189,7 @@ function give_form_shortcode( $atts ) {
 			trailingslashit( $url )
 		);
 
-		$iframe_url = Utils::removeDonationAction( $iframe_url );
+		$iframe_url = GlobalUtils::removeDonationAction( $iframe_url );
 
 		$uniqueId         = uniqid( 'give-' );
 		$buttonModeActive = 'button' === $atts['display_style'];

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -11,6 +11,7 @@ namespace Give\Controller;
 
 use Give\Form\LoadTemplate;
 use Give\Form\Template;
+use Give\Helpers\Utils;
 use Give_Notices;
 use WP_Post;
 use function Give\Helpers\Form\Template\getActiveID;
@@ -31,8 +32,6 @@ use function Give\Helpers\Form\Utils\isProcessingGiveActionOnAjax;
 use function Give\Helpers\Form\Utils\isViewingForm;
 use function Give\Helpers\Form\Utils\isViewingFormReceipt;
 use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
-use function Give\Helpers\removeDonationAction;
-use function Give\Helpers\switchRequestedURL;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -215,7 +214,7 @@ class Form {
 		$template = Give()->templates->getTemplate();
 
 		return $template->openSuccessPageInIframe ?
-			createSuccessPageURL( switchRequestedURL( $url, getIframeParentURL() ) ) :
+			createSuccessPageURL( Utils::switchRequestedURL( $url, getIframeParentURL() ) ) :
 			$url;
 	}
 
@@ -232,7 +231,7 @@ class Form {
 		$template = Give()->templates->getTemplate( getActiveID() );
 
 		return $template->openFailedPageInIframe ?
-			createFailedPageURL( switchRequestedURL( $url, getIframeParentURL() ) ) :
+			createFailedPageURL( Utils::switchRequestedURL( $url, getIframeParentURL() ) ) :
 			$url;
 	}
 
@@ -277,7 +276,7 @@ class Form {
 		if ( 0 === strpos( $location, home_url() ) ) {
 			if ( isIframeParentSuccessPageURL( $location ) ) {
 				$location = getSuccessPageURL();
-				$location = removeDonationAction( $location );
+				$location = Utils::removeDonationAction( $location );
 
 				// Open link in window?
 				if ( ! $template->openSuccessPageInIframe ) {
@@ -289,7 +288,7 @@ class Form {
 
 			if ( isIframeParentFailedPageURL( $location ) ) {
 				$location = add_query_arg( [ 'showFailedDonationError' => 1 ], $template->getFailedPageURL( getFormId() ) );
-				$location = removeDonationAction( $location );
+				$location = Utils::removeDonationAction( $location );
 
 				// Open link in window?
 				if ( ! $template->openFailedPageInIframe ) {

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -17,7 +17,7 @@ use Give\Helpers\Form\Utils as FormUtils;
 use Give_Notices;
 use WP_Post;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -273,7 +273,7 @@ class Form {
 			}
 
 			if ( FormUtils::isIframeParentFailedPageURL( $location ) ) {
-				$location = add_query_arg( [ 'showFailedDonationError' => 1 ], $template->getFailedPageURL( getFormId() ) );
+				$location = add_query_arg( [ 'showFailedDonationError' => 1 ], $template->getFailedPageURL( FrontendFormTemplateUtils::getFormId() ) );
 				$location = Utils::removeDonationAction( $location );
 
 				// Open link in window?

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -11,6 +11,7 @@ namespace Give\Controller;
 
 use Give\Form\LoadTemplate;
 use Give\Form\Template;
+use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
 use Give\Helpers\Utils;
 use Give_Notices;
 use WP_Post;
@@ -31,7 +32,6 @@ use function Give\Helpers\Form\Utils\isIframeParentSuccessPageURL;
 use function Give\Helpers\Form\Utils\isProcessingGiveActionOnAjax;
 use function Give\Helpers\Form\Utils\isViewingForm;
 use function Give\Helpers\Form\Utils\isViewingFormReceipt;
-use function Give\Helpers\Frontend\getReceiptShortcodeFromConfirmationPage;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -150,7 +150,7 @@ class Form {
 	 * @return string
 	 */
 	public function showReceiptInIframeOnSuccessPage( $content ) {
-		$receiptShortcode = getReceiptShortcodeFromConfirmationPage();
+		$receiptShortcode = ShortcodeUtils::getReceiptShortcodeFromConfirmationPage();
 		$content          = str_replace( $receiptShortcode, give_form_shortcode( [] ), $content );
 
 		return $content;

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -14,7 +14,7 @@ use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,7 +46,7 @@ class LoadTemplate {
 	 * @param int $formId Form Id. Default value: check explanation in src/Helpers/Form/Utils.php:103
 	 */
 	private function setUpTemplate( $formId = null ) {
-		$formId = (int) ( $formId ?: getFormId() );
+		$formId = (int) ( $formId ?: FrontendFormTemplateUtils::getFormId() );
 
 		$templateID = FormTemplateUtils::getActiveID( $formId ) ?: $this->defaultTemplateID;
 

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -12,11 +12,9 @@ namespace Give\Form;
 use _WP_Dependency;
 use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Utils as FormUtils;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
-use function Give\Helpers\Form\Utils\getSuccessPageURL;
-use function Give\Helpers\Form\Utils\inIframe;
-use function Give\Helpers\Form\Utils\isLegacyForm;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -50,7 +48,7 @@ class LoadTemplate {
 	private function setUpTemplate( $formId = null ) {
 		$formId = (int) ( $formId ?: getFormId() );
 
-		$templateID = getActiveID( $formId ) ?: $this->defaultTemplateID;
+		$templateID = FormTemplateUtils::getActiveID( $formId ) ?: $this->defaultTemplateID;
 
 		$this->template = Give()->templates->getTemplate( $templateID );
 	}
@@ -120,12 +118,12 @@ class LoadTemplate {
 	 */
 	public function handleReceiptAjax() {
 		// Do not handle form template receipt for legacy form.
-		if ( isLegacyForm() ) {
+		if ( FormUtils::isLegacyForm() ) {
 			return;
 		}
 
 		// Show new receipt view only on donation confirmation page.
-		if ( false === strpos( wp_get_referer(), untrailingslashit( getSuccessPageURL() ) ) ) {
+		if ( false === strpos( wp_get_referer(), untrailingslashit( FormUtils::getSuccessPageURL() ) ) ) {
 			return;
 		}
 
@@ -169,7 +167,7 @@ class LoadTemplate {
 
 		$classes[] = 'give-embed-form';
 
-		if ( inIframe() ) {
+		if ( FormUtils::inIframe() ) {
 			$classes[] = 'give-viewing-form-in-iframe';
 		}
 

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -10,7 +10,7 @@
 namespace Give\Form;
 
 use Give\Form\Template\Options;
-use function Give\Helpers\Form\Utils\createFailedPageURL;
+use Give\Helpers\Form\Utils as FormUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -200,7 +200,7 @@ abstract class Template {
 	 * @since 2.7.0
 	 */
 	public function getFailedPageURL( $formId ) {
-		return createFailedPageURL( Give()->routeForm->getURL( get_post_field( 'post_name', $formId ) ) );
+		return FormUtils::createFailedPageURL( Give()->routeForm->getURL( get_post_field( 'post_name', $formId ) ) );
 	}
 
 	/**

--- a/src/Form/Template/Options.php
+++ b/src/Form/Template/Options.php
@@ -2,7 +2,7 @@
 
 namespace Give\Form\Template;
 
-use Give\FormAPI\Group;
+use Give\FormAPI\Section;
 
 /**
  * Class Options
@@ -17,7 +17,7 @@ class Options {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	public $groups = [];
+	public $sections = [];
 
 	/**
 	 * ThemeOptions constructor.
@@ -31,8 +31,8 @@ class Options {
 		$options = new static();
 
 		foreach ( $array as $id => $group ) {
-			$group['id']       = $id;
-			$options->groups[] = Group::fromArray( $group );
+			$group['id']         = $id;
+			$options->sections[] = Section::fromArray( $group );
 		}
 
 		return $options;

--- a/src/Form/Templates.php
+++ b/src/Form/Templates.php
@@ -11,7 +11,7 @@ namespace Give\Form;
 
 use Give\Views\Form\Templates\Legacy\Legacy;
 use Give\Views\Form\Templates\Sequoia\Sequoia;
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -89,7 +89,7 @@ class Templates {
 	 * @since 2.7.0
 	 */
 	public function getTemplate( $templateId = null ) {
-		$templateId = $templateId ?: getActiveID();
+		$templateId = $templateId ?: FormTemplateUtils::getActiveID();
 
 		if ( isset( $this->templateObjs[ $templateId ] ) ) {
 			return $this->templateObjs[ $templateId ];

--- a/src/FormAPI/Form/File.php
+++ b/src/FormAPI/Form/File.php
@@ -1,7 +1,5 @@
 <?php
 namespace Give\FormAPI\Form;
 
-use Give\FormAPI\Form\Media;
-
 class File extends Media {
 }

--- a/src/FormAPI/Form/Group.php
+++ b/src/FormAPI/Form/Group.php
@@ -2,7 +2,7 @@
 
 namespace Give\FormAPI\Form;
 
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 
 class Group extends Field {
 	/**

--- a/src/FormAPI/Form/Text.php
+++ b/src/FormAPI/Form/Text.php
@@ -2,8 +2,6 @@
 
 namespace Give\FormAPI\Form;
 
-use InvalidArgumentException;
-
 class Text extends Field {
 	/**
 	 * Before field.

--- a/src/FormAPI/Section.php
+++ b/src/FormAPI/Section.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  * @since   2.7.0
  * @package Give\Form\Theme
  */
-class Group {
+class Section {
 
 	/**
 	 * Group id.

--- a/src/Helpers/Form/Template.php
+++ b/src/Helpers/Form/Template.php
@@ -2,7 +2,7 @@
 namespace Give\Helpers\Form;
 
 use Give\Form\Template\LegacyFormSettingCompatibility;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\Helpers\Form\Template\Utils\Frontend;
 
 class Template {
 	/**
@@ -14,7 +14,7 @@ class Template {
 	 * @since 2.7.0
 	 */
 	public static function getActiveID( $formId = null ) {
-		return Give()->form_meta->get_meta( $formId ?: FrontendFormTemplateUtils::getFormId(), '_give_form_template', true );
+		return Give()->form_meta->get_meta( $formId ?: Frontend::getFormId(), '_give_form_template', true );
 	}
 
 	/**
@@ -27,7 +27,7 @@ class Template {
 	 * @since 2.7.0
 	 */
 	public static function getOptions( $formId = null, $templateId = '' ) {
-		$formId   = $formId ?: FrontendFormTemplateUtils::getFormId();
+		$formId   = $formId ?: Frontend::getFormId();
 		$template = $templateId ?: Give()->form_meta->get_meta( $formId, '_give_form_template', true );
 		$settings = Give()->form_meta->get_meta( $formId, "_give_{$template}_form_template_settings", true );
 

--- a/src/Helpers/Form/Template/Template.php
+++ b/src/Helpers/Form/Template/Template.php
@@ -2,7 +2,7 @@
 namespace Give\Helpers\Form;
 
 use Give\Form\Template\LegacyFormSettingCompatibility;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 class Template {
 	/**
@@ -14,7 +14,7 @@ class Template {
 	 * @since 2.7.0
 	 */
 	public static function getActiveID( $formId = null ) {
-		return Give()->form_meta->get_meta( $formId ?: getFormId(), '_give_form_template', true );
+		return Give()->form_meta->get_meta( $formId ?: FrontendFormTemplateUtils::getFormId(), '_give_form_template', true );
 	}
 
 	/**
@@ -27,7 +27,7 @@ class Template {
 	 * @since 2.7.0
 	 */
 	public static function getOptions( $formId = null, $templateId = '' ) {
-		$formId   = $formId ?: getFormId();
+		$formId   = $formId ?: FrontendFormTemplateUtils::getFormId();
 		$template = $templateId ?: Give()->form_meta->get_meta( $formId, '_give_form_template', true );
 		$settings = Give()->form_meta->get_meta( $formId, "_give_{$template}_form_template_settings", true );
 

--- a/src/Helpers/Form/Template/Template.php
+++ b/src/Helpers/Form/Template/Template.php
@@ -1,65 +1,65 @@
 <?php
-namespace Give\Helpers\Form\Template;
+namespace Give\Helpers\Form;
 
-use Give\Form\Template;
 use Give\Form\Template\LegacyFormSettingCompatibility;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
-/**
- * This function will return selected form template for a specific form.
- *
- * @param int $formId Form id. Default value: check explanation in ./Utils.php:103
- *
- * @return string
- * @since 2.7.0
- */
-function getActiveID( $formId = null ) {
-	return Give()->form_meta->get_meta( $formId ?: getFormId(), '_give_form_template', true );
-}
-
-
-/**
- * Return saved form template settings
- *
- * @param int    $formId
- * @param string $templateId
- *
- * @return array
- * @since 2.7.0
- */
-function get( $formId = null, $templateId = '' ) {
-	$formId   = $formId ?: getFormId();
-	$template = $templateId ?: Give()->form_meta->get_meta( $formId, '_give_form_template', true );
-	$settings = Give()->form_meta->get_meta( $formId, "_give_{$template}_form_template_settings", true );
-
-	return $settings ?: [];
-}
-
-/**
- * Save settings
- *
- * @sinxe 2.7.0
- * @param $formId
- * @param $settings
- *
- * @return mixed
- */
-function set( $formId, $settings ) {
-	$templateId = Give()->form_meta->get_meta( $formId, '_give_form_template', true );
-
-	/* @var Template $template */
-	$template = Give()->templates->getTemplate( $templateId );
-
-	$isUpdated = Give()->form_meta->update_meta( $formId, "_give_{$templateId}_form_template_settings", $settings );
-
-	/*
-	 * Below code save legacy setting which connected/mapped to form template setting.
-	 * Existing form render on basis of these settings if missed then required output will not generate from give_form_shortcode -> give_get_donation_form function.
+class Template {
+	/**
+	 * This function will return selected form template for a specific form.
 	 *
-	 * Note: We can remove legacy setting compatibility by returning anything except LegacyFormSettingCompatibility class object.
+	 * @param int $formId Form id. Default value: check explanation in ./Utils.php:103
+	 *
+	 * @return string
+	 * @since 2.7.0
 	 */
-	$legacySettingHandler = new LegacyFormSettingCompatibility( $template );
-	$legacySettingHandler->save( $formId, $settings );
+	public static function getActiveID( $formId = null ) {
+		return Give()->form_meta->get_meta( $formId ?: getFormId(), '_give_form_template', true );
+	}
 
-	return $isUpdated;
+	/**
+	 * Return saved form template settings
+	 *
+	 * @param int    $formId
+	 * @param string $templateId
+	 *
+	 * @return array
+	 * @since 2.7.0
+	 */
+	public static function getOptions( $formId = null, $templateId = '' ) {
+		$formId   = $formId ?: getFormId();
+		$template = $templateId ?: Give()->form_meta->get_meta( $formId, '_give_form_template', true );
+		$settings = Give()->form_meta->get_meta( $formId, "_give_{$template}_form_template_settings", true );
+
+		return $settings ?: [];
+	}
+
+	/**
+	 * Save settings
+	 *
+	 * @sinxe 2.7.0
+	 * @param $formId
+	 * @param $settings
+	 *
+	 * @return mixed
+	 */
+	public static function saveOptions( $formId, $settings ) {
+		$templateId = Give()->form_meta->get_meta( $formId, '_give_form_template', true );
+
+		/* @var \Give\Form\Template $template */
+		$template = Give()->templates->getTemplate( $templateId );
+
+		$isUpdated = Give()->form_meta->update_meta( $formId, "_give_{$templateId}_form_template_settings", $settings );
+
+		/*
+		 * Below code save legacy setting which connected/mapped to form template setting.
+		 * Existing form render on basis of these settings if missed then required output will not generate from give_form_shortcode -> give_get_donation_form function.
+		 *
+		 * Note: We can remove legacy setting compatibility by returning anything except LegacyFormSettingCompatibility class object.
+		 */
+		$legacySettingHandler = new LegacyFormSettingCompatibility( $template );
+		$legacySettingHandler->save( $formId, $settings );
+
+		return $isUpdated;
+	}
 }

--- a/src/Helpers/Form/Template/Utils/Admin.php
+++ b/src/Helpers/Form/Template/Utils/Admin.php
@@ -5,7 +5,8 @@ use Give\Form\Template;
 use Give\FormAPI\Form\Field;
 use Give\FormAPI\Group;
 use WP_Post;
-use function Give\Helpers\Form\Template\get as getTheme;
+use Give\Helpers\Form\Template as FormTemplateUtils;
+
 
 /**
  * Render template setting in form metabox.
@@ -21,7 +22,7 @@ function renderMetaboxSettings( $template ) {
 
 	ob_start();
 
-	$saveOptions = getTheme( $post->ID, $template->getID() );
+	$saveOptions = FormTemplateUtils::getOptions( $post->ID, $template->getID() );
 
 	/* @var Group $option */
 	foreach ( $template->getOptions()->groups as $group ) {

--- a/src/Helpers/Form/Template/Utils/Admin.php
+++ b/src/Helpers/Form/Template/Utils/Admin.php
@@ -1,5 +1,5 @@
 <?php
-namespace Give\Helpers\Form\Template\Utils\Admin;
+namespace Give\Helpers\Form\Template\Utils;
 
 use Give\Form\Template;
 use Give\FormAPI\Form\Field;
@@ -8,57 +8,59 @@ use WP_Post;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 
 
-/**
- * Render template setting in form metabox.
- *
- * @since 2.7.0
- *
- * @global WP_Post $post
- * @param Template $template
- * @return string
- */
-function renderMetaboxSettings( $template ) {
-	global $post;
+class Admin {
+	/**
+	 * Render template setting in form metabox.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @global WP_Post $post
+	 * @param Template $template
+	 * @return string
+	 */
+	public static function renderMetaboxSettings( $template ) {
+		global $post;
 
-	ob_start();
+		ob_start();
 
-	$saveOptions = FormTemplateUtils::getOptions( $post->ID, $template->getID() );
+		$saveOptions = FormTemplateUtils::getOptions( $post->ID, $template->getID() );
 
-	/* @var Group $option */
-	foreach ( $template->getOptions()->groups as $group ) {
-		printf(
-			'<div class="give-row %1$s">',
-			$group->id
-		);
+		/* @var Group $option */
+		foreach ( $template->getOptions()->groups as $group ) {
+			printf(
+				'<div class="give-row %1$s">',
+				$group->id
+			);
 
-		printf(
-			'<div class="give-row-head">
+			printf(
+				'<div class="give-row-head">
 							<button type="button" class="handlediv" aria-expanded="true">
 								<span class="toggle-indicator"/>
 							</button>
 							<h2 class="hndle"><span>%1$s</span></h2>
 						</div>',
-			$group->name
-		);
+				$group->name
+			);
 
-		echo '<div class="give-row-body">';
+			echo '<div class="give-row-body">';
 
-		/* @var Field $field */
-		foreach ( $group->fields as $field ) {
-			$field = $field->toArray();
-			if ( isset( $saveOptions[ $group->id ][ $field['id'] ] ) ) {
-				$field['attributes']['value'] = $saveOptions[ $group->id ][ $field['id'] ];
+			/* @var Field $field */
+			foreach ( $group->fields as $field ) {
+				$field = $field->toArray();
+				if ( isset( $saveOptions[ $group->id ][ $field['id'] ] ) ) {
+					$field['attributes']['value'] = $saveOptions[ $group->id ][ $field['id'] ];
+				}
+
+				$field['id'] = "{$template->getID()}[{$group->id}][{$field['id']}]";
+
+				give_render_field( $field );
 			}
 
-			$field['id'] = "{$template->getID()}[{$group->id}][{$field['id']}]";
-
-			give_render_field( $field );
+			echo '</div></div>';
 		}
 
-		echo '</div></div>';
+		return ob_get_clean();
 	}
-
-	return ob_get_clean();
 }
 
 

--- a/src/Helpers/Form/Template/Utils/Admin.php
+++ b/src/Helpers/Form/Template/Utils/Admin.php
@@ -3,7 +3,7 @@ namespace Give\Helpers\Form\Template\Utils;
 
 use Give\Form\Template;
 use Give\FormAPI\Form\Field;
-use Give\FormAPI\Group;
+use Give\FormAPI\Section;
 use WP_Post;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 
@@ -25,8 +25,8 @@ class Admin {
 
 		$saveOptions = FormTemplateUtils::getOptions( $post->ID, $template->getID() );
 
-		/* @var Group $option */
-		foreach ( $template->getOptions()->groups as $group ) {
+		/* @var Section $option */
+		foreach ( $template->getOptions()->sections as $group ) {
 			printf(
 				'<div class="give-row %1$s">',
 				$group->id

--- a/src/Helpers/Form/Template/Utils/Frontend.php
+++ b/src/Helpers/Form/Template/Utils/Frontend.php
@@ -1,80 +1,83 @@
 <?php
-namespace Give\Helpers\Form\Template\Utils\Frontend;
+namespace Give\Helpers\Form\Template\Utils;
 
 use WP_Post;
 
-/**
- * This function will return form id.
- *
- * There are two ways to auto detect form id:
- *   1. If global $post is give_forms post type then we assume that we are on donation form page and return id.
- *   2. if we are not on donation form page and process donation then we will return form id from submitted donation form data.
- *   3. if we are not on donation form page then we will get donation form id from session.
- *
- * This function can be use in donation processing flow i.e from donation form to receipt/failed transaction
- *
- * @return int|null
- * @global WP_Post $post
- * @since 2.7.0
- */
-function getFormId() {
-	global $post;
+class Frontend {
+	/**
+	 * This function will return form id.
+	 *
+	 * There are two ways to auto detect form id:
+	 *   1. If global $post is give_forms post type then we assume that we are on donation form page and return id.
+	 *   2. if we are not on donation form page and process donation then we will return form id from submitted donation form data.
+	 *   3. if we are not on donation form page then we will get donation form id from session.
+	 *
+	 * This function can be use in donation processing flow i.e from donation form to receipt/failed transaction
+	 *
+	 * @return int|null
+	 * @global WP_Post $post
+	 * @since 2.7.0
+	 */
+	public static function getFormId() {
+		global $post;
 
-	if ( 'give_forms' === get_post_type( $post ) ) {
-		return $post->ID;
+		if ( 'give_forms' === get_post_type( $post ) ) {
+			return $post->ID;
+		}
+
+		if ( $formId = get_query_var( 'give_form_id' ) ) {
+			$form = current(
+				get_posts(
+					[
+						'name'        => $formId,
+						'numberposts' => 1,
+						'post_type'   => 'give_forms',
+					]
+				)
+			);
+
+			return $form->ID;
+		}
+
+		// Get form Id on ajax request.
+		if ( isset( $_REQUEST['give_form_id'] ) && ( $formId = absint( $_REQUEST['give_form_id'] ) ) ) {
+			return $formId;
+		}
+
+		// Get form Id on ajax request.
+		if ( isset( $_REQUEST['form_id'] ) && ( $formId = absint( $_REQUEST['form_id'] ) ) ) {
+			return $formId;
+		}
+
+		// Get form id from donor purchase session.
+		$donorSession = give_get_purchase_session();
+		$formId       = ! empty( $donorSession['post_data']['give-form-id'] ) ?
+			absint( $donorSession['post_data']['give-form-id'] ) :
+			null;
+
+		if ( $formId ) {
+			return $formId;
+		}
+
+		return null;
 	}
 
-	if ( $formId = get_query_var( 'give_form_id' ) ) {
-		$form = current(
-			get_posts(
-				[
-					'name'        => $formId,
-					'numberposts' => 1,
-					'post_type'   => 'give_forms',
-				]
-			)
-		);
-
-		return $form->ID;
+	/**
+	 * This function will return payment id.
+	 *
+	 * The payment id is found by getting information on the current purchase session, and returning the
+	 * donation id associated with the current purchase session.
+	 *
+	 * This function is used in the purchasing flow (ie building the receipt page)
+	 *
+	 * @return int|null
+	 * @global WP_Post $post
+	 * @since 2.7.0
+	 */
+	public static function getPaymentId() {
+		$session = give_get_purchase_session();
+		return isset( $session['donation_id'] ) ? intval( $session['donation_id'] ) : null;
 	}
 
-	// Get form Id on ajax request.
-	if ( isset( $_REQUEST['give_form_id'] ) && ( $formId = absint( $_REQUEST['give_form_id'] ) ) ) {
-		return $formId;
-	}
 
-	// Get form Id on ajax request.
-	if ( isset( $_REQUEST['form_id'] ) && ( $formId = absint( $_REQUEST['form_id'] ) ) ) {
-		return $formId;
-	}
-
-	// Get form id from donor purchase session.
-	$donorSession = give_get_purchase_session();
-	$formId       = ! empty( $donorSession['post_data']['give-form-id'] ) ?
-		absint( $donorSession['post_data']['give-form-id'] ) :
-		null;
-
-	if ( $formId ) {
-		return $formId;
-	}
-
-	return null;
 }
-
-/**
- * This function will return payment id.
- *
- * The payment id is found by getting information on the current purchase session, and returning the
- * donation id associated with the current purchase session.
- *
- * This function is used in the purchasing flow (ie building the receipt page)
- *
- * @return int|null
- * @global WP_Post $post
- * @since 2.7.0
- */
-function getPaymentId() {
-	$session = give_get_purchase_session();
-	return isset( $session['donation_id'] ) ? intval( $session['donation_id'] ) : null;
-}
-

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -2,9 +2,8 @@
 namespace Give\Helpers\Form;
 
 use Give\Controller\Form;
+use Give\Helpers\Form\Template\Utils\Frontend;
 use Give\Helpers\Utils as GlobalUtils;
-use Give\Helpers\Form\Template as FormTemplateUtils;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 class Utils {
 	/**
@@ -30,7 +29,7 @@ class Utils {
 	 */
 	public static function isProcessingForm() {
 		$base     = Give()->routeForm->getBase();
-		$formName = get_post_field( 'post_name', FrontendFormTemplateUtils::getFormId() );
+		$formName = get_post_field( 'post_name', Frontend::getFormId() );
 		$referer  = trailingslashit( wp_get_referer() );
 
 		return ! empty( $_REQUEST['give_embed_form'] ) ||
@@ -211,10 +210,10 @@ class Utils {
 	 * @since 2.7.0
 	 */
 	public static function isLegacyForm( $formID = null ) {
-		$formID       = $formID ?: getFormId();
-		$formTemplate = FormTemplateUtils::getActiveID( $formID );
+		$formID       = $formID ?: Frontend::getFormId();
+		$formTemplate = Template::getActiveID( $formID );
 
-		return ! $formTemplate || 'legacy' === FormTemplateUtils::getActiveID( $formID );
+		return ! $formTemplate || 'legacy' === Template::getActiveID( $formID );
 	}
 
 }

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -2,9 +2,9 @@
 namespace Give\Helpers\Form\Utils;
 
 use Give\Controller\Form;
+use Give\Helpers\Utils;
 use function Give\Helpers\Form\Template\getActiveID;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
-use function Give\Helpers\getQueryParamFromURL;
 
 /**
  * Get result if we are viewing embed form or not
@@ -81,7 +81,7 @@ function canShowFailedDonationError() {
  * @since 2.7.0
  */
 function isIframeParentFailedPageURL( $url ) {
-	$action = getQueryParamFromURL( $url, 'giveDonationAction' );
+	$action = Utils::getQueryParamFromURL( $url, 'giveDonationAction' );
 
 	return $action && 'failedDonation' === $action;
 }
@@ -95,7 +95,7 @@ function isIframeParentFailedPageURL( $url ) {
  * @since 2.7.0
  */
 function isIframeParentSuccessPageURL( $url ) {
-	$action = getQueryParamFromURL( $url, 'giveDonationAction' );
+	$action = Utils::getQueryParamFromURL( $url, 'giveDonationAction' );
 
 	return $action && 'showReceipt' === $action;
 }

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -1,224 +1,220 @@
 <?php
-namespace Give\Helpers\Form\Utils;
+namespace Give\Helpers\Form;
 
 use Give\Controller\Form;
-use Give\Helpers\Utils;
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Utils as GlobalUtils;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
 
-/**
- * Get result if we are viewing embed form or not
- *
- * @return bool
- * @since 2.7.0
- */
-function isViewingForm() {
-	$base = Give()->routeForm->getBase();
+class Utils {
+	/**
+	 * Get result if we are viewing embed form or not
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public static function isViewingForm() {
+		$base = Give()->routeForm->getBase();
 
-	return (
-		$base === get_query_var( 'name' ) ||
-		( wp_doing_ajax() && false !== strpos( wp_get_referer(), "/{$base}/" ) ) // for ajax
-	);
-}
+		return (
+			$base === get_query_var( 'name' ) ||
+			( wp_doing_ajax() && false !== strpos( wp_get_referer(), "/{$base}/" ) ) // for ajax
+		);
+	}
 
-/**
- * Get result if we are processing embed form or not
- *
- * @return bool
- * @since 2.7.0
- */
-function isProcessingForm() {
-	$base     = Give()->routeForm->getBase();
-	$formName = get_post_field( 'post_name', getFormId() );
-	$referer  = trailingslashit( wp_get_referer() );
+	/**
+	 * Get result if we are processing embed form or not
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public static function isProcessingForm() {
+		$base     = Give()->routeForm->getBase();
+		$formName = get_post_field( 'post_name', getFormId() );
+		$referer  = trailingslashit( wp_get_referer() );
 
-	return ! empty( $_REQUEST['give_embed_form'] ) ||
-		   false !== strpos( trailingslashit( wp_get_referer() ), "/{$base}/{$formName}/" ) ||
-		   inIframe() ||
-		   false !== strpos( $referer, 'giveDonationFormInIframe' );
-}
+		return ! empty( $_REQUEST['give_embed_form'] ) ||
+			   false !== strpos( trailingslashit( wp_get_referer() ), "/{$base}/{$formName}/" ) ||
+			   self::inIframe() ||
+			   false !== strpos( $referer, 'giveDonationFormInIframe' );
+	}
 
+	/**
+	 * Get result whether or not performing Give core action on ajax or not.
+	 *
+	 * @since 2.7.0
+	 * @return bool
+	 */
+	public static function isProcessingGiveActionOnAjax() {
+		$action            = isset( $_REQUEST['action'] ) ? give_clean( $_REQUEST['action'] ) : '';
+		$whiteListedAction = [ 'get_receipt' ];
+		return $action && wp_doing_ajax() && ( 0 === strpos( $action, 'give_' ) || in_array( $action, $whiteListedAction, true ) );
+	}
 
-/**
- * Get result whether or not performing Give core action on ajax or not.
- *
- * @since 2.7.0
- * @return bool
- */
-function isProcessingGiveActionOnAjax() {
-	$action            = isset( $_REQUEST['action'] ) ? give_clean( $_REQUEST['action'] ) : '';
-	$whiteListedAction = [ 'get_receipt' ];
-	return $action && wp_doing_ajax() && ( 0 === strpos( $action, 'give_' ) || in_array( $action, $whiteListedAction, true ) );
-}
+	/**
+	 * Get result whether or not show failed transaction error.
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public static function canShowFailedDonationError() {
+		return ! empty( $_REQUEST['showFailedDonationError'] );
+	}
 
+	/**
+	 * This function check whether or not given url is of iframe parent failed page.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 */
+	public static function isIframeParentFailedPageURL( $url ) {
+		$action = GlobalUtils::getQueryParamFromURL( $url, 'giveDonationAction' );
 
-/**
- * Get result if we are viewing embed form receipt or not
- *
- * @return bool
- * @since 2.7.0
- */
-function isViewingFormReceipt() {
-	return give_is_success_page();
-}
+		return $action && 'failedDonation' === $action;
+	}
 
-/**
- * Get result whether or not show failed transaction error.
- *
- * @return bool
- * @since 2.7.0
- */
-function canShowFailedDonationError() {
-	return ! empty( $_REQUEST['showFailedDonationError'] );
-}
+	/**
+	 * This function check whether or not given url is of iframe parent success page.
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 */
+	public static function isIframeParentSuccessPageURL( $url ) {
+		$action = GlobalUtils::getQueryParamFromURL( $url, 'giveDonationAction' );
 
-/**
- * This function check whether or not given url is of iframe parent failed page.
- *
- * @param string $url
- *
- * @return string
- * @since 2.7.0
- */
-function isIframeParentFailedPageURL( $url ) {
-	$action = Utils::getQueryParamFromURL( $url, 'giveDonationAction' );
+		return $action && 'showReceipt' === $action;
+	}
 
-	return $action && 'failedDonation' === $action;
-}
+	/**
+	 * This function will create success page URL.
+	 *
+	 * Note: this function is use to get success page url for parent page when perform donation with off-site checkout.
+	 *
+	 * @since 2.7.0
+	 * @param array       $args
+	 * @param string|null $url
+	 *
+	 * @return string
+	 */
+	public static function createSuccessPageURL( $url, $args = [] ) {
+		$args = array_merge( $args, [ 'giveDonationAction' => 'showReceipt' ] );
 
-/**
- * This function check whether or not given url is of iframe parent success page.
- *
- * @param string $url
- *
- * @return string
- * @since 2.7.0
- */
-function isIframeParentSuccessPageURL( $url ) {
-	$action = Utils::getQueryParamFromURL( $url, 'giveDonationAction' );
+		return add_query_arg(
+			$args,
+			$url
+		);
+	}
 
-	return $action && 'showReceipt' === $action;
-}
+	/**
+	 * Return whether or not we are confirming donation or not.
+	 *
+	 * @since 2.7.0
+	 * @return bool
+	 */
+	public static function isConfirmingDonation() {
+		return isset( $_GET['payment-confirmation'] ) && has_filter( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ) );
+	}
 
+	/**
+	 * Get Iframe parent page URL.
+	 *
+	 * Note: must be use only inside iframe logic.
+	 *
+	 * @since 2.7.0
+	 */
+	public static function getIframeParentURL() {
+		return isset( $_REQUEST['give-current-url'] ) ? give_clean( $_REQUEST['give-current-url'] ) : '';
+	}
 
-/**
- * Returns whether or not the given form uses the legacy form template
- *
- * @param int|null $formID
- *
- * @return bool
- * @since 2.7.0
- */
-function isLegacyForm( $formID = null ) {
-	$formID       = $formID ?: getFormId();
-	$formTemplate = getActiveID( $formID );
+	/**
+	 * Return legacy failed page url.
+	 *
+	 * Wrapper function for give_get_failed_transaction_uri and without embed form filter
+	 *
+	 * @since 2.7.0
+	 * @return string
+	 */
+	public static function getLegacyFailedPageURL() {
+		remove_filter( 'give_get_failed_transaction_uri', [ Form::class, 'editFailedPageURI' ] );
+		$url = give_get_failed_transaction_uri();
+		add_filter( 'give_get_failed_transaction_uri', [ Form::class, 'editFailedPageURI' ] );
 
-	return ! $formTemplate || 'legacy' === getActiveID( $formID );
-}
+		return $url;
+	}
 
+	/**
+	 * Return success page url.
+	 *
+	 * Wrapper function for give_get_success_page_uri and without embed form filter.
+	 *
+	 * @since 2.7.0
+	 * @return string
+	 */
+	public static function getSuccessPageURL() {
+		remove_filter( 'give_get_success_page_uri', [ Form::class, 'editSuccessPageURI' ] );
+		$url = give_get_success_page_uri();
+		add_filter( 'give_get_success_page_uri', [ Form::class, 'editSuccessPageURI' ] );
 
-/**
- * This function will create failed transaction page URL.
- *
- * Note: this function is use to get failed page url for parent page when perform donation with off-site checkout.
- *
- * @since 2.7.0
- * @param array       $args
- * @param string|null $url
- *
- * @return string
- */
-function createFailedPageURL( $url, $args = [] ) {
-	$args = array_merge( $args, [ 'giveDonationAction' => 'failedDonation' ] );
+		return $url;
+	}
 
-	return add_query_arg(
-		$args,
-		$url
-	);
-}
+	/**
+	 * Get result if we are viewing embed form receipt or not
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public static function isViewingFormReceipt() {
+		return give_is_success_page();
+	}
 
-/**
- * This function will create success page URL.
- *
- * Note: this function is use to get success page url for parent page when perform donation with off-site checkout.
- *
- * @since 2.7.0
- * @param array       $args
- * @param string|null $url
- *
- * @return string
- */
-function createSuccessPageURL( $url, $args = [] ) {
-	$args = array_merge( $args, [ 'giveDonationAction' => 'showReceipt' ] );
+	/**
+	 * This function will create failed transaction page URL.
+	 *
+	 * Note: this function is use to get failed page url for parent page when perform donation with off-site checkout.
+	 *
+	 * @since 2.7.0
+	 * @param array       $args
+	 * @param string|null $url
+	 *
+	 * @return string
+	 */
+	public static function createFailedPageURL( $url, $args = [] ) {
+		$args = array_merge( $args, [ 'giveDonationAction' => 'failedDonation' ] );
 
-	return add_query_arg(
-		$args,
-		$url
-	);
-}
+		return add_query_arg(
+			$args,
+			$url
+		);
+	}
 
+	/**
+	 * Return if current URL loading in iframe or not.
+	 *
+	 * @since 2.7.0
+	 * @return bool
+	 */
+	public static function inIframe() {
+		return ! empty( $_GET['giveDonationFormInIframe'] );
+	}
 
-/**
- * Return if current URL loading in iframe or not.
- *
- * @since 2.7.0
- * @return bool
- */
-function inIframe() {
-	return ! empty( $_GET['giveDonationFormInIframe'] );
-}
+	/**
+	 * Returns whether or not the given form uses the legacy form template
+	 *
+	 * @param int|null $formID
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public static function isLegacyForm( $formID = null ) {
+		$formID       = $formID ?: getFormId();
+		$formTemplate = FormTemplateUtils::getActiveID( $formID );
 
+		return ! $formTemplate || 'legacy' === FormTemplateUtils::getActiveID( $formID );
+	}
 
-/**
- * Return success page url.
- *
- * Wrapper function for give_get_success_page_uri and without embed form filter.
- *
- * @since 2.7.0
- * @return string
- */
-function getSuccessPageURL() {
-	remove_filter( 'give_get_success_page_uri', [ Form::class, 'editSuccessPageURI' ] );
-	$url = give_get_success_page_uri();
-	add_filter( 'give_get_success_page_uri', [ Form::class, 'editSuccessPageURI' ] );
-
-	return $url;
-}
-
-/**
- * Return legacy failed page url.
- *
- * Wrapper function for give_get_failed_transaction_uri and without embed form filter
- *
- * @since 2.7.0
- * @return string
- */
-function getLegacyFailedPageURL() {
-	remove_filter( 'give_get_failed_transaction_uri', [ Form::class, 'editFailedPageURI' ] );
-	$url = give_get_failed_transaction_uri();
-	add_filter( 'give_get_failed_transaction_uri', [ Form::class, 'editFailedPageURI' ] );
-
-	return $url;
-}
-
-
-/**
- * Get Iframe parent page URL.
- *
- * Note: must be use only inside iframe logic.
- *
- * @since 2.7.0
- */
-function getIframeParentURL() {
-	return isset( $_REQUEST['give-current-url'] ) ? give_clean( $_REQUEST['give-current-url'] ) : '';
-}
-
-/**
- * Return whether or not we are confirming donation or not.
- *
- * @since 2.7.0
- * @return bool
- */
-function isConfirmingDonation() {
-	return isset( $_GET['payment-confirmation'] ) && has_filter( 'give_payment_confirm_' . give_clean( $_GET['payment-confirmation'] ) );
 }

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -4,7 +4,7 @@ namespace Give\Helpers\Form;
 use Give\Controller\Form;
 use Give\Helpers\Utils as GlobalUtils;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 class Utils {
 	/**
@@ -30,7 +30,7 @@ class Utils {
 	 */
 	public static function isProcessingForm() {
 		$base     = Give()->routeForm->getBase();
-		$formName = get_post_field( 'post_name', getFormId() );
+		$formName = get_post_field( 'post_name', FrontendFormTemplateUtils::getFormId() );
 		$referer  = trailingslashit( wp_get_referer() );
 
 		return ! empty( $_REQUEST['give_embed_form'] ) ||

--- a/src/Helpers/Frontend/Shortcode.php
+++ b/src/Helpers/Frontend/Shortcode.php
@@ -2,25 +2,27 @@
 
 namespace Give\Helpers\Frontend;
 
-/**
- * Get give_receipt shortcode with attributes from confirmation page.
- *
- * @return string
- * @since 2.7.0
- */
-function getReceiptShortcodeFromConfirmationPage() {
-	$pattern = get_shortcode_regex();
-	$post    = get_post( give_get_option( 'success_page', 0 ) );
-	$content = $post->post_content;
+class Shortcode {
+	/**
+	 * Get give_receipt shortcode with attributes from confirmation page.
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 */
+	public static function getReceiptShortcodeFromConfirmationPage() {
+		$pattern = get_shortcode_regex();
+		$post    = get_post( give_get_option( 'success_page', 0 ) );
+		$content = $post->post_content;
 
-	if (
-		! empty( $content ) &&
-		preg_match_all( '/' . $pattern . '/s', $content, $matches ) &&
-		array_key_exists( 2, $matches ) &&
-		in_array( 'give_receipt', $matches[2], true )
-	) {
-		return $matches[0][0];
+		if (
+			! empty( $content ) &&
+			preg_match_all( '/' . $pattern . '/s', $content, $matches ) &&
+			array_key_exists( 2, $matches ) &&
+			in_array( 'give_receipt', $matches[2], true )
+		) {
+			return $matches[0][0];
+		}
+
+		return '';
 	}
-
-	return '';
 }

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -2,74 +2,80 @@
 namespace Give\Helpers;
 
 /**
- * Extract query param from URL
+ * Class Utils
  *
- * @since 2.7.0
- *
- * @param string $url
- * @param string $queryParamName
- * @param mixed  $default
- *
- * @return string
+ * @package Give\Helpers
  */
-function getQueryParamFromURL( $url, $queryParamName, $default = '' ) {
-	$queryArgs = wp_parse_args( parse_url( $url, PHP_URL_QUERY ) );
+class Utils {
+	/**
+	 * Extract query param from URL
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param string $url
+	 * @param string $queryParamName
+	 * @param mixed  $default
+	 *
+	 * @return string
+	 */
+	public static function getQueryParamFromURL( $url, $queryParamName, $default = '' ) {
+		$queryArgs = wp_parse_args( parse_url( $url, PHP_URL_QUERY ) );
 
-	return isset( $queryArgs[ $queryParamName ] ) ? give_clean( $queryArgs[ $queryParamName ] ) : $default;
-}
-
-/**
- * This function will change request url with other url.
- *
- * @since 2.7.0
- *
- * @param string $location Requested URL.
- * @param string $url URL.
- * @param array  $removeArgs Remove extra query params.
- * @param array  $addArgs add extra query params.
- *
- * @return string
- */
-function switchRequestedURL( $location, $url, $addArgs = [], $removeArgs = [] ) {
-	$queryString = [];
-
-	if ( $index = strpos( $location, '?' ) ) {
-		$queryString = wp_parse_args( substr( $location, strpos( $location, '?' ) + 1 ) );
+		return isset( $queryArgs[ $queryParamName ] ) ? give_clean( $queryArgs[ $queryParamName ] ) : $default;
 	}
 
-	if ( $index = strpos( $url, '?' ) ) {
-		$queryString = array_merge( $queryString, wp_parse_args( substr( $url, strpos( $url, '?' ) + 1 ) ) );
-	}
+	/**
+	 * This function will change request url with other url.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param string $location Requested URL.
+	 * @param string $url URL.
+	 * @param array  $removeArgs Remove extra query params.
+	 * @param array  $addArgs add extra query params.
+	 *
+	 * @return string
+	 */
+	public static function switchRequestedURL( $location, $url, $addArgs = [], $removeArgs = [] ) {
+		$queryString = [];
 
-	$url = add_query_arg(
-		$queryString,
-		$url
-	);
-
-	if ( $removeArgs ) {
-		foreach ( $removeArgs as $name ) {
-			$url = add_query_arg( [ $name => false ], $url );
+		if ( $index = strpos( $location, '?' ) ) {
+			$queryString = wp_parse_args( substr( $location, strpos( $location, '?' ) + 1 ) );
 		}
-	}
 
-	if ( $addArgs ) {
-		foreach ( $addArgs as $name => $value ) {
-			$url = add_query_arg( [ $name => $value ], $url );
+		if ( $index = strpos( $url, '?' ) ) {
+			$queryString = array_merge( $queryString, wp_parse_args( substr( $url, strpos( $url, '?' ) + 1 ) ) );
 		}
+
+		$url = add_query_arg(
+			$queryString,
+			$url
+		);
+
+		if ( $removeArgs ) {
+			foreach ( $removeArgs as $name ) {
+				$url = add_query_arg( [ $name => false ], $url );
+			}
+		}
+
+		if ( $addArgs ) {
+			foreach ( $addArgs as $name => $value ) {
+				$url = add_query_arg( [ $name => $value ], $url );
+			}
+		}
+
+		return $url;
 	}
 
-	return $url;
-}
-
-
-/**
- * Remove giveDonationAction  from URL.
- *
- * @since 2.7.0
- * @param $url
- *
- * @return string
- */
-function removeDonationAction( $url ) {
-	return add_query_arg( [ 'giveDonationAction' => false ], $url );
+	/**
+	 * Remove giveDonationAction  from URL.
+	 *
+	 * @since 2.7.0
+	 * @param $url
+	 *
+	 * @return string
+	 */
+	public static function removeDonationAction( $url ) {
+		return add_query_arg( [ 'giveDonationAction' => false ], $url );
+	}
 }

--- a/src/Views/Admin/Form/Metabox-Settings.php
+++ b/src/Views/Admin/Form/Metabox-Settings.php
@@ -2,10 +2,10 @@
 global $post;
 
 use Give\Form\Template;
-use function Give\Helpers\Form\Template\getActiveID;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Admin\renderMetaboxSettings;
 
-$activatedTemplate   = getActiveID( $post->ID );
+$activatedTemplate   = FormTemplateUtils::getActiveID( $post->ID );
 $registeredTemplates = Give()->templates->getTemplates();
 ?>
 <div class="form_template_options_wrap inner-panel<?php echo $activatedTemplate ? ' has-activated-template' : ''; ?>">

--- a/src/Views/Admin/Form/Metabox-Settings.php
+++ b/src/Views/Admin/Form/Metabox-Settings.php
@@ -3,7 +3,7 @@ global $post;
 
 use Give\Form\Template;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Admin\renderMetaboxSettings;
+use Give\Helpers\Form\Template\Utils\Admin as AdminFormTemplateUtils;
 
 $activatedTemplate   = FormTemplateUtils::getActiveID( $post->ID );
 $registeredTemplates = Give()->templates->getTemplates();
@@ -68,7 +68,7 @@ $registeredTemplates = Give()->templates->getTemplates();
 				'<div class="template-options %1$s" data-id="%2$s">%3$s</div>',
 				$template->getID() . ( $activatedTemplate === $template->getID() ? ' active' : '' ),
 				$template->getID(),
-				renderMetaboxSettings( $template )
+				AdminFormTemplateUtils::renderMetaboxSettings( $template )
 			);
 		}
 		?>

--- a/src/Views/Form/Templates/Sequoia/Actions.php
+++ b/src/Views/Form/Templates/Sequoia/Actions.php
@@ -3,8 +3,7 @@
 namespace Give\Views\Form\Templates\Sequoia;
 
 use Give_Donate_Form;
-use function Give\Helpers\Form\Template\get as getTheme;
-
+use Give\Helpers\Form\Template as FormTemplateUtils;
 
 /**
  * Class Actions
@@ -23,7 +22,7 @@ class Actions {
 	 */
 	public function init() {
 		// Get Template options
-		$this->templateOptions = getTheme();
+		$this->templateOptions = FormTemplateUtils::getOptions();
 
 		// Set zero number of decimal.
 		add_filter( 'give_get_currency_formatting_settings', [ $this, 'setupZeroNumberOfDecimalInCurrencyFormattingSetting' ], 1 );

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -1,10 +1,11 @@
 <?php
 namespace Give\Views\Form\Templates\Sequoia;
 
+use Give\Controller\Form;
 use Give\Form\Template;
 use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
-use function Give\Helpers\Form\Template\get as getTemplateOptions;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use \Give_Donate_Form as DonationForm;
 
 /**
@@ -18,7 +19,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 	 */
 	public function getFormStartingHeight( int $formId ) {
 		$form            = new DonationForm( $formId );
-		$templateOptions = getTemplateOptions( $formId );
+		$templateOptions = FormTemplateUtils::getOptions( $formId );
 		if ( $templateOptions['introduction']['enabled'] === 'disabled' ) {
 			return 645;
 		}

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -1,7 +1,6 @@
 <?php
 namespace Give\Views\Form\Templates\Sequoia;
 
-use Give\Controller\Form;
 use Give\Form\Template;
 use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
@@ -56,7 +55,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 	public function loadScripts() {
 
 		// Localize Template options
-		$templateOptions = getTemplateOptions();
+		$templateOptions = FormTemplateUtils::getOptions();
 
 		// Set defaults
 		$templateOptions['introduction']['donate_label']          = ! empty( $templateOptions['introduction']['donate_label'] ) ? $templateOptions['introduction']['donate_label'] : __( 'Donate Now', 'give' );

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -1,9 +1,9 @@
 <?php
 
 use Give\Form\Template\Options;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
-$formInfo = get_post( getFormId() );
+$formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
 $introHeadline    = $formInfo->post_title ? $formInfo->post_title : __( 'Campaign Heading', 'give' );

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -1,13 +1,13 @@
 <?php
 
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
-$formInfo = get_post( getFormId() );
+$formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Get headline and description
 $headline    = ! empty( $this->templateOptions['introduction']['headline'] ) ? $this->templateOptions['introduction']['headline'] : $formInfo->post_title;
 $description = ! empty( $this->templateOptions['introduction']['description'] ) ? $this->templateOptions['introduction']['description'] : $formInfo->post_excerpt;
-$image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $this->templateOptions['introduction']['image'] : get_the_post_thumbnail_url( getFormId() );
+$image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $this->templateOptions['introduction']['image'] : get_the_post_thumbnail_url( FrontendFormTemplateUtils::getFormId() );
 ?>
 
 <div class="give-section introduction">

--- a/src/Views/Form/Templates/Sequoia/views/loading.php
+++ b/src/Views/Form/Templates/Sequoia/views/loading.php
@@ -1,7 +1,7 @@
 <?php
-use function Give\Helpers\Form\Template\get as getTemplateOptions;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 
-$templateOptions = getTemplateOptions();
+$templateOptions = FormTemplateUtils::getOptions();
 $primaryColor    = ! empty( $templateOptions['introduction']['primary_color'] ) ? $templateOptions['introduction']['primary_color'] : '#28C77B';
 $primaryColor    = trim( $primaryColor, '#' );
 

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -1,7 +1,7 @@
 <?php
 
 use Give\Views\IframeView;
-use function Give\Helpers\Form\Template\get as getTemplateOptions;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use function Give\Helpers\Form\Template\Utils\Frontend\getPaymentId;
 use function give_get_gateway_admin_label as getGatewayLabel;
 use function give_currency_filter as filterCurrency;
@@ -11,7 +11,7 @@ use Give_Payment as Payment;
 
 /* @var Payment $payment */
 $payment = new Payment( getPaymentId() );
-$options = getTemplateOptions();
+$options = FormTemplateUtils::getOptions();
 
 ob_start();
 ?>

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -2,7 +2,7 @@
 
 use Give\Views\IframeView;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use function Give\Helpers\Form\Template\Utils\Frontend\getPaymentId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use function give_get_gateway_admin_label as getGatewayLabel;
 use function give_currency_filter as filterCurrency;
 use function give_sanitize_amount as sanitizeAmount;
@@ -10,7 +10,7 @@ use function give_do_email_tags as formatContent;
 use Give_Payment as Payment;
 
 /* @var Payment $payment */
-$payment = new Payment( getPaymentId() );
+$payment = new Payment( FrontendFormTemplateUtils::getPaymentId() );
 $options = FormTemplateUtils::getOptions();
 
 ob_start();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -5,9 +5,9 @@
  * @since 2.7.0
  */
 use Give\Views\IframeView;
-use function Give\Helpers\Form\Template\Utils\Frontend\getFormId;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
-$formId     = getFormId();
+$formId     = FrontendFormTemplateUtils::getFormId();
 $iframeView = new IframeView();
 
 // Fetch the Give Form.

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -4,7 +4,7 @@
  */
 
 // Exit if accessed directly.
-use function Give\Helpers\Form\Utils\isLegacyForm;
+use Give\Helpers\Form\Utils as FormUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -113,7 +113,7 @@ $excerpt          = ''; // Trimmed form excerpt ready for display.
 	<?php
 	// If modal, print form in hidden container until it is time to be revealed.
 	if ( 'modal_reveal' === $atts['display_style'] ) {
-		if ( ! isLegacyForm( $form_id ) ) {
+		if ( ! FormUtils::isLegacyForm( $form_id ) ) {
 			echo give_form_shortcode(
 				[
 					'id'            => $form_id,


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4699 

To organize code better and reduce unnecessary `use function`, simple helper functions have been moved to class as a static function.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
 It will affect all files in `src/Helpers` and files which were using helper functions.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Process donation with `manual` and `papal standard` payment gateway. In wp backend edit form setting and review if changes reflect on the form on not.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
