### PR TITLE
print localize date on donor wall

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2140,15 +2140,21 @@ function give_get_safe_asset_url( $url ) {
  * @param string $date           Date.
  * @param string $format         Date Format.
  * @param string $current_format Current date Format.
+ * @param bool   $localize
  *
  * @return string
  * @since 2.3.0
  */
-function give_get_formatted_date( $date, $format = 'Y-m-d', $current_format = '' ) {
+function give_get_formatted_date( $date, $format = 'Y-m-d', $current_format = '', $localize = false ) {
 	$current_format = empty( $current_format ) ? give_date_format() : $current_format;
 	$date_obj       = DateTime::createFromFormat( $current_format, $date );
+	$formatted_date = '';
 
-	$formatted_date = $date_obj instanceof DateTime ? $date_obj->format( $format ) : '';
+	if ( $date_obj instanceof DateTime ) {
+		$formatted_date = $localize ?
+			date_i18n( $format, $date_obj->getTimestamp() ) :
+			$date_obj->format( $format );
+	}
 
 	/**
 	 * Give get formatted date.

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -53,7 +53,7 @@ $atts          = $args[2]; // Shortcode attributes.
 							? __( 'Anonymous', 'give' )
 							: trim( $donation['_give_donor_billing_first_name'] . ' ' . $donation['_give_donor_billing_last_name'] );
 						?>
-						<?php esc_html_e( $donor_name ); ?>
+						<?php esc_html_e( $donor_name, 'give' ); ?>
 					</h3>
 				<?php endif; ?>
 
@@ -65,7 +65,7 @@ $atts          = $args[2]; // Shortcode attributes.
 
 				<?php if ( true === $atts['show_time'] ) : ?>
 					<span class="give-donor__timestamp">
-						<?php echo esc_html( give_get_formatted_date( $donation['donation_date'], give_date_format(), 'Y-m-d H:i:s' ) ); ?>
+						<?php echo esc_html( give_get_formatted_date( $donation['donation_date'], give_date_format(), 'Y-m-d H:i:s', true ) ); ?>
 					</span>
 				<?php endif; ?>
 			</div>

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -53,7 +53,7 @@ $atts          = $args[2]; // Shortcode attributes.
 							? __( 'Anonymous', 'give' )
 							: trim( $donation['_give_donor_billing_first_name'] . ' ' . $donation['_give_donor_billing_last_name'] );
 						?>
-						<?php esc_html_e( $donor_name, 'give' ); ?>
+						<?php echo esc_html( $donor_name ); ?>
 					</h3>
 				<?php endif; ?>
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4721 
Previously we are not printing localize dates on the donor wall. This pr will upgrade `give_get_formatted_date` to return localize date.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Added the fourth param to `give_get_formatted_date` function to check if whether or not return localize date.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
```
function spark_change_language( $locale ){
    return 'ug_CN';
}
add_filter( 'locale', 'spark_change_language' );

```
Use above code snippet to set locale dynamically and review the date printed on the donor wall.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/81564110-de3a9900-93b4-11ea-8bd5-2700a3cd98cf.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
