### PR TITLE
get stripe payment method list outside of loop to improve performance

### DIFF
--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -45,14 +45,15 @@ function give_stripe_supported_payment_methods() {
 function give_stripe_is_any_payment_method_active() {
 
 	// Get settings.
-	$settings = give_get_settings();
-	$gateways = isset( $settings['gateways'] ) ? $settings['gateways'] : [];
+	$settings             = give_get_settings();
+	$gateways             = isset( $settings['gateways'] ) ? $settings['gateways'] : [];
+	$stripePaymentMethods = give_stripe_supported_payment_methods();
 
 	// Loop through gateways list.
 	foreach ( array_keys( $gateways ) as $gateway ) {
 
 		// Return true, if even single payment method is active.
-		if ( in_array( $gateway, give_stripe_supported_payment_methods(), true ) ) {
+		if ( in_array( $gateway, $stripePaymentMethods, true ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

As you can see in the screenshot, this function used in multiple places in addons, so it will be a small quick fix to improve performance.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr changes only limited to `give_stripe_is_any_payment_method_active` function.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
I think it is a minor change. By reading code you can guess that it will not break any existing functionality and also no need test.

## Screenshots:
<!-- Optional. Any screenshots or animated gifs that may help others understand the changes -->
![image](https://user-images.githubusercontent.com/1784821/85029209-ab48a980-b199-11ea-85ab-54ca3c976ebd.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
