### PR TITLE
fix: embedded credit card fields are styled consistently with Sequoia form template #4742

### DIFF
--- a/assets/src/js/frontend/give-stripe-becs.js
+++ b/assets/src/js/frontend/give-stripe-becs.js
@@ -1,5 +1,5 @@
 /**
- * Give - Stripe Gateway Add-on JS
+ * Give - Stripe BECS Payment Method JS
  */
 const stripe = {};
 
@@ -13,7 +13,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	const fontStyles = [];
 	const preferredLocale = give_stripe_vars.preferred_locale;
 	const formWraps = document.querySelectorAll( '.give-form-wrap' );
-	
+
 	// If font styles are defined, add them to font styles array
 	if ( Object.keys( give_stripe_vars.element_font_styles ).length !== 0 ) {
 		fontStyles.push( give_stripe_vars.element_font_styles );
@@ -127,12 +127,12 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	} );
 
 	/**
-	 * Mount Card Elements
+	 * Mount IBAN Elements
 	 *
 	 * @param {string} idPrefix     ID Prefix.
 	 * @param {array}  bankAccountElements List of card elements to be mounted.
 	 *
-	 * @since 1.6
+	 * @since 2.6.3
 	 */
 	function giveStripeMountIbanElements( idPrefix, bankAccountElements = [] ) {
 		const bankAccountElementsLength = Object.keys( bankAccountElements ).length;
@@ -152,11 +152,11 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	}
 
 	/**
-	 * Un-mount Card Elements
+	 * Un-mount IBAN Elements
 	 *
 	 * @param {array} bankAccountElements List of card elements to be unmounted.
 	 *
-	 * @since 1.6
+	 * @since 2.6.3
 	 */
 	function giveStripeUnmountIbanElements( bankAccountElements = [] ) {
 		// Un-mount required card elements.
@@ -169,13 +169,13 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	}
 
 	/**
-	 * Create required card elements.
+	 * Create required IBAN elements.
 	 *
 	 * @param {object} formElement Form Element.
 	 * @param {object} elements     Stripe Element.
 	 * @param {string} idPrefix     ID Prefix.
 	 *
-	 * @since 1.6
+	 * @since 2.6.3
 	 *
 	 * @return {array} elements
 	 */
@@ -240,7 +240,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 	}
 
 	/**
-	 * Stripe Process CC
+	 * Stripe Process BECS payment.
 	 *
 	 * @param {object} $form Form Object.
 	 * @param {object} $iban IBAN Object.

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1284,7 +1284,7 @@ function give_stripe_get_iban_placeholder_country() {
  *
  * @param int $form_id Donation Form ID.
  *
- * @since 2.6.1
+ * @since 2.6.3
  *
  * @return string
  */
@@ -1300,7 +1300,7 @@ function give_stripe_becs_hide_icon( $form_id ) {
  *
  * @param int $form_id Donation Form ID.
  *
- * @since 2.6.1
+ * @since 2.6.3
  *
  * @return string
  */

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
@@ -111,26 +111,14 @@ if ( ! class_exists( 'Give_Stripe_Becs' ) ) {
 					</div>
 					<?php
 					/**
-					 * This action hook is used to display content after the Credit Card expiration field.
-					 *
-					 * Note: Kept this hook as it is.
+					 * This action hook is used to display content after the Stripe BECS field.
 					 *
 					 * @param int   $form_id Donation Form ID.
 					 * @param array $args    List of additional arguments.
 					 *
-					 * @since 2.5.0
+					 * @since 2.6.3
 					 */
-					do_action( 'give_after_cc_expiration', $form_id, $args );
-
-					/**
-					 * This action hook is used to display content after the Credit Card expiration field.
-					 *
-					 * @param int   $form_id Donation Form ID.
-					 * @param array $args    List of additional arguments.
-					 *
-					 * @since 2.5.0
-					 */
-					do_action( 'give_stripe_after_cc_expiration', $form_id, $args );
+					do_action( 'give_stripe_after_becs_fields', $form_id, $args );
 				}
 				?>
 			</fieldset>
@@ -249,7 +237,7 @@ if ( ! class_exists( 'Give_Stripe_Becs' ) ) {
 					/**
 					 * This filter hook is used to update the payment intent arguments.
 					 *
-					 * @since 2.5.0
+					 * @since 2.6.3
 					 */
 					$intent_args = apply_filters(
 						'give_stripe_create_intent_args',


### PR DESCRIPTION
## Description
This PR is related to the correction for #4742 

## Affects
- includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
- includes/gateways/stripe/includes/give-stripe-helpers.php
- includes/gateways/stripe/includes/payment-methods/class-give-stripe-becs.php
- assets/src/js/frontend/give-stripe-becs.js 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
