### PR TITLE
fix: Stripe errors now hidden correctly for default gateways

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -220,7 +220,7 @@
 				// Remove purchase_loading text
 				window.give_global_vars.purchase_loading = '';
 
-				$( '.give_error' ).each( function() {
+				$( '.give_error', '[id*="give-stripe-payment-errors-"]', '[id*="give-square-payment-errors-"]' ).each( function() {
 					moveErrorNotice( $( this ) );
 				} );
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -220,7 +220,8 @@
 				// Remove purchase_loading text
 				window.give_global_vars.purchase_loading = '';
 
-				$( '.give_error', '[id*="give-stripe-payment-errors-"]', '[id*="give-square-payment-errors-"]' ).each( function() {
+				// Move errors
+				$( '.give_error' ).each( function() {
 					moveErrorNotice( $( this ) );
 				} );
 
@@ -294,6 +295,10 @@
 						for ( let i = 0; i < mutation.addedNodes.length; i++ ) {
 							// do things to your newly added nodes here
 							const node = mutation.addedNodes[ i ];
+
+							if ( $( node ).find( '.give_error' ).length > 0 ) {
+								moveErrorNotice( $( node ).find( '.give_error' ) );
+							}
 
 							if ( $( node ).children().hasClass( 'give_errors' ) && ! $( node ).parent().hasClass( 'donation-errors' ) ) {
 								$( node ).children( '.give_errors' ).each( function() {
@@ -383,6 +388,11 @@
 	 * @param {node} node The error notice node to be moved
 	 */
 	function moveErrorNotice( node ) {
+		//If the error is inside stripe payment button, do nothing
+		if ( $( node ).parent().hasClass( 'give-stripe-payment-request-button' ) ) {
+			return;
+		}
+
 		// First check if specific donation notice container has been set up
 		if ( $( '.donation-errors' ).length === 0 ) {
 			$( '.payment' ).prepend( '<div class="donation-errors"></div>' );


### PR DESCRIPTION
## Description
Resolves #4879 
This PR improves frontend form rendering logic in the Multi-Step form template so that errors generated by the Give Stripe addon are handled correctly. Previously, when a set Google Pay or Apple Pay as the default payment gateway, an error inacureately appeared at the top of the form indicating to users that they did not have a Google/Apple pay account setup, and would not be able to donate - even when the donation would still process successfully. This issue was caused by JS in the Multi-Step form template, which moved errors to the top of the form (as expected), but did not move the wrapper around the errors (which the Give Stripe addon uses to identify and remove errors). This PR introduces a fix to ensure that wrappers associated with the Give Stripe addon are moved to the top of the form, enabling the Give Stripe addon to correctly handle hiding/showing these errors.

## Affects
This PR affects frontend form rending logic of the Multi-Step form template. Specifically, how errors associated with the Give Stripe addon are handled for default gateways.

## What to test
With Give Stripe enabled and Google/Apple pay setup, set Google/Apple Pay as the default gateway for a form. View the form on the frontend.
- [ ] Are you no longer shown an error indicating that the donation cannot be processed (even though it can)?
- [ ] If you are viewing the form in a non-SSL environment, does an error appear where the "Donate Now" button was, to succesfully indicate that you cannot donate with this gateway?

## Screenshots:
<img width="586" alt="Screen Shot 2020-06-30 at 10 18 00 AM" src="https://user-images.githubusercontent.com/5186078/86157983-01ccb680-babd-11ea-9b17-9ac30f187c23.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
