### PR TITLE
fix: #4714 View payement detail of a deleted Donor

### DIFF
--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -606,12 +606,17 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 
 												// Check whether the donor name and WP_User name is same or not.
 												if ( $donor_billing_name !== $donor_name ) {
-													echo sprintf(
-														'%1$s (<a href="%2$s" target="_blank">%3$s</a>)',
-														esc_html( $donor_billing_name ),
-														esc_url( admin_url( "edit.php?post_type=give_forms&page=give-donors&view=overview&id={$donor_id}" ) ),
-														esc_html( $donor_name )
-													);
+													// Donors can be deleted by the user, but we can show the donor billing name from donation details.
+													if ( empty( $donor_name ) ) {
+														echo esc_html( $donor_billing_name );
+													} else {
+														echo sprintf(
+															'%1$s (<a href="%2$s" target="_blank">%3$s</a>)',
+															esc_html( $donor_billing_name ),
+															esc_url( admin_url( "edit.php?post_type=give_forms&page=give-donors&view=overview&id={$donor_id}" ) ),
+															esc_html( $donor_name )
+														);
+													}
 												} else {
 													echo esc_html( $donor_name );
 												}
@@ -621,7 +626,7 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 												<strong><?php esc_html_e( 'Donor Email:', 'give' ); ?></strong><br>
 												<?php
 												// Show Donor donation email first and Primary email on parenthesis if not match both email.
-												echo hash_equals( $donor->email, $payment->email )
+												echo ( empty( $donor->email ) || hash_equals( $donor->email, $payment->email ) )
 													? $payment->email
 													: sprintf(
 														'%1$s (<a href="%2$s" target="_blank">%3$s</a>)',


### PR DESCRIPTION
## Description
Resolves #4714 

## Affects
Donor Details meta box on the Donation detail screen

## What to test
Create a test donation, then go to Donors screen and delete the donor without deleting all associated donations and records. Now go to Donations screen and view donation payment details. Donor name and email should be displayed.

## Screenshots:
![image](https://user-images.githubusercontent.com/4222590/85207915-79b41780-b32c-11ea-9b44-b9cbb28ce898.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
