### PR TITLE
set script version to plugin version to load fresh file on every plugin release

### DIFF
--- a/src/Views/Admin/DashboardWidgets/Reports.php
+++ b/src/Views/Admin/DashboardWidgets/Reports.php
@@ -52,13 +52,13 @@ class Reports {
 			'give-admin-reports-widget-style',
 			GIVE_PLUGIN_URL . 'assets/dist/css/admin-reports-widget.css',
 			[],
-			'0.0.1'
+			GIVE_VERSION
 		);
 		wp_enqueue_script(
 			'give-admin-reports-widget-js',
 			GIVE_PLUGIN_URL . 'assets/dist/js/admin-reports-widget.js',
 			[ 'wp-element', 'wp-api', 'wp-i18n' ],
-			'0.0.1',
+			GIVE_VERSION,
 			true
 		);
 		wp_localize_script(


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Discussion: https://givewp.slack.com/archives/C0FAGC83C/p1593484441049500

@JasonTheAdams  reported that the report widget is not loading correctly on dashboard in Give `2.7.0`. I find out that we did not update script versions which cause or load older script on a few hosts who cache script and style files. 
This pr update script and style version to plugin version which will auto burst cache on every plugin release.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This will only affect script registration logic.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Is updated admin report script and style loading on the dashboard?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
