### PR TITLE
Update class-give-email-tags.php

### DIFF
--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -413,6 +413,12 @@ function give_setup_email_tags() {
 			'func'    => 'give_email_tag_donor_note',
 			'context' => 'donation',
 		),
+		array(
+			'tag'      => 'anonymous_status',
+			'desc'     => esc_html__( 'Did the donor check the anonymous donation checkbox?', 'give' ),
+			'func'     => 'give_email_tag_anonymous_status',
+			'context'  => 'donation',
+		),
 
 		/* Donation Form */
 		array(
@@ -1479,6 +1485,39 @@ function give_email_tag_donor_note( $tag_args ) {
 	return apply_filters(
 		'give_email_tag_donor_note',
 		$donor_note,
+		$tag_args
+	);
+}
+
+/**
+ * Email template tag: {anonymous_status}
+ *
+ * @param array $tag_args Array of arguments for email tags.
+ *
+ * @since 2.6
+ *
+ * @return array
+ */
+function give_email_tag_anonymous_status( $tag_args ) {
+	$anonymous_status_meta = give_get_meta( $tag_args['payment_id'], '_give_anonymous_donation', true );
+
+	if ( $anonymous_status_meta ) {
+		$anonymous_status = __( 'Anonymous donation', 'give' );
+	} else {
+		$anonymous_status = __( 'Not an anonymous donation', 'give' );
+	}
+
+	/**
+	 * Filter the {anonymous_status} email template tag output.
+	 *
+	 * @param string $anonymous_status Tag output.
+	 * @param array  $tag_args   Email Tag arguments.
+	 *
+	 * @since 2.6
+	 */
+	return apply_filters(
+		'give_email_tag_anonymous_status',
+		$anonymous_status,
 		$tag_args
 	);
 }


### PR DESCRIPTION
Now that an anonymous checkbox is part of the core plugin, add an email tag {anonymous_status} to output if the donation has been marked as anonymous or not

## Description
Added the `anonymous_status` email tag using the same code style as the rest of the default email tags.

## Affects
Provides the anonymous_staus email tag by default instead of needing to use a snippet or plugin.

## What to test
Test the functionality of using the tag in a donor or admin email.
Test with the box checked or unchecked.
Ensure it does not interfere with other email tags.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows has proper inline documentation.