### PR TITLE
migrate old form setting in favor of legacy from template

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -27,7 +27,7 @@ class Give_MetaBox_Form_Data {
 	 * @since 1.8
 	 * @var   array
 	 */
-	private $settings = array();
+	private $settings = [];
 
 	/**
 	 * Metabox ID.
@@ -54,23 +54,23 @@ class Give_MetaBox_Form_Data {
 		$this->metabox_label = __( 'Donation Form Options', 'give' );
 
 		// Setup.
-		add_action( 'admin_init', array( $this, 'setup' ) );
+		add_action( 'admin_init', [ $this, 'setup' ] );
 
 		// Add metabox.
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 10 );
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ], 10 );
 
 		// Save form meta.
-		add_action( 'save_post_give_forms', array( $this, 'save' ), 10, 2 );
+		add_action( 'save_post_give_forms', [ $this, 'save' ], 10, 2 );
 
-		add_action( 'give_save__give_form_template', array( $this, 'save_form_template_settings' ), 10, 3 );
+		add_action( 'give_save__give_form_template', [ $this, 'save_form_template_settings' ], 10, 3 );
 
 		// cmb2 old setting loaders.
 		// add_filter( 'give_metabox_form_data_settings', array( $this, 'cmb2_metabox_settings' ) );
 		// Add offline donations options.
-		add_filter( 'give_metabox_form_data_settings', array( $this, 'add_offline_donations_setting_tab' ), 0, 1 );
+		add_filter( 'give_metabox_form_data_settings', [ $this, 'add_offline_donations_setting_tab' ], 0, 1 );
 
 		// Maintain active tab query parameter after save.
-		add_filter( 'redirect_post_location', array( $this, 'maintain_active_tab' ), 10, 2 );
+		add_filter( 'redirect_post_location', [ $this, 'maintain_active_tab' ], 10, 2 );
 	}
 
 	/**
@@ -99,25 +99,25 @@ class Give_MetaBox_Form_Data {
 		// Start with an underscore to hide fields from custom fields list
 		$prefix = '_give_';
 
-		$settings = array(
+		$settings = [
 			/**
 			 * Theme Options
 			 */
 			'form_template_options' => apply_filters(
 				'give_form_template_options',
-				array(
+				[
 					'id'        => 'form_template_options',
 					'title'     => __( 'Form Template', 'give' ),
 					'icon-html' => '<i class="fas fa-palette"></i>',
-					'fields'    => array(
-						array(
+					'fields'    => [
+						[
 							'id'      => $prefix . 'form_template',
 							'name'    => 'form_template',
 							'type'    => 'hidden',
 							'default' => '',
-						),
-					),
-				)
+						],
+					],
+				]
 			),
 
 			/**
@@ -125,13 +125,13 @@ class Give_MetaBox_Form_Data {
 			 */
 			'form_field_options'    => apply_filters(
 				'give_forms_field_options',
-				array(
+				[
 					'id'        => 'form_field_options',
 					'title'     => __( 'Donation Options', 'give' ),
 					'icon-html' => '<i class="fas fa-heart"></i>',
 					'fields'    => apply_filters(
 						'give_forms_donation_form_metabox_fields',
-						array(
+						[
 							// Donation Option.
 							[
 								'name'        => __( 'Donation Option', 'give' ),
@@ -160,140 +160,140 @@ class Give_MetaBox_Form_Data {
 								'wrapper_class' => 'give-hidden',
 							],
 							// Custom Amount.
-							array(
+							[
 								'name'        => __( 'Custom Amount', 'give' ),
 								'description' => __( 'Do you want the user to be able to input their own donation amount?', 'give' ),
 								'id'          => $prefix . 'custom_amount',
 								'type'        => 'radio_inline',
 								'default'     => 'enabled',
-								'options'     => array(
+								'options'     => [
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'          => __( 'Donation Limit', 'give' ),
 								'description'   => __( 'Set the minimum and maximum amount for all gateways.', 'give' ),
 								'id'            => $prefix . 'custom_amount_range',
 								'type'          => 'donation_limit',
 								'wrapper_class' => 'give-hidden',
 								'data_type'     => 'price',
-								'attributes'    => array(
+								'attributes'    => [
 									'placeholder' => $price_placeholder,
 									'class'       => 'give-money-field',
-								),
-								'options'       => array(
+								],
+								'options'       => [
 									'display_label' => __( 'Donation Limits: ', 'give' ),
 									'minimum'       => give_format_decimal( '1.00', false, false ),
 									'maximum'       => give_format_decimal( '999999.99', false, false ),
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'          => __( 'Custom Amount Text', 'give' ),
 								'description'   => __( 'This text appears as a label below the custom amount field for set donation forms. For multi-level forms the text will appear as it\'s own level (ie button, radio, or select option).', 'give' ),
 								'id'            => $prefix . 'custom_amount_text',
 								'type'          => 'text_medium',
 								'default'       => __( 'Custom Amount', 'give' ),
-								'attributes'    => array(
+								'attributes'    => [
 									'rows' => 3,
-								),
+								],
 								'wrapper_class' => 'give-hidden',
-							),
+							],
 							// Donation Levels.
-							array(
+							[
 								'id'            => $prefix . 'donation_levels',
 								'type'          => 'group',
-								'options'       => array(
+								'options'       => [
 									'add_button'    => __( 'Add Level', 'give' ),
 									'header_title'  => __( 'Donation Level', 'give' ),
 									'remove_button' => '<span class="dashicons dashicons-no"></span>',
-								),
-								'default'       => array(
-									array(
+								],
+								'default'       => [
+									[
 										'_give_id'     =>
-											array(
+											[
 												'level_id' => 0,
-											),
+											],
 										'_give_amount' => '10.000000',
-									),
-									array(
+									],
+									[
 										'_give_id'     =>
-											array(
+											[
 												'level_id' => 1,
-											),
+											],
 										'_give_amount' => '25.000000',
-									),
-									array(
+									],
+									[
 										'_give_id'     =>
-											array(
+											[
 												'level_id' => 2,
-											),
+											],
 										'_give_amount' => '50.000000',
-									),
-									array(
+									],
+									[
 										'_give_id'      =>
-											array(
+											[
 												'level_id' => 3,
-											),
+											],
 										'_give_amount'  => '100.000000',
 										'_give_default' => 'default',
-									),
-									array(
+									],
+									[
 										'_give_id'     =>
-											array(
+											[
 												'level_id' => 5,
-											),
+											],
 										'_give_amount' => '250.000000',
-									),
-								),
+									],
+								],
 								'wrapper_class' => 'give-hidden',
 								// Fields array works the same, except id's only need to be unique for this group.
 								// Prefix is not needed.
 								'fields'        => apply_filters(
 									'give_donation_levels_table_row',
-									array(
-										array(
+									[
+										[
 											'name' => __( 'ID', 'give' ),
 											'id'   => $prefix . 'id',
 											'type' => 'levels_id',
-										),
-										array(
+										],
+										[
 											'name'       => __( 'Amount', 'give' ),
 											'id'         => $prefix . 'amount',
 											'type'       => 'text_small',
 											'data_type'  => 'price',
-											'attributes' => array(
+											'attributes' => [
 												'placeholder' => $price_placeholder,
 												'class' => 'give-money-field',
-											),
-										),
-										array(
+											],
+										],
+										[
 											'name'       => __( 'Text', 'give' ),
 											'id'         => $prefix . 'text',
 											'type'       => 'text',
-											'attributes' => array(
+											'attributes' => [
 												'placeholder' => __( 'Donation Level', 'give' ),
 												'class' => 'give-multilevel-text-field',
-											),
-										),
-										array(
+											],
+										],
+										[
 											'name' => __( 'Default', 'give' ),
 											'id'   => $prefix . 'default',
 											'type' => 'give_default_radio_inline',
-										),
-									)
+										],
+									]
 								),
-							),
-							array(
+							],
+							[
 								'name'  => 'donation_options_docs',
 								'type'  => 'docs_link',
 								'url'   => 'http://docs.givewp.com/form-donation-options',
 								'title' => __( 'Donation Options', 'give' ),
-							),
-						),
+							],
+						],
 						$post_id
 					),
-				)
+				]
 			),
 
 			/**
@@ -301,33 +301,33 @@ class Give_MetaBox_Form_Data {
 			 */
 			'form_display_options'  => apply_filters(
 				'give_form_display_options',
-				array(
+				[
 					'id'        => 'form_display_options',
 					'title'     => __( 'Form Fields', 'give' ),
 					'icon-html' => '<i class="fas fa-stream"></i>',
 					'fields'    => apply_filters(
 						'give_forms_display_options_metabox_fields',
-						array(
-							array(
+						[
+							[
 								'name' => __( 'Default Gateway', 'give' ),
 								'desc' => __( 'By default, the gateway for this form will inherit the global default gateway (set under GiveWP > Settings > Payment Gateways). This option allows you to customize the default gateway for this form only.', 'give' ),
 								'id'   => $prefix . 'default_gateway',
 								'type' => 'default_gateway',
-							),
-							array(
+							],
+							[
 								'name'    => __( 'Name Title Prefix', 'give' ),
 								'desc'    => __( 'Do you want to add a name title prefix dropdown field before the donor\'s first name field? This will display a dropdown with options such as Mrs, Miss, Ms, Sir, and Dr for donor to choose from.', 'give' ),
 								'id'      => $prefix . 'name_title_prefix',
 								'type'    => 'radio_inline',
-								'options' => array(
+								'options' => [
 									'global'   => __( 'Global Option', 'give' ),
 									'required' => __( 'Required', 'give' ),
 									'optional' => __( 'Optional', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
+								],
 								'default' => 'global',
-							),
-							array(
+							],
+							[
 								'name'          => __( 'Title Prefixes', 'give' ),
 								'desc'          => __( 'Add or remove salutations from the dropdown using the field above.', 'give' ),
 								'id'            => $prefix . 'title_prefixes',
@@ -336,79 +336,79 @@ class Give_MetaBox_Form_Data {
 								'style'         => 'width: 100%',
 								'wrapper_class' => 'give-hidden give-title-prefixes-wrap',
 								'options'       => give_get_default_title_prefixes(),
-							),
-							array(
+							],
+							[
 								'name'    => __( 'Company Donations', 'give' ),
 								'desc'    => __( 'Do you want a Company field to appear after First Name and Last Name?', 'give' ),
 								'id'      => $prefix . 'company_field',
 								'type'    => 'radio_inline',
 								'default' => 'global',
-								'options' => array(
+								'options' => [
 									'global'   => __( 'Global Option', 'give' ),
 									'required' => __( 'Required', 'give' ),
 									'optional' => __( 'Optional', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
 
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'    => __( 'Anonymous Donations', 'give' ),
 								'desc'    => __( 'Do you want to provide donors the ability mark themselves anonymous while giving. This will prevent their information from appearing publicly on your website but you will still receive their information for your records in the admin panel.', 'give' ),
 								'id'      => "{$prefix}anonymous_donation",
 								'type'    => 'radio_inline',
 								'default' => 'global',
-								'options' => array(
+								'options' => [
 									'global'   => __( 'Global Option', 'give' ),
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'    => __( 'Donor Comments', 'give' ),
 								'desc'    => __( 'Do you want to provide donors the ability to add a comment to their donation? The comment will display publicly on the donor wall if they do not select to give anonymously.', 'give' ),
 								'id'      => "{$prefix}donor_comment",
 								'type'    => 'radio_inline',
 								'default' => 'global',
-								'options' => array(
+								'options' => [
 									'global'   => __( 'Global Option', 'give' ),
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'    => __( 'Guest Donations', 'give' ),
 								'desc'    => __( 'Do you want to allow non-logged-in users to make donations?', 'give' ),
 								'id'      => $prefix . 'logged_in_only',
 								'type'    => 'radio_inline',
 								'default' => 'enabled',
-								'options' => array(
+								'options' => [
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'    => __( 'Registration', 'give' ),
 								'desc'    => __( 'Display the registration and login forms in the payment section for non-logged-in users.', 'give' ),
 								'id'      => $prefix . 'show_register_form',
 								'type'    => 'radio',
-								'options' => array(
+								'options' => [
 									'none'         => __( 'None', 'give' ),
 									'registration' => __( 'Registration', 'give' ),
 									'login'        => __( 'Login', 'give' ),
 									'both'         => __( 'Registration + Login', 'give' ),
-								),
+								],
 								'default' => 'none',
-							),
-							array(
+							],
+							[
 								'name'  => 'form_display_docs',
 								'type'  => 'docs_link',
 								'url'   => 'http://docs.givewp.com/form-display-options',
 								'title' => __( 'Form Display', 'give' ),
-							),
-						),
+							],
+						],
 						$post_id
 					),
-				)
+				]
 			),
 
 			/**
@@ -416,111 +416,111 @@ class Give_MetaBox_Form_Data {
 			 */
 			'donation_goal_options' => apply_filters(
 				'give_donation_goal_options',
-				array(
+				[
 					'id'        => 'donation_goal_options',
 					'title'     => __( 'Donation Goal', 'give' ),
 					'icon-html' => '<i class="fas fa-bullseye"></i>',
 					'fields'    => apply_filters(
 						'give_forms_donation_goal_metabox_fields',
-						array(
+						[
 							// Goals
-							array(
+							[
 								'name'        => __( 'Donation Goal', 'give' ),
 								'description' => __( 'Do you want to set a donation goal for this form?', 'give' ),
 								'id'          => $prefix . 'goal_option',
 								'type'        => 'radio_inline',
 								'default'     => 'disabled',
-								'options'     => array(
+								'options'     => [
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
-							),
+								],
+							],
 
-							array(
+							[
 								'name'        => __( 'Goal Format', 'give' ),
 								'description' => __( 'Do you want to display the total amount raised based on your monetary goal or a percentage? For instance, "$500 of $1,000 raised" or "50% funded" or "1 of 5 donations". You can also display a donor-based goal, such as "100 of 1,000 donors have given".', 'give' ),
 								'id'          => $prefix . 'goal_format',
 								'type'        => 'donation_form_goal',
 								'default'     => 'amount',
-								'options'     => array(
+								'options'     => [
 									'amount'     => __( 'Amount Raised', 'give' ),
 									'percentage' => __( 'Percentage Raised', 'give' ),
 									'donation'   => __( 'Number of Donations', 'give' ),
 									'donors'     => __( 'Number of Donors', 'give' ),
-								),
-							),
+								],
+							],
 
-							array(
+							[
 								'name'          => __( 'Goal Amount', 'give' ),
 								'description'   => __( 'This is the monetary goal amount you want to reach for this form.', 'give' ),
 								'id'            => $prefix . 'set_goal',
 								'type'          => 'text_small',
 								'data_type'     => 'price',
-								'attributes'    => array(
+								'attributes'    => [
 									'placeholder' => $price_placeholder,
 									'class'       => 'give-money-field',
-								),
+								],
 								'wrapper_class' => 'give-hidden',
-							),
-							array(
+							],
+							[
 								'id'         => $prefix . 'number_of_donation_goal',
 								'name'       => __( 'Donation Goal', 'give' ),
 								'desc'       => __( 'Set the total number of donations as a goal.', 'give' ),
 								'type'       => 'number',
 								'default'    => 1,
-								'attributes' => array(
+								'attributes' => [
 									'placeholder' => 1,
-								),
-							),
-							array(
+								],
+							],
+							[
 								'id'         => $prefix . 'number_of_donor_goal',
 								'name'       => __( 'Donor Goal', 'give' ),
 								'desc'       => __( 'Set the total number of donors as a goal.', 'give' ),
 								'type'       => 'number',
 								'default'    => 1,
-								'attributes' => array(
+								'attributes' => [
 									'placeholder' => 1,
-								),
-							),
-							array(
+								],
+							],
+							[
 								'name'          => __( 'Progress Bar Color', 'give' ),
 								'desc'          => __( 'Customize the color of the goal progress bar.', 'give' ),
 								'id'            => $prefix . 'goal_color',
 								'type'          => 'colorpicker',
 								'default'       => '#2bc253',
 								'wrapper_class' => 'give-hidden',
-							),
+							],
 
-							array(
+							[
 								'name'          => __( 'Close Form', 'give' ),
 								'desc'          => __( 'Do you want to close the donation forms and stop accepting donations once this goal has been met?', 'give' ),
 								'id'            => $prefix . 'close_form_when_goal_achieved',
 								'type'          => 'radio_inline',
 								'default'       => 'disabled',
-								'options'       => array(
+								'options'       => [
 									'enabled'  => __( 'Enabled', 'give' ),
 									'disabled' => __( 'Disabled', 'give' ),
-								),
+								],
 								'wrapper_class' => 'give-hidden',
-							),
-							array(
+							],
+							[
 								'name'          => __( 'Goal Achieved Message', 'give' ),
 								'desc'          => __( 'Do you want to display a custom message when the goal is closed?', 'give' ),
 								'id'            => $prefix . 'form_goal_achieved_message',
 								'type'          => 'wysiwyg',
 								'default'       => __( 'Thank you to all our donors, we have met our fundraising goal.', 'give' ),
 								'wrapper_class' => 'give-hidden',
-							),
-							array(
+							],
+							[
 								'name'  => 'donation_goal_docs',
 								'type'  => 'docs_link',
 								'url'   => 'http://docs.givewp.com/form-donation-goal',
 								'title' => __( 'Donation Goal', 'give' ),
-							),
-						),
+							],
+						],
 						$post_id
 					),
-				)
+				]
 			),
 
 			/**
@@ -528,60 +528,60 @@ class Give_MetaBox_Form_Data {
 			 */
 			'form_terms_options'    => apply_filters(
 				'give_forms_terms_options',
-				array(
+				[
 					'id'        => 'form_terms_options',
 					'title'     => __( 'Terms & Conditions', 'give' ),
 					'icon-html' => '<i class="far fa-check-square"></i>',
 					'fields'    => apply_filters(
 						'give_forms_terms_options_metabox_fields',
-						array(
+						[
 							// Donation Option
-							array(
+							[
 								'name'        => __( 'Terms and Conditions', 'give' ),
 								'description' => __( 'Do you want to require the donor to accept terms prior to being able to complete their donation?', 'give' ),
 								'id'          => $prefix . 'terms_option',
 								'type'        => 'radio_inline',
 								'options'     => apply_filters(
 									'give_forms_content_options_select',
-									array(
+									[
 										'global'   => __( 'Global Option', 'give' ),
 										'enabled'  => __( 'Customize', 'give' ),
 										'disabled' => __( 'Disable', 'give' ),
-									)
+									]
 								),
 								'default'     => 'global',
-							),
-							array(
+							],
+							[
 								'id'            => $prefix . 'agree_label',
 								'name'          => __( 'Agreement Label', 'give' ),
 								'desc'          => __( 'The label shown next to the agree to terms check box. Add your own to customize or leave blank to use the default text placeholder.', 'give' ),
 								'type'          => 'textarea',
-								'attributes'    => array(
+								'attributes'    => [
 									'placeholder' => __( 'Agree to Terms?', 'give' ),
 									'rows'        => 1,
-								),
+								],
 								'wrapper_class' => 'give-hidden',
-							),
-							array(
+							],
+							[
 								'id'            => $prefix . 'agree_text',
 								'name'          => __( 'Agreement Text', 'give' ),
 								'desc'          => __( 'This is the actual text which the user will have to agree to in order to make a donation.', 'give' ),
 								'default'       => give_get_option( 'agreement_text' ),
 								'type'          => 'wysiwyg',
 								'wrapper_class' => 'give-hidden',
-							),
-							array(
+							],
+							[
 								'name'  => 'terms_docs',
 								'type'  => 'docs_link',
 								'url'   => 'http://docs.givewp.com/form-terms',
 								'title' => __( 'Terms and Conditions', 'give' ),
-							),
-						),
+							],
+						],
 						$post_id
 					),
-				)
+				]
 			),
-		);
+		];
 
 		/**
 		 * Filter the metabox tabbed panel settings.
@@ -603,8 +603,8 @@ class Give_MetaBox_Form_Data {
 		add_meta_box(
 			$this->get_metabox_ID(),
 			$this->get_metabox_label(),
-			array( $this, 'output' ),
-			array( 'give_forms' ),
+			[ $this, 'output' ],
+			[ 'give_forms' ],
 			'normal',
 			'high'
 		);
@@ -614,8 +614,8 @@ class Give_MetaBox_Form_Data {
 			add_meta_box(
 				'give-form-goal-stats',
 				__( 'Goal Statistics', 'give' ),
-				array( $this, 'output_goal' ),
-				array( 'give_forms' ),
+				[ $this, 'output_goal' ],
+				[ 'give_forms' ],
 				'side',
 				'low'
 			);
@@ -670,29 +670,29 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	public function get_tabs() {
-		$tabs = array();
+		$tabs = [];
 
 		if ( ! empty( $this->settings ) ) {
 			foreach ( $this->settings as $setting ) {
 				if ( ! isset( $setting['id'] ) || ! isset( $setting['title'] ) ) {
 					continue;
 				}
-				$tab = array(
+				$tab = [
 					'id'        => $setting['id'],
 					'label'     => $setting['title'],
 					'icon-html' => ( ! empty( $setting['icon-html'] ) ? $setting['icon-html'] : '' ),
-				);
+				];
 
 				if ( $this->has_sub_tab( $setting ) ) {
 					if ( empty( $setting['sub-fields'] ) ) {
-						$tab = array();
+						$tab = [];
 					} else {
 						foreach ( $setting['sub-fields'] as $sub_fields ) {
-							$tab['sub-fields'][] = array(
+							$tab['sub-fields'][] = [
 								'id'        => $sub_fields['id'],
 								'label'     => $sub_fields['title'],
 								'icon-html' => ( ! empty( $sub_fields['icon-html'] ) ? $sub_fields['icon-html'] : '' ),
-							);
+							];
 						}
 					}
 				}
@@ -881,7 +881,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	function cmb2_metabox_settings() {
-		$all_cmb2_settings   = apply_filters( 'cmb2_meta_boxes', array() );
+		$all_cmb2_settings   = apply_filters( 'cmb2_meta_boxes', [] );
 		$give_forms_settings = $all_cmb2_settings;
 
 		// Filter settings: Use only give forms related settings.
@@ -948,7 +948,7 @@ class Give_MetaBox_Form_Data {
 				// Set default value for checkbox fields.
 				if (
 					! isset( $_POST[ $form_meta_key ] ) &&
-					in_array( $this->get_field_type( $form_meta_key ), array( 'checkbox', 'chosen' ) )
+					in_array( $this->get_field_type( $form_meta_key ), [ 'checkbox', 'chosen' ] )
 				) {
 					$_POST[ $form_meta_key ] = '';
 				}
@@ -967,7 +967,7 @@ class Give_MetaBox_Form_Data {
 								break;
 
 							case 'group':
-								$form_meta_value = array();
+								$form_meta_value = [];
 
 								foreach ( $_POST[ $form_meta_key ] as $index => $group ) {
 
@@ -976,7 +976,7 @@ class Give_MetaBox_Form_Data {
 										continue;
 									}
 
-									$group_meta_value = array();
+									$group_meta_value = [];
 									foreach ( $group as $field_id => $field_value ) {
 										switch ( $this->get_field_type( $field_id, $form_meta_key ) ) {
 											case 'wysiwyg':
@@ -1103,7 +1103,7 @@ class Give_MetaBox_Form_Data {
 								continue;
 							}
 
-							$group_of_values = array();
+							$group_of_values = [];
 
 							foreach ( $subFields as $field_id => $field_value ) {
 								switch ( $field->getFieldArguments( $field_id )['type'] ) {
@@ -1167,7 +1167,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	private function get_fields_id( $setting ) {
-		$meta_keys = array();
+		$meta_keys = [];
 
 		if (
 			! empty( $setting )
@@ -1194,7 +1194,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	private function get_sub_fields_id( $setting ) {
-		$meta_keys = array();
+		$meta_keys = [];
 
 		if ( $this->has_sub_tab( $setting ) && ! empty( $setting['sub-fields'] ) ) {
 			foreach ( $setting['sub-fields'] as $fields ) {
@@ -1220,7 +1220,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	private function get_meta_keys_from_settings() {
-		$meta_keys = array();
+		$meta_keys = [];
 
 		foreach ( $this->settings as $setting ) {
 			$meta_key = $this->get_fields_id( $setting );
@@ -1268,7 +1268,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	private function get_field( $setting, $field_id ) {
-		$setting_field = array();
+		$setting_field = [];
 
 		if ( ! empty( $setting['fields'] ) ) {
 			foreach ( $setting['fields'] as $field ) {
@@ -1293,7 +1293,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	private function get_sub_field( $setting, $field_id ) {
-		$setting_field = array();
+		$setting_field = [];
 
 		if ( ! empty( $setting['sub-fields'] ) ) {
 			foreach ( $setting['sub-fields'] as $fields ) {
@@ -1318,7 +1318,7 @@ class Give_MetaBox_Form_Data {
 	 * @return array
 	 */
 	function get_setting_field( $field_id, $group_id = '' ) {
-		$setting_field = array();
+		$setting_field = [];
 
 		$_field_id = $field_id;
 		$field_id  = empty( $group_id ) ? $field_id : $group_id;
@@ -1360,12 +1360,12 @@ class Give_MetaBox_Form_Data {
 		if ( give_is_gateway_active( 'offline' ) ) {
 			$settings['offline_donations_options'] = apply_filters(
 				'give_forms_offline_donations_options',
-				array(
+				[
 					'id'        => 'offline_donations_options',
 					'title'     => __( 'Offline Donations', 'give' ),
 					'icon-html' => '<i class="fas fa-wallet"></i>',
-					'fields'    => apply_filters( 'give_forms_offline_donations_metabox_fields', array() ),
-				)
+					'fields'    => apply_filters( 'give_forms_offline_donations_metabox_fields', [] ),
+				]
 			);
 		}
 
@@ -1414,11 +1414,11 @@ class Give_MetaBox_Form_Data {
 						give_sanitize_amount_for_db( $meta_value ) :
 						( in_array(
 							$setting_field['id'],
-							array(
+							[
 								'_give_set_price',
 								'_give_custom_amount_minimum',
 								'_give_set_goal',
-							)
+							]
 						) ?
 							give_sanitize_amount_for_db( '1.00' ) :
 							0 );

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -716,6 +716,8 @@ class Give_MetaBox_Form_Data {
 	public function output() {
 		// Bailout.
 		if ( $form_data_tabs = $this->get_tabs() ) :
+			Template\LegacyFormSettingCompatibility::migrateExistingFormSettings( absint( $_GET['post'] ) );
+
 			$active_tab = ! empty( $_GET['give_tab'] ) ? give_clean( $_GET['give_tab'] ) : 'form_template_options';
 			wp_nonce_field( 'give_save_form_meta', 'give_form_meta_nonce' );
 

--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -2,6 +2,7 @@
 namespace Give\Form\Template;
 
 use Give\Form\Template;
+use Give\Helpers\Form\Utils;
 
 /**
  * Class LegacyFormSettingCompatibility
@@ -92,5 +93,42 @@ class LegacyFormSettingCompatibility {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Migrate existing legacy form settings.
+	 *
+	 * @param  int  $formId
+	 *
+	 * @since 2.7.0
+	 */
+	public static function migrateExistingFormSettings( $formId ) {
+		if ( ! Utils::isLegacyForm( $formId ) || 'edit' !== give_clean( $_GET['action'] ) ) {
+			return;
+		}
+
+		if ( Give()->form_meta->get_meta( $formId, '_give_legacy_form_template_settings', true ) ) {
+			return;
+		}
+
+		$mapToSetting = [
+			'display_style'        => '_give_display_style',
+			'payment_display'      => '_give_payment_display',
+			'reveal_label'         => '_give_reveal_label',
+			'checkout_label'       => '_give_checkout_label',
+			'form_floating_labels' => '_give_form_floating_labels',
+			'display_content'      => '_give_display_content',
+			'content_placement'    => '_give_content_placement',
+			'form_content'         => '_give_form_content',
+		];
+
+		foreach ( $mapToSetting as $newSetting => $oldSetting ) {
+			if ( $value = Give()->form_meta->get_meta( $formId, $oldSetting, true ) ) {
+				$settings['display_settings'][ $newSetting ] = $value;
+			}
+		}
+
+		Give()->form_meta->update_meta( $formId, '_give_form_template', 'legacy' );
+		Give()->form_meta->update_meta( $formId, '_give_legacy_form_template_settings', $settings );
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This pr add logic to migrate old form setting when someone opens old form edit admin page the first time.

issue detail: https://givewp.slack.com/archives/C0FAGC83C/p1592293217047400

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
I tested this by visiting the old donation form edit page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
