### PR TITLE
show  SEPA Mandate acceptance text setting on fresh install

### DIFF
--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -418,7 +418,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						],
 					];
 
-					$is_hide_icon = give_is_setting_enabled( give_get_option( 'stripe_hide_icon' ) );
+					$is_hide_icon = give_is_setting_enabled( give_get_option( 'stripe_hide_icon', 'enabled' ) );
 
 					$settings['sepa'][] = [
 						'name'          => __( 'Icon Style', 'give' ),
@@ -446,7 +446,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						],
 					];
 
-					$is_hide_mandate = give_is_setting_enabled( give_get_option( 'stripe_mandate_acceptance_option' ) );
+					$is_hide_mandate = give_is_setting_enabled( give_get_option( 'stripe_mandate_acceptance_option', 'enabled' ) );
 
 					$settings['sepa'][] = [
 						'name'          => __( 'Mandate Acceptance Text', 'give' ),


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4855 

I find out that default value was not to `enabled` when accessing settings which cause of hiding other settings.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr will affect stripe setting registration code.


## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Can you see  `Icon Style` and `Mandate Acceptance Text` setting on a fresh install?
- [x] Do these settings toggle correctly?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
