### PR TITLE
fix: Form Template loader now only appears when loading is triggered from within Form Template iframe

### DIFF
--- a/assets/src/js/plugins/form-template/iframe-content.js
+++ b/assets/src/js/plugins/form-template/iframe-content.js
@@ -6,15 +6,6 @@ const iFrameResizer = {
 		if ( ! document.getElementById( 'give-receipt' ) ) {
 			window.parentIFrame.sendMessage( { action: 'giveEmbedFormContentLoaded' } );
 		}
-
-		window.addEventListener( 'beforeunload', function() {
-			const height = document.querySelector( '.give-form-templates' ).offsetHeight;
-			const message = {
-				action: 'showLoader',
-				payload: height,
-			};
-			window.parentIFrame.sendMessage( message );
-		} );
 	},
 
 	onMessage: function( message ) {

--- a/assets/src/js/plugins/form-template/parent-page.js
+++ b/assets/src/js/plugins/form-template/parent-page.js
@@ -1,7 +1,6 @@
-/* globals CustomEvent */
 import { initializeIframeResize } from './utils';
 
-jQuery( function( $ ) {
+jQuery( function() {
 	// This script is only for parent page.
 	if ( document.querySelector( 'body.give-form-templates' ) ) {
 		return false;
@@ -15,8 +14,8 @@ jQuery( function( $ ) {
 	document.querySelectorAll( '.js-give-embed-form-modal-opener' ).forEach( function( button ) {
 		button.addEventListener( 'click', function() {
 			const iframeContainer = document.getElementById( button.getAttribute( 'data-form-id' ) ),
-				  iframe = iframeContainer.querySelector( 'iframe[name="give-embed-form"]' ),
-				  iframeURL = iframe.getAttribute( 'data-src' );
+				iframe = iframeContainer.querySelector( 'iframe[name="give-embed-form"]' ),
+				iframeURL = iframe.getAttribute( 'data-src' );
 
 			// Load iframe.
 			if ( iframeURL ) {
@@ -52,9 +51,9 @@ jQuery( function( $ ) {
 	 * Note: This code with make form template (other then legacy form template) compatible with form grid.
 	 */
 	document.querySelectorAll( '.js-give-grid-modal-launcher' ).forEach( function( $formModalLauncher ) {
-		$formModalLauncher.addEventListener( 'click', function( evt ) {
+		$formModalLauncher.addEventListener( 'click', function() {
 			const $embedFormLauncher = $formModalLauncher.nextElementSibling.firstElementChild,
-				  $magnificPopContainer = document.querySelector( '.mfp-wrap.give-modal' );
+				$magnificPopContainer = document.querySelector( '.mfp-wrap.give-modal' );
 
 			$magnificPopContainer && $magnificPopContainer.classList.add( 'mfp-hide' );
 
@@ -97,7 +96,7 @@ jQuery( function( $ ) {
 		const $iframe = document.querySelector( '.modal-content iframe[data-autoScroll="1"]' );
 		if ( $iframe ) {
 			const containerId = $iframe.parentElement.parentElement.parentElement.getAttribute( 'id' ),
-				  $button = document.querySelector( `.js-give-embed-form-modal-opener[data-form-id="${ containerId }"]` );
+				$button = document.querySelector( `.js-give-embed-form-modal-opener[data-form-id="${ containerId }"]` );
 
 			if ( $button ) {
 				$button.click();

--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -1,4 +1,4 @@
-/*globals Give, jQuery*/
+/* globals Give */
 
 import { iframeResize } from 'iframe-resizer';
 
@@ -42,15 +42,21 @@ export const initializeIframeResize = function( iframe ) {
 							iframe.style.minHeight = '';
 						}
 						break;
-					case 'showLoader':
-						parent.querySelector( '.iframe-loader' ).style.opacity = 1;
-						parent.querySelector( '.iframe-loader' ).style.transition = '';
-						iframe.style.visibility = 'hidden';
-						iframe.style.minHeight = `${ messageData.message.payload }px`;
-						break;
 				}
 			},
-			onInit: function( iframe ) {
+			onInit: function() {
+				let parentUnload = false;
+				window.addEventListener( 'beforeunload', function() {
+					parentUnload = true;
+				} );
+				iframe.contentWindow.addEventListener( 'beforeunload', function() {
+					if ( parentUnload === false ) {
+						iframe.parentElement.querySelector( '.iframe-loader' ).style.opacity = 1;
+						iframe.parentElement.querySelector( '.iframe-loader' ).style.transition = '';
+						iframe.style.visibility = 'hidden';
+					}
+				} );
+
 				iframe.iFrameResizer.sendMessage( {
 					currentPage: Give.fn.removeURLParameter( window.location.href, 'giveDonationAction' ),
 				} );

--- a/src/Views/Form/Templates/Sequoia/Actions.php
+++ b/src/Views/Form/Templates/Sequoia/Actions.php
@@ -255,7 +255,7 @@ class Actions {
 	 * @since 2.7.0
 	 */
 	public function getStartWrapperHTMLForAmountSection() {
-		$content = isset( $this->templateOptions['payment_amount']['content'] ) ? $this->templateOptions['payment_amount']['content'] : __( 'As a contributor to Save the Whales we make sure your money gets put to work. How much would you like to donate? Your donation goes directly to supporting our cause.', 'give' );
+		$content = isset( $this->templateOptions['payment_amount']['content'] ) && !empty($this->templateOptions['payment_amount']['content']) ? $this->templateOptions['payment_amount']['content'] : sprintf( __( 'How much would you like to donate? As a contributor to %s we make sure your goes directly to supporting our cause. Thank you for your generosity!', 'give' ), get_bloginfo('sitename') );
 		$label   = ! empty( $this->templateOptions['introduction']['donate_label'] ) ? $this->templateOptions['introduction']['donate_label'] : __( 'Donate Now', 'give' );
 
 		printf(

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -90,9 +90,8 @@ return [
 				'desc'       => __( 'Do you want to customize the content that appears before amount options? The content displays above the amount option buttons during the second step. We recommend keeping it to 1-2 short sentences.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
-					'placeholder' => __( 'As a contributor to Save the Whales we make sure your money gets put to work. How much would you like to donate? Your donation goes directly to supporting our cause.', 'give' ),
+					'placeholder' => sprintf( __( 'How much would you like to donate? As a contributor to %s we make sure your goes directly to supporting our cause. Thank you for your generosity!', 'give' ), get_bloginfo('sitename') )
 				],
-				'default'    => __( 'As a contributor to Save the Whales we make sure your money gets put to work. How much would you like to donate? Your donation goes directly to supporting our cause.', 'give' ),
 			],
 			[
 				'id'         => 'next_label',


### PR DESCRIPTION
## Description
Resolves #4815 
This PR improves frontend logic so that the form template loader is only shown when a 'beforeunload' event originates form within the form template iframe. Previously, the form template loader was displayed anytime the 'beforeunload' event was fired, including when the fired by the parent iframe. This resulted in unexpected behavior, whereby the form template loader would appear when a user clicked on a link in the parent page. 

## Affects
This PR affects the form template rendering logic, specifically logic around ensuring that the form loader is only displayed when a 'beforeunload' event is fired from within the form template iframe.

## What to test
- [ ] Complete a normal donation, does the form loader appear in the moments you expect it to?
- [ ] While on a page with a form template, navigate to another page (eg: click on a menu link), does the form loader appear prior to the parent page navigating to anothe rpage?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/84957667-86c4d280-b0b0-11ea-9e32-4286963c947d.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
