### PR TITLE
resolve conflict with "All 404 Redirect to Homepage" plugin

### DIFF
--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -37,34 +37,11 @@ class Form {
 	 * @since 2.7.0
 	 */
 	public function init() {
-		add_filter( 'pre_handle_404', [ $this, 'doNotSetEmbedIframeURLAs404' ], 99, 2 );
 		add_action( 'wp', [ $this, 'loadTemplateOnFrontend' ], 11, 0 );
 		add_action( 'admin_init', [ $this, 'loadTemplateOnAjaxRequest' ] );
 		add_action( 'init', [ $this, 'embedFormRedirectURIHandler' ], 1 );
 		add_action( 'template_redirect', [ $this, 'loadReceiptView' ], 1 );
 		add_action( 'give_before_single_form_summary', [ $this, 'handleSingleDonationFormPage' ], 0 );
-	}
-
-	/**
-	 * Return true if embed iframe url otherwise false.
-	 * Note: few plugins redirect 404 urls to url, to prevent this we adding status handling logic.
-	 *
-	 * @param bool $status
-	 * @param WP_Query $wp_query
-	 *
-	 * @return bool
-	 * @since 2.7.0
-	 */
-	public function doNotSetEmbedIframeURLAs404( $status, $wp_query ) {
-		$base = Give()->routeForm->getBase();
-
-		if ( $base === get_query_var( 'name' ) ) {
-			$wp_query->is_404 = false;
-
-			return true;
-		}
-
-		return $status;
 	}
 
 	/**

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -20,6 +20,7 @@ use Give_Notices;
 use WP_Post;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use WP_Query;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,11 +37,34 @@ class Form {
 	 * @since 2.7.0
 	 */
 	public function init() {
+		add_filter( 'pre_handle_404', [ $this, 'doNotSetEmbedIframeURLAs404' ], 99, 2 );
 		add_action( 'wp', [ $this, 'loadTemplateOnFrontend' ], 11, 0 );
 		add_action( 'admin_init', [ $this, 'loadTemplateOnAjaxRequest' ] );
 		add_action( 'init', [ $this, 'embedFormRedirectURIHandler' ], 1 );
 		add_action( 'template_redirect', [ $this, 'loadReceiptView' ], 1 );
 		add_action( 'give_before_single_form_summary', [ $this, 'handleSingleDonationFormPage' ], 0 );
+	}
+
+	/**
+	 * Return true if embed iframe url otherwise false.
+	 * Note: few plugins redirect 404 urls to url, to prevent this we adding status handling logic.
+	 *
+	 * @param bool $status
+	 * @param WP_Query $wp_query
+	 *
+	 * @return bool
+	 * @since 2.7.0
+	 */
+	public function doNotSetEmbedIframeURLAs404( $status, $wp_query ) {
+		$base = Give()->routeForm->getBase();
+
+		if ( $base === get_query_var( 'name' ) ) {
+			$wp_query->is_404 = false;
+
+			return true;
+		}
+
+		return $status;
 	}
 
 	/**

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -16,7 +16,7 @@ class Utils {
 		$base = Give()->routeForm->getBase();
 
 		return (
-			$base === get_query_var( 'name' ) ||
+			$base === get_query_var( 'url_prefix' ) ||
 			( wp_doing_ajax() && false !== strpos( wp_get_referer(), "/{$base}/" ) ) // for ajax
 		);
 	}

--- a/src/Route/Form.php
+++ b/src/Route/Form.php
@@ -77,7 +77,7 @@ class Form {
 		add_rewrite_rule(
 			"{$this->base}/(.+?)/?$",
 			sprintf(
-				'index.php?name=%1$s&give_form_id=$matches[1]',
+				'index.php?url_prefix=%1$s&give_form_id=$matches[1]',
 				$this->base
 			),
 			'top'
@@ -95,6 +95,7 @@ class Form {
 	 */
 	public function addQueryVar( $queryVars ) {
 		$queryVars[] = 'give_form_id';
+		$queryVars[] = 'url_prefix';
 
 		return $queryVars;
 	}


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4865 

I find out that `name` query var in custom rewrite URL was the cause to set `is_404` to `true`. I rename it to `url_prefix` to resolve the issue.

**Note: you have to reset permalink before testing this pr.**

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr only rename query var `name --> url_prefix`.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Are you able to view donation form when "All 404 Redirect to Homepage" plugin enabled?
- [x] Are you able to view donation form without "All 404 Redirect to Homepage" plugin?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
