### PR TITLE
fix: Apple/Google Pay gateways are now compatible with Sequoia form template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -86,10 +86,11 @@
 
 	input[type='checkbox']:checked + .give-fee-message-label-text::after {
 		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 	}
 
 	input[type='checkbox'] + .give-fee-message-label-text::after {
-		transition: clip-path 0.2s ease;
+		transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 		border-radius: 11px;
 		width: 20px;
 		height: 20px;
@@ -102,5 +103,6 @@
 		background-repeat: no-repeat;
 		background-position: center;
 		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+		-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -35,7 +35,7 @@
 		}
 
 		&::after {
-			transition: clip-path 0.2s ease;
+			transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 			border-radius: 11px;
 			width: 20px;
 			height: 20px;
@@ -48,11 +48,13 @@
 			background-repeat: no-repeat;
 			background-position: center;
 			clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+			-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 		}
 
 		&.checked {
 			&::after {
 				clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+				-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 			}
 		}
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -844,6 +844,8 @@ p {
 
 			&.StripeElement {
 				margin-top: 48px;
+				display: flex !important;
+				justify-content: center;
 			}
 
 			> *:not(.give_error) {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -861,6 +861,7 @@ p {
 			flex-direction: column;
 			align-items: center;
 			position: relative;
+			order: 3;
 
 			.sequoia-loader {
 				height: 30px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -862,6 +862,10 @@ p {
 				position: absolute;
 				font-size: 4px;
 			}
+
+			.give-submit:not(:disabled) + .sequoia-loader {
+				display: none;
+			}
 		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -591,7 +591,7 @@ p {
 			}
 
 			&::after {
-				transition: clip-path 0.2s ease;
+				transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 				border-radius: 11px;
 				width: 20px;
 				height: 20px;
@@ -604,11 +604,13 @@ p {
 				background-repeat: no-repeat;
 				background-position: center;
 				clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+				-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 			}
 
 			&.checked {
 				&::after {
 					clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+					-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 				}
 			}
 		}
@@ -734,6 +736,11 @@ p {
 		}
 	}
 	#give-payment-mode-select {
+		.gateway-stripe-google_pay,
+		.gateway-stripe-apple_pay {
+			display: none !important;
+		}
+
 		legend {
 			display: none;
 		}
@@ -804,6 +811,7 @@ p {
 			}
 		}
 	}
+
 	#give_purchase_form_wrap {
 		background: #fbfbfb;
 		padding: 12px 20px 6px 20px;
@@ -823,9 +831,18 @@ p {
 	#give_purchase_submit {
 		display: flex;
 		flex-direction: column;
+		order: 3;
 
 		#give-final-total-wrap {
 			display: none;
+		}
+
+		input[value='stripe_apple_pay'] ~ .give-stripe-payment-request-button,
+		input[value='stripe_google_pay'] ~ .give-stripe-payment-request-button {
+			width: 236px;
+			height: 64px;
+			margin: 48px auto 16px auto;
+			order: 3;
 		}
 	}
 
