### PR TITLE
Fixes the default headline value for the new form template in 2.7.0

### DIFF
--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -6,7 +6,7 @@ use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
-$introHeadline    = $formInfo->post_title ? $formInfo->post_title : __( 'Campaign Heading', 'give' );
+$introHeadline    = ($formInfo->post_title && 'Auto Draft' !== $formInfo->post_title ) ? $formInfo->post_title : __( 'Support Our Cause', 'give' );
 $introDescription = $formInfo->post_excerpt ? $formInfo->post_excerpt : __( 'Help make a difference today! All donations go directly to making a difference for our cause.', 'give' );
 
 return [
@@ -33,7 +33,6 @@ return [
 				'attributes' => [
 					'placeholder' => $introHeadline,
 				],
-				'default'    => $introHeadline,
 			],
 			[
 				'id'         => 'description',

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -7,7 +7,7 @@ $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
 
-$introHeadline    = empty( $formInfo->post_title ) || $formInfo->post_title === __( 'Auto Draft', 'give' ) ? __( 'Support Our Cause', 'give' ) : $formInfo->post_title;
+$introHeadline    = empty( $formInfo->post_title ) || $formInfo->post_title === __( 'Auto Draft' ) ? __( 'Support Our Cause', 'give' ) : $formInfo->post_title;
 $introDescription = $formInfo->post_excerpt ? $formInfo->post_excerpt : __( 'Help make a difference today! All donations go directly to making a difference for our cause.', 'give' );
 
 return [

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -6,7 +6,8 @@ use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
-$introHeadline    = ( $formInfo->post_title && ! empty( $formInfo->post_title ) ) ? $formInfo->post_title : __( 'Support Our Cause', 'give' );
+
+$introHeadline    = empty( $formInfo->post_title ) || $formInfo->post_title === __( 'Auto Draft', 'give' ) ? __( 'Support Our Cause', 'give' ) : $formInfo->post_title;
 $introDescription = $formInfo->post_excerpt ? $formInfo->post_excerpt : __( 'Help make a difference today! All donations go directly to making a difference for our cause.', 'give' );
 
 return [

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -6,7 +6,7 @@ use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
-$introHeadline    = ($formInfo->post_title && 'Auto Draft' !== $formInfo->post_title ) ? $formInfo->post_title : __( 'Support Our Cause', 'give' );
+$introHeadline    = ( $formInfo->post_title && ! empty( $formInfo->post_title ) ) ? $formInfo->post_title : __( 'Support Our Cause', 'give' );
 $introDescription = $formInfo->post_excerpt ? $formInfo->post_excerpt : __( 'Help make a difference today! All donations go directly to making a difference for our cause.', 'give' );
 
 return [

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -13,22 +13,22 @@ $image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $thi
 <div class="give-section introduction">
 	<h2 class="headline">
 		<?php
-		if ( empty( $headline ) || $headline === __( 'Auto Draft' ) ) {
-			echo __( 'Support Our Cause', 'give' );
+		if ( empty( $headline ) || $headline === __( 'Auto Draft', 'give' ) ) {
+			_e( 'Support Our Cause', 'give' );
 		} else {
-			echo $headline;
+			esc_html_e( $headline, 'give' );
 		}
 		?>
 	</h2>
 	<?php if ( ! empty( $description ) ) : ?>
 		<div class="seperator"></div>
 		<p class="description">
-			<?php echo $description; ?>
+			<?php esc_html_e( $description, 'give' ); ?>
 		</p>
 	<?php endif; ?>
 	<?php if ( ! empty( $image ) ) : ?>
 		<div class="image">
-			<img src="<?php echo $image; ?>" />
+			<img src="<?php esc_html_e( $image, 'give' ); ?>" />
 		</div>
 	<?php endif; ?>
 

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -12,7 +12,13 @@ $image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $thi
 
 <div class="give-section introduction">
 	<h2 class="headline">
-		<?php echo $headline; ?>
+		<?php
+		if ( ! empty( $headline ) ) {
+			echo $headline;
+		} else {
+			echo __( 'Support Our Cause', 'give' );
+		}
+		?>
 	</h2>
 	<?php if ( ! empty( $description ) ) : ?>
 		<div class="seperator"></div>

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -13,7 +13,7 @@ $image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $thi
 <div class="give-section introduction">
 	<h2 class="headline">
 		<?php
-		if ( empty( $headline ) || $headline === __( 'Auto Draft', 'give' ) ) {
+		if ( empty( $headline ) || $headline === __( 'Auto Draft' ) ) {
 			_e( 'Support Our Cause', 'give' );
 		} else {
 			esc_html_e( $headline, 'give' );

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -13,10 +13,10 @@ $image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $thi
 <div class="give-section introduction">
 	<h2 class="headline">
 		<?php
-		if ( ! empty( $headline ) ) {
-			echo $headline;
-		} else {
+		if ( empty( $headline ) || $headline === __( 'Auto Draft' ) ) {
 			echo __( 'Support Our Cause', 'give' );
+		} else {
+			echo $headline;
 		}
 		?>
 	</h2>


### PR DESCRIPTION
Resolves #4812

## Description
<!-- Please describe your changes -->

I removed the default field value for the "Headline" field because we have a fallback in place should one not be provided.

## What to Test

- [x] Publishing a donation form without a title or headline uses the text "Support Our Cause"
- [x] Customizing the donation form title replaces "Support Our Cause" text
- [x] Customizing the Form Template's heading replaces the text from the donation form's post title.
