### PR TITLE
Feature: fee recovery inputs are now styled in Sequoia template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -97,7 +97,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 				border-color: {$primaryColor}!important;
 				color: {$primaryColor} !important;
 			}
-			input[type=\'radio\'] + label::after {
+			input[type='radio'] + label::after {
 				background: {$primaryColor} !important;
 			}
 		";

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -65,47 +65,54 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		$templateOptions['payment_information']['header_label']   = ! empty( $templateOptions['payment_information']['header_label'] ) ? $templateOptions['payment_information']['header_label'] : __( 'Add Your Information', 'give' );
 		$templateOptions['payment_information']['checkout_label'] = ! empty( $templateOptions['payment_information']['checkout_label'] ) ? $templateOptions['payment_information']['checkout_label'] : __( 'Process Donation', 'give' );
 
-		wp_enqueue_style( 'give-google-font-montserrat', 'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap', [], GIVE_VERSION );
-		wp_enqueue_style( 'give-sequoia-template-css', GIVE_PLUGIN_URL . 'assets/dist/css/give-sequoia-template.css', [ 'give-styles' ], GIVE_VERSION );
+		wp_enqueue_style( 'give-google-font-montserrat', 'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap', array(), GIVE_VERSION );
+		wp_enqueue_style( 'give-sequoia-template-css', GIVE_PLUGIN_URL . 'assets/dist/css/give-sequoia-template.css', array( 'give-styles' ), GIVE_VERSION );
 
 		$primaryColor = $templateOptions['introduction']['primary_color'];
-		$dynamic_css  = sprintf(
-			'
+		$primaryColor = $templateOptions['introduction']['primary_color'];
+		$rawColor     = trim( $primaryColor, '#' );
+		$dynamic_css  = "
 			.seperator {
-				background: %1$s!important;
+				background: {$primaryColor}!important;
 			}
 			.give-btn {
-				border: 2px solid %1$s!important;
-				background: %1$s!important;
+				border: 2px solid {$primaryColor}!important;
+				background: {$primaryColor}!important;
 			}
 			.give-btn:hover {
-				background: %1$s!important;
+				background: {$primaryColor}!important;
 			}
 			.give-donation-level-btn {
-				border: 2px solid %1$s!important;
+				border: 2px solid {$primaryColor}!important;
 			}
 			.give-donation-level-btn.give-default-level {
-				color: %1$s!important; background: #fff!important;
+				color: {$primaryColor}!important; background: #fff!important;
 				transition: background 0.2s ease, color 0.2s ease;
 			}
 			.give-donation-level-btn.give-default-level:hover {
-				color: %1$s!important; background: #fff!important;
+				color: {$primaryColor}!important; background: #fff!important;
 			}
 			.give-input:focus, .give-select:focus {
-				border: 1px solid %1$s!important;
+				border: 1px solid {$primaryColor}!important;
 			}
 			.checkmark {
-				border-color: %1$s!important;
-				color: %1$s!important;
+				border-color: {$primaryColor}!important;
+				color: {$primaryColor}!important;
 			}
 			input[type=\'radio\'] + label::after {
-				background: %1$s!important;
-			}',
-			$primaryColor
-		);
+				background: {$primaryColor}!important;
+			}
+			.give-fee-recovery-donors-choice.give-fee-message:hover,
+			.give-fee-recovery-donors-choice.give-fee-message.active {
+				border: 1px solid {$primaryColor};
+			}
+			.give-fee-recovery-donors-choice.give-fee-message input[type='checkbox'] + .give-fee-message-label-text::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
+			}
+		";
 		wp_add_inline_style( 'give-sequoia-template-css', $dynamic_css );
 
