### PR TITLE
update Monaco country state configuration to hide state as required field

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -700,6 +700,12 @@ function give_get_country_locale() {
 					'required' => false,
 				),
 			),
+			'MC' => array(
+				'state' => array(
+					'required' => false,
+					'hidden'   => true,
+				),
+			),
 			'MQ' => array(
 				'state' => array(
 					'required' => false,


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4773 

I found that we do not have a country locale setting in `give_get_country_locale` function which causes of showing default state field. I added the `state` configuration for `Monaco` country to hide the default state field.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
It will affect  array list in `give_get_country_locale` function.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
As you can see screenshot we will not see state field as a required field in the donation form and we will able to process donation without any error.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/83516662-22711300-a4f5-11ea-8e3e-0a4e8ef939ef.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