@@ -917,7 +934,7 @@ input[type='checkbox'] + label {
 	}
 
 	&::after {
-		transition: clip-path 0.2s ease;
+		transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 		border-radius: 11px;
 		width: 20px;
 		height: 20px;
@@ -930,17 +947,20 @@ input[type='checkbox'] + label {
 		background-repeat: no-repeat;
 		background-position: center;
 		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+		-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 	}
 
 	&.checked {
 		&::after {
 			clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+			-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 		}
 	}
 }
 
 input[type='checkbox']:checked + label::after {
 	clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+	-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 }
 
 .give-square-cc-fields,

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -839,9 +839,16 @@ p {
 
 		input[value='stripe_apple_pay'] ~ .give-stripe-payment-request-button,
 		input[value='stripe_google_pay'] ~ .give-stripe-payment-request-button {
-			width: 236px;
-			margin: 48px auto 16px auto;
+			margin: 16px auto 16px auto;
 			order: 3;
+
+			&.StripeElement {
+				margin-top: 48px;
+			}
+
+			> *:not(.give_error) {
+				width: 236px;
+			}
 		}
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -840,7 +840,6 @@ p {
 		input[value='stripe_apple_pay'] ~ .give-stripe-payment-request-button,
 		input[value='stripe_google_pay'] ~ .give-stripe-payment-request-button {
 			width: 236px;
-			height: 64px;
 			margin: 48px auto 16px auto;
 			order: 3;
 		}

--- a/src/Views/Form/Templates/Sequoia/assets/css/newsletter.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/newsletter.scss
@@ -60,10 +60,11 @@
 
 	input[type='checkbox']:checked + span::after {
 		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 	}
 
 	input[type='checkbox'] + span::after {
-		transition: clip-path 0.2s ease;
+		transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 		border-radius: 11px;
 		width: 20px;
 		height: 20px;
@@ -76,5 +77,6 @@
 		background-repeat: no-repeat;
 		background-position: center;
 		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+		-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
@@ -55,10 +55,11 @@
 
 	input[type='checkbox']:checked + label::after {
 		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+		-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
 	}
 
 	input[type='checkbox'] + label::after {
-		transition: clip-path 0.2s ease;
+		transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
 		border-radius: 11px;
 		width: 20px;
 		height: 20px;
@@ -71,6 +72,7 @@
 		background-repeat: no-repeat;
 		background-position: center;
 		clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+		-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
 	}
 
 	.give-recurring-donors-choice-period {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -376,6 +376,9 @@
 		donateFieldsetElements.forEach( function( selector ) {
 			if ( $( `#donate-fieldset  ${ selector }` ).length === 0 ) {
 				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
+			} else if ( $( `#donate-fieldset  ${ selector }` ).html() !== $( `#give_purchase_form_wrap  ${ selector }` ).html() ) {
+				$( `#donate-fieldset  ${ selector }` ).remove();
+				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
 			} else {
 				$( `#give_purchase_form_wrap ${ selector }` ).remove();
 			}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -349,6 +349,21 @@
 			}
 		} );
 
+		// Clear gateway related errors
+		$( document ).on( 'Give:onPreGatewayLoad', function() {
+			const persistedNotices = [
+				'give_error_test_mode',
+			];
+
+			$( '.give_errors, .give_notices, .give_error' ).each( function() {
+				if ( ! persistedNotices.includes( $( this ).attr( 'id' ) ) ) {
+					$( this ).slideUp( 200, function() {
+						$( this ).remove();
+					} );
+				}
+			} );
+		} );
+
 		// Refresh payment information section.
 		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -364,6 +364,10 @@
 			$( '#give-payment-mode-select' ).after( '<fieldset id="donate-fieldset"></fieldset>' );
 		}
 
+		if ( $( '#give_purchase_form_wrap .give_error' ).length !== 0 ) {
+			$( '.payment' ).prepend( $( '#give_purchase_form_wrap .give_error' ) );
+		}
+
 		// Elements to move into donate fieldset (located at bottom of form)
 		// The elements will appear in order of array
 		const donateFieldsetElements = [

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -376,11 +376,9 @@
 		donateFieldsetElements.forEach( function( selector ) {
 			if ( $( `#donate-fieldset  ${ selector }` ).length === 0 ) {
 				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
-			} else if ( $( `#donate-fieldset  ${ selector }` ).html() !== $( `#give_purchase_form_wrap  ${ selector }` ).html() ) {
+			} else {
 				$( `#donate-fieldset  ${ selector }` ).remove();
 				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
-			} else {
-				$( `#give_purchase_form_wrap ${ selector }` ).remove();
 			}
 		} );
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -436,6 +436,12 @@
 				case 'paypalpro_payflow':
 					icon = 'far fa-credit-card';
 					break;
+				case 'stripe_google_pay':
+					icon = 'fab fa-google';
+					break;
+				case 'stripe_apple_pay':
+					icon = 'fab fa-apple';
+					break;
 				default:
 					icon = 'fas fa-hand-holding-heart';
 					break;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -184,8 +184,7 @@
 				window.give_global_vars.purchase_loading = '';
 
 				const testNotice = $( '#give_error_test_mode' );
-				$( testNotice ).clone().prependTo( '.give-section.payment' );
-				$( testNotice ).remove();
+				moveErrorNotice( testNotice );
 
 				// Persist the recurring input border when selected
 				$( '.give-recurring-period' ).change( function() {
@@ -272,14 +271,15 @@
 							// do things to your newly added nodes here
 							const node = mutation.addedNodes[ i ];
 
-							if ( $( node ).children().hasClass( 'give_errors' ) && ! $( node ).hasClass( 'payment' ) ) {
-								$( node ).children( '.give_errors' ).clone().prependTo( '.give-section.payment' );
-								$( node ).children( '.give_errors' ).remove();
+							if ( $( node ).children().hasClass( 'give_errors' ) && ! $( node ).parent().hasClass( 'donation-errors' ) ) {
+								$( node ).children( '.give_errors' ).each( function() {
+									const notice = $( this );
+									moveErrorNotice( notice );
+								} );
 							}
 
-							if ( $( node ).hasClass( 'give_errors' ) && ! $( node ).parent().hasClass( 'payment' ) ) {
-								$( node ).clone().prependTo( '.give-section.payment' );
-								$( node ).remove();
+							if ( $( node ).hasClass( 'give_errors' ) && ! $( node ).parent().hasClass( 'donation-errors' ) ) {
+								moveErrorNotice( $( node ) );
 								$( '.sequoia-loader' ).removeClass( 'spinning' );
 							}
 
@@ -350,6 +350,26 @@
 
 		// Refresh payment information section.
 		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
+	}
+
+	/**
+	 * Move error notices to error notice container at the top of the payment section
+	 * @since 2.7.0
+	 * @param {node} node The error notice node to be moved
+	 */
+	function moveErrorNotice( node ) {
+		// First check if specific donation notice container has been set up
+		if ( $( '.donation-errors' ).length === 0 ) {
+			$( '.payment' ).prepend( '<div class="donation-errors"></div>' );
+		}
+
+		// If a specific notice does not already exist, proceed with moving the error
+		if ( ! $( '.donation-errors' ).html().includes( $( node ).html() ) ) {
+			$( node ).appendTo( '.donation-errors' );
+		} else {
+			// If the specific notice already exists, do not add it
+			$( node ).remove();
+		}
 	}
 
 	/**

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -322,6 +322,16 @@
 			$( '#give_purchase_form_wrap' ).slideUp( 200 );
 		} );
 
+		// Hide Donate Now button for Apple and Google Pay gateways
+		$( document ).on( 'Give:onPreGatewayLoad', function() {
+			const gateway = $( '.give-gateway-option-selected input' ).attr( 'value' );
+			if ( gateway === 'stripe_google_pay' || gateway === 'stripe_apple_pay' ) {
+				$( '.give-submit' ).hide();
+			} else {
+				$( '.give-submit' ).show();
+			}
+		} );
+
 		// Refresh payment information section.
 		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
 	}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -369,10 +369,6 @@
 			$( '#give-payment-mode-select' ).after( '<fieldset id="donate-fieldset"></fieldset>' );
 		}
 
-		if ( $( '#give_purchase_form_wrap .give_error' ).length !== 0 ) {
-			$( '.payment' ).prepend( $( '#give_purchase_form_wrap .give_error' ) );
-		}
-
 		// Elements to move into donate fieldset (located at bottom of form)
 		// The elements will appear in order of array
 		const donateFieldsetElements = [

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -381,9 +381,11 @@
 		donateFieldsetElements.forEach( function( selector ) {
 			if ( $( `#donate-fieldset  ${ selector }` ).length === 0 ) {
 				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
-			} else {
+			} else if ( $( `#donate-fieldset  ${ selector }` ).html() !== $( `#give_purchase_form_wrap  ${ selector }` ).html() ) {
 				$( `#donate-fieldset  ${ selector }` ).remove();
 				$( '#donate-fieldset' ).append( $( `#give_purchase_form_wrap ${ selector }` ) );
+			} else {
+				$( `#give_purchase_form_wrap ${ selector }` ).remove();
 			}
 		} );
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -339,16 +339,6 @@
 			$( '#give_purchase_form_wrap' ).slideUp( 200 );
 		} );
 
-		// Hide Donate Now button for Apple and Google Pay gateways
-		$( document ).on( 'Give:onPreGatewayLoad', function() {
-			const gateway = $( '.give-gateway-option-selected input' ).attr( 'value' );
-			if ( gateway === 'stripe_google_pay' || gateway === 'stripe_apple_pay' ) {
-				$( '.give-submit' ).hide();
-			} else {
-				$( '.give-submit' ).show();
-			}
-		} );
-
 		// Clear gateway related errors
 		$( document ).on( 'Give:onPreGatewayLoad', function() {
 			const persistedNotices = [


### PR DESCRIPTION
## Description
Resolves #4767 
This PR introduces a handful of style and functionality improvements to make Google Pay and Apple Pay gateways more compatible with the Sequoia form template. Previously, when a user selected these gateways, they would be shown both an Apple/Google pay link and the Donate Now button, which created confusion. This PR hides the Donate Now button when Apple or Google Pay gateways are open, so the user is only shown once button to process their donation. The PR also sets up brand icons for Google Pay and Apple Pay.

For testing purposes, a live demo of the changes introduced by this PR can be found here: https://livegive.wpsteward.com/donations/homeless-outreach-fund/

## Affects
The PR primarily affects Sequoia form template assets (particularly form.js).

## What to test
Enable/disable the Apple and Google Pay gateways. From the frontend, select each gateway and see how it loads. Is the "Donate Now" button hidden when the gateway is opened? Are the correct brand icons visible for each gateway? Are the Google Pay and Apple Pay buttons padded nicely, and responsive to changes in the gateway display options panel? Try donating without completing all the required fields, do validation notices appear as expected, and are they cleared when you select a different gateway?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/83434220-09d6ff00-a408-11ea-8d14-c8049c7b2afe.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
