### PR TITLE
do not load styles and scripts from theme in embedded form iframe

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -198,13 +198,20 @@ class LoadTemplate {
 	 * @since 2.7.0
 	 */
 	private function getListOfScriptsToDequeue( $scripts ) {
-		$list = [];
-		$skip = [ 'babel-polyfill' ];
+		$list     = [];
+		$skip     = [ 'babel-polyfill' ];
+		$themeDir = get_template_directory_uri();
 
 		/* @var _WP_Dependency $data */
 		foreach ( $scripts as $handle => $data ) {
 			// Do not unset dependency.
 			if ( in_array( $handle, $skip, true ) ) {
+				continue;
+			}
+
+			// Do not allow styles and scripts from theme.
+			if ( false !== strpos( (string) $data->src, $themeDir ) ) {
+				$list[] = $handle;
 				continue;
 			}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4804 

This pr add logic to prevent styles and scripts from the theme in embedded form iframe.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This PR will affect the list of scripts and styles which load in form iframe.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Are there any scripts and styles which load from the theme? (expected to zero )
- [x] Does this patch affect existing list of scripts and styles which were loading? (expected to zero, the updated patch must not affect/block existing script and styles of addons and Give core )

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/84899783-c4ccf100-b0c6-11ea-937b-8ef13fd647b9.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
