### PR TITLE
fix: Don't load stripe assets if stripe isn't being used

### DIFF
--- a/includes/gateways/stripe/includes/give-stripe-scripts.php
+++ b/includes/gateways/stripe/includes/give-stripe-scripts.php
@@ -21,9 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function give_stripe_frontend_scripts() {
-
 	// Get publishable key.
 	$publishable_key = give_stripe_get_publishable_key();
+
+	// If a key is not found, bail out and don't load stripe assets.
+	if ( ! $publishable_key ) {
+		return;
+	}
 
 	// Checkout options.
 	// @TODO: convert checkboxes to radios.


### PR DESCRIPTION
## Description
On form pages, we are currently loading Stripe frontend scripts, even if Stripe isn't being used.

## Affects
Affects the front-end form scripts.

## What to test
Should be tested on forms with and without stripe set up. Without the stripe keys in place, the form should still display as normal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
