### PR TITLE
show excerpt in widget only for non legacy form

### DIFF
--- a/includes/forms/widget.php
+++ b/includes/forms/widget.php
@@ -65,13 +65,13 @@ class Give_Forms_Widget extends WP_Widget {
 		parent::__construct(
 			strtolower( $this->self ),
 			esc_html__( 'GiveWP - Donation Form', 'give' ),
-			array(
+			[
 				'description' => esc_html__( 'Display a GiveWP Donation Form in your theme\'s widget powered sidebar.', 'give' ),
-			)
+			]
 		);
 
-		add_action( 'widgets_init', array( $this, 'widget_init' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_widget_scripts' ) );
+		add_action( 'widgets_init', [ $this, 'widget_init' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_widget_scripts' ] );
 	}
 
 	/**
@@ -113,7 +113,7 @@ class Give_Forms_Widget extends WP_Widget {
 			return;
 		}
 
-		$form_id = (int) $instance['id'];
+		$form_id      = (int) $instance['id'];
 		$isLegacyForm = FormUtils::isLegacyForm( $form_id );
 
 		echo $args['before_widget']; // XSS ok.
@@ -164,7 +164,7 @@ class Give_Forms_Widget extends WP_Widget {
 	 * @param array $instance Current settings.
 	 */
 	public function form( $instance ) {
-		$defaults = array(
+		$defaults = [
 			'title'                     => '',
 			'id'                        => 0,
 			'float_labels'              => 'global',
@@ -178,7 +178,7 @@ class Give_Forms_Widget extends WP_Widget {
 			// These settings are aliases for shortcode setting which prevent conflict when saving and showing setting. Later we will use them to set original settings.
 			'tmp_display_style'         => 'button',
 			'tmp_continue_button_title' => __( 'Continue', 'give' ),
-		);
+		];
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
 

--- a/includes/forms/widget.php
+++ b/includes/forms/widget.php
@@ -90,11 +90,8 @@ class Give_Forms_Widget extends WP_Widget {
 		// Directories of assets.
 		$js_dir = GIVE_PLUGIN_URL . 'assets/dist/';
 
-		// Use minified libraries if SCRIPT_DEBUG is turned off.
-		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
-		wp_enqueue_script( "{$this->scriptHandle}-js", $js_dir . 'js/admin-widgets' . $suffix . '.js', [ 'give-admin-scripts' ], GIVE_VERSION, false );
-		wp_enqueue_style( "{$this->scriptHandle}-css", $js_dir . 'css/admin-widgets' . $suffix . '.css', [], GIVE_VERSION, false );
+		wp_enqueue_script( "{$this->scriptHandle}-js", $js_dir . 'js/admin-widgets.js', [ 'give-admin-scripts' ], GIVE_VERSION, false );
+		wp_enqueue_style( "{$this->scriptHandle}-css", $js_dir . 'css/admin-widgets.css', [], GIVE_VERSION, false );
 	}
 
 	/**

--- a/includes/forms/widget.php
+++ b/includes/forms/widget.php
@@ -114,14 +114,7 @@ class Give_Forms_Widget extends WP_Widget {
 		}
 
 		$form_id = (int) $instance['id'];
-
-		// Use alias setting to set display setting when form template other then Legacy.
-		if ( ! FormUtils::isLegacyForm( $form_id ) ) {
-			$instance['display_style']         = $instance['tmp_display_style'];
-			$instance['continue_button_title'] = $instance['tmp_continue_button_title'];
-
-			unset( $instance['tmp_display_style'], $instance['tmp_continue_button_title'] );
-		}
+		$isLegacyForm = FormUtils::isLegacyForm( $form_id );
 
 		echo $args['before_widget']; // XSS ok.
 
@@ -136,11 +129,19 @@ class Give_Forms_Widget extends WP_Widget {
 
 		echo $title ? $args['before_title'] . $title . $args['after_title'] : ''; // XSS ok.
 
-		if ( ! empty( $instance['introduction_text'] ) ) {
-			printf(
-				'<p>%1$s</p>',
-				$instance['introduction_text']
-			);
+		// Use alias setting to set display setting when form template other then Legacy.
+		if ( ! $isLegacyForm ) {
+			$instance['display_style']         = $instance['tmp_display_style'];
+			$instance['continue_button_title'] = $instance['tmp_continue_button_title'];
+
+			unset( $instance['tmp_display_style'], $instance['tmp_continue_button_title'] );
+
+			if ( ! empty( $instance['introduction_text'] ) ) {
+				printf(
+					'<p>%1$s</p>',
+					$instance['introduction_text']
+				);
+			}
 		}
 
 		echo give_form_shortcode( $instance );

--- a/includes/forms/widget.php
+++ b/includes/forms/widget.php
@@ -133,7 +133,7 @@ class Give_Forms_Widget extends WP_Widget {
 
 			unset( $instance['tmp_display_style'], $instance['tmp_continue_button_title'] );
 
-			if ( ! empty( $instance['introduction_text'] ) ) {
+			if ( 'button' === $instance['display_style'] && ! empty( $instance['introduction_text'] ) ) {
 				printf(
 					'<p>%1$s</p>',
 					$instance['introduction_text']


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4840 

This patch adds a condition which prevents excerpt to print for non legacy forms.

This pr also fixes #4841. I already explained fix here: https://github.com/impress-org/givewp/issues/4841#issuecomment-646748741

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Changes in this patch are limited to `Give_Forms_Widget::widget`.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is excerpt setting works as expected for donation form with `Multi Step Donation Form`?
- [x] Is excerpt setting works as expected for donation form with `Legacy Donation Form`?
- [x] Are we not enqueuing widget script and style file with `.min` prefix?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