-		wp_enqueue_script( 'give-sequoia-template-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-sequoia-template.js', [ 'give' ], GIVE_VERSION, true );
+		wp_enqueue_script( 'give-sequoia-template-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-sequoia-template.js', array( 'give' ), GIVE_VERSION, true );
 		wp_localize_script( 'give-sequoia-template-js', 'sequoiaTemplateOptions', $templateOptions );
 	}
 

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -73,34 +73,34 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		$rawColor     = trim( $primaryColor, '#' );
 		$dynamic_css  = "
 			.seperator {
-				background: {$primaryColor}!important;
+				background: {$primaryColor} !important;
 			}
 			.give-btn {
-				border: 2px solid {$primaryColor}!important;
-				background: {$primaryColor}!important;
+				border: 2px solid {$primaryColor} !important;
+				background: {$primaryColor} !important;
 			}
 			.give-btn:hover {
-				background: {$primaryColor}!important;
+				background: {$primaryColor} !important;
 			}
 			.give-donation-level-btn {
-				border: 2px solid {$primaryColor}!important;
+				border: 2px solid {$primaryColor} !important;
 			}
 			.give-donation-level-btn.give-default-level {
-				color: {$primaryColor}!important; background: #fff!important;
+				color: {$primaryColor}!important; background: #fff !important;
 				transition: background 0.2s ease, color 0.2s ease;
 			}
 			.give-donation-level-btn.give-default-level:hover {
-				color: {$primaryColor}!important; background: #fff!important;
+				color: {$primaryColor}!important; background: #fff !important;
 			}
 			.give-input:focus, .give-select:focus {
-				border: 1px solid {$primaryColor}!important;
+				border: 1px solid {$primaryColor} !important;
 			}
 			.checkmark {
 				border-color: {$primaryColor}!important;
-				color: {$primaryColor}!important;
+				color: {$primaryColor} !important;
 			}
 			input[type=\'radio\'] + label::after {
-				background: {$primaryColor}!important;
+				background: {$primaryColor} !important;
 			}
 			.give-fee-recovery-donors-choice.give-fee-message:hover,
 			.give-fee-recovery-donors-choice.give-fee-message.active {

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -69,9 +69,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		wp_enqueue_style( 'give-sequoia-template-css', GIVE_PLUGIN_URL . 'assets/dist/css/give-sequoia-template.css', array( 'give-styles' ), GIVE_VERSION );
 
 		$primaryColor = $templateOptions['introduction']['primary_color'];
-		$primaryColor = $templateOptions['introduction']['primary_color'];
-		$rawColor     = trim( $primaryColor, '#' );
-		$dynamic_css  = "
+		$dynamicCss   = "
 			.seperator {
 				background: {$primaryColor} !important;
 			}
@@ -102,6 +100,11 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			input[type=\'radio\'] + label::after {
 				background: {$primaryColor} !important;
 			}
+		";
+		wp_add_inline_style( 'give-sequoia-template-css', $dynamicCss );
+
+		$rawColor              = trim( $primaryColor, '#' );
+		$feeRecoveryDynamicCss = "
 			.give-fee-recovery-donors-choice.give-fee-message:hover,
 			.give-fee-recovery-donors-choice.give-fee-message.active {
 				border: 1px solid {$primaryColor};
@@ -110,7 +113,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
 			}
 		";
-		wp_add_inline_style( 'give-sequoia-template-css', $dynamic_css );
+		wp_add_inline_style( 'give-sequoia-template-css', $feeRecoveryDynamicCss );
 
 		wp_enqueue_script( 'give-sequoia-template-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-sequoia-template.js', array( 'give' ), GIVE_VERSION, true );
 		wp_localize_script( 'give-sequoia-template-js', 'sequoiaTemplateOptions', $templateOptions );

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -7,7 +7,7 @@
 	box-sizing: border-box;
 	box-shadow: 0 0 16px rgba(0, 0, 0, 0.121203);
 	border-radius: 5px;
-	margin: 34px 30px 0 30px !important;
+	margin: 20px 30px 0 30px !important;
 	padding: 0 !important;
 	position: relative;
 	transition: border 0.2s ease;

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -11,6 +11,10 @@
 	transition: border 0.2s ease;
 	width: auto !important;
 
+	.give-fee-message-label {
+		margin: 0;
+	}
+
 	input[type='checkbox'] {
 		display: none !important;
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -46,9 +46,9 @@
 		}
 	}
 
