### PR TITLE
feature: Form Field Manager inputs are styled in Sequoia form template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -68,8 +68,8 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		$templateOptions['payment_information']['header_label']   = ! empty( $templateOptions['payment_information']['header_label'] ) ? $templateOptions['payment_information']['header_label'] : __( 'Add Your Information', 'give' );
 		$templateOptions['payment_information']['checkout_label'] = ! empty( $templateOptions['payment_information']['checkout_label'] ) ? $templateOptions['payment_information']['checkout_label'] : __( 'Process Donation', 'give' );
 
-		wp_enqueue_style( 'give-google-font-montserrat', 'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap', [], GIVE_VERSION );
-		wp_enqueue_style( 'give-sequoia-template-css', GIVE_PLUGIN_URL . 'assets/dist/css/give-sequoia-template.css', [ 'give-styles' ], GIVE_VERSION );
+		wp_enqueue_style( 'give-google-font-montserrat', 'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap', array(), GIVE_VERSION );
+		wp_enqueue_style( 'give-sequoia-template-css', GIVE_PLUGIN_URL . 'assets/dist/css/give-sequoia-template.css', array( 'give-styles' ), GIVE_VERSION );
 
 		$primaryColor = $templateOptions['introduction']['primary_color'];
 		$dynamicCss   = sprintf(
@@ -133,7 +133,17 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		";
 		wp_add_inline_style( 'give-sequoia-template-css', $feeRecoveryDynamicCss );
 
-		wp_enqueue_script( 'give-sequoia-template-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-sequoia-template.js', [ 'give' ], GIVE_VERSION, true );
+		$ffmDynamicCss = "
+			.ffm-checkbox-field label.checked::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
+			}
+			.ffm-radio-field label::after {
+				background: {$primaryColor};
+			}
+		";
+		wp_add_inline_style( 'give-sequoia-template-css', $ffmDynamicCss );
+
+		wp_enqueue_script( 'give-sequoia-template-js', GIVE_PLUGIN_URL . 'assets/dist/js/give-sequoia-template.js', array( 'give' ), GIVE_VERSION, true );
 		wp_localize_script( 'give-sequoia-template-js', 'sequoiaTemplateOptions', $templateOptions );
 	}
 
@@ -173,7 +183,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		$options = FormTemplateUtils::getOptions();
 
 		$receipt->heading = esc_html( $options['thank-you']['headline'] );
-		$receipt->message = esc_html( formatContent( $options['thank-you']['description'], [ 'payment_id' => $donationId ] ) );
+		$receipt->message = esc_html( formatContent( $options['thank-you']['description'], array( 'payment_id' => $donationId ) ) );
 
 		return $receipt;
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -1,0 +1,55 @@
+/* stylelint-disable */
+.give-ffm-form-row-responsive {
+	.give-label {
+		display: block !important;
+		position: absolute;
+	}
+	.ffm-checkbox-field {
+		input[type='checkbox'] {
+			display: none !important;
+		}
+
+		label {
+			font-weight: 500;
+			font-size: 16px;
+			line-height: 1.4;
+			padding: 0 0 0 36px;
+			width: 100%;
+			margin-left: 0;
+			color: #333;
+			display: inline-block;
+		}
+
+		label::before {
+			content: ' ';
+			position: absolute;
+			top: calc(50% - 12px);
+			left: 0;
+			width: 20px;
+			height: 20px;
+			border: 1px solid #b4b9be;
+			background-color: #fff;
+			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+		}
+
+		label::after {
+			transition: clip-path 0.2s ease;
+			border-radius: 11px;
+			width: 20px;
+			height: 20px;
+			position: absolute;
+			top: calc(50% - 12px);
+			left: 0;
+			content: ' ';
+			display: block;
+			background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%231E8CBE'/%3E%3C/svg%3E%0A");
+			background-repeat: no-repeat;
+			background-position: center;
+			clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+		}
+
+		label.checked {
+			clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		}
+	}
+}

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -13,7 +13,7 @@
 			font-weight: 500;
 			font-size: 16px;
 			line-height: 1.4;
-			padding: 0 0 0 36px;
+			padding: 0 0 0 32px;
 			width: 100%;
 			margin-left: 0;
 			color: #333;
@@ -27,6 +27,53 @@
 			left: 0;
 			width: 20px;
 			height: 20px;
