### PR TITLE
prevent php notices on new form edit page

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -716,7 +716,7 @@ class Give_MetaBox_Form_Data {
 	public function output() {
 		// Bailout.
 		if ( $form_data_tabs = $this->get_tabs() ) :
-			Template\LegacyFormSettingCompatibility::migrateExistingFormSettings( absint( $_GET['post'] ) );
+			Template\LegacyFormSettingCompatibility::migrateExistingFormSettings();
 
 			$active_tab = ! empty( $_GET['give_tab'] ) ? give_clean( $_GET['give_tab'] ) : 'form_template_options';
 			wp_nonce_field( 'give_save_form_meta', 'give_form_meta_nonce' );

--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -97,13 +97,19 @@ class LegacyFormSettingCompatibility {
 
 	/**
 	 * Migrate existing legacy form settings.
-	 *
-	 * @param  int  $formId
+	 * Note: Only for internal use. This function can be remove or change in future
 	 *
 	 * @since 2.7.0
 	 */
-	public static function migrateExistingFormSettings( $formId ) {
-		if ( ! Utils::isLegacyForm( $formId ) || 'edit' !== give_clean( $_GET['action'] ) ) {
+	public static function migrateExistingFormSettings() {
+		// Only migrate settings for existing form when editing.
+		if ( ! isset( $_GET['action'] ) || 'edit' !== give_clean( $_GET['action'] ) ) {
+			return;
+		}
+
+		$formId = absint( $_GET['post'] );
+
+		if ( ! Utils::isLegacyForm( $formId ) ) {
 			return;
 		}
 

--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -97,7 +97,7 @@ class LegacyFormSettingCompatibility {
 
 	/**
 	 * Migrate existing legacy form settings.
-	 * Note: Only for internal use. This function can be remove or change in future
+	 * Note: Only for internal use. This function can be removed or change in future
 	 *
 	 * @since 2.7.0
 	 */


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This PR prevents PHP notice which occurs because of a lack of parameter existence validation.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr effect logic which helps to migrate old form setting  to make it compatible with a legacy form template.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Are you getting PHP notice on new form edit page?
- [x] Are you getting any notice on the existing form edit page?
- [x] Does old form settings migrate successfully? That means you see legacy as a select form template for old form and old setting values also reflect in settings.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
<img width="893" alt="Screen Shot 2020-06-17 at 11 13 52 AM" src="https://user-images.githubusercontent.com/1784821/84936292-ac28ff00-b0f7-11ea-9884-a6ade0766950.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
