### PR TITLE
prevent wp_editor related PHP notices when save or open form edit page

### DIFF
--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -668,7 +668,11 @@ function give_wysiwyg( $field ) {
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
 
+	// Since WP 3.9.0 WP does not allow square brackets in field id.
+	// If we pass square brackets in field id then code will work as expected but you will get PHP warnings.
+	// wp-includes/class-wp-editor.php::parse_settings::106
 	$field['unique_field_id'] = str_replace( [ '[', ']' ], [ '_', '' ], give_get_field_name( $field ) );
+
 	$editor_attributes        = [
 		'textarea_name' => isset( $field['repeatable_field_id'] ) ? $field['repeatable_field_id'] : $field['id'],
 		'textarea_rows' => '10',

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -668,20 +668,20 @@ function give_wysiwyg( $field ) {
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
 
-	$field['unique_field_id'] = give_get_field_name( $field );
-	$editor_attributes        = array(
+	$field['unique_field_id'] = str_replace( [ '[', ']' ], [ '_', '' ], give_get_field_name( $field ) );
+	$editor_attributes        = [
 		'textarea_name' => isset( $field['repeatable_field_id'] ) ? $field['repeatable_field_id'] : $field['id'],
 		'textarea_rows' => '10',
 		'editor_css'    => esc_attr( $field['style'] ),
 		'editor_class'  => $field['attributes']['class'],
-	);
+	];
 	$data_wp_editor           = ' data-wp-editor="' . base64_encode(
 		json_encode(
-			array(
+			[
 				$field['value'],
 				$field['unique_field_id'],
 				$editor_attributes,
-			)
+			]
 		)
 	) . '"';
 	$data_wp_editor           = isset( $field['repeatable_field_id'] ) ? $data_wp_editor : '';


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4824 

This PR replace `[ --> _` and `] --> {empty string}` symbols from `wp_editor` field id to suppress PHP warnings. 

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Change is limited to `give_wysiwyg`. My only concern that if id change for a setting field then style or javascript code can be affected but I did not notice in our core codebase or addon any use of the `WYSIWYG` field with an id which contains `[ ]` bracket, so I think this change will not break any existing functionality.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is `wysiwyg` field render/save value without any PHP notices?
- [x] Is there not any javascript error in the console tab of Google Chrome?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
