### PR TITLE
resolve WeGlot conflict with new form template in 2.7

### DIFF
--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -20,7 +20,6 @@ use Give_Notices;
 use WP_Post;
 use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
-use WP_Query;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1319,6 +1319,11 @@ form.give-form .form-row select.multiselect {
 	}
 }
 
+/* Hide everything which is not output by Give core or addon */
+body > *:not([class^='give']):not([id^='give']) {
+	display: none;
+}
+
 @keyframes slideInRight {
 	from {
 		transform: translate3d(100%, 0, 0);


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4866 

I find out that `WeGlot` plugin starts an output buffer (as you can see in the screenshot) which prints output on the screen when WordPress ran a  [wp_ob_end_flush_all](https://github.com/WordPress/WordPress/blob/5a60d4b3b00e0a2406c709a0d798e201cb46f347/wp-includes/default-filters.php#L354) function on `shutdown` hook.

![image](https://user-images.githubusercontent.com/1784821/85998547-920cec00-ba28-11ea-8bfb-a4c71e0251ef.png)

As per my research, I did not find the best way to resolve this conflict but I think it will be good to hide everything which is not output for Give donation form. As you can see in pr code I add a CSS to hide all DOM element in `body` whose `id/class` does not start with `give`

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr affect donation form view.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [ ] Is the donation form look fine?
- [ ] Can you process donations with donation form?
- [ ] Is the information on receipt correct?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
