### PR TITLE
fix: terms and conditions checkbox is now styled in Multi-Step form template

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -159,6 +159,17 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			.payment [id*='give-create-account-wrap-'] label::after {
 				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\");
 			}
+			#give_terms_agreement:hover,
+			#give_terms_agreement:focus-within,
+			#give_terms_agreement.active {
+				border: 1px solid {$primaryColor} !important;
+			}
+			#give_terms_agreement input[type='checkbox']:focus + label::before {
+				border-color: {$primaryColor};
+			}
+			#give_terms_agreement input[type='checkbox'] + label::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\") !important;
+			}
 		";
 
 		if ( Utils::isPluginActive( 'give-recurring/give-recurring.php' ) ) {

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -28,6 +28,7 @@
 		padding: 17px 20px 17px 22px !important;
 		color: #333;
 		display: inline-block;
+		cursor: pointer;
 
 		@media screen and (max-width: $break-phone) {
 			font-size: 14px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -612,10 +612,16 @@ p {
 		width: auto !important;
 		padding: 17px 20px 17px 22px !important;
 		display: flex;
+		justify-content: space-between;
+		flex-wrap: wrap;
 
 		input[type='checkbox'] {
 			bottom: 14px;
 			left: 27px;
+		}
+
+		#give_show_terms {
+			order: 3;
 		}
 
 		#give_terms {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -613,6 +613,11 @@ p {
 		padding: 17px 20px 17px 22px !important;
 		display: flex;
 
+		input[type='checkbox'] {
+			bottom: 14px;
+			left: 27px;
+		}
+
 		#give_terms {
 			padding-bottom: 10px;
 		}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -619,7 +619,7 @@ p {
 		}
 
 		#give_terms {
-			margin-bottom: 10px;
+			margin-bottom: 17px;
 			max-height: 300px;
 			overflow-y: scroll;
 		}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -639,6 +639,7 @@ p {
 			font-size: 16px;
 			line-height: 1.4;
 			position: relative;
+			cursor: pointer;
 		}
 
 		&:hover {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -619,7 +619,9 @@ p {
 		}
 
 		#give_terms {
-			padding-bottom: 10px;
+			margin-bottom: 10px;
+			max-height: 300px;
+			overflow-y: scroll;
 		}
 
 		label {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -598,6 +598,49 @@ p {
 		width: 100%;
 	}
 
+	#give_terms_agreement {
+		order: 3;
+		background: #fff;
+		border: 1px solid rgba(255, 255, 255, 0) !important;
+		box-sizing: border-box;
+		box-shadow: 0 0 16px rgba(0, 0, 0, 0.121203);
+		border-radius: 5px;
+		margin: 20px 0 0 0 !important;
+		padding: 0 !important;
+		position: relative;
+		transition: border 0.2s ease;
+		width: auto !important;
+		padding: 17px 20px 17px 22px !important;
+		display: flex;
+
+		#give_terms {
+			padding-bottom: 10px;
+		}
+
+		label {
+			margin: 0;
+			padding: 0 0 0 40px;
+			width: calc(100% - 180px);
+			display: inline-block;
+			font-weight: 400;
+			font-size: 16px;
+			line-height: 1.4;
+			position: relative;
+		}
+
+		&:hover {
+			border: 1px solid #3398db !important;
+
+			.give-mc-message-text::before {
+				background-color: rgba(245, 245, 245, 0.815);
+			}
+		}
+
+		&.active {
+			border: 1px solid #3398db !important;
+		}
+	}
+
 	[id*='give-checkout-login-register-'] {
 		width: 100%;
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -601,7 +601,7 @@ p {
 	#give_terms_agreement {
 		order: 3;
 		background: #fff;
-		border: 1px solid rgba(255, 255, 255, 0) !important;
+		border: 1px solid rgba(255, 255, 255, 0);
 		box-sizing: border-box;
 		box-shadow: 0 0 16px rgba(0, 0, 0, 0.121203);
 		border-radius: 5px;
@@ -629,7 +629,7 @@ p {
 		}
 
 		&:hover {
-			border: 1px solid #3398db !important;
+			border: 1px solid #3398db;
 
 			.give-mc-message-text::before {
 				background-color: rgba(245, 245, 245, 0.815);
@@ -637,7 +637,7 @@ p {
 		}
 
 		&.active {
-			border: 1px solid #3398db !important;
+			border: 1px solid #3398db;
 		}
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/newsletter.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/newsletter.scss
@@ -16,6 +16,7 @@
 	label,
 	p {
 		margin: 0;
+		cursor: pointer;
 	}
 
 	span {

--- a/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
@@ -27,6 +27,7 @@
 		margin-left: 40px !important;
 		color: #333;
 		display: inline-block;
+		cursor: pointer;
 
 		@media screen and (max-width: $break-phone) {
 			font-size: 14px !important;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -252,6 +252,13 @@
 					input: 'input[name="give_constant_contact_signup"]',
 				} );
 
+				// Setup terms and conditions opt-in event listeners
+				setupCheckbox( {
+					container: '#give_terms_agreement',
+					label: '#give_terms_agreement label',
+					input: 'input[name="give_agree_to_terms"]',
+				} );
+
 				// Show Sequoia loader on click/touchend
 				$( 'body.give-form-templates' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function() {
 					//Override submit loader with Sequoia loader
@@ -439,6 +446,7 @@
 		const donateFieldsetElements = [
 			'.give-constant-contact-fieldset',
 			'.give-mailchimp-fieldset',
+			'#give_terms_agreement',
 			'.give-donation-submit',
 		];
 


### PR DESCRIPTION
## Description
Resolves #4838 
This PR introduces styles for the Terms and Conditions agremeent checkbox, and moves the checkbox below all payment gateways. Previously, when the term and conditions setting was enabled on a form using the Multi-Step form template, the checkbox was unstyled and loaded inside each individual payment gateway. 

## Affects
This PR affects frontend styles and form rendering logic of the Multi-Step form tempalte, specifically regarding the presentation of the "Terms and Conditions" checkbox.

## What to test
Enable Terms and Conditions for a form using the Multi-Step form template.
- [x] Does the terms and conditions checkbox appear beneath payment gateways?
- [x] If you attempt to submit without checking the terms and conditions does a validation notice appear?
- [x] Does the "Show Terms" button work as expected?
- [x] Does the terms and conditions checkbox use the form's primary color?
- [x] If a user sets a long string as the terms and conditions label, does it adjust accordingly?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/85075961-2f883600-b174-11ea-9edd-7419aca9edbd.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
