### PR TITLE
fix: login fields are now styled in Sequoia template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -105,7 +105,8 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			input[type=\'radio\'] + label::after {
 				background: %1$s !important;
 			}
-			a.give-checkout-login {
+			a.give-checkout-login,
+			.give-forgot-password a {
 				color: %1$s;
 			}
 		',

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -109,12 +109,20 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			.give-forgot-password a {
 				color: %1$s;
 			}
+			
 		',
 			$primaryColor
 		);
 		wp_add_inline_style( 'give-sequoia-template-css', $dynamicCss );
 
-		$rawColor            = trim( $primaryColor, '#' );
+		$rawColor        = trim( $primaryColor, '#' );
+		$registrationCss = "
+			.payment [id*='give-create-account-wrap-'] label::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
+			}
+		";
+		wp_add_inline_style( 'give-sequoia-template-css', $registrationCss );
+
 		$recurringDynamicCss = "
 			.give-recurring-donors-choice:hover,
 			.give-recurring-donors-choice.active {

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -105,8 +105,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			input[type=\'radio\'] + label::after {
 				background: %1$s !important;
 			}
-			a.give-checkout-login,
-			.give-forgot-password a {
+			a.give-checkout-login {
 				color: %1$s;
 			}
 			

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -105,6 +105,9 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			input[type=\'radio\'] + label::after {
 				background: %1$s !important;
 			}
+			a.give-checkout-login {
+				color: %1$s;
+			}
 		',
 			$primaryColor
 		);

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -568,6 +568,28 @@ p {
 				background-color: #fff;
 				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
 			}
+
+			&::after {
+				transition: clip-path 0.2s ease;
+				border-radius: 11px;
+				width: 20px;
+				height: 20px;
+				position: absolute;
+				top: calc(50% - 12px);
+				left: 0;
+				content: ' ';
+				display: block;
+				background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%231E8CBE'/%3E%3C/svg%3E%0A");
+				background-repeat: no-repeat;
+				background-position: center;
+				clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+			}
+
+			&.checked {
+				&::after {
+					clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+				}
+			}
 		}
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -537,6 +537,9 @@ p {
 // Payment Section
 
 .payment {
+	> * {
+		order: 99;
+	}
 	[id*='give-checkout-login-register-'] {
 		width: 100%;
 	}
@@ -603,21 +606,18 @@ p {
 				padding: 0;
 				background: none !important;
 				font-size: 14px;
-				display: inline-block;
+				display: block;
 				width: fit-content;
 				border: none !important;
 				text-decoration: underline;
 				color: #b8b8b8;
+				float: right;
 			}
 
 			[id*='give-forgot-password-wrap-'] {
 				grid-column: 1;
 				grid-row: 2;
 				font-size: 14px;
-
-				a {
-					float: right;
-				}
 			}
 		}
 	}
