### PR TITLE
setup embed form custom route on fresh site

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -161,6 +161,10 @@ function give_run_install() {
 		return;
 	}
 
+	// Setup embed form route on fresh install or plugin activation.
+	Give()->routeForm->setBasePrefix();
+	Give()->routeForm->addRule();
+
 	// Flush rewrite rules.
 	flush_rewrite_rules();
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4825

I find out that plugin activation hooks fire before the initialization of embed form custom route which causes of custom route does not save in the database. I updated logic to setup route on plugin activate and fresh install.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr changes limited to `give_run_install` function which fires either on plugin activation or fresh install.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [ ] Is `Multi Step Donation Form` loads when install `Give 2.7.0` on fresh site?
- [ ] Is `Multi Step Donation Form` loads when update from any old Give plugin version to `Give 2.7.0`?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