+			border: 1px solid #b4b9be;
+			background-color: #fff;
+			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+		}
+
+		label::after {
+			transition: transform 0.2s ease;
+			width: 16px;
+			height: 16px;
+			position: absolute;
+			transform: scale3d(0, 0, 0);
+			top: calc(50% - 12px);
+			left: 0;
+			content: ' ';
+			display: block;
+			background: rgb(65, 65, 65);
+			background-position: center;
+		}
+
+		label.selected {
+			transform: scale3d(1, 1, 1);
+		}
+	}
+	.ffm-radio-field {
+		input[type='radio'] {
+			display: none !important;
+		}
+
+		label {
+			font-weight: 500;
+			font-size: 16px;
+			line-height: 1.4;
+			padding: 0 0 0 32px;
+			width: 100%;
+			margin-left: 0;
+			color: #333;
+			display: inline-block;
+		}
+
+		label::before {
+			content: ' ';
+			position: absolute;
+			top: calc(50% - 12px);
+			left: 0;
+			width: 20px;
+			height: 20px;
+			border-radius: 50%;
 			border: 1px solid #b4b9be;
 			background-color: #fff;
 			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -3,6 +3,7 @@
 	.give-label {
 		display: block !important;
 		position: absolute;
+		font-size: 14px;
 	}
 }
 
@@ -103,5 +104,36 @@
 				transform: scale3d(1, 1, 1);
 			}
 		}
