### PR TITLE
Gift Aid addon is styled in Sequoia form template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -142,6 +142,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		wp_add_inline_style( 'give-sequoia-template-css', $recurringDynamicCss );
 
 		$giftaidDynamicCss = "
+			.mfp-content a,
 			a.give-gift-aid-explanation-content-more,
 			a.give-gift-aid-explanation-content-more:visited {
 				color: {$primaryColor};

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -114,7 +114,15 @@ class Sequoia extends Template implements Hookable, Scriptable {
 		);
 		wp_add_inline_style( 'give-sequoia-template-css', $dynamicCss );
 
-		$rawColor        = trim( $primaryColor, '#' );
+		$rawColor = trim( $primaryColor, '#' );
+
+		$checkboxCss = "
+			input[type='checkbox'] + label::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
+			}
+		";
+		wp_add_inline_style( 'give-sequoia-template-css', $checkboxCss );
+
 		$registrationCss = "
 			.payment [id*='give-create-account-wrap-'] label::after {
 				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
@@ -132,6 +140,14 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			}
 		";
 		wp_add_inline_style( 'give-sequoia-template-css', $recurringDynamicCss );
+
+		$giftaidDynamicCss = "
+			a.give-gift-aid-explanation-content-more,
+			a.give-gift-aid-explanation-content-more:visited {
+				color: {$primaryColor};
+			}
+		";
+		wp_add_inline_style( 'give-sequoia-template-css', $giftaidDynamicCss );
 
 		$feeRecoveryDynamicCss = "
 			.give-fee-recovery-donors-choice.give-fee-message:hover,

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -657,6 +657,10 @@ p {
 		}
 	}
 
+	.give-gift-aid-explanation-content-more-wrap {
+		padding-bottom: 8px;
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -779,7 +779,7 @@ p {
 				display: none !important;
 			}
 
-			label::before {
+			.give-gateway-option::before {
 				content: ' ';
 				position: absolute;
 				top: calc(50% - 10px);
@@ -839,6 +839,11 @@ p {
 	}
 }
 
+// Gift Aid Styles
+.give_gift_aid_address_state_label {
+	display: none !important;
+}
+
 // Fieldsets and Inputs
 
 fieldset {
@@ -877,6 +882,59 @@ fieldset {
 
 .give-label {
 	display: none !important;
+}
+
+input[type='checkbox'] {
+	display: none !important;
+}
+
+input[type='checkbox'] + label {
+	font-weight: 500;
+	font-size: 16px;
+	line-height: 1.4;
+	padding: 0 0 0 32px;
+	width: 100%;
+	margin-left: 0;
+	color: #333;
+	display: inline-block;
+
+	&::before {
+		content: ' ';
+		position: absolute;
+		top: calc(50% - 12px);
+		left: 0;
+		width: 20px;
+		height: 20px;
+		border: 1px solid #b4b9be;
+		background-color: #fff;
+		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+	}
+
+	&::after {
+		transition: clip-path 0.2s ease;
+		border-radius: 11px;
+		width: 20px;
+		height: 20px;
+		position: absolute;
+		top: calc(50% - 12px);
+		left: 0;
+		content: ' ';
+		display: block;
+		background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%231E8CBE'/%3E%3C/svg%3E%0A");
+		background-repeat: no-repeat;
+		background-position: center;
+		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+	}
+
+	&.checked {
+		&::after {
+			clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		}
+	}
+}
+
+input[type='checkbox']:checked + label::after {
+	clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 form[id*='give-form'] .form-row textarea,

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -661,6 +661,10 @@ p {
 		padding-bottom: 8px;
 	}
 
+	[id*='give-gift-aid-checkbox-label-wrap-'] {
+		margin-bottom: 0 !important;
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -716,7 +716,7 @@ p {
 		legend {
 			display: none;
 		}
-		ul {
+		#give-gateway-radio-list {
 			@include before-after-content-none;
 			display: grid;
 			grid-gap: 10px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -665,6 +665,10 @@ p {
 		margin-bottom: 0 !important;
 	}
 
+	.give-modal .mfp-content {
+		padding: 0 16px 16px 16px !important;
+	}
+
 	#give_error_invalid_donation_maximum,
 	#give_error_invalid_donation_amount {
 		cursor: pointer;

--- a/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
@@ -18,7 +18,7 @@
 		display: none !important;
 	}
 
-	label {
+	input[type='checkbox'] + label {
 		font-weight: 500;
 		font-size: 16px;
 		line-height: 1.4;
@@ -29,7 +29,7 @@
 		display: inline-block;
 	}
 
-	label::before {
+	input[type='checkbox'] + label::before {
 		content: ' ';
 		position: absolute;
 		top: calc(50% - 12px);


### PR DESCRIPTION
## Description
Resolves #4732

This PR introduces styling to that makes inputs and copy associated with the Gift Aid addon consistent within the Sequoia form template.

Because Gift Aid copy/fields are placed within payment gateways, it was necessary to move toward making input styles for the Sequoia form template more generic (previously, an additional stylesheet would be introduced for each addon). For this reason, the PR lightly touches some existing styles relating to other addons (only where greater specification was necessary). 

## Affects
This PR affects the Sequoia assets folder, and the Sequoia template class.

## What to test
Setup the Gift Aid addon (involves setting your currency to Pounds Sterling and base location to UK), then enable Gift Aid for your form. Try several different Payment Gateways. Does the Gift Aid content/fields load as expected?

## Screenshots:
<img width="596" alt="Screen Shot 2020-05-18 at 5 27 42 PM" src="https://user-images.githubusercontent.com/5186078/82262077-41d14300-992e-11ea-84f6-c077dc391780.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
