### PR TITLE
fix: single gateway styles are now consistent

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -19,6 +19,14 @@
 	}
 }
 
+#give_purchase_form_wrap {
+	.give-fee-total-wrap.fee-coverage-required.give-fee-message,
+	.give-fee-recovery-donors-choice.give-fee-message,
+	.fee-break-down-message {
+		margin: 20px 0 0 0 !important;
+	}
+}
+
 .give-fee-total-wrap.fee-coverage-required.give-fee-message,
 .give-fee-recovery-donors-choice.give-fee-message {
 	.give-fee-message-label-text {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -972,7 +972,14 @@ p {
 		.no-fields {
 			margin-bottom: 8px;
 		}
+
+		&.give-single-gateway-wrap {
+			background: none;
+			padding: 0;
+			margin: 0 20px;
+		}
 	}
+
 	#give_purchase_submit {
 		display: flex;
 		flex-direction: column;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -976,7 +976,7 @@ p {
 		&.give-single-gateway-wrap {
 			background: none;
 			padding: 0;
-			margin: -10px 20px 0 20px;
+			margin: 0 20px;
 		}
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -976,7 +976,7 @@ p {
 		&.give-single-gateway-wrap {
 			background: none;
 			padding: 0;
-			margin: 0 20px;
+			margin: -10px 20px 0 20px;
 		}
 	}
 
@@ -1009,25 +1009,25 @@ p {
 	#donate-fieldset {
 		display: flex;
 		flex-direction: column;
+	}
 
-		.give-submit-button-wrap {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			position: relative;
-			order: 3;
+	.give-submit-button-wrap {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		position: relative;
+		order: 3;
 
-			.sequoia-loader {
-				height: 30px;
-				width: 30px;
-				bottom: 32px;
-				position: absolute;
-				font-size: 4px;
-			}
+		.sequoia-loader {
+			height: 30px;
+			width: 30px;
+			bottom: 32px;
+			position: absolute;
+			font-size: 4px;
+		}
 
-			.give-submit:not(:disabled) + .sequoia-loader {
-				display: none;
-			}
+		.give-submit:not(:disabled) + .sequoia-loader {
+			display: none;
 		}
 	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -349,6 +349,7 @@
 		$( document ).on( 'give_gateway_loaded', function() {
 			setupTabOrder();
 			moveFieldsUnderPaymentGateway( true );
+			setupSelectInputs();
 			$( '#give_purchase_form_wrap' ).slideDown( 200, function() {
 				gatewayAnimating = false;
 			} );
@@ -377,6 +378,7 @@
 		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
 	} else {
 		$( '#give_purchase_form_wrap' ).addClass( 'give-single-gateway-wrap' );
+		setupSelectInputs();
 	}
 
 	/**
@@ -678,5 +680,21 @@
 
 	function clearLoginNotices() {
 		$( '#give_error_must_log_in' ).remove();
+	}
+
+	/**
+	 * Setup select inputs
+	 *
+	 * @since 2.7.0
+	 */
+	function setupSelectInputs() {
+		if ( $( 'select option[selected="selected"][value=""]' ).length > 0 ) {
+			$( 'select option[selected="selected"][value=""]' ).each( function() {
+				if ( $( this ).parent().siblings( 'label' ).length ) {
+					$( this ).text( $( this ).parent().siblings( 'label' ).text().replace( '*', '' ).trim() );
+					$( this ).attr( 'disabled', true );
+				}
+			} );
+		}
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -375,6 +375,8 @@
 
 		// Refresh payment information section.
 		$( document ).on( 'give_gateway_loaded', refreshPaymentInformationSection );
+	} else {
+		$( '#give_purchase_form_wrap' ).addClass( 'give-single-gateway-wrap' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Resolves #4882
This PR introduces some form rendering logic and styles for the Multi-Step form template to ensure that forms using a single gateway are displayed consistently with those using multiple gateway options. Previously, when an admin created a form with only one gateway option the fee recovery opt-in widht was wrong, spacing around the gateway fields was awkward, and the "Donate Now" button was aligned left, rather than centered. This PR resolves all these issues, while testing to make sure that forms displaying multiple gateways continue to work as expected.

## Affects
This PR affects the frontend form rending logic of the Multi-Step form, specifically how payment step is displayed when only one gateway is enabled.

## What to test
In a form using the Multi-Step form template, enable only one gateway.
- [x] Is the "Donate Now" button center aligned
- [ ] Are gateway fields aligned (in terms of widht/spacing) with other fields on the screen?
- [x] With an additional gateway is enabled, do the gateway fields continue to appear as expected?

With only one gateway enabled again, enable fee recovery, and set position to "Below Credit Card Fields" take a look at the form.
- [x] Is the fee recovery opt-in width consistent with other prominent checkboxes (like newsletter opt-ins)?

## Screenshots:
<img width="573" alt="Screen Shot 2020-07-01 at 12 22 42 PM" src="https://user-images.githubusercontent.com/5186078/86283941-ce5e5a80-bb96-11ea-8331-e4ea65f81d4b.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
