### PR TITLE
fix: trend percentage rounding is now based on significant digits

### DIFF
--- a/assets/src/js/admin/reports/components/mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/index.js
@@ -47,7 +47,7 @@ const MiniChart = ( { title, data } ) => {
 
 	useEffect( () => {
 		const newHighlightValue = getHighlightValue( data );
-		const newTrend = getTrend( data ) === 0 ? 0 : numberToDigits( getTrend( data ), 2, 2 );
+		const newTrend = getTrend( data ) === 0 ? 0 : numberToDigits( getTrend( data ), 3, 2 );
 		const newTooltipText = getTooltipText( data );
 		let newIndicator;
 

--- a/assets/src/js/admin/reports/components/mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/index.js
@@ -47,7 +47,7 @@ const MiniChart = ( { title, data } ) => {
 
 	useEffect( () => {
 		const newHighlightValue = getHighlightValue( data );
-		const newTrend = getTrend( data );
+		const newTrend = getTrend( data ) === 0 ? 0 : numberToDigits( getTrend( data ), 2, 2 );
 		const newTooltipText = getTooltipText( data );
 		let newIndicator;
 
@@ -56,7 +56,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ down }
 					<span style={ { color: '#D75A4B' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
+						{ `${ Math.abs( newTrend ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -65,7 +65,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ up }
 					<span style={ { color: '#69B868' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
+						{ `${ Math.abs( newTrend ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -73,7 +73,7 @@ const MiniChart = ( { title, data } ) => {
 			default: {
 				newIndicator = <Fragment>
 					<span style={ { color: '#82878c' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
+						{ `${ Math.abs( newTrend ) }%` }
 					</span>
 				</Fragment>;
 				break;

--- a/assets/src/js/admin/reports/components/mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 //Import ChartJS dependencies
 import ChartJS from 'chart.js';
-import { createConfig, getTrend, getHighlightValue, getTooltipText } from './utils';
+import { createConfig, getTrend, getHighlightValue, getTooltipText, numberToDigits } from './utils';
 
 import Tooltip from '../tooltip';
 
@@ -56,7 +56,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ down }
 					<span style={ { color: '#D75A4B' } }>
-						{ `${ Math.abs( newTrend ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -65,7 +65,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ up }
 					<span style={ { color: '#69B868' } }>
-						{ `${ Math.abs( newTrend ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -73,7 +73,7 @@ const MiniChart = ( { title, data } ) => {
 			default: {
 				newIndicator = <Fragment>
 					<span style={ { color: '#82878c' } }>
-						{ `${ Math.abs( newTrend ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;

--- a/assets/src/js/admin/reports/components/mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/index.js
@@ -56,7 +56,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ down }
 					<span style={ { color: '#D75A4B' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -65,7 +65,7 @@ const MiniChart = ( { title, data } ) => {
 				newIndicator = <Fragment>
 					{ up }
 					<span style={ { color: '#69B868' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;
@@ -73,7 +73,7 @@ const MiniChart = ( { title, data } ) => {
 			default: {
 				newIndicator = <Fragment>
 					<span style={ { color: '#82878c' } }>
-						{ `${ numberToDigits( Math.abs( newTrend ), 2 ) }%` }
+						{ `${ numberToDigits( Math.abs( newTrend ), 2, 2 ) }%` }
 					</span>
 				</Fragment>;
 				break;

--- a/assets/src/js/admin/reports/components/mini-chart/utils/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/utils/index.js
@@ -123,3 +123,19 @@ export function createConfig( data ) {
 	};
 	return config;
 }
+
+/**
+ * Sets a fixed amount of decimal digits conditionally based on the number of signficant digits
+ *
+ * @since 0.9.0
+ *
+ * @param {Number} value – the value to format
+ * @param {Number} totalDigits – the max digits
+ * @param {Number} afterDecimal – the max decimal places
+ * @returns {Number} Number rounded to significant digits
+ */
+export function numberToDigits( value, totalDigits, afterDecimal ) {
+	const lengthBeforeDecimal = Math.floor( value ).toString().length;
+
+	return value.toFixed( Math.max( 0, Math.min( afterDecimal, totalDigits - lengthBeforeDecimal ) ) );
+}

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -149,10 +149,10 @@ class AverageDonation extends Endpoint {
 			// Check if it is a percent decreate, or increase
 			if ( $prevAverage > $currentAverage ) {
 				// Calculate a percent decrease
-				$trend = round( ( ( ( $prevAverage - $currentAverage ) / $prevAverage ) * 100 ), 1 ) * -1;
+				$trend = ( ( ( $prevAverage - $currentAverage ) / $prevAverage ) * 100 ) * -1;
 			} elseif ( $currentAverage > $prevAverage ) {
 				// Calculate a percent increase
-				$trend = round( ( ( ( $currentAverage - $prevAverage ) / $prevAverage ) * 100 ), 1 );
+				$trend = ( ( $currentAverage - $prevAverage ) / $prevAverage ) * 100;
 			}
 		}
 

--- a/src/API/Endpoints/Reports/TotalDonors.php
+++ b/src/API/Endpoints/Reports/TotalDonors.php
@@ -133,10 +133,10 @@ class TotalDonors extends Endpoint {
 			// Check if it is a percent decreate, or increase
 			if ( $prevDonors > $currentDonors ) {
 				// Calculate a percent decrease
-				$trend = round( ( ( ( $prevDonors - $currentDonors ) / $prevDonors ) * 100 ), 1 ) * -1;
+				$trend = ( ( ( $prevDonors - $currentDonors ) / $prevDonors ) * 100 ) * -1;
 			} elseif ( $currentDonors > $prevDonors ) {
 				// Calculate a percent increase
-				$trend = round( ( ( ( $currentDonors - $prevDonors ) / $prevDonors ) * 100 ), 1 );
+				$trend = ( ( $currentDonors - $prevDonors ) / $prevDonors ) * 100;
 			}
 		}
 

--- a/src/API/Endpoints/Reports/TotalIncome.php
+++ b/src/API/Endpoints/Reports/TotalIncome.php
@@ -145,10 +145,10 @@ class TotalIncome extends Endpoint {
 			// Check if it is a percent decreate, or increase
 			if ( $prevIncome > $currentIncome ) {
 				// Calculate a percent decrease
-				$trend = round( ( ( ( $prevIncome - $currentIncome ) / $prevIncome ) * 100 ), 1 ) * -1;
+				$trend = ( ( ( $prevIncome - $currentIncome ) / $prevIncome ) * 100 ) * -1;
 			} elseif ( $currentIncome > $prevIncome ) {
 				// Calculate a percent increase
-				$trend = round( ( ( ( $currentIncome - $prevIncome ) / $prevIncome ) * 100 ), 1 );
+				$trend = ( ( $currentIncome - $prevIncome ) / $prevIncome ) * 100;
 			}
 		}
 

--- a/src/API/Endpoints/Reports/TotalRefunds.php
+++ b/src/API/Endpoints/Reports/TotalRefunds.php
@@ -135,10 +135,10 @@ class TotalRefunds extends Endpoint {
 			// Check if it is a percent decreate, or increase
 			if ( $prevRefunds > $currentRefunds ) {
 				// Calculate a percent decrease
-				$trend = round( ( ( ( $prevRefunds - $currentRefunds ) / $prevRefunds ) * 100 ), 1 ) * -1;
+				$trend = ( ( ( $prevRefunds - $currentRefunds ) / $prevRefunds ) * 100 ) * -1;
 			} elseif ( $currentRefunds > $prevRefunds ) {
 				// Calculate a percent increase
-				$trend = round( ( ( ( $currentRefunds - $prevRefunds ) / $prevRefunds ) * 100 ), 1 );
+				$trend = ( ( $currentRefunds - $prevRefunds ) / $prevRefunds ) * 100;
 			}
 		}
 


### PR DESCRIPTION
## Description
Resolves #4766
This PR introduces frontend logic to ensure that trend percentages are rounded appropriately, based on the size of the number and a maximum number of significant digits. Previously, when the server provided a large number as the potential trend percentage (sometimes in the thousands) it was still displayed with point values, despite adding little tangible value to users and further cluttering the mini charts at the top of the Reports page. Now, when a large value is returned, it will include no point values, while small values do maintain appropriate point values. This improvement draws on work from the GiveIO reports project to tackle the same problem, and utilizes the numberToDigits function. 

## Affects
This PR impacts frontend rendering logic, specifically how trend percentages are rounded and displayed on mini charts at the top of the Reports page. Now, large percentages are rounded to their whole number, while small percentages maintain up to two decimal places. 

## What to test
With sample donation data imported, go to the Reports page. Test out a few different reporting periods.
- [ ] Do the percent trends (found in mini charts beneath the income over time chart) round as expected?
- [ ] Are large percentages rounded to whole numbers?
- [ ] Are smaller, more specific percentages extended to two decimal places?

## Screenshots:
<img width="1209" alt="Screen Shot 2020-06-29 at 3 35 44 PM" src="https://user-images.githubusercontent.com/5186078/86062747-3a698300-ba1e-11ea-95de-0f3c6bb21a45.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
