### PR TITLE
new form  preview  with Sequoia template render successfully

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -92,6 +92,7 @@ class LoadTemplate {
 		add_action( 'give_embed_footer', 'wp_print_footer_scripts', 20 );
 		add_filter( 'give_form_wrap_classes', [ $this, 'editClassList' ], 999 );
 		add_action( 'give_hidden_fields_after', [ $this, 'addHiddenField' ] );
+		add_filter( 'give_donation_form_submit_button', [ $this, 'disableDonationButtonInPreviewMode' ], 999, 2 );
 
 		// Handle receipt screen template
 		add_action( 'wp_ajax_get_receipt', [ $this, 'handleReceiptAjax' ], 9 );
@@ -187,6 +188,28 @@ class LoadTemplate {
 			'give_embed_form',
 			'1'
 		);
+	}
+
+	/**
+	 * Disable donation submit in donation form preview mode.
+	 *
+	 * @param string $buttonHtml
+	 * @param int  $formId
+	 * @return string
+	 * @since 2.7.0
+	 */
+	public function disableDonationButtonInPreviewMode( $buttonHtml, $formId ) {
+		if ( $formId === (int) FormTemplateUtils\Utils\Frontend::getPreviewDonationFormId() ) {
+			$search = 'input type="submit"';
+
+			$buttonHtml = str_replace(
+				$search,
+				"{$search} onclick=\"return false;\"",
+				$buttonHtml
+			);
+		}
+
+		return $buttonHtml;
 	}
 
 	/**

--- a/src/Helpers/Form/Template/Utils/Frontend.php
+++ b/src/Helpers/Form/Template/Utils/Frontend.php
@@ -59,4 +59,27 @@ class Frontend {
 
 		return null;
 	}
+
+	/**
+	 * Return form id if admin previewing donation form.
+	 *
+	 * @return int|null
+	 * @since 2.7.0
+	 */
+	public static function getPreviewDonationFormId() {
+		if ( ! is_user_logged_in() ) {
+			return null;
+		}
+
+		if (
+			isset( $_GET['preview'], $_GET['p'], $_GET['post_type'] ) &&
+			filter_var( $_GET['preview'], FILTER_VALIDATE_BOOLEAN ) &&
+			( 'give_forms' === give_clean( $_GET['post_type'] ) ) &&
+			( $formId = absint( $_GET['p'] ) )
+		) {
+			return $formId;
+		}
+
+		return null;
+	}
 }

--- a/src/Helpers/Form/Template/Utils/Frontend.php
+++ b/src/Helpers/Form/Template/Utils/Frontend.php
@@ -31,6 +31,11 @@ class Frontend {
 			return $formId;
 		}
 
+		// Check if admin previewing donation form.
+		if ( $formId = self::getPreviewDonationFormId() ) {
+			return $formId;
+		}
+
 		// Get form Id on ajax request.
 		if ( isset( $_REQUEST['give_form_id'] ) && ( $formId = absint( $_REQUEST['give_form_id'] ) ) ) {
 			return $formId;

--- a/src/Helpers/Form/Template/Utils/Frontend.php
+++ b/src/Helpers/Form/Template/Utils/Frontend.php
@@ -72,7 +72,7 @@ class Frontend {
 	 * @since 2.7.0
 	 */
 	public static function getPreviewDonationFormId() {
-		if ( ! is_user_logged_in() ) {
+		if ( ! current_user_can( 'edit_give_forms' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4805 

This PR fix issue related to donation form preview in preview mode.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr affect form rendering in preview mode (form set to draft) when form template set to multi-step form.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is donation form render with a multiple-step form template as expected.
- [x] Admin can not perform donation when the admin views donation form in preview mode.
- [x] Is donation form render with legacy form template as expected.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/84891437-7fee8d80-b0b9-11ea-9cb6-c770906af6b6.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
