### PR TITLE
fix: PHP errors no longer logged on Reports page

### DIFF
--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -56,8 +56,6 @@ class AverageDonation extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$income   = [];
 		$tooltips = [];
 
@@ -163,13 +161,15 @@ class AverageDonation extends Endpoint {
 
 	public function get_average_donation( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$earnings     = 0;
 		$paymentCount = 0;
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->date > $startStr && $payment->date < $endStr ) {
-				if ( $payment->status == 'publish' || $payment->status == 'give_subscription' ) {
-					$earnings     += $payment->total;
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
+					$earnings     += $paymentObject->total;
 					$paymentCount += 1;
 				}
 			}
@@ -188,7 +188,7 @@ class AverageDonation extends Endpoint {
 		$earnings     = 0;
 		$paymentCount = 0;
 
-		foreach ( $this->paymentObjects as $paymentObject ) {
+		foreach ( $paymentObjects as $paymentObject ) {
 			if ( $paymentObjects->date > $startStr && $paymentObject->date < $endStr ) {
 				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
 					$earnings     += $paymentObject->total;

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -137,7 +137,7 @@ class AverageDonation extends Endpoint {
 
 		$prevEnd = clone $start;
 
-		$prevAverage    = $this->get_prev_average_donation( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
+		$prevAverage    = $this->get_average_donation( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
 		$currentAverage = $this->get_average_donation( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
 
 		// Set default trend to 0
@@ -168,28 +168,6 @@ class AverageDonation extends Endpoint {
 
 		foreach ( $paymentObjects as $paymentObject ) {
 			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
-				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
-					$earnings     += $paymentObject->total;
-					$paymentCount += 1;
-				}
-			}
-		}
-
-		$average = $paymentCount > 0 ? $earnings / $paymentCount : 0;
-
-		// Return rounded average (avoid displaying figures with many decimal places)
-		return round( $average, 2 );
-	}
-
-	public function get_prev_average_donation( $startStr, $endStr ) {
-
-		$paymentObjects = $this->get_payments( $startStr, $endStr );
-
-		$earnings     = 0;
-		$paymentCount = 0;
-
-		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObjects->date > $startStr && $paymentObject->date < $endStr ) {
 				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
 					$earnings     += $paymentObject->total;
 					$paymentCount += 1;

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -28,19 +28,19 @@ class FormPerformance extends Endpoint {
 
 	public function get_data( $start, $end ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), 'date', -1 );
+		$paymentObjects = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ), 'date', -1 );
 
 		$forms    = [];
 		$labels   = [];
 		$tooltips = [];
 
-		if ( count( $this->payments ) > 0 ) {
+		if ( count( $paymentObjects ) > 0 ) {
 
-			foreach ( $this->payments as $payment ) {
-				if ( $payment->status === 'publish' || $payment->status === 'give_subscription' ) {
-					$forms[ $payment->form_id ]['income']    = isset( $forms[ $payment->form_id ]['income'] ) ? $forms[ $payment->form_id ]['income'] += $payment->total : $payment->total;
-					$forms[ $payment->form_id ]['donations'] = isset( $forms[ $payment->form_id ]['donations'] ) ? $forms[ $payment->form_id ]['donations'] += 1 : 1;
-					$forms[ $payment->form_id ]['title']     = $payment->form_title;
+			foreach ( $paymentObjects as $paymentObject ) {
+				if ( $paymentObject->status === 'publish' || $paymentObject->status === 'give_subscription' ) {
+					$forms[ $paymentObject->form_id ]['income']    = isset( $forms[ $paymentObject->form_id ]['income'] ) ? $forms[ $paymentObject->form_id ]['income'] += $paymentObject->total : $paymentObject->total;
+					$forms[ $paymentObject->form_id ]['donations'] = isset( $forms[ $paymentObject->form_id ]['donations'] ) ? $forms[ $paymentObject->form_id ]['donations'] += 1 : 1;
+					$forms[ $paymentObject->form_id ]['title']     = $paymentObject->form_title;
 				}
 			}
 

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -47,8 +47,6 @@ class Income extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$tooltips = [];
 		$income   = [];
 
@@ -124,14 +122,16 @@ class Income extends Endpoint {
 
 	public function get_values( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$earnings = 0;
 		$donors   = [];
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->date > $startStr && $payment->date < $endStr ) {
-				if ( $payment->status == 'publish' || $payment->status == 'give_subscription' ) {
-					$earnings += $payment->total;
-					$donors[]  = $payment->donor_id;
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
+					$earnings += $paymentObject->total;
+					$donors[]  = $paymentObject->donor_id;
 				}
 			}
 		}

--- a/src/API/Endpoints/Reports/IncomeBreakdown.php
+++ b/src/API/Endpoints/Reports/IncomeBreakdown.php
@@ -43,8 +43,6 @@ class IncomeBreakdown extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$tooltips = [];
 		$income   = [];
 
@@ -99,24 +97,26 @@ class IncomeBreakdown extends Endpoint {
 
 	public function get_values( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$income      = 0;
 		$refundTotal = 0;
 		$refunds     = 0;
 		$donors      = [];
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->date > $startStr && $payment->date < $endStr ) {
-				switch ( $payment->status ) {
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+				switch ( $paymentObject->status ) {
 					case 'give_subscription':
 					case 'publish': {
-						$income  += $payment->total;
-						$donors[] = $payment->donor_id;
+						$income  += $paymentObject->total;
+						$donors[] = $paymentObject->donor_id;
 						break;
 					}
 					case 'refunded': {
 						$refunds     += 1;
-						$income      += $payment->total;
-						$refundTotal += $payment->total;
+						$income      += $paymentObject->total;
+						$refundTotal += $paymentObject->total;
 						break;
 					}
 				}

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -23,28 +23,28 @@ class TopDonors extends Endpoint {
 
 	public function get_data( $start, $end ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d 23:i:s' ), 'date', -1 );
+		$paymentObjects = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d 23:i:s' ), 'date', -1 );
 
 		$donors = [];
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->status === 'publish' || $payment->status === 'give_subscription' ) {
-				$donors[ $payment->donor_id ]['type']      = 'donor';
-				$donors[ $payment->donor_id ]['earnings']  = isset( $donors[ $payment->donor_id ]['earnings'] ) ? $donors[ $payment->donor_id ]['earnings'] += $payment->total : $payment->total;
-				$donors[ $payment->donor_id ]['total']     = give_currency_filter(
-					give_format_amount( $donors[ $payment->donor_id ]['earnings'], [ 'sanitize' => false ] ),
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->status === 'publish' || $paymentObject->status === 'give_subscription' ) {
+				$donors[ $paymentObject->donor_id ]['type']      = 'donor';
+				$donors[ $paymentObject->donor_id ]['earnings']  = isset( $donors[ $paymentObject->donor_id ]['earnings'] ) ? $donors[ $paymentObject->donor_id ]['earnings'] += $paymentObject->total : $paymentObject->total;
+				$donors[ $paymentObject->donor_id ]['total']     = give_currency_filter(
+					give_format_amount( $donors[ $paymentObject->donor_id ]['earnings'], [ 'sanitize' => false ] ),
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
 					]
 				);
-				$donors[ $payment->donor_id ]['donations'] = isset( $donors[ $payment->donor_id ]['donations'] ) ? $donors[ $payment->donor_id ]['donations'] += 1 : 1;
-				$countLabel                                = _n( 'Donation', 'Donations', $donors[ $payment->donor_id ]['donations'], 'give' );
-				$donors[ $payment->donor_id ]['count']     = $donors[ $payment->donor_id ]['donations'] . ' ' . $countLabel;
-				$donors[ $payment->donor_id ]['name']      = $payment->first_name . ' ' . $payment->last_name;
-				$donors[ $payment->donor_id ]['email']     = $payment->email;
-				$donors[ $payment->donor_id ]['image']     = give_validate_gravatar( $payment->email ) ? get_avatar_url( $payment->email, 60 ) : null;
-				$donors[ $payment->donor_id ]['url']       = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . absint( $payment->donor_id ) );
+				$donors[ $paymentObject->donor_id ]['donations'] = isset( $donors[ $paymentObject->donor_id ]['donations'] ) ? $donors[ $paymentObject->donor_id ]['donations'] += 1 : 1;
+				$countLabel                                      = _n( 'Donation', 'Donations', $donors[ $paymentObject->donor_id ]['donations'], 'give' );
+				$donors[ $paymentObject->donor_id ]['count']     = $donors[ $paymentObject->donor_id ]['donations'] . ' ' . $countLabel;
+				$donors[ $paymentObject->donor_id ]['name']      = $paymentObject->first_name . ' ' . $paymentObject->last_name;
+				$donors[ $paymentObject->donor_id ]['email']     = $paymentObject->email;
+				$donors[ $paymentObject->donor_id ]['image']     = give_validate_gravatar( $paymentObject->email ) ? get_avatar_url( $paymentObject->email, 60 ) : null;
+				$donors[ $paymentObject->donor_id ]['url']       = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . absint( $paymentObject->donor_id ) );
 			}
 		}
 

--- a/src/API/Endpoints/Reports/TotalDonors.php
+++ b/src/API/Endpoints/Reports/TotalDonors.php
@@ -121,7 +121,7 @@ class TotalDonors extends Endpoint {
 
 		$prevEnd = clone $start;
 
-		$prevDonors    = $this->get_prev_donors( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
+		$prevDonors    = $this->get_donors( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
 		$currentDonors = $this->get_donors( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
 
 		// Set default trend to 0
@@ -159,23 +159,6 @@ class TotalDonors extends Endpoint {
 
 		$unique     = array_unique( $donors );
 		$donorCount = count( $unique );
-
-		return $donorCount;
-	}
-
-	public function get_prev_donors( $startStr, $endStr ) {
-
-		$prevPaymentObjects = $this->get_payments( $startStr, $endStr, 'date', -1 );
-
-		$donorIds = [];
-		foreach ( $prevPaymentObjects as $paymentObject ) {
-			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
-				$donorIds[] = $paymentObject->donor_id;
-			}
-		}
-
-		$uniqueDonorIds = array_unique( $donorIds );
-		$donorCount     = count( $uniqueDonorIds );
 
 		return $donorCount;
 	}

--- a/src/API/Endpoints/Reports/TotalDonors.php
+++ b/src/API/Endpoints/Reports/TotalDonors.php
@@ -44,8 +44,6 @@ class TotalDonors extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$tooltips = [];
 		$donors   = [];
 
@@ -147,12 +145,14 @@ class TotalDonors extends Endpoint {
 
 	public function get_donors( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$donors = [];
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->date > $startStr && $payment->date < $endStr ) {
-				if ( $payment->status == 'publish' || $payment->status == 'give_subscription' ) {
-					$donors[] = $payment->donor_id;
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
+					$donors[] = $paymentObject->donor_id;
 				}
 			}
 		}

--- a/src/API/Endpoints/Reports/TotalIncome.php
+++ b/src/API/Endpoints/Reports/TotalIncome.php
@@ -44,8 +44,6 @@ class TotalIncome extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$tooltips = [];
 		$income   = [];
 
@@ -159,13 +157,15 @@ class TotalIncome extends Endpoint {
 
 	public function get_income( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$income = 0;
 
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->currency === $this->currency ) {
-				if ( $payment->date > $startStr && $payment->date < $endStr ) {
-					if ( $payment->status === 'publish' || $payment->status === 'give_subscription' ) {
-						$income += $payment->total;
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->currency === $this->currency ) {
+				if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+					if ( $paymentObject->status === 'publish' || $paymentObject->status === 'give_subscription' ) {
+						$income += $paymentObject->total;
 					}
 				}
 			}

--- a/src/API/Endpoints/Reports/TotalRefunds.php
+++ b/src/API/Endpoints/Reports/TotalRefunds.php
@@ -46,8 +46,6 @@ class TotalRefunds extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$this->payments = $this->get_payments( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-
 		$tooltips = [];
 		$refunds  = [];
 
@@ -149,9 +147,11 @@ class TotalRefunds extends Endpoint {
 
 	public function get_refunds( $startStr, $endStr ) {
 
+		$paymentObjects = $this->get_payments( $startStr, $endStr );
+
 		$refunds = 0;
-		foreach ( $this->payments as $payment ) {
-			if ( $payment->status == 'refunded' && $payment->date > $startStr && $payment->date < $endStr ) {
+		foreach ( $paymentObjects as $paymentObject ) {
+			if ( $paymentObject->status == 'refunded' && $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
 				$refunds += 1;
 			}
 		}

--- a/src/API/Endpoints/Reports/TotalRefunds.php
+++ b/src/API/Endpoints/Reports/TotalRefunds.php
@@ -123,7 +123,7 @@ class TotalRefunds extends Endpoint {
 
 		$prevEnd = clone $start;
 
-		$prevRefunds    = $this->get_prev_refunds( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
+		$prevRefunds    = $this->get_refunds( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
 		$currentRefunds = $this->get_refunds( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
 
 		// Set default trend to 0
@@ -159,17 +159,4 @@ class TotalRefunds extends Endpoint {
 		return $refunds;
 	}
 
-	public function get_prev_refunds( $startStr, $endStr ) {
-
-		$prevPaymentObjects = $this->get_payments( $startStr, $endStr, 'date', -1 );
-
-		$refundCount = 0;
-		foreach ( $prevPaymentObjects as $paymentObject ) {
-			if ( $paymentObject->status == 'refunded' && $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
-				$refundCount += 1;
-			}
-		}
-
-		return $refundCount;
-	}
 }

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -222,7 +222,7 @@ class LoadTemplate {
 	 */
 	private function getListOfScriptsToDequeue( $scripts ) {
 		$list     = [];
-		$skip     = [ 'babel-polyfill' ];
+		$skip     = [ 'babel-polyfill', 'plupload-handlers' ];
 		$themeDir = get_template_directory_uri();
 
 		/* @var _WP_Dependency $data */

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -222,7 +222,7 @@ class LoadTemplate {
 	 */
 	private function getListOfScriptsToDequeue( $scripts ) {
 		$list     = [];
-		$skip     = [ 'babel-polyfill', 'plupload-handlers' ];
+		$skip     = [ 'babel-polyfill' ];
 		$themeDir = get_template_directory_uri();
 
 		/* @var _WP_Dependency $data */


### PR DESCRIPTION
## Description
Resolves #4826 
This PR resolves an incorrect variable reference in the AverageDonations endpoint class that caused PHP errors to be logged every time a user visited the Reports page. Additionally, this PR refactors other endpoints to ensure consistent naming conventions and remove redundant code.

## Affects
This PR affects Report generating logic, specifically how the AverageDonation endpoint processes payment objects to determine average donations for a period. The PR also refactors a number of other endpoints to ensure that all endpoints use the consistent "paymentObjects" variable name, to avoid the type of mistake/oversight that caused this issue. In the process of updating varaible references, certain code also became redundant, and was removed.

## What to test
- [ ] Navigate to the Reports admin page. Are any errors logged to the WP Debug Log?
- [ ] Do mini charts behave as expected? 
- [ ] Are charts responsive to changes in currency and viewing test mode data?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
