### PR TITLE
authorized donor   able to see errors

### DIFF
--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -106,7 +106,7 @@ class Give_Email_Access {
 	public function __construct() {
 
 		// Get it started.
-		add_action( 'wp', array( $this, 'setup' ) );
+		add_action( 'wp', [ $this, 'setup' ] );
 	}
 
 	/**
@@ -120,7 +120,7 @@ class Give_Email_Access {
 
 		if ( $is_email_access_on_page ) {
 			// Get it started.
-			add_action( 'wp', array( $this, 'init' ), 14 );
+			add_action( 'wp', [ $this, 'init' ], 14 );
 		}
 	}
 
@@ -157,7 +157,7 @@ class Give_Email_Access {
 
 		if ( $this->token_exists ) {
 			add_filter( 'give_user_pending_verification', '__return_false' );
-			add_filter( 'give_get_users_donations_args', array( $this, 'users_donations_args' ) );
+			add_filter( 'give_get_users_donations_args', [ $this, 'users_donations_args' ] );
 		}
 
 	}

--- a/includes/class-give-email-access.php
+++ b/includes/class-give-email-access.php
@@ -253,8 +253,10 @@ class Give_Email_Access {
 			}
 
 			// Set Receipt Access Session.
+			Give()->session->maybe_start_session();
 			Give()->session->set( 'receipt_access', true );
 			$this->token_exists = true;
+
 			// Set cookie.
 			$lifetime = current_time( 'timestamp' ) + Give()->session->set_expiration_time();
 			@setcookie( 'give_nl', $token, $lifetime, COOKIEPATH, COOKIE_DOMAIN, false );

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -178,6 +178,7 @@ class Give_Session {
 		}
 
 		add_action( 'give_process_donation_after_validation', array( $this, 'maybe_start_session' ) );
+		add_action( 'wp_login', array( $this, 'startSessionWhenLoginAsWPUser' ), 10, 2 );
 
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
@@ -426,6 +427,22 @@ class Give_Session {
 			&& ! $this->has_cookie
 		) {
 			$this->set_session_cookies( true );
+		}
+	}
+
+	/**
+	 * Setup donor session when authorized by WP user credentials
+	 *
+	 * @param string $wpUserLogin
+	 * @param WP_User $wpUser
+	 * @since 2.7.0
+	 */
+	public function startSessionWhenLoginAsWPUser( $wpUserLogin, $wpUser ){
+		$donor = Give()->donors->get_donor_by( 'user_id', $wpUser->ID );
+
+		// Setup session only if donor exist for specific WP user.
+		if( $donor ) {
+			$this->maybe_start_session();
 		}
 	}
 

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -35,7 +35,7 @@ class Give_Session {
 	 *
 	 * @var    array
 	 */
-	private $session = array();
+	private $session = [];
 
 	/**
 	 * Holds our session data
@@ -177,18 +177,18 @@ class Give_Session {
 			$this->generate_donor_id();
 		}
 
-		add_action( 'give_process_donation_after_validation', array( $this, 'maybe_start_session' ) );
-		add_action( 'wp_login', array( $this, 'startSessionWhenLoginAsWPUser' ), 10, 2 );
+		add_action( 'give_process_donation_after_validation', [ $this, 'maybe_start_session' ] );
+		add_action( 'wp_login', [ $this, 'startSessionWhenLoginAsWPUser' ], 10, 2 );
 
-		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
-		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
+		add_action( 'shutdown', [ $this, 'save_data' ], 20 );
+		add_action( 'wp_logout', [ $this, 'destroy_session' ] );
 
 		if ( ! is_user_logged_in() ) {
-			add_filter( 'nonce_user_logged_out', array( $this, '__nonce_user_logged_out' ) );
+			add_filter( 'nonce_user_logged_out', [ $this, '__nonce_user_logged_out' ] );
 		}
 
 		// Remove old sessions.
-		Give_Cron::add_daily_event( array( $this, '__cleanup_sessions' ) );
+		Give_Cron::add_daily_event( [ $this, '__cleanup_sessions' ] );
 	}
 
 	/**
@@ -200,7 +200,7 @@ class Give_Session {
 	 * @return array
 	 */
 	public function get_session_data() {
-		return $this->has_session() ? (array) Give()->session_db->get_session( $this->donor_id, array() ) : array();
+		return $this->has_session() ? (array) Give()->session_db->get_session( $this->donor_id, [] ) : [];
 	}
 
 
@@ -213,7 +213,7 @@ class Give_Session {
 	 * @return array
 	 */
 	public function get_session_cookie() {
-		$session      = array();
+		$session      = [];
 		$cookie_value = isset( $_COOKIE[ $this->cookie_name ] ) ? give_clean( $_COOKIE[ $this->cookie_name ] ) : $this->__handle_ajax_cookie(); // @codingStandardsIgnoreLine.
 
 		if ( empty( $cookie_value ) || ! is_string( $cookie_value ) ) {
@@ -241,7 +241,7 @@ class Give_Session {
 		 */
 		$cookie_data = apply_filters(
 			'give_get_session_cookie',
-			array( $donor_id, $session_expiration, $session_expiring, $cookie_hash )
+			[ $donor_id, $session_expiration, $session_expiring, $cookie_hash ]
 		);
 
 		return $cookie_data;
@@ -437,11 +437,11 @@ class Give_Session {
 	 * @param WP_User $wpUser
 	 * @since 2.7.0
 	 */
-	public function startSessionWhenLoginAsWPUser( $wpUserLogin, $wpUser ){
+	public function startSessionWhenLoginAsWPUser( $wpUserLogin, $wpUser ) {
 		$donor = Give()->donors->get_donor_by( 'user_id', $wpUser->ID );
 
 		// Setup session only if donor exist for specific WP user.
-		if( $donor ) {
+		if ( $donor ) {
 			$this->maybe_start_session();
 		}
 	}
@@ -474,16 +474,16 @@ class Give_Session {
 
 			Give()->session_db->__replace(
 				Give()->session_db->table_name,
-				array(
+				[
 					'session_key'    => $this->donor_id,
 					'session_value'  => maybe_serialize( $this->session ),
 					'session_expiry' => $this->session_expiration,
-				),
-				array(
+				],
+				[
 					'%s',
 					'%s',
 					'%d',
-				)
+				]
 			);
 
 			$this->session_data_changed = false;
@@ -502,7 +502,7 @@ class Give_Session {
 
 		Give()->session_db->delete_session( $this->donor_id );
 
-		$this->session              = array();
+		$this->session              = [];
 		$this->session_data_changed = false;
 
 		$this->generate_donor_id();
@@ -652,7 +652,7 @@ class Give_Session {
 
 			$blacklist = apply_filters(
 				'give_session_start_uri_blacklist',
-				array(
+				[
 					'feed',
 					'feed',
 					'feed/rss',
@@ -660,7 +660,7 @@ class Give_Session {
 					'feed/rdf',
 					'feed/atom',
 					'comments/feed/',
-				)
+				]
 			);
 			$uri       = ltrim( $_SERVER['REQUEST_URI'], '/' ); // // @codingStandardsIgnoreLine
 			$uri       = untrailingslashit( $uri );


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolved #4729 

I found that we are not initializing sessions for authorized donors and for some reason donor was not able to see errors when authorized with WP user credential or email. I updated logic to start a donor session in both circumstances.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Main changes you can see in the following commits.
https://github.com/impress-org/givewp/commit/d6ba9f4eaf19e9ecb4b24b11dd072fefc7c3f3b2: starting donor session when donor authorized with email.
https://github.com/impress-org/givewp/commit/7d0916d2521ae7ee71bc5baccf81d8b0d9794f39: starting a donor session when donor authorized with WP user credentials.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
I tested this pr with https://github.com/impress-org/give-recurring/pull/940 by updating the subscription amount.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
