### PR TITLE
show receipt after payment 

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -121,7 +121,7 @@ class LoadTemplate {
 		}
 
 		// Show new receipt view only on donation confirmation page.
-		if ( false === strpos( wp_get_referer(), untrailingslashit( FormUtils::getSuccessPageURL() ) ) ) {
+		if ( false === strpos( untrailingslashit( wp_get_referer() ), untrailingslashit( FormUtils::getSuccessPageURL() ) ) ) {
 			return;
 		}
 

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -84,6 +84,7 @@ class LoadTemplate {
 	 * @since 2.7.0
 	 */
 	private function setUpFrontendHooks() {
+		add_action( 'give_embed_head', [ $this, 'noRobots' ] );
 		add_action( 'give_embed_head', 'wp_enqueue_scripts', 1 );
 		add_action( 'give_embed_head', [ $this, 'handleEnqueueScripts' ], 2 );
 		add_action( 'give_embed_head', 'wp_print_styles', 8 );
@@ -95,6 +96,17 @@ class LoadTemplate {
 		// Handle receipt screen template
 		add_action( 'wp_ajax_get_receipt', [ $this, 'handleReceiptAjax' ], 9 );
 		add_action( 'wp_ajax_nopriv_get_receipt', [ $this, 'handleReceiptAjax' ], 9 );
+	}
+
+	/**
+	 * Display a noindex meta tag.
+	 *
+	 * Outputs a noindex meta tag that tells web robots not to index and follow content.
+	 *
+	 * @since 2.7.0
+	 */
+	public function noRobots() {
+		echo "<meta name='robots' content='noindex,nofollow'/>\n";
 	}
 
 	/**

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -84,20 +84,6 @@ class LoadTemplate {
 	 * @since 2.7.0
 	 */
 	private function setUpFrontendHooks() {
-		add_action( 'give_embed_head', 'rel_canonical' );
-		add_action( 'give_embed_head', 'wp_enqueue_scripts', 1 );
-		add_action( 'give_embed_head', 'wp_resource_hints', 2 );
-		add_action( 'give_embed_head', 'feed_links', 2 );
-		add_action( 'give_embed_head', 'feed_links_extra', 3 );
-		add_action( 'give_embed_head', 'rsd_link' );
-		add_action( 'give_embed_head', 'wlwmanifest_link' );
-		add_action( 'give_embed_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
-		add_action( 'give_embed_head', 'noindex', 1 );
-		add_action( 'give_embed_head', 'wp_generator' );
-		add_action( 'give_embed_head', 'rel_canonical' );
-		add_action( 'give_embed_head', 'wp_shortlink_wp_head', 10, 0 );
-		add_action( 'give_embed_head', 'wp_site_icon', 99 );
-
 		add_action( 'give_embed_head', 'wp_enqueue_scripts', 1 );
 		add_action( 'give_embed_head', [ $this, 'handleEnqueueScripts' ], 2 );
 		add_action( 'give_embed_head', 'wp_print_styles', 8 );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -5,6 +5,7 @@
 	const $advanceButton = $( '.advance-btn', $container );
 	const $backButton = $( '.back-btn' );
 	const $navigatorTitle = $( '.give-form-navigator .title' );
+	const $paymentGatewayContainer = $( '#give-payment-mode-select' );
 	let gatewayAnimating = false;
 
 	const navigator = {
@@ -305,7 +306,7 @@
 	navigator.init();
 
 	// Check if only a single gateway is enabled
-	if ( $( '#give-payment-mode-select' ).css( 'display' ) !== 'none' ) {
+	if ( $paymentGatewayContainer.length && $paymentGatewayContainer.css( 'display' ) !== 'none' ) {
 		// Move payment information section when document load.
 		moveFieldsUnderPaymentGateway( true );
 
@@ -331,8 +332,8 @@
 	 */
 	function moveFieldsUnderPaymentGateway() {
 		// Handle "Donate Now" button placement
-		if ( ! $( '#give-payment-mode-select' ).next().hasClass( 'give-submit' ) ) {
-			$( '#give-payment-mode-select' ).after( $( '#give_purchase_form_wrap .give-submit' ) );
+		if ( ! $paymentGatewayContainer.next().hasClass( 'give-submit' ) ) {
+			$paymentGatewayContainer.after( $( '#give_purchase_form_wrap .give-submit' ) );
 		} else {
 			$( '#give_purchase_form_wrap .give-submit' ).remove();
 		}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
I notice that I was not able to donation receipt after payment and I found that reason was that the referer URL contains a trailing slash. To fix this issue I removed trailing slash from the referer and success page URL before comparison.
I also found a javascript related issues. a piece of code warning even if the donor was on donation form but we expect it to run only on that view. I added an update condition to fix the issue.
In this pr, I also removed WordPress default head related functions which we do not need.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
I tested this pr by processing a donation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