-	// &.active {
-	// 	border: 1px solid #3398db;
-	// }
+	&.active {
+		border: 1px solid #3398db;
+	}
 
 	input[type='checkbox']:checked + .give-fee-message-label-text::after {
 		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -1,0 +1,72 @@
+/* stylelint-disable */
+.give-fee-recovery-donors-choice.give-fee-message {
+	background: #fff;
+	border: 1px solid rgba(255, 255, 255, 0);
+	box-sizing: border-box;
+	box-shadow: 0 0 16px rgba(0, 0, 0, 0.121203);
+	border-radius: 5px;
+	margin: 34px 30px 0 30px !important;
+	padding: 0 !important;
+	position: relative;
+	transition: border 0.2s ease;
+	width: auto !important;
+
+	input[type='checkbox'] {
+		display: none !important;
+	}
+
+	.give-fee-message-label-text {
+		font-weight: 500;
+		font-size: 16px;
+		line-height: 1.4;
+		padding: 20px 22px 20px 22px !important;
+		width: calc(100% - 62px);
+		margin-left: 40px !important;
+		color: #333;
+		display: inline-block;
+	}
+
+	.give-fee-message-label-text::before {
+		content: ' ';
+		position: absolute;
+		top: calc(50% - 12px);
+		left: 22px;
+		width: 20px;
+		height: 20px;
+		border: 1px solid #b4b9be;
+		background-color: #fff;
+		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+	}
+
+	&:hover {
+		border: 1px solid #3398db;
+
+		.give-fee-message-label-text::before {
+			background-color: rgba(245, 245, 245, 0.815);
+		}
+	}
+
+	// &.active {
+	// 	border: 1px solid #3398db;
+	// }
+
+	input[type='checkbox']:checked + .give-fee-message-label-text::after {
+		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+	}
+
+	input[type='checkbox'] + .give-fee-message-label-text::after {
+		transition: clip-path 0.2s ease;
+		border-radius: 11px;
+		width: 20px;
+		height: 20px;
+		position: absolute;
+		top: calc(50% - 12px);
+		left: 22px;
+		content: ' ';
+		display: block;
+		background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%231E8CBE'/%3E%3C/svg%3E%0A");
+		background-repeat: no-repeat;
+		background-position: center;
+		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+	}
+}

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable */
+.give-fee-total-wrap.fee-coverage-required.give-fee-message,
 .give-fee-recovery-donors-choice.give-fee-message {
 	background: #fff;
 	border: 1px solid rgba(255, 255, 255, 0);
@@ -11,6 +12,24 @@
 	transition: border 0.2s ease;
 	width: auto !important;
 
+	.give-fee-message-label-text {
+		font-weight: 500;
+		font-size: 16px;
+		line-height: 1.4;
+		padding: 20px 20px 20px 22px !important;
+		color: #333;
+		display: inline-block;
+	}
+}
+
+.give-fee-total-wrap.fee-coverage-required.give-fee-message {
+	.give-fee-message-label-text {
+		text-align: center;
+		width: calc(100% - 40px);
+	}
+}
+
+.give-fee-recovery-donors-choice.give-fee-message {
 	.give-fee-message-label {
 		margin: 0;
 	}
@@ -20,13 +39,8 @@
 	}
 
 	.give-fee-message-label-text {
-		font-weight: 500;
-		font-size: 16px;
-		line-height: 1.4;
-		padding: 20px 20px 20px 22px !important;
 		width: calc(100% - 82px);
 		margin-left: 40px !important;
-		color: #333;
 		display: inline-block;
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable */
 .give-fee-total-wrap.fee-coverage-required.give-fee-message,
-.give-fee-recovery-donors-choice.give-fee-message {
+.give-fee-recovery-donors-choice.give-fee-message,
+.fee-break-down-message {
 	order: 3;
 	background: #fff;
 	border: 1px solid rgba(255, 255, 255, 0);
@@ -12,7 +13,10 @@
 	position: relative;
 	transition: border 0.2s ease;
 	width: auto !important;
+}
 
+.give-fee-total-wrap.fee-coverage-required.give-fee-message,
+.give-fee-recovery-donors-choice.give-fee-message {
 	.give-fee-message-label-text {
 		font-weight: 500;
 		font-size: 16px;
@@ -21,6 +25,17 @@
 		color: #333;
 		display: inline-block;
 	}
+}
+
+.fee-break-down-message {
+	margin: 20px 0 0 0 !important;
+	font-weight: 500;
+	font-size: 16px;
+	line-height: 1.4;
+	padding: 20px 20px 20px 22px !important;
+	color: #333;
+	display: inline-block;
+	text-align: center;
 }
 
 .give-fee-total-wrap.fee-coverage-required.give-fee-message {

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -23,8 +23,8 @@
 		font-weight: 500;
 		font-size: 16px;
 		line-height: 1.4;
-		padding: 20px 22px 20px 22px !important;
-		width: calc(100% - 62px);
+		padding: 20px 20px 20px 22px !important;
+		width: calc(100% - 82px);
 		margin-left: 40px !important;
 		color: #333;
 		display: inline-block;

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -1,6 +1,7 @@
 /* stylelint-disable */
 .give-fee-total-wrap.fee-coverage-required.give-fee-message,
 .give-fee-recovery-donors-choice.give-fee-message {
+	order: 3;
 	background: #fff;
 	border: 1px solid rgba(255, 255, 255, 0);
 	box-sizing: border-box;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -684,6 +684,9 @@ p {
 			}
 		}
 	}
+	#give_purchase_form_wrap {
+		width: 100%;
+	}
 	#give_purchase_submit {
 		display: flex;
 		flex-direction: column;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -86,6 +86,7 @@ p {
 .advance-btn,
 .give-submit,
 .download-btn {
+	order: 99 !important;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -10,6 +10,7 @@
 
 // Receipt Styles
 @import 'receipt';
+@import 'feerecovery';
 
 // Structure
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -179,8 +179,8 @@
 				$( testNotice ).remove();
 
 				// Perist fee recovery input border when selected
-				$( '.give-fee-recovery-donors-choice > label' ).on( 'click', function() {
-					$( '.give-fee-recover-donors-choice' ).toggleClass( 'active' );
+				$( '.give-fee-message-label-text' ).on( 'click touchend', function() {
+					$( '.give-fee-recovery-donors-choice' ).toggleClass( 'active' );
 				} );
 
 				// Show Sequoia loader on click/touchend

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -178,6 +178,11 @@
 				$( testNotice ).clone().prependTo( '.give-section.payment' );
 				$( testNotice ).remove();
 
+				// Perist fee recovery input border when selected
+				$( '.give-fee-recovery-donors-choice > label' ).on( 'click', function() {
+					$( '.give-fee-recover-donors-choice' ).toggleClass( 'active' );
+				} );
+
 				// Show Sequoia loader on click/touchend
 				$( 'body.give-form-templates' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
 					//Override submit loader with Sequoia loader


### PR DESCRIPTION
## Description
Resolves #4712
This PR introduces frontend styles for fee recovery donation inputs as they appear in the Sequoia form template.

## Affects
This PR affects the Sequoia styles, and Sequoia template class. It introduces the feerecovery.scss file.

## What to test
Test frontend appearance of the fee recovery donation inputs, using different option configurations in the Fee Recovery panel. Do they appear as expected? Does the input handle long custom fee recovery copy gracefully?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/81118539-15adcf00-8ef7-11ea-8799-9dee31205e63.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
