### PR TITLE
fix: paypal help content no longer appears in legacy forms

### DIFF
--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -14,8 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Give\Helpers\Form\Template as FormTemplateUtils;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\Helpers\Form\Utils as FormUtils;
 
 /**
  * Manual Gateway does not need a CC form, so remove it.
@@ -32,7 +31,7 @@ use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
  * @return bool
  **/
 function give_manual_form_ouput() {
-	if ( FormTemplateUtils::getActiveId( FrontendFormTemplateUtils::getFormId() ) === 'legacy' ) {
+	if ( FormUtils::isLegacyForm( $form_id ) ) {
 		return false;
 	}
 

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -13,8 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Give\Helpers\Form\Template as FormTemplateUtils;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\Helpers\Form\Utils as FormUtils;
 
 /**
  * Toggle PayPal CC Billing Detail Fieldset.
@@ -32,7 +31,7 @@ function give_paypal_standard_billing_fields( $form_id ) {
 		return true;
 	}
 
-	if ( FormTemplateUtils::getActiveID( FrontendFormTemplateUtils::getFormId() ) === 'legacy' ) {
+	if ( FormUtils::isLegacyForm( $form_id ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Description
Resolves #4753 
This PR prevents gateway help content from appearing inside Legacy forms when the PayPal gateway is selected. It also addresses a related bug whereby help content appeared in Legacy forms when the test/manual gateway was selected.

Previously, these gateways relied on helper methods to determine if the current form is using the Legacy form tempalte. With the introduction of the FormUtils helper facade, these methods became unsupported. This PR replaces these unsupported methods with calls to the new FormUtils helper class, enabling gateways to properly check if the current form is using the Legacy form template. 

## Affects
This PR affects the manual and paypal-standard files in the gateways directory. These files include a handful of global functions related to each gateway's funcitonality.

## What to test
Using the Legacy form template, try using the PayPal Standard gateway for checkout. Are you still shown the PayPal help content? Also checkout the Test Donation gateway. Do you see help content loaded there?

## Screenshots:
<img width="699" alt="Screen Shot 2020-05-19 at 10 43 51 AM" src="https://user-images.githubusercontent.com/5186078/82341662-b5229580-99be-11ea-9551-d3ace6984c4b.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
