### PR TITLE
fix: unable to process recurring donations via onpage stripe credit card fields #948

### DIFF
--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -123,17 +123,6 @@ function give_stripe_is_connected() {
 }
 
 /**
- * Is Stripe Checkout Enabled?
- *
- * @since 2.5.0
- *
- * @return bool
- */
-function give_stripe_is_checkout_enabled() {
-	return give_is_setting_enabled( give_get_option( 'stripe_checkout_enabled', 'disabled' ) );
-}
-
-/**
  * Displays Stripe Connect Button.
  *
  * @since 2.5.0

--- a/includes/gateways/stripe/includes/class-give-stripe-gateway.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-gateway.php
@@ -287,13 +287,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 
 			$card_exists = false;
 			$all_sources = $stripe_customer->sources->all();
-
-			if ( give_stripe_is_checkout_enabled() && 'stripe' === $this->id ) {
-				$card = $this->get_token_details( $id );
-			} else {
-				$card = $this->get_source_details( $id );
-			}
-
+			$card        = $this->get_source_details( $id );
 			$source_list = wp_list_pluck( $all_sources->data, 'id' );
 
 			// Check whether the source is already attached to customer or not.

--- a/includes/gateways/stripe/includes/deprecated/deprecated-functions.php
+++ b/includes/gateways/stripe/includes/deprecated/deprecated-functions.php
@@ -104,3 +104,20 @@ if ( ! function_exists( 'get_give_stripe_connect_options' ) ) {
 		return give_stripe_get_connect_settings();
 	}
 }
+
+/**
+ * Is Stripe Checkout Enabled?
+ *
+ * @since 2.5.0
+ * @deprecated 2.6.4
+ *
+ * @return bool
+ */
+function give_stripe_is_checkout_enabled() {
+
+	$backtrace = debug_backtrace();
+
+	_give_deprecated_function( __FUNCTION__, '2.6.4', 'give_stripe_is_checkout_enabled', $backtrace );
+
+	return give_is_setting_enabled( give_get_option( 'stripe_checkout_enabled', 'disabled' ) );
+}

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -896,58 +896,47 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 			// Save donation summary to donation.
 			give_update_meta( $donation_id, '_give_stripe_donation_summary', $donation_summary );
 
-			if ( give_stripe_is_checkout_enabled() ) {
+			/**
+			 * This filter hook is used to update the payment intent arguments.
+			 *
+			 * @since 2.5.0
+			 */
+			$intent_args = apply_filters(
+				'give_stripe_create_intent_args',
+				array(
+					'amount'               => $stripe_gateway->format_amount( $donation_data['price'] ),
+					'currency'             => give_get_currency( $form_id ),
+					'payment_method_types' => array( 'card' ),
+					'statement_descriptor' => give_stripe_get_statement_descriptor(),
+					'description'          => give_payment_gateway_donation_summary( $donation_data ),
+					'metadata'             => $stripe_gateway->prepare_metadata( $donation_id ),
+					'customer'             => $stripe_customer_id,
+					'payment_method'       => $payment_method_id,
+					'confirm'              => true,
+					'return_url'           => give_get_success_page_uri(),
+				)
+			);
 
-				// Process charge w/ support for preapproval.
-				$charge = $stripe_gateway->process_charge( $donation_data, $stripe_customer_id );
-
-				// Verify the Stripe payment.
-				$stripe_gateway->verify_payment( $donation_id, $stripe_customer_id, $charge );
-			} else {
-
-				/**
-				 * This filter hook is used to update the payment intent arguments.
-				 *
-				 * @since 2.5.0
-				 */
-				$intent_args = apply_filters(
-					'give_stripe_create_intent_args',
-					array(
-						'amount'               => $stripe_gateway->format_amount( $donation_data['price'] ),
-						'currency'             => give_get_currency( $form_id ),
-						'payment_method_types' => array( 'card' ),
-						'statement_descriptor' => give_stripe_get_statement_descriptor(),
-						'description'          => give_payment_gateway_donation_summary( $donation_data ),
-						'metadata'             => $stripe_gateway->prepare_metadata( $donation_id ),
-						'customer'             => $stripe_customer_id,
-						'payment_method'       => $payment_method_id,
-						'confirm'              => true,
-						'return_url'           => give_get_success_page_uri(),
-					)
-				);
-
-				// Send Stripe Receipt emails when enabled.
-				if ( give_is_setting_enabled( give_get_option( 'stripe_receipt_emails' ) ) ) {
-					$intent_args['receipt_email'] = $donation_data['user_email'];
-				}
-
-				$intent = $stripe_gateway->payment_intent->create( $intent_args );
-
-				// Save Payment Intent Client Secret to donation note and DB.
-				give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );
-				give_update_meta( $donation_id, '_give_stripe_payment_intent_client_secret', $intent->client_secret );
-
-				// Set Payment Intent ID as transaction ID for the donation.
-				give_set_payment_transaction_id( $donation_id, $intent->id );
-				give_insert_payment_note( $donation_id, 'Stripe Charge/Payment Intent ID: ' . $intent->id );
-
-				// Process additional steps for SCA or 3D secure.
-				give_stripe_process_additional_authentication( $donation_id, $intent );
-
-				// Send them to success page.
-				give_send_to_success_page();
-
+			// Send Stripe Receipt emails when enabled.
+			if ( give_is_setting_enabled( give_get_option( 'stripe_receipt_emails' ) ) ) {
+				$intent_args['receipt_email'] = $donation_data['user_email'];
 			}
+
+			$intent = $stripe_gateway->payment_intent->create( $intent_args );
+
+			// Save Payment Intent Client Secret to donation note and DB.
+			give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );
+			give_update_meta( $donation_id, '_give_stripe_payment_intent_client_secret', $intent->client_secret );
+
+			// Set Payment Intent ID as transaction ID for the donation.
+			give_set_payment_transaction_id( $donation_id, $intent->id );
+			give_insert_payment_note( $donation_id, 'Stripe Charge/Payment Intent ID: ' . $intent->id );
+
+			// Process additional steps for SCA or 3D secure.
+			give_stripe_process_additional_authentication( $donation_id, $intent );
+
+			// Send them to success page.
+			give_send_to_success_page();
 		} else {
 
 			// No customer, failed.


### PR DESCRIPTION
## Description
This PR resolves https://github.com/impress-org/give-recurring/issues/948 and supports PR https://github.com/impress-org/give-recurring/pull/949

## Affects
We deprecated a function which is no longer in use `give_stripe_is_checkout_enabled`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
