### PR TITLE
fix: receipt now scrolls into view after processing donation

### DIFF
--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -26,7 +26,6 @@ export const initializeIframeResize = function( iframe ) {
 
 				switch ( messageData.message.action ) {
 					case 'giveEmbedFormContentLoaded':
-
 						const timer = setTimeout( function() {
 							revealIframe();
 						}, 400 );
@@ -51,6 +50,7 @@ export const initializeIframeResize = function( iframe ) {
 				} );
 				iframe.contentWindow.addEventListener( 'beforeunload', function() {
 					if ( parentUnload === false ) {
+						iframe.scrollIntoView( { behavior: 'smooth', inline: 'nearest' } );
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.opacity = 1;
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.transition = '';
 						iframe.style.visibility = 'hidden';

--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -39,21 +39,26 @@ export const initializeIframeResize = function( iframe ) {
 							parent.querySelector( '.iframe-loader' ).style.transition = 'opacity 0.2s ease';
 							iframe.style.visibility = 'visible';
 							iframe.style.minHeight = '';
+							parent.style.minHeight = iframe.offsetHeight;
 						}
 						break;
 				}
 			},
 			onInit: function() {
+				const parent = iframe.parentElement;
+
 				let parentUnload = false;
 				window.addEventListener( 'beforeunload', function() {
 					parentUnload = true;
 				} );
+
 				iframe.contentWindow.addEventListener( 'beforeunload', function() {
 					if ( parentUnload === false ) {
 						iframe.scrollIntoView( { behavior: 'smooth', inline: 'nearest' } );
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.opacity = 1;
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.transition = '';
 						iframe.style.visibility = 'hidden';
+						parent.style.minHeight = iframe.offsetHeight;
 					}
 				} );
 

--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -39,7 +39,7 @@ export const initializeIframeResize = function( iframe ) {
 							parent.querySelector( '.iframe-loader' ).style.transition = 'opacity 0.2s ease';
 							iframe.style.visibility = 'visible';
 							iframe.style.minHeight = '';
-							parent.style.minHeight = iframe.offsetHeight;
+							parent.style.height = null;
 						}
 						break;
 				}
@@ -58,7 +58,7 @@ export const initializeIframeResize = function( iframe ) {
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.opacity = 1;
 						iframe.parentElement.querySelector( '.iframe-loader' ).style.transition = '';
 						iframe.style.visibility = 'hidden';
-						parent.style.minHeight = iframe.offsetHeight;
+						parent.style.height = '700px';
 					}
 				} );
 


### PR DESCRIPTION
## Description
Resolves #4847 
This PR introduces frontend logic to ensure that when a donation is processed, the receipt page is scrolled into the viewport. Previously, when a donation processed, if the payment form was especially long (had multiple gateways or fields) it meant that a user would scroll down to the "donate" button, then have to manually scroll up to see the receipt when it loaded. This PR ensures that the viewport is autoscrolled when the receipt appears.

## Affects
This PR affects the frontend javascript logic for frontend forms, specifically causing the viewport to scroll so that the top of the receipt is in view when it loads. 

## What to test
Setup a form with multiple gateways/additional fields (eg enable "company" field). 
- [x] When you process a donation, does the window auto scroll so that the top of the receipt is in view?

## Screenshots:
![PRDemo](https://user-images.githubusercontent.com/5186078/85316166-25ff1680-b471-11ea-8fe1-0e007cda8d62.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
