### PR TITLE
prevent php notice on fresh install

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -3746,7 +3746,7 @@ function give_v270_upgrades() {
 		}
 	}
 
-	// Do need to go beyond this if you are on fresh install and on fresh install donationmeta property is not defined for $wpdb.
+	// Do not need to go beyond this if you are on fresh install and on fresh install donationmeta property is not defined for $wpdb.
 	// Below code is to check if site have donations which processed with Stripe payment method
 	// if not then we will auto complete stripe background update.
 	if ( ! property_exists( $wpdb, 'donationmeta' ) ) {

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -3746,6 +3746,13 @@ function give_v270_upgrades() {
 		}
 	}
 
+	// Do need to go beyond this if you are on fresh install.
+	// Below code is to check if site have donations which processed with Stripe payment method
+	// if not then we will auto complete stripe background update.
+	if ( doing_action( 'give_upgrades' ) ) {
+		return;
+	}
+
 	$canStoreStripeInformationInDonation = (bool) $wpdb->get_var(
 		$wpdb->prepare(
 			"

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -3746,10 +3746,10 @@ function give_v270_upgrades() {
 		}
 	}
 
-	// Do need to go beyond this if you are on fresh install.
+	// Do need to go beyond this if you are on fresh install and on fresh install donationmeta property is not defined for $wpdb.
 	// Below code is to check if site have donations which processed with Stripe payment method
 	// if not then we will auto complete stripe background update.
-	if ( doing_action( 'give_upgrades' ) ) {
+	if ( ! property_exists( $wpdb, 'donationmeta' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

@DevinWalker reported an issue about a PHP notice on a fresh install:
```
[18-Jun-2020 18:32:11 UTC] PHP Notice:  Undefined property: wpdb::$donationmeta in /Users/devinwalker/Local Sites/freshtest/app/public/wp-includes/wp-db.php on line 647
```

The automatic upgrade must not run on a fresh install but the system works like that only. To resolve the issue I added a condition to prevent code from running on fresh install which causes PHP warning.

Discussion: https://givewp.slack.com/archives/C0FAGC83C/p1592505352032600

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Code changes limited to `give_v270_upgrades` function and it affects plugin fresh install and upgrade process.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [ ] Are you getting a PHP warning as described above on fresh install?
- [ ] Does automatic upgrade running smoothly on existing install?
- [ ] Is the upgrade process related to store stripe account information to donation meta ( if donation process with stripe payment method ) running smoothly?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