+	}
+}
+
+.ffm-attachment-upload-filelist {
+	font-family: 'Montserrat', sans-serif;
+	background: #fff;
+	border: 1px solid #b8b8b8;
+	box-sizing: border-box;
+	box-shadow: inset 0 1px 5px rgba(0, 0, 0, 0.152289);
+	border-radius: 4px !important;
+	font-weight: 400;
+	font-size: 14px;
+	line-height: 1;
+	color: #8d8e8e;
+	padding: 0;
+	position: relative;
+	display: flex;
+	overflow: hidden;
+
+	a.file-selector {
+		display: inline-block;
+		height: 100%;
+		top: 0;
+		padding: 14px;
+		border-radius: 0;
+		border-right: 1px solid #b8b8b8;
+		font-size: 14px;
+		line-height: 20px;
+		color: #333;
+		background: #f1f1f1;
+		text-decoration: none;
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -4,82 +4,36 @@
 		display: block !important;
 		position: absolute;
 	}
-	.ffm-checkbox-field {
-		input[type='checkbox'] {
-			display: none !important;
-		}
+}
 
-		label {
-			font-weight: 500;
-			font-size: 16px;
-			line-height: 1.4;
-			padding: 0 0 0 32px;
-			width: 100%;
-			margin-left: 0;
-			color: #333;
-			display: inline-block;
-		}
-
-		label::before {
-			content: ' ';
-			position: absolute;
-			top: calc(50% - 12px);
-			left: 0;
-			width: 20px;
-			height: 20px;
-			border: 1px solid #b4b9be;
-			background-color: #fff;
-			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
-		}
-
-		label::after {
-			transition: transform 0.2s ease;
-			width: 16px;
-			height: 16px;
-			position: absolute;
-			transform: scale3d(0, 0, 0);
-			top: calc(50% - 12px);
-			left: 0;
-			content: ' ';
-			display: block;
-			background: rgb(65, 65, 65);
-			background-position: center;
-		}
-
-		label.selected {
-			transform: scale3d(1, 1, 1);
-		}
+.ffm-checkbox-field {
+	input[type='checkbox'] {
+		display: none !important;
 	}
-	.ffm-radio-field {
-		input[type='radio'] {
-			display: none !important;
-		}
 
-		label {
-			font-weight: 500;
-			font-size: 16px;
-			line-height: 1.4;
-			padding: 0 0 0 32px;
-			width: 100%;
-			margin-left: 0;
-			color: #333;
-			display: inline-block;
-		}
+	label {
+		font-weight: 500;
+		font-size: 16px;
+		line-height: 1.4;
+		padding: 0 0 0 32px;
+		width: 100%;
+		margin-left: 0;
+		color: #333;
+		display: inline-block;
 
-		label::before {
+		&::before {
 			content: ' ';
 			position: absolute;
 			top: calc(50% - 12px);
 			left: 0;
 			width: 20px;
 			height: 20px;
-			border-radius: 50%;
 			border: 1px solid #b4b9be;
 			background-color: #fff;
 			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
 		}
 
-		label::after {
+		&::after {
 			transition: clip-path 0.2s ease;
 			border-radius: 11px;
 			width: 20px;
@@ -95,8 +49,59 @@
 			clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 		}
 
-		label.checked {
-			clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		&.checked {
+			&::after {
+				clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+			}
+		}
+	}
+}
+.ffm-radio-field {
+	input[type='radio'] {
+		display: none !important;
+	}
+
+	label {
+		font-weight: 500;
+		font-size: 16px;
+		line-height: 1.4;
+		padding: 0 0 0 32px;
+		width: 100%;
+		margin-left: 0;
+		color: #333;
+		display: inline-block;
+
+		&::before {
+			content: ' ';
+			position: absolute;
+			top: calc(50% - 12px);
+			left: 0;
+			width: 20px;
+			height: 20px;
+			border-radius: 50%;
+			border: 1px solid #b4b9be;
+			background-color: #fff;
+			box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+		}
+
+		&::after {
+			transform: scale3d(0, 0, 0);
+			transition: transform 0.2s ease;
+			border-radius: 12px;
+			width: 10px;
+			height: 10px;
+			position: absolute;
+			top: calc(50% - 6px);
+			left: 6px;
+			content: ' ';
+			display: block;
+			background: #333;
+		}
+
+		&.selected {
+			&::after {
+				transform: scale3d(1, 1, 1);
+			}
 		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -816,6 +816,12 @@ form.give-form .form-row select,
 	background-size: 0.65em auto, 100%;
 }
 
+form[id*='give-form'] .form-row select.multiselect,
+#give-recurring-form .form-row select.multiselect,
+form.give-form .form-row select.multiselect {
+	background-image: none;
+}
+
 .give-input:hover,
 .give-select:hover {
 	border: 1px solid rgb(54, 54, 54);

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -787,6 +787,12 @@ form.give-form .form-row input[type='url'] {
 	padding: 14px !important;
 }
 
+form[id*='give-form'] .form-row textarea,
+#give-recurring-form .form-row textarea,
+form.give-form .form-row textarea {
+	line-height: 1.4;
+}
+
 .give-select {
 	font-family: 'Montserrat', sans-serif;
 	font-size: 14px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -738,7 +738,7 @@ fieldset {
 		> i {
 			position: absolute;
 			bottom: 18px;
-			left: 24px;
+			left: 22px;
 			font-size: 12px;
 			color: #989898;
 		}
@@ -754,21 +754,18 @@ fieldset {
 	display: none !important;
 }
 
-form[id*='give-form'] .form-row select,
 form[id*='give-form'] .form-row textarea,
 form[id*='give-form'] .form-row input[type='text'],
 form[id*='give-form'] .form-row input[type='tel'],
 form[id*='give-form'] .form-row input[type='email'],
 form[id*='give-form'] .form-row input[type='password'],
 form[id*='give-form'] .form-row input[type='url'],
-#give-recurring-form .form-row select,
 #give-recurring-form .form-row textarea,
 #give-recurring-form .form-row input[type='text'],
 #give-recurring-form .form-row input[type='tel'],
 #give-recurring-form .form-row input[type='email'],
 #give-recurring-form .form-row input[type='password'],
 #give-recurring-form .form-row input[type='url'],
-form.give-form .form-row select,
 form.give-form .form-row textarea,
 form.give-form .form-row input[type='text'],
 form.give-form .form-row input[type='tel'],
@@ -794,6 +791,9 @@ form.give-form .form-row textarea {
 	line-height: 1.4;
 }
 
+form[id*='give-form'] .form-row select,
+#give-recurring-form .form-row select,
+form.give-form .form-row select,
 .give-select {
 	font-family: 'Montserrat', sans-serif;
 	font-size: 14px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -730,6 +730,18 @@ fieldset {
 			color: #989898;
 		}
 	}
+
+	.give-ffm-form-row-responsive {
+		position: relative;
+
+		> i {
+			position: absolute;
+			top: 18px;
+			left: 24px;
+			font-size: 12px;
+			color: #989898;
+		}
+	}
 	.give_error,
 	.give_success,
 	.give_warning {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -12,6 +12,7 @@
 @import 'receipt';
 @import 'recurring';
 @import 'feerecovery';
+@import 'ffm';
 
 // Structure
 
@@ -724,7 +725,7 @@ fieldset {
 
 		> i {
 			position: absolute;
-			top: 18px;
+			bottom: 18px;
 			left: 16px;
 			font-size: 12px;
 			color: #989898;
@@ -736,7 +737,7 @@ fieldset {
 
 		> i {
 			position: absolute;
-			top: 18px;
+			bottom: 18px;
 			left: 24px;
 			font-size: 12px;
 			color: #989898;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -741,7 +741,27 @@ fieldset {
 	display: none !important;
 }
 
-.give-input {
+form[id*='give-form'] .form-row select,
+form[id*='give-form'] .form-row textarea,
+form[id*='give-form'] .form-row input[type='text'],
+form[id*='give-form'] .form-row input[type='tel'],
+form[id*='give-form'] .form-row input[type='email'],
+form[id*='give-form'] .form-row input[type='password'],
+form[id*='give-form'] .form-row input[type='url'],
+#give-recurring-form .form-row select,
+#give-recurring-form .form-row textarea,
+#give-recurring-form .form-row input[type='text'],
+#give-recurring-form .form-row input[type='tel'],
+#give-recurring-form .form-row input[type='email'],
+#give-recurring-form .form-row input[type='password'],
+#give-recurring-form .form-row input[type='url'],
+form.give-form .form-row select,
+form.give-form .form-row textarea,
+form.give-form .form-row input[type='text'],
+form.give-form .form-row input[type='tel'],
+form.give-form .form-row input[type='email'],
+form.give-form .form-row input[type='password'],
+form.give-form .form-row input[type='url'] {
 	font-family: 'Montserrat', sans-serif;
 	background: #fff;
 	border: 1px solid #b8b8b8;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -211,6 +211,29 @@
 					navigator.goToStep( 1 );
 				} );
 
+				$( '#give-ffm-section' ).on( 'click', handleFFMInput );
+
+				$( '#give-ffm-section input' ).each( function() {
+					switch ( $( this ).prop( 'type' ) ) {
+						case 'checkbox': {
+							if ( $( this ).prop( 'checked' ) ) {
+								$( this ).parent().addClass( 'checked' );
+							} else {
+								$( this ).parent().removeClass( 'checked' );
+							}
+							break;
+						}
+						case 'radio': {
+							if ( $( this ).prop( 'checked' ) ) {
+								$( this ).parent().addClass( 'selected' );
+							} else {
+								$( this ).parent().removeClass( 'selected' );
+							}
+							break;
+						}
+					}
+				} );
+
 				//Setup input icons
 				setupInputIcon( '#give-first-name-wrap', 'user' );
 				setupInputIcon( '#give-email-wrap', 'envelope' );
@@ -423,5 +446,27 @@
 	 */
 	function getInitialStep() {
 		return Give.fn.getParameterByName( 'showDonationProcessingError' ) || Give.fn.getParameterByName( 'showFailedDonationError' ) ? 2 : 0;
+	}
+
+	/**
+	 * Handle updating label classes for FFM radios and checkboxes
+	 *
+	 * @since 2.7.0
+	 * @param {object} evt Reference to FFM input element click event
+	 */
+	function handleFFMInput( evt ) {
+		if ( $( evt.target ).is( 'input' ) ) {
+			switch ( $( evt.target ).prop( 'type' ) ) {
+				case 'checkbox': {
+					$( evt.target ).parent().toggleClass( 'checked' );
+					break;
+				}
+				case 'radio': {
+					$( evt.target ).parent().addClass( 'selected' );
+					$( evt.target ).parent().siblings().removeClass( 'selected' );
+					break;
+				}
+			}
+		}
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -215,6 +215,7 @@
 				setupInputIcon( '#give-first-name-wrap', 'user' );
 				setupInputIcon( '#give-email-wrap', 'envelope' );
 				setupInputIcon( '#give-company-wrap', 'building' );
+				setupInputIcon( '#date_field-wrap', 'calendar-alt' );
 
 				// Setup gateway icons
 				setupGatewayIcons();

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -216,6 +216,9 @@
 				setupInputIcon( '#give-email-wrap', 'envelope' );
 				setupInputIcon( '#give-company-wrap', 'building' );
 				setupInputIcon( '#date_field-wrap', 'calendar-alt' );
+				setupInputIcon( '#url_field-wrap', 'globe' );
+				setupInputIcon( '#phone_field-wrap', 'phone' );
+				setupInputIcon( '#email_field-wrap', 'envelope' );
 
 				// Setup gateway icons
 				setupGatewayIcons();


### PR DESCRIPTION
## Description
Resolves #4719 
This PR introduces styling and frontend functionality for inputs rendered by the form fields manager addon. Previously, these inputs were not styled and used default browser styles. Now, through a combination of css, pseudo elements and javascript, the inputs are consistent with other inputs native to the Sequoia form template. 

Because Form Field Manager outputs fields in a non-standard way (nesting inputs within labels) some frontend logic was introduced to listen for changes to these inputs, and add "selected" or "checked" classes to the corresponding label. Ultimately, modifying the means by which FFM renders inputs was beyond the scope of this PR, so a javascript solution was utilized. 

Early on it was suggested that Sequoia should introduce a new "separate step" location for Form Fields. After discussion with @ravinderk, it was determined that this kind of modification to FFM is not currently supported, and wouldn't be feasible to implement on a per template basis.

## Affects
This PR affects Sequoia form template assets (css and js).

## What to test
With form fields manager enabled, test out different field types. Do they behave as expected? Test out different locations for the fields, do they work as expected?

## Screenshots:
![PRDemo2](https://user-images.githubusercontent.com/5186078/81609293-a5df8e80-93a5-11ea-9229-1a31235da936.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
