### PR TITLE
prevent live donation in WP backend

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -1054,6 +1054,11 @@ class Give_MetaBox_Form_Data {
 	 * @param int    $formID
 	 */
 	public function save_form_template_settings( $meta_key, $new_template, $formID ) {
+		// Save setting for new template only if it is not empty.
+		if ( ! $new_template ) {
+			return;
+		}
+
 		$options = $_POST[ $new_template ];
 
 		// Exit

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -12,6 +12,7 @@ namespace Give\Form;
 use _WP_Dependency;
 use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
+use Give\Helpers\Form\Utils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
@@ -199,7 +200,7 @@ class LoadTemplate {
 	 * @since 2.7.0
 	 */
 	public function disableDonationButtonInPreviewMode( $buttonHtml, $formId ) {
-		if ( $formId === (int) FormTemplateUtils\Utils\Frontend::getPreviewDonationFormId() ) {
+		if ( Utils::canDisableDonationNowButton() ) {
 			$search = 'input type="submit"';
 
 			$buttonHtml = str_replace(

--- a/src/Helpers/Form/Template/Utils/Frontend.php
+++ b/src/Helpers/Form/Template/Utils/Frontend.php
@@ -67,6 +67,7 @@ class Frontend {
 
 	/**
 	 * Return form id if admin previewing donation form.
+	 * Note: only for internal use. This function can be update or remove in future.
 	 *
 	 * @return int|null
 	 * @since 2.7.0

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -205,4 +205,14 @@ class Utils {
 
 		return ! $formTemplate || 'legacy' === Template::getActiveID( $formID );
 	}
+
+	/**
+	 * Return whether or not disable donate now button.
+	 *
+	 * @since 2.7.0
+	 * @return bool
+	 */
+	public static function canDisableDonationNowButton(){
+		return ! empty( $_GET['giveDisableDonateNowButton'] );
+	}
 }

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -212,7 +212,7 @@ class Utils {
 	 * @since 2.7.0
 	 * @return bool
 	 */
-	public static function canDisableDonationNowButton(){
+	public static function canDisableDonationNowButton() {
 		return ! empty( $_GET['giveDisableDonateNowButton'] );
 	}
 }

--- a/src/Route/Form.php
+++ b/src/Route/Form.php
@@ -10,6 +10,7 @@
 namespace Give\Route;
 
 use Give\Controller\Form as Controller;
+use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -172,7 +173,9 @@ class Form {
 				)
 			);
 
-			$formId = $form->ID;
+			if ( $form instanceof WP_Post ) {
+				$formId = $form->ID;
+			}
 		}
 
 		return $formId;

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -169,13 +169,23 @@ class IframeView {
 	}
 
 	/**
+	 * Return whether or not rest api request to render donation form block.
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	private function isDonationFormBlockRendererApiRequest() {
+		return false !== strpos( $_SERVER['REQUEST_URI'], rest_get_url_prefix() . '/wp/v2/block-renderer/give/donation-form' );
+	}
+
+	/**
 	 * Extra extra query param to iframe url.
 	 *
 	 * @since 2.7.0
 	 */
 	private function addExtraQueryParams() {
 		// We can prevent live donation on in appropriate situation like: previewing donation form (with draft status)
-		if ( FormTemplateUtils\Utils\Frontend::getPreviewDonationFormId() ) {
+		if ( FormTemplateUtils\Utils\Frontend::getPreviewDonationFormId() || $this->isDonationFormBlockRendererApiRequest() ) {
 			$this->url = add_query_arg(
 				[ 'giveDisableDonateNowButton' => 1 ],
 				$this->url

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -109,7 +109,7 @@ class IframeView {
 	 */
 	public function setURL( $url = null ) {
 		$this->url = add_query_arg(
-			array_merge( [ 'giveDonationFormInIframe' => 1 ] ),
+			[ 'giveDonationFormInIframe' => 1 ],
 			$url
 		);
 

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -169,6 +169,21 @@ class IframeView {
 	}
 
 	/**
+	 * Extra extra query param to iframe url.
+	 *
+	 * @since 2.7.0
+	 */
+	private function addExtraQueryParams() {
+		// We can prevent live donation on in appropriate situation like: previewing donation form (with draft status)
+		if ( FormTemplateUtils\Utils\Frontend::getPreviewDonationFormId() ) {
+			$this->url = add_query_arg(
+				[ 'giveDisableDonateNowButton' => 1 ],
+				$this->url
+			);
+		}
+	}
+
+	/**
 	 * Get iframe HTML.
 	 *
 	 * @return string
@@ -289,6 +304,8 @@ class IframeView {
 		$this->minHeight    = $this->template->getFormStartingHeight( $this->formId );
 
 		$this->url = $this->url ?: $this->getIframeURL();
+
+		$this->addExtraQueryParams();
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4850 

In this pr, we added logic to disable `Donate Now` button when donation form renders in wp backed.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr mostly affects `iframeView.php`.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is admin NOT able to donate in donation form preview mode?
- [x] Is admin NOT able to donate from donation form block in Gutenberg editor?
- [x] Is the donor able to donate from the frontend?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
