### PR TITLE
fix: terms and agreements now appears before Google/Apple pay buttons in Legacy Forms

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string Donation form.
  * @since 1.0
  */
-function give_get_donation_form( $args = array() ) {
+function give_get_donation_form( $args = [] ) {
 
 	global $post;
 	static $count = 1;
@@ -62,9 +62,9 @@ function give_get_donation_form( $args = array() ) {
 	$form_action = add_query_arg(
 		apply_filters(
 			'give_form_action_args',
-			array(
+			[
 				'payment-mode' => $payment_mode,
-			)
+			]
 		),
 		give_get_current_page_url()
 	);
@@ -132,12 +132,12 @@ function give_get_donation_form( $args = array() ) {
 			do_action( 'give_pre_form', $form->ID, $args, $form );
 
 			// Set form html tags.
-			$form_html_tags = array(
+			$form_html_tags = [
 				'id'      => "give-form-{$args['id_prefix']}",
 				'class'   => $form_classes,
 				'action'  => esc_url_raw( $form_action ),
 				'data-id' => $args['id_prefix'],
-			);
+			];
 
 			/**
 			 * Filter the form html tags.
@@ -391,7 +391,7 @@ add_action( 'give_donation_form_register_login_fields', 'give_show_register_logi
  * @return void
  * @since  1.0
  */
-function give_output_donation_amount_top( $form_id = 0, $args = array() ) {
+function give_output_donation_amount_top( $form_id = 0, $args = [] ) {
 
 	$give_options        = give_get_settings();
 	$variable_pricing    = give_has_variable_prices( $form_id );
@@ -401,10 +401,10 @@ function give_output_donation_amount_top( $form_id = 0, $args = array() ) {
 	$currency_output     = '<span class="give-currency-symbol give-currency-position-' . $currency_position . '">' . $symbol . '</span>';
 	$default_amount      = give_format_amount(
 		give_get_default_form_amount( $form_id ),
-		array(
+		[
 			'sanitize' => false,
 			'currency' => give_get_currency( $form_id ),
-		)
+		]
 	);
 	$custom_amount_text  = give_get_meta( $form_id, '_give_custom_amount_text', true );
 
@@ -533,15 +533,15 @@ function give_output_levels( $form_id ) {
 			$output .= '<ul id="give-donation-level-button-wrap" class="give-donation-levels-wrap give-list-inline">';
 
 			foreach ( $prices as $price ) {
-				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
+				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], [ 'sanitize' => false ] ), [ 'currency_code' => give_get_currency( $form_id ) ] ), $form_id, $price );
 				$level_classes = apply_filters( 'give_form_level_classes', 'give-donation-level-btn give-btn give-btn-level-' . $price['_give_id']['level_id'] . ' ' . ( give_is_default_level_id( $price ) ? 'give-default-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'],
-					array(
+					[
 						'sanitize' => false,
 						'currency' => give_get_currency( $form_id ),
-					)
+					]
 				);
 
 				$output .= sprintf(
@@ -574,15 +574,15 @@ function give_output_levels( $form_id ) {
 			$output .= '<ul id="give-donation-level-radio-list" class="give-donation-levels-wrap">';
 
 			foreach ( $prices as $price ) {
-				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
+				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], [ 'sanitize' => false ] ), [ 'currency_code' => give_get_currency( $form_id ) ] ), $form_id, $price );
 				$level_classes = apply_filters( 'give_form_level_classes', 'give-radio-input give-radio-input-level give-radio-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ), $form_id, $price );
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'],
-					array(
+					[
 						'sanitize' => false,
 						'currency' => give_get_currency( $form_id ),
-					)
+					]
 				);
 
 				$output .= sprintf(
@@ -617,7 +617,7 @@ function give_output_levels( $form_id ) {
 
 			// first loop through prices.
 			foreach ( $prices as $price ) {
-				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], array( 'sanitize' => false ) ), array( 'currency_code' => give_get_currency( $form_id ) ) ), $form_id, $price );
+				$level_text    = apply_filters( 'give_form_level_text', ! empty( $price['_give_text'] ) ? $price['_give_text'] : give_currency_filter( give_format_amount( $price['_give_amount'], [ 'sanitize' => false ] ), [ 'currency_code' => give_get_currency( $form_id ) ] ), $form_id, $price );
 				$level_classes = apply_filters(
 					'give_form_level_classes',
 					'give-donation-level-' . $price['_give_id']['level_id'] . ( give_is_default_level_id( $price ) ? ' give-default-level' : '' ),
@@ -627,10 +627,10 @@ function give_output_levels( $form_id ) {
 
 				$formatted_amount = give_format_amount(
 					$price['_give_amount'],
-					array(
+					[
 						'sanitize' => false,
 						'currency' => give_get_currency( $form_id ),
-					)
+					]
 				);
 
 				$output .= sprintf(
@@ -1383,13 +1383,13 @@ function give_get_register_fields( $form_id ) {
 					$id                = 'give-create-account-' . $form_id;
 					if ( ! give_is_setting_enabled( $is_guest_checkout ) ) {
 						echo Give()->tooltips->render(
-							array(
+							[
 								'tag_content' => sprintf(
 									'<input type="checkbox" name="give_create_account" value="on" id="%s" class="give-input give-disabled" checked />',
 									$id
 								),
 								'label'       => __( 'Registration is required to donate.', 'give' ),
-							)
+							]
 						);
 					} else {
 						?>
@@ -1650,7 +1650,7 @@ function give_payment_mode_select( $form_id, $args ) {
 				$give_settings    = give_get_settings();
 				$gateways_label   = array_key_exists( 'gateways_label', $give_settings ) ?
 					$give_settings['gateways_label'] :
-					array();
+					[];
 
 				foreach ( $gateways as $gateway_id => $gateway ) :
 					// Determine the default gateway.
@@ -1819,7 +1819,7 @@ function give_terms_agreement( $form_id ) {
 	<?php
 }
 
-add_action( 'give_donation_form_after_cc_form', 'give_terms_agreement', 8888, 1 );
+add_action( 'give_donation_form_after_cc_form', 'give_terms_agreement', 9, 1 );
 
 /**
  * Checkout Final Total.
@@ -1834,7 +1834,7 @@ add_action( 'give_donation_form_after_cc_form', 'give_terms_agreement', 8888, 1 
 function give_checkout_final_total( $form_id ) {
 
 	$total = isset( $_POST['give_total'] ) ?
-		apply_filters( 'give_donation_total', give_maybe_sanitize_amount( $_POST['give_total'], array( 'currency' => give_get_currency( $form_id ) ) ) ) :
+		apply_filters( 'give_donation_total', give_maybe_sanitize_amount( $_POST['give_total'], [ 'currency' => give_get_currency( $form_id ) ] ) ) :
 		give_get_default_form_amount( $form_id );
 
 	// Only proceed if give_total available.
@@ -1855,17 +1855,17 @@ function give_checkout_final_total( $form_id ) {
 			<?php echo apply_filters( 'give_donation_total_label', esc_html__( 'Donation Total:', 'give' ) ); ?>
 		</span>
 		<span class="give-final-total-amount"
-			  data-total="<?php echo give_format_amount( $total, array( 'sanitize' => false ) ); ?>">
+			  data-total="<?php echo give_format_amount( $total, [ 'sanitize' => false ] ); ?>">
 			<?php
 			echo give_currency_filter(
 				give_format_amount(
 					$total,
-					array(
+					[
 						'sanitize' => false,
 						'currency' => give_get_currency( $form_id ),
-					)
+					]
 				),
-				array( 'currency_code' => give_get_currency( $form_id ) )
+				[ 'currency_code' => give_get_currency( $form_id ) ]
 			);
 			?>
 		</span>
@@ -1929,7 +1929,7 @@ add_action( 'give_donation_form_after_cc_form', 'give_checkout_submit', 9999, 2 
  * @return string
  * @since  1.8.8
  */
-function give_get_donation_form_submit_button( $form_id, $args = array() ) {
+function give_get_donation_form_submit_button( $form_id, $args = [] ) {
 
 	$display_label_field = give_get_meta( $form_id, '_give_checkout_label', true );
 	$display_label_field = apply_filters( 'give_donation_form_submit_button_text', $display_label_field, $form_id, $args );
@@ -1957,15 +1957,15 @@ function give_get_donation_form_submit_button( $form_id, $args = array() ) {
  *
  * @since        1.0
  */
-function give_show_goal_progress( $form_id, $args = array() ) {
+function give_show_goal_progress( $form_id, $args = [] ) {
 
 	ob_start();
 	give_get_template(
 		'shortcode-goal',
-		array(
+		[
 			'form_id' => $form_id,
 			'args'    => $args,
-		)
+		]
 	);
 
 	/**
@@ -1999,10 +1999,10 @@ function give_show_goal_totals_progress( $total, $total_goal ) {
 	ob_start();
 	give_get_template(
 		'shortcode-totals-progress',
-		array(
+		[
 			'total'      => $total,
 			'total_goal' => $total_goal,
-		)
+		]
 	);
 
 	echo apply_filters( 'give_total_progress_output', ob_get_clean() );
@@ -2026,10 +2026,10 @@ function give_get_form_content_placement( $form_id, $args ) {
 
 	if ( isset( $args['show_content'] ) && ! empty( $args['show_content'] ) ) {
 		// Content positions.
-		$content_placement = array(
+		$content_placement = [
 			'above' => 'give_pre_form',
 			'below' => 'give_post_form',
-		);
+		];
 
 		// Check if content position already decoded.
 		if ( in_array( $args['show_content'], $content_placement ) ) {
@@ -2138,7 +2138,7 @@ function give_form_display_content( $form_id, $args ) {
  * @return void
  * @since 1.0
  */
-function give_checkout_hidden_fields( $form_id, $args = array() ) {
+function give_checkout_hidden_fields( $form_id, $args = [] ) {
 
 	/**
 	 * Fires while rendering hidden checkout fields, before the fields.
@@ -2425,10 +2425,10 @@ function give_redirect_and_popup_form( $redirect, $args ) {
 
 		// Add query parameters 'form-id' and 'payment-mode'.
 		$redirect = add_query_arg(
-			array(
+			[
 				'form-id'      => $form_id,
 				'payment-mode' => $payment_mode,
-			),
+			],
 			$redirect
 		);
 	}


### PR DESCRIPTION
## Description
Resolves #4871 
This PR improves the placement of the Terms Agreement markup in Legacy Forms by ensuring that it is added before the Apple/Google Pay functions added by the Give Stripe addon. Previously, when an admin enabled Apple/Google Pay on a form using the Legacy Form template, the Terms Agreement checkbox would appear below the Donate button. 

## Affects
This PR affects Form Template rendering, specifically where the Terms Agreement checkbox is rendered. It changes the index the Terms Agreement output function is hooked into the `give_after_cc_fields` action, so that the Term Agreement function executes before Give Stripe adds the Donate button for Google/Apple pay gateways.

## What to test
_With the Give Addon enabled, setup a Legacy form using the Apple/Google pay gateway._
- [ ] Does the Terms Agreement checkbox appear before the Apple/Google pay button?
- [ ] When not using Apple/Google Pay, does the Terms Agreement checkbox appear before the Donate button?

_With the Give Addon enabled, setup a Multi-Step form using the Apple/Google pay gateway._
- [ ] Does the Terms Agreement checkbox appear before the Apple/Google pay button?
- [ ] When not using Apple/Google Pay, does the Terms Agreement checkbox appear before the Donate button?

## Screenshots:
<img width="550" alt="Screen Shot 2020-06-26 at 1 25 08 PM" src="https://user-images.githubusercontent.com/5186078/85898106-844d3180-b7b0-11ea-9d5b-f9f19f900b95.png">

<img width="582" alt="Screen Shot 2020-06-26 at 1 24 24 PM" src="https://user-images.githubusercontent.com/5186078/85898116-86af8b80-b7b0-11ea-9bf9-282e16ae3b41.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
