### PR TITLE
fix: set default template to legacy if missing

### DIFF
--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -19,8 +19,10 @@ $stripped_content = ''; // Form content stripped of HTML tags and shortcodes.
 $excerpt          = ''; // Trimmed form excerpt ready for display.
 
 
+$activeTemplate = FormUtils::isLegacyForm( $form_id ) ? 'legacy' : Template::getActiveID( $form_id );
+
 /* @var \Give\Form\Template $formTemplate */
-$formTemplate = Give()->templates->getTemplate( Template::getActiveID( $form_id ) );
+$formTemplate = Give()->templates->getTemplate( $activeTemplate );
 ?>
 
 <div class="give-grid__item">


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolves #4877 

I find out we are using the default template `legacy` if form template meta missing from the old donation form. This pr update logic to handle form template default value.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This Pr affect from grid shortcode output.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
- [x] Are you able to see form grid output with new and old donation form without any error?
- [x] Are you seeing form grid preview in the Gutenberg block without any error?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
