### PR TITLE
Form Grid Block handle heading, description and featured image correctly for any form template

### DIFF
--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -295,7 +295,7 @@ abstract class Template {
 	 *
 	 */
 	public function getFormFeaturedImage( $formId ) {
-		return get_the_post_thumbnail_url( $formId );
+		return get_the_post_thumbnail_url( $formId, 'full' );
 	}
 
 	/**

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -281,7 +281,9 @@ abstract class Template {
 	 * @since 2.7.0
 	 *
 	 */
-	abstract public function getFormHeading( $formId );
+	public function getFormHeading( $formId ) {
+		return get_the_title( $formId );
+	}
 
 	/**
 	 * Get form image
@@ -292,7 +294,9 @@ abstract class Template {
 	 * @since 2.7.0
 	 *
 	 */
-	abstract public function getFormFeaturedImage( $formId );
+	public function getFormFeaturedImage( $formId ) {
+		return get_the_post_thumbnail_url( $formId );
+	}
 
 	/**
 	 * Get form excerpt
@@ -303,5 +307,7 @@ abstract class Template {
 	 * @since 2.7.0
 	 *
 	 */
-	abstract public function getFormExcerpt( $formId );
+	public function getFormExcerpt( $formId ) {
+		return get_the_excerpt( $formId );
+	}
 }

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -87,7 +87,7 @@ abstract class Template {
 	 * Returns starting height for iframe (in pixels), this is used to predict iframe height before the iframe loads
 	 * Implemented in includes/shortcodes.php:
 	 *
-	 * @param int $formId Form ID
+	 * @param  int  $formId  Form ID
 	 *
 	 * @return int
 	 **/
@@ -111,9 +111,9 @@ abstract class Template {
 	/**
 	 * Get loading view filepath
 	 *
+	 * @return string
 	 * @since 2.7.0
 	 *
-	 * @return string
 	 */
 	public function getLoadingView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultLoadingView.php';
@@ -122,9 +122,9 @@ abstract class Template {
 	/**
 	 * Get form view filepath
 	 *
+	 * @return string
 	 * @since 2.7.0
 	 *
-	 * @return string
 	 */
 	public function getFormView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultFormTemplate.php';
@@ -133,9 +133,9 @@ abstract class Template {
 	/**
 	 * Get receipt view filepath
 	 *
+	 * @return string
 	 * @since 2.7.0
 	 *
-	 * @return string
 	 */
 	public function getReceiptView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultFormReceiptTemplate.php';
@@ -189,14 +189,17 @@ abstract class Template {
 	 * @since 2.7.0
 	 */
 	public function getFailedDonationMessage() {
-		return esc_html__( 'We\'re sorry, your donation failed to process. Please try again or contact site support.', 'give' );
+		return esc_html__(
+			'We\'re sorry, your donation failed to process. Please try again or contact site support.',
+			'give'
+		);
 	}
 
 
 	/**
 	 * Get failed donation page URL.
 	 *
-	 * @param int $formId
+	 * @param  int  $formId
 	 *
 	 * @return mixed
 	 * @since 2.7.0
@@ -208,8 +211,8 @@ abstract class Template {
 	/**
 	 * Get donate now button label text.
 	 *
-	 * @since 2.7.0
 	 * @return string
+	 * @since 2.7.0
 	 */
 	public function getDonateNowButtonLabel() {
 		return __( 'Donate Now', 'give' );
@@ -218,8 +221,8 @@ abstract class Template {
 	/**
 	 * Get continue to donation form button label text.
 	 *
-	 * @since 2.7.0
 	 * @return string
+	 * @since 2.7.0
 	 */
 	public function getContinueToDonationFormLabel() {
 		return __( 'Donate Now', 'give' );
@@ -228,8 +231,8 @@ abstract class Template {
 	/**
 	 * Get donation introduction text.
 	 *
-	 * @since 2.7.0
 	 * @return string|null
+	 * @since 2.7.0
 	 */
 	public function getDonationIntroductionContent() {
 		return null;
@@ -251,10 +254,10 @@ abstract class Template {
 	/**
 	 * Get receipt details.
 	 *
-	 * @since 2.7.0
-	 * @param int $donationId
+	 * @param  int  $donationId
 	 *
 	 * @return DonationReceipt
+	 * @since 2.7.0
 	 */
 	public function getReceiptDetails( $donationId ) {
 		$receipt = new DonationReceipt( $donationId );
@@ -275,7 +278,7 @@ abstract class Template {
 	 * @param  int  $formId
 	 *
 	 * @return string
-	 *@since 2.7.0
+	 * @since 2.7.0
 	 *
 	 */
 	abstract public function getFormHeading( $formId );
@@ -286,9 +289,9 @@ abstract class Template {
 	 * @param  int  $formId
 	 *
 	 * @return string
-	 *@since 2.7.0
- *
- */
+	 * @since 2.7.0
+	 *
+	 */
 	abstract public function getFormFeaturedImage( $formId );
 
 	/**
@@ -298,7 +301,7 @@ abstract class Template {
 	 *
 	 * @return string
 	 * @since 2.7.0
- *
- */
+	 *
+	 */
 	abstract public function getFormExcerpt( $formId );
 }

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -10,6 +10,7 @@
 namespace Give\Form;
 
 use Give\Form\Template\Options;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Receipt\DonationReceipt;
 
@@ -267,4 +268,37 @@ abstract class Template {
 
 		return $receipt;
 	}
+
+	/**
+	 * Get form heading
+	 *
+	 * @param  int  $formId
+	 *
+	 * @return string
+	 *@since 2.7.0
+	 *
+	 */
+	abstract public function getFormHeading( $formId );
+
+	/**
+	 * Get form image
+	 *
+	 * @param  int  $formId
+	 *
+	 * @return string
+	 *@since 2.7.0
+ *
+ */
+	abstract public function getFormFeaturedImage( $formId );
+
+	/**
+	 * Get form excerpt
+	 *
+	 * @param  int|null  $formId
+	 *
+	 * @return string
+	 * @since 2.7.0
+ *
+ */
+	abstract public function getFormExcerpt( $formId );
 }

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -338,7 +338,7 @@ class Sequoia extends Template implements Hookable, Scriptable {
 
 		return ! empty( $templateOptions['introduction']['image'] ) ?
 			$templateOptions['introduction']['image'] :
-			get_the_post_thumbnail_url( $formId );
+			get_the_post_thumbnail_url( $formId, 'full' );
 	}
 
 	/**

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -306,4 +306,55 @@ class Sequoia extends Template implements Hookable, Scriptable {
 
 		return $receipt;
 	}
+
+	/**
+	 * Get form heading
+	 *
+	 * @param  int  $formId
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 *
+	 */
+	public function getFormHeading( $formId ) {
+		$templateOptions = FormTemplateUtils::getOptions( $formId );
+
+		return ! empty( $templateOptions['introduction']['headline'] ) ?
+			$templateOptions['introduction']['headline'] :
+			get_the_title( $formId );
+	}
+
+	/**
+	 * Get form image
+	 *
+	 * @param  int  $formId
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 *
+	 */
+	public function getFormFeaturedImage( $formId ) {
+		$templateOptions = FormTemplateUtils::getOptions( $formId );
+
+		return ! empty( $templateOptions['introduction']['image'] ) ?
+			$templateOptions['introduction']['image'] :
+			get_the_post_thumbnail_url( $formId );
+	}
+
+	/**
+	 * Get form excerpt
+	 *
+	 * @param  int|null  $formId
+	 *
+	 * @return string
+	 * @since 2.7.0
+	 *
+	 */
+	public function getFormExcerpt( $formId ) {
+		$templateOptions = FormTemplateUtils::getOptions( $formId );
+
+		return ! empty( $templateOptions['introduction']['description'] ) ?
+			$templateOptions['introduction']['description'] :
+			get_the_excerpt( $formId );
+	}
 }

--- a/src/Views/Form/Templates/Sequoia/sections/introduction.php
+++ b/src/Views/Form/Templates/Sequoia/sections/introduction.php
@@ -1,13 +1,17 @@
 <?php
 
+use Give\Helpers\Form\Template;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 
 $formInfo = get_post( FrontendFormTemplateUtils::getFormId() );
 
+/* @var \Give\Form\Template $formTemplate */
+$formTemplate = Give()->templates->getTemplate();
+
 // Get headline and description
-$headline    = ! empty( $this->templateOptions['introduction']['headline'] ) ? $this->templateOptions['introduction']['headline'] : $formInfo->post_title;
-$description = ! empty( $this->templateOptions['introduction']['description'] ) ? $this->templateOptions['introduction']['description'] : $formInfo->post_excerpt;
-$image       = ! empty( $this->templateOptions['introduction']['image'] ) ? $this->templateOptions['introduction']['image'] : get_the_post_thumbnail_url( FrontendFormTemplateUtils::getFormId() );
+$headline    = $formTemplate->getFormHeading( $formInfo->ID );
+$description = $formTemplate->getFormExcerpt( $formInfo->ID );
+$image       = $formTemplate->getFormFeaturedImage( $formInfo->ID );
 ?>
 
 <div class="give-section introduction">

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -188,7 +188,7 @@ class IframeView {
 				%1$s
 				%4$s
 				data-autoScroll="%2$s"
-				onload="Give.initializeIframeResize(this)"
+				onload="if( \'undefined\' !== typeof Give ) { Give.initializeIframeResize(this) }"
 				style="border: 0;visibility: hidden;%3$s"></iframe>%5$s',
 			$this->modal ? "data-src=\"{$this->url}\"" : "src=\"{$this->url}\"",
 			$this->autoScroll,

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -4,6 +4,7 @@
  */
 
 // Exit if accessed directly.
+use Give\Helpers\Form\Template;
 use Give\Helpers\Form\Utils as FormUtils;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +17,10 @@ $atts             = $args[1]; // Shortcode attributes.
 $raw_content      = ''; // Raw form content.
 $stripped_content = ''; // Form content stripped of HTML tags and shortcodes.
 $excerpt          = ''; // Trimmed form excerpt ready for display.
+
+
+/* @var \Give\Form\Template $formTemplate */
+$formTemplate = Give()->templates->getTemplate( Template::getActiveID( $form_id ) );
 ?>
 
 <div class="give-grid__item">
@@ -39,14 +44,15 @@ $excerpt          = ''; // Trimmed form excerpt ready for display.
 			<?php
 			// Maybe display the form title.
 			if ( true === $atts['show_title'] ) {
-				the_title( '<h3 class="give-card__title">', '</h3>' );
+				printf(
+					'<h3 class="give-card__title">%1$s</h3>',
+					$formTemplate->getFormHeading( $form_id )
+				);
 			}
 
 			// Maybe display the form excerpt.
 			if ( true === $atts['show_excerpt'] ) {
-				if ( has_excerpt( $form_id ) ) {
-					// Get excerpt from the form post's excerpt field.
-					$raw_content      = get_the_excerpt( $form_id );
+				if ( $raw_content = $formTemplate->getFormExcerpt( $form_id ) ) {
 					$stripped_content = wp_strip_all_tags(
 						strip_shortcodes( $raw_content )
 					);
@@ -87,7 +93,7 @@ $excerpt          = ''; // Trimmed form excerpt ready for display.
 		// Maybe display the featured image.
 		if (
 			give_is_setting_enabled( $give_settings['form_featured_img'] )
-			&& has_post_thumbnail()
+			&& ( $imageSrc = $formTemplate->getFormFeaturedImage( $form_id ) )
 			&& true === $atts['show_featured_image']
 		) {
 			/*
@@ -99,14 +105,16 @@ $excerpt          = ''; // Trimmed form excerpt ready for display.
 			$image_size = apply_filters( 'give_form_grid_image_size', $atts['image_size'], $atts );
 			$image_attr = '';
 
-			echo '<div class="give-card__media">';
 			if ( 'auto' !== $atts['image_height'] ) {
-				$image_attr = array(
+				$image_attr = [
 					'style' => 'height: ' . $atts['image_height'],
-				);
+				];
 			}
-				the_post_thumbnail( $image_size, $image_attr );
-			echo '</div>';
+
+			printf(
+				'<div class="give-card__media">%1$s</div>',
+				wp_get_attachment_image( attachment_url_to_postid( $imageSrc ), $image_size, false, $image_attr )
+			);
 		}
 		?>
 	</a>


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolved #4844 

This patch will add logic to show fallback values correctly for heading, description, and image in form grid.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
Changes of this patch are limited to `Template`  class, `Sequoia` class, and default form grid template.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is Form template settings (heading, description, and featured image) reflecting on the frontend as expected?
- [x] Is Form template settings (heading, description, and featured image) reflecting on the frontend as expected in form grid shortcode?


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
