### PR TITLE
hotfix: Fee Recovery option consistently appears below donation amount buttons

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -420,7 +420,7 @@
 			$( '#give-payment-mode-select' ).after( '<fieldset id="donate-fieldset"></fieldset>' );
 		}
 
-		// Elements to move into donate field`set (located at bottom of form)
+		// Elements to move into donate fieldset (located at bottom of form)
 		// The elements will appear in order of array
 		const donateFieldsetElements = [
 			'.give-constant-contact-fieldset',

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -442,10 +442,13 @@
 
 		// Handle per-Gateway fee option
 		if ( $( '#give_purchase_form_wrap fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {
+			let checked = false;
 			if ( $( '.choose-amount fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {
+				checked = $( 'input[name="give_fee_mode_checkbox"]' ).prop( 'checked' );
 				$( '.choose-amount fieldset[id*="give-fee-recovery-wrap"]' ).remove();
 			}
 			$( '.choose-amount' ).append( $( '#give_purchase_form_wrap fieldset[id*="give-fee-recovery-wrap"]' ) );
+			$( 'input[name="give_fee_mode_checkbox"]' ).prop( 'checked', checked );
 		}
 
 		// Move purchase fields (credit card, billing, etc)

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -420,7 +420,7 @@
 			$( '#give-payment-mode-select' ).after( '<fieldset id="donate-fieldset"></fieldset>' );
 		}
 
-		// Elements to move into donate fieldset (located at bottom of form)
+		// Elements to move into donate field`set (located at bottom of form)
 		// The elements will appear in order of array
 		const donateFieldsetElements = [
 			'.give-constant-contact-fieldset',
@@ -439,6 +439,14 @@
 				$( `#give_purchase_form_wrap ${ selector }` ).remove();
 			}
 		} );
+
+		// Handle per-Gateway fee option
+		if ( $( '#give_purchase_form_wrap fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {
+			if ( $( '.choose-amount fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {
+				$( '.choose-amount fieldset[id*="give-fee-recovery-wrap"]' ).remove();
+			}
+			$( '.choose-amount' ).append( $( '#give_purchase_form_wrap fieldset[id*="give-fee-recovery-wrap"]' ) );
+		}
 
 		// Move purchase fields (credit card, billing, etc)
 		$( 'li.give-gateway-option-selected' ).after( $( '#give_purchase_form_wrap' ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -441,6 +441,7 @@
 		} );
 
 		// Handle per-Gateway fee option
+		// If the fee recovery option wrapper is present, move it to the choose amount screen
 		if ( $( '#give_purchase_form_wrap fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {
 			let checked = false;
 			if ( $( '.choose-amount fieldset[id*="give-fee-recovery-wrap"]' ).length !== 0 ) {


### PR DESCRIPTION
## Description
Previously, when an admin setup different fee recovery options for specific gateways, the Fee Recovery checkbox loaded within each individual gateway. This hotfix ensures that every time a gateway is loaded, if a Fee Recovery checkbox is present, it is moved below the donation amount buttons in the "choose amount" step. Additionally, checked/unchecked status of the Fee Recovery option is persisted even as a user changes their selected gateway.

## Affects
This PR affects how the Multi-Step form template is rendered, specifically moving the Fee Recovery opt-in checkbox so that it appears consistently beneath the Choose Amount step.

## What to test

_The following conditions have been tested in my local install. Use this list for reference of known possible configurations this PR impacts._

With the Fee Recovery addon enabled, try setting up custom fee recovery options on a per gateway basis. 
- [x] Are you shown the option to opt-into Fee Recovery beneath the donation amount buttons? 
- [x] When you change gateways, and return to that page does opt-in message reflect the appropriate fee for the chosen gateway? 
- [x] If you select Fee Recovery, and then change gateways, is your selection persisted? 
- [x] Likewise, if you opt-out of Fee Recovery, and change gateways, is your decision persisted across gateways?
- [x] If you disable Fee Recovery for some gateways, and enable it for others, is the option and fee recovery message hidden as you would expect?

## Screenshots:
<img width="623" alt="Screen Shot 2020-06-16 at 3 58 34 PM" src="https://user-images.githubusercontent.com/5186078/84836861-7e569400-afeb-11ea-9bd4-931b5d3b384e.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
