### PR TITLE
fix: Form Template no longer logs plupload error

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -222,7 +222,7 @@ class LoadTemplate {
 	 */
 	private function getListOfScriptsToDequeue( $scripts ) {
 		$list     = [];
-		$skip     = [ 'babel-polyfill' ];
+		$skip     = [ 'babel-polyfill', 'plupload-handlers' ];
 		$themeDir = get_template_directory_uri();
 
 		/* @var _WP_Dependency $data */


### PR DESCRIPTION
## Description
Resolves #4830
This PR ensures that the 'plupload-handlers' script is able to be enqueued in the Form Template iframe, so that forms using FFM upload fields are operational, and do not log any JS errors. Previously, when a form used FFM to add an upload field, it would log an error the JS console, and the upload button would not function. 

## Affects
This PR affects the Form Template loading logic, specifically with regard to which scripts are able to be enqueued. 

## What to test
WIth FFM enabled, create a new form with an upload field. Activate the Multi-Step form, and view the form from the frontend. Open the browser console.
- [ ] Are any JS errors logged relating to plupload?
- [ ] Does the upload field work as expected?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
