### PR TITLE
Fix PHP Notice on fresh install with 2.7.0

### DIFF
--- a/includes/gateways/stripe/includes/filters.php
+++ b/includes/gateways/stripe/includes/filters.php
@@ -53,9 +53,15 @@ add_filter( 'give_get_payment_transaction_id-stripe_ach', 'give_stripe_get_payme
  *
  * @since 2.7.0
  *
- * @return mixed
+ * @return array|bool
  */
-function __give_stripe_form_add_credentials( $form_html_tags, $form ) {
+function give_stripe_form_add_data_tag_keys( $form_html_tags, $form ) {
+
+	// Must have a Stripe payment gateway active.
+	if ( ! give_stripe_is_any_payment_method_active() ) {
+		return false;
+	}
+
 	$publishable_key = give_stripe_get_publishable_key( $form->ID );
 	$account_id      = give_stripe_get_connected_account_id( $form->ID );
 
@@ -65,4 +71,4 @@ function __give_stripe_form_add_credentials( $form_html_tags, $form ) {
 	return $form_html_tags;
 }
 
-add_filter( 'give_form_html_tags', '__give_stripe_form_add_credentials', 0, 2 );
+add_filter( 'give_form_html_tags', 'give_stripe_form_add_data_tag_keys', 0, 2 );

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -52,7 +52,7 @@ function give_stripe_get_secret_key( $form_id = 0 ) {
 function give_stripe_get_connected_account_id( $form_id = 0 ) {
 	$default_account = give_stripe_get_default_account( $form_id );
 
-	return trim( $default_account['account_id'] );
+	return isset( $default_account['account_id'] ) ? trim( $default_account['account_id'] ) :  false;
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4820 

If no Stripe Account is connected we were causing a PHP Notice to display because `give_stripe_form_add_data_tag_keys()` is using `give_stripe_get_connected_account_id()` which was attempting to pass an non-existent array key.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
- Fresh Installs
- Stripe

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [ ] Install GiveWP fresh
- [ ] View logs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
