### PR TITLE
fix: global floating labels option no longer impacts non-legacy forms

### DIFF
--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 							/* translators: %s: http://docs.givewp.com/form-floating-labels */
 							'desc'    => sprintf(
 								wp_kses(
-									__( '<a href="%s" target="_blank">Floating labels</a> allows your labels to be inset within the form fields to provide a cleaner form appearance. Note that if the "Disable CSS" option is enabled, you will need to style the floating labels yourself.', 'give' ),
+									__( '<a href="%s" target="_blank">Floating labels</a> allows your labels to be inset within the form fields to provide a cleaner form appearance. Note that if the "Disable CSS" option is enabled, you will need to style the floating labels yourself. This option only affects legacy forms, as floating labels are not a display option in new form templates.', 'give' ),
 									array(
 										'a' => array(
 											'href'   => array(),

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -77,6 +77,7 @@ function give_is_float_labels_enabled( $args ) {
 		$float_labels = give_get_option( 'floatlabels', 'disabled' );
 	}
 
+	// If the form is using a non-legacy form template, do not use floating labels
 	if ( !isLegacyForm( $args['form_id'] ) ) {
 		$float_labels = 'disabled';
 	}

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use function Give\Helpers\Form\Utils\isLegacyForm;
+
 /**
  * Filter: Do not show the Give shortcut button on Give Forms CPT
  *
@@ -73,6 +75,10 @@ function give_is_float_labels_enabled( $args ) {
 
 	if ( empty( $float_labels ) || ( 'global' === $float_labels ) ) {
 		$float_labels = give_get_option( 'floatlabels', 'disabled' );
+	}
+
+	if ( !isLegacyForm( $args['form_id'] ) ) {
+		$float_labels = 'disabled';
 	}
 
 	return give_is_setting_enabled( $float_labels );


### PR DESCRIPTION
## Description
Resolves #4598 
This PR prevents the global floating labels option from impacting non-legacy forms. Previously, when the global floating labels option was enabled, it interfered with styling non-legacy forms as it would output additional classes to form elements. The solution proposed here uses the `isLegacyForm` helper function to modify the `give_is_float_labels_enabled` function, checking if the form is a legacy form, and returning `disabled` if not.

## Affects
This PR touches main functions file, and the global display options configuration.

## What to test
Try enabling and disabling the global floating labels options. Does it impact forms using the Sequoia template? Do floating labels still work as expected in forms using legacy templates?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
