### PR TITLE
feature: Sequoia PDF receipt download button is now compatable with PDF receipt addon

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -122,7 +122,7 @@ p {
 	line-height: 20px;
 	margin-top: 10px;
 	margin-bottom: 15px;
-	padding: 16px 22px !important;
+	padding: 16px 10px !important;
 
 	> i {
 		font-size: 16px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
@@ -209,4 +209,10 @@
 			display: none !important;
 		}
 	}
+
+	#give-pdf-receipt-link,
+	#give-pdf-receipt-link:visited {
+		text-decoration: none;
+		color: #fff;
+	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
@@ -212,7 +212,24 @@
 
 	#give-pdf-receipt-link,
 	#give-pdf-receipt-link:visited {
+		display: flex;
+		align-items: center;
 		text-decoration: none;
 		color: #fff;
+
+		&::after {
+			display: inline-block;
+			content: '\f1c1';
+			font-family: 'Font Awesome 5 Free', serif;
+			font-weight: 900;
+			font-size: 20px;
+			margin-left: 15px;
+			-moz-osx-font-smoothing: grayscale;
+			-webkit-font-smoothing: antialiased;
+			font-style: normal;
+			font-variant: normal;
+			text-rendering: auto;
+			line-height: 1;
+		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
@@ -204,5 +204,9 @@
 				border-bottom: 2px solid #f2f2f2;
 			}
 		}
+
+		.details-table:empty {
+			display: none !important;
+		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -8,6 +8,7 @@ use Give\Views\Form\Templates\Sequoia\Sequoia;
 use Give\Views\IframeContentView;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give_Payment as Payment;
+use GivePdfReceipt\Receipt\PdfReceiptDetailsGroup\Details\Receipt as PdfReceiptDetailItem;
 
 $donationSessionAccessor = new DonationAccessor();
 $donation                = new Payment( $donationSessionAccessor->getDonationId() );
@@ -17,6 +18,9 @@ $options                 = FormTemplateUtils::getOptions();
 $sequoiaTemplate = Give()->templates->getTemplate();
 
 $receiptDetails = $sequoiaTemplate->getReceiptDetails( $donation->ID );
+
+/* @var PdfReceiptDetailItem $pdfReceiptDownloadLinkDetailItem */
+$pdfReceiptDownloadLinkDetailItem = null;
 
 ob_start();
 ?>
@@ -64,6 +68,12 @@ ob_start();
 						continue;
 					}
 
+					// We will render download pdf receipt separately.
+					if ( PdfReceiptDetailItem::class === $detailItemClassName ) {
+						$pdfReceiptDownloadLinkDetailItem = $detail;
+						continue;
+					}
+
 					// This class is required to highlight total donation amount in receipt.
 					$detailRowClass = $detailItemClassName === TotalAmountDetailItem::class ? ' total' : '';
 
@@ -87,10 +97,13 @@ ob_start();
 			echo '</div>';
 		}
 		?>
-		<!-- Download Receipt TODO: make this conditional on presence of pdf receipts addon -->
-		<button class="give-btn download-btn">
-			<?php _e( 'Donation Receipt', 'give' ); ?> <i class="fas fa-file-pdf"></i>
-		</button>
+
+		<?php if ( $pdfReceiptDownloadLinkDetailItem instanceof PdfReceiptDetailItem ) : ?>
+			<div class="give-btn download-btn">
+				<?php echo $pdfReceiptDownloadLinkDetailItem->getValue(); ?>
+			</div>
+		<?php endif; ?>
+
 	</div>
 	<div class="form-footer">
 		<div class="secure-notice">


### PR DESCRIPTION
## Description
Resolves #4657

_This PR includes backend compatibility work by @ravinderk and front end styling by @henryholtgeerts. It requires PDF receipts addon running off of this branch (until it is merged): https://github.com/impress-org/give-pdf-receipts/tree/issue/fix-pdf-receipt-template-rendering-220._

Previously, when the PDF receipts addon was active, the PDF receipt link was rendered in the receipt area as just another receipt detail row. This PR ensures that in the Sequoia template the PDF receipt link is rendered as a large button, styled to match Figma designs.

## Affects
This PR affects Sequoia assets and the Sequoia receipt view.

## What to test
With PDF receipts enabled and using the correct branch, process a new donation. Are you shown a PDF receipt link as expected? Does the link work correctly? Can the link be shown/hidden based on settings in the PDF Receipts options panel?

## Screenshots:
<img width="594" alt="Screen Shot 2020-05-13 at 11 54 29 AM" src="https://user-images.githubusercontent.com/5186078/81837044-4c48a280-9512-11ea-87c8-c8a2abe103e9.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
