### PR TITLE
fix: donation amount styles no longer break when the "custom amount" setting is disabled

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -450,48 +450,40 @@ p {
 	// Amount Total
 	.give-total-wrap {
 		width: 100%;
+	}
+
+	.give-donation-amount {
+		@include before-after-content-none;
 		display: flex;
-		justify-content: center;
+		width: 207px;
 		align-items: center;
-		margin-top: 5px;
-		margin-bottom: 15px;
+		background-color: #fff;
+		box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.22);
+		border: 1px solid #979797;
+		border-radius: 4px !important;
+		overflow: hidden;
+		padding: 18px 24px;
+		margin: 5px auto 15px !important;
 
 		@media screen and (max-width: $break-phone) {
+			padding: 12px 16px;
 			margin-top: 0;
 			margin-bottom: 5px;
 		}
 
-		.give-donation-amount {
-			@include before-after-content-none;
-			display: flex;
-			width: 207px;
-			align-items: center;
-			background-color: #fff;
-			box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.22);
-			border: 1px solid #979797;
-			border-radius: 4px !important;
-			overflow: hidden;
-			padding: 18px 24px;
-			margin: 0;
+		.give-amount-top {
+			font-family: 'Montserrat', sans-serif;
+			height: auto !important;
+			width: auto !important;
+			text-align: center;
+			font-weight: 500 !important;
+			font-size: 42px !important;
+			line-height: 1 !important;
+			color: #333;
+			border: 0 !important;
 
-			@media screen and (max-width: $break-phone) {
-				padding: 12px 16px;
-			}
-
-			input {
-				font-family: 'Montserrat', sans-serif;
-				height: auto !important;
-				width: auto !important;
-				text-align: center;
-				font-weight: 500 !important;
-				font-size: 42px !important;
-				line-height: 1 !important;
-				color: #333;
-				border: 0 !important;
-
-				&:focus {
-					outline: none;
-				}
+			&:focus {
+				outline: none;
 			}
 		}
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -140,7 +140,7 @@
 			label: templateOptions.payment_amount.next_label,
 			showErrors: false,
 			tabOrder: [
-				'.give-amount-top',
+				'input.give-amount-top',
 				'.give-donation-levels-wrap button',
 				'.give-recurring-period',
 				'.give-recurring-donors-choice-period',

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -151,6 +151,14 @@
 			],
 			firstFocus: '.give-default-level',
 			setup: () => {
+				// Dynamically set grid columns based on number of buttons
+				const buttonCount = $( '.give-donation-level-btn' ).length;
+				if ( buttonCount === 1 ) {
+					$( '.give-donation-levels-wrap' ).attr( 'style', 'display: none!important;' );
+				} else if ( buttonCount % 2 === 0 && buttonCount < 6 ) {
+					$( '.give-donation-levels-wrap' ).css( 'grid-template-columns', 'repeat(2, minmax(0, 1fr))' );
+				}
+
 				$( '#give-amount' ).on( 'blur', function() {
 					if ( ! Give.form.fn.isValidDonationAmount( $( 'form' ) ) ) {
 						$( '.advance-btn' ).attr( 'disabled', true );


### PR DESCRIPTION
## Description
Resolves #4810 
This PR improves styling of the donation amount, so that it is consistent regardless of whether the "custom amount" setting is enabled. The PR also introduces frontend logic to programmatically set the number of grid columns used to display amount buttons based on the total number of buttons. 

Previously, when an admin disabled the "custom amount" setting, the donation amount styling would break and was rendered with default GiveWP styles. This PR refactors the styles applied to the donation amount input field, so that they also apply to the donation amount div (when it is not an input). In testing this feature, it also became apparent that for the best user experience, the number of columns that buttons are rendered in should change based on the total number of buttons. Before, when a form had 4 buttons, they were rendered in two rows (with the 3 in the 1st row, and 1 in the 2nd). Now, when a form contains an even number of buttons fewer than 6, the buttons are displayed in 2 columns (eg: 4 buttons is display 2 in the 1st row, 2 in the 2nd row). 

## Affects
This PR impacts form rendering and styles, specifically how the Multi-Step form renders donation amounts and donation buttons when. the "custom amount" feature is enabled/disabled.

## What to test
- [ ] Enable/disable the custom amount setting, does the form appear as expected on the frontend?
- [ ] Set up your form to use different amount of buttons (fewer than 6), do the buttons appear in balanced columns? 
- [ ] Set up your form to only have one amount button. Is the button hidden, and only the amount/input area shown?

## Screenshots:
Form with "custom amount" setting disabled:
<img width="580" alt="Screen Shot 2020-06-17 at 10 26 59 AM" src="https://user-images.githubusercontent.com/5186078/84930786-ae9f4080-b086-11ea-887c-ae18a0438c4b.png">

Form with even number of amount buttons (fewer than 6):
<img width="575" alt="Screen Shot 2020-06-17 at 10 27 28 AM" src="https://user-images.githubusercontent.com/5186078/84930817-b9f26c00-b086-11ea-905d-b289e7a25878.png">

Form with only one amount button (only shows amount area):
<img width="577" alt="Screen Shot 2020-06-17 at 10 38 16 AM" src="https://user-images.githubusercontent.com/5186078/84930858-c5459780-b086-11ea-88f6-cfe7fbfce540.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