@@ -644,6 +644,7 @@ p {
 	}
 	.give_notices {
 		width: 100%;
+		order: 1;
 	}
 	.give_notices + .heading {
 		padding: 28px 3px 0;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -572,6 +572,56 @@ p {
 		font-size: 14px;
 	}
 
+	[id*='give-login-fields-'] {
+		display: grid;
+		grid-template-columns: 1fr;
+
+		.give-user-login-fields-container {
+			grid-row: 1;
+		}
+
+		.give-new-account-link {
+			grid-row: 2;
+			display: none;
+		}
+
+		[id*='give-user-login-submit-'] {
+			grid-row: 3;
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			margin-bottom: 16px;
+
+			.give-submit {
+				margin-top: 0;
+				grid-column: span 2;
+				grid-row: 1;
+			}
+
+			.give-cancel-login {
+				grid-column: 2;
+				grid-row: 2;
+				padding: 0;
+				background: none !important;
+				font-size: 14px;
+				display: inline-block;
+				width: fit-content;
+				border: none !important;
+				text-decoration: underline;
+				color: #b8b8b8;
+			}
+
+			[id*='give-forgot-password-wrap-'] {
+				grid-column: 1;
+				grid-row: 2;
+				font-size: 14px;
+
+				a {
+					float: right;
+				}
+			}
+		}
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -624,9 +624,12 @@ p {
 
 			.give-submit {
 				margin-top: 0;
-				margin-bottom: 6px;
+				margin-bottom: 12px;
 				flex-basis: 100%;
 				order: 1;
+				padding: 14px !important;
+				line-height: 1;
+				font-size: 16px;
 			}
 
 			.give-cancel-login {
@@ -638,12 +641,18 @@ p {
 				border: none !important;
 				text-decoration: underline;
 				color: #b8b8b8;
-				float: right;
+				margin-left: 10px;
+				font-weight: 400;
 			}
 
 			[id*='give-forgot-password-wrap-'] {
 				font-size: 14px;
 				display: inline-block;
+
+				a {
+					color: #b8b8b8;
+					font-weight: 400;
+				}
 			}
 		}
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -612,23 +612,28 @@ p {
 
 		[id*='give-user-login-submit-'] {
 			grid-row: 3;
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			margin-bottom: 16px;
+			display: flex;
+			flex-direction: row-reverse;
+			flex-wrap: wrap;
+			justify-content: center;
+			margin-bottom: 10px;
+
+			> * {
+				order: 99;
+			}
 
 			.give-submit {
 				margin-top: 0;
-				grid-column: span 2;
-				grid-row: 1;
+				margin-bottom: 6px;
+				flex-basis: 100%;
+				order: 1;
 			}
 
 			.give-cancel-login {
-				grid-column: 2;
-				grid-row: 2;
 				padding: 0;
 				background: none !important;
 				font-size: 14px;
-				display: block;
+				display: inline-block;
 				width: fit-content;
 				border: none !important;
 				text-decoration: underline;
@@ -637,9 +642,8 @@ p {
 			}
 
 			[id*='give-forgot-password-wrap-'] {
-				grid-column: 1;
-				grid-row: 2;
 				font-size: 14px;
+				display: inline-block;
 			}
 		}
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -536,6 +536,10 @@ p {
 // Payment Section
 
 .payment {
+	> div {
+		width: 100%;
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;
@@ -579,6 +583,10 @@ p {
 
 	fieldset {
 		padding: 0 20px;
+
+		> fieldset {
+			padding: 0;
+		}
 	}
 
 	#give_checkout_user_info {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -568,6 +568,10 @@ p {
 		}
 	}
 
+	.give-login-message {
+		font-size: 14px;
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -537,7 +537,7 @@ p {
 // Payment Section
 
 .payment {
-	> div {
+	[id*='give-checkout-login-register-'] {
 		width: 100%;
 	}
 
@@ -550,7 +550,7 @@ p {
 			padding-left: 30px;
 			font-size: 14px;
 
-			i {
+			.give-tooltip {
 				padding-left: 6px;
 			}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -540,6 +540,33 @@ p {
 		width: 100%;
 	}
 
+	[id*='give-create-account-wrap-'] {
+		input {
+			display: none;
+		}
+
+		label {
+			padding-left: 30px;
+			font-size: 14px;
+
+			i {
+				padding-left: 6px;
+			}
+
+			&::before {
+				content: ' ';
+				position: absolute;
+				top: calc(50% - 12px);
+				left: 0;
+				width: 20px;
+				height: 20px;
+				border: 1px solid #b4b9be;
+				background-color: #fff;
+				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+			}
+		}
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;
@@ -809,13 +836,13 @@ fieldset {
 		box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
 		word-wrap: normal;
 		white-space: normal;
-		width: fit-content;
+		width: 136px;
 		max-width: 136px;
 	}
 
-	&.wide {
+	&.narrow {
 		&::after {
-			width: 136px;
+			width: fit-content;
 		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -171,6 +171,14 @@
 			setup: () => {
 				// Setup payment information screen
 
+				$( '.give-section.payment' ).on( 'click', '.give-cancel-login, .give-checkout-register-cancel', clearLoginNotices );
+
+				// Show Sequoia loader on click/touchend
+				$( '.give-section.payment' ).on( 'click touchend', 'input[name="give_login_submit"]', function() {
+					//Override submit loader with Sequoia loader
+					$( 'input[name="give_login_submit"] + .give-loading-animation' ).removeClass( 'give-loading-animation' ).addClass( 'sequoia-loader spinning' );
+				} );
+
 				// Remove purchase_loading text
 				window.give_global_vars.purchase_loading = '';
 
@@ -256,7 +264,7 @@
 							// do things to your newly added nodes here
 							const node = mutation.addedNodes[ i ];
 
-							if ( $( node ).parent().hasClass( 'give-submit-button-wrap' ) && $( node ).hasClass( 'give_errors' ) ) {
+							if ( $( node ).hasClass( 'give_errors' ) && ! $( node ).parent().hasClass( 'payment' ) ) {
 								$( node ).clone().prependTo( '.give-section.payment' );
 								$( node ).remove();
 								$( '.sequoia-loader' ).removeClass( 'spinning' );
@@ -468,5 +476,9 @@
 				}
 			}
 		}
+	}
+
+	function clearLoginNotices() {
+		$( '#give_error_must_log_in' ).remove();
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -220,6 +220,7 @@
 				} );
 
 				$( '#give-ffm-section' ).on( 'click', handleFFMInput );
+				$( '[id*="give-register-account-fields"]' ).on( 'click', handleFFMInput );
 
 				$( '#give-ffm-section input' ).each( function() {
 					switch ( $( this ).prop( 'type' ) ) {
@@ -268,6 +269,10 @@
 								$( node ).clone().prependTo( '.give-section.payment' );
 								$( node ).remove();
 								$( '.sequoia-loader' ).removeClass( 'spinning' );
+							}
+
+							if ( $( node ).attr( 'id' ) && $( node ).attr( 'id' ).includes( 'give-checkout-login-register' ) ) {
+								$( '[id*="give-register-account-fields"]' ).on( 'click', handleFFMInput );
 							}
 						}
 					} );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -155,7 +155,7 @@
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
-						const wrap = `<span class="give-tooltip hint--top hint--bounce ${ text.length > 50 ? 'wide' : '' }" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
+						const wrap = `<span class="give-tooltip hint--top hint--bounce ${ text.length < 50 ? 'narrow' : '' }" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}


### PR DESCRIPTION
## Description
Resolves #4727
This PR introduces styling for login/registration fields within the Sequoia form template checkout process, as they appear to users who are not logged in. Previously, when a user was not logged in they were shown login/registration fields are were not styled consistently with the Sequoia form template. Through a combination of css and js, these fields are now styled correctly, regardless of what registration fields setting the site admin has selected.

Initially, it was suggested that these fields should be rebuilt to match designs presented in the Figma boards for the Sequoia template. Upon further investigation and discussion, it was decided that a more time effective approach would be to simply style the existing fields and use javascript to minimally impact markup.

## Affects
This PR impacts Sequoia form template assets and Sequoia.php.

## What to test
Enabled registration or login in the form fields panel, then in an incognito window (to ensure that you are not logged into the site) view the form on the front end. Do the login/registration fields appear as expected? Try different registration options available in the form fields tab. Do they all work as expected?

## Screenshots:
With _registration_ setting selected:
<img width="582" alt="Screen Shot 2020-05-14 at 2 53 09 PM" src="https://user-images.githubusercontent.com/5186078/81974904-39a69a00-95f4-11ea-9006-3fd4e679702f.png">

With _login_ setting selected:
<img width="596" alt="Screen Shot 2020-05-14 at 2 52 48 PM" src="https://user-images.githubusercontent.com/5186078/81974940-47f4b600-95f4-11ea-849e-a3ae3e9474f0.png">

With _login and registration_ setting selected:
![PRDemo2](https://user-images.githubusercontent.com/5186078/81975002-65298480-95f4-11ea-8764-4ad1b4dbcf35.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
