### PR TITLE
Stop adding donation id to invalid or empty donation session

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -199,10 +199,12 @@ function give_insert_payment( $payment_data = array() ) {
 	// Setup donor id.
 	$payment_data['user_info']['donor_id'] = $payment->donor_id;
 
-	// Set donation id to purchase session.
-	$purchase_session                = Give()->session->get( 'give_purchase' );
-	$purchase_session['donation_id'] = $payment->ID;
-	Give()->session->set( 'give_purchase', $purchase_session );
+	// Set donation id to purchase session only donor session for donation exist.
+	$purchase_session = (array) Give()->session->get( 'give_purchase' );
+	if ( $purchase_session && array_key_exists( 'purchase_key', $purchase_session ) ) {
+		$purchase_session['donation_id'] = $payment->ID;
+		Give()->session->set( 'give_purchase', $purchase_session );
+	}
 
 	/**
 	 * Fires while inserting payments.


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves: https://givewp.slack.com/archives/C0FAGC83C/p1588794766128000

In `epic/form-template` branch test start falling because `date` param was not found in the donation session.  A valid donation session must have a few required values (as mentioned in screenshot 2).
We insert `donation_id` to donation session when donation creates but we are not validating that donation session. That means even if the donation is not processed from frontend a donation session will be set up with minimum `donation_id` param which is not correct.
To resolve this issue, this pr adds a validate donation session before adding `donation_id` to the donation session.

**Screenshot 1**
<img width="836" alt="Screen Shot 2020-05-06 at 3 47 04 PM" src="https://user-images.githubusercontent.com/1784821/81291134-e3cb7280-9086-11ea-846e-0a02e7c2fff0.png">


**Screenshot 2**
![image](https://user-images.githubusercontent.com/1784821/81291262-12494d80-9087-11ea-8f70-c2f7fc8f8bcf.png)


## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This patch will add a condition block in the `give_insert_payment` function.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
Confirm if we can process donations with payment gateways.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
