### PR TITLE
improve default donation form heading logic

### DIFF
--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -3,11 +3,11 @@
 use Give\Form\Template\Options;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
+global $pagenow;
 $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
 // Setup dynamic defaults
-
-$introHeadline    = empty( $formInfo->post_title ) || $formInfo->post_title === __( 'Auto Draft' ) ? __( 'Support Our Cause', 'give' ) : $formInfo->post_title;
+$introHeadline    = ( ! $formInfo->post_title || 'post-new.php' === $pagenow ) ? __( 'Support Our Cause', 'give' ) : $formInfo->post_title;
 $introDescription = $formInfo->post_excerpt ? $formInfo->post_excerpt : __( 'Help make a difference today! All donations go directly to making a difference for our cause.', 'give' );
 
 return [
@@ -34,6 +34,7 @@ return [
 				'attributes' => [
 					'placeholder' => $introHeadline,
 				],
+				'default'    => $introHeadline,
 			],
 			[
 				'id'         => 'description',
@@ -90,7 +91,7 @@ return [
 				'desc'       => __( 'Do you want to customize the content that appears before amount options? The content displays above the amount option buttons during the second step. We recommend keeping it to 1-2 short sentences.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
-					'placeholder' => sprintf( __( 'How much would you like to donate? As a contributor to %s we make sure your goes directly to supporting our cause. Thank you for your generosity!', 'give' ), get_bloginfo('sitename') )
+					'placeholder' => sprintf( __( 'How much would you like to donate? As a contributor to %s we make sure your goes directly to supporting our cause. Thank you for your generosity!', 'give' ), get_bloginfo( 'sitename' ) ),
 				],
 			],
 			[

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -12,13 +12,7 @@ $image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $thi
 
 <div class="give-section introduction">
 	<h2 class="headline">
-		<?php
-		if ( empty( $headline ) || $headline === __( 'Auto Draft' ) ) {
-			_e( 'Support Our Cause', 'give' );
-		} else {
-			echo $headline;
-		}
-		?>
+		<?php echo $headline; ?>
 	</h2>
 	<?php if ( ! empty( $description ) ) : ?>
 		<div class="seperator"></div>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
This pr improve logic to assign default form heading for form modal. When discussing the issue with @henryholtgeerts I find out that I pointed him to the wrong file. Default heading logo must be updated in `src/Views/Form/Templates/Sequoia/optionConfig.php`

Related: https://github.com/impress-org/givewp/pull/4813
Discussion: https://givewp.slack.com/archives/C0FAGC83C/p1592421291031300

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This PR affects default form heading logic which runs in WP Backed when creating a new form or editing an existing form.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is form heading set to `Support Our Cause` when creating a new donation form and leave `Form Template > Multi Step Donation Form > Introduction > Heading` setting empty?
- [x] Is form heading set to form title if leave form heading empty for an existing donation form.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
