### PR TITLE
Add the PayPal Checkout payment gateway

### DIFF
--- a/src/PaymentGateways/PayPalCheckout/PayPalCheckout.php
+++ b/src/PaymentGateways/PayPalCheckout/PayPalCheckout.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCheckout;
+
+use Give\PaymentGateways\PaymentGateway;
+
+class PayPalCheckout implements PaymentGateway {
+
+	public function getId() {
+		return 'paypal-checkout';
+	}
+
+	public function getName() {
+		 return __( 'PayPal Checkout', 'give' );
+	}
+
+	public function getPaymentMethodLabel() {
+		return __( 'Credit Card', 'give' );
+	}
+}

--- a/src/PaymentGateways/PayPalCheckout/PayPalCheckout.php
+++ b/src/PaymentGateways/PayPalCheckout/PayPalCheckout.php
@@ -5,15 +5,23 @@ namespace Give\PaymentGateways\PayPalCheckout;
 use Give\PaymentGateways\PaymentGateway;
 
 class PayPalCheckout implements PaymentGateway {
-
+	/**
+	 * @inheritDoc
+	 */
 	public function getId() {
 		return 'paypal-checkout';
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function getName() {
-		 return __( 'PayPal Checkout', 'give' );
+		return __( 'PayPal Checkout', 'give' );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function getPaymentMethodLabel() {
 		return __( 'Credit Card', 'give' );
 	}

--- a/src/PaymentGateways/PaymentGateway.php
+++ b/src/PaymentGateways/PaymentGateway.php
@@ -2,8 +2,15 @@
 
 namespace Give\PaymentGateways;
 
+/**
+ * Interface PaymentGateway
+ *
+ * For use when defining a Payment Gateway. This gives the basic configurations needed to register
+ * the gateway with GiveWP.
+ *
+ * @since 2.8.0
+ */
 interface PaymentGateway {
-
 	/**
 	 * Returns a unique ID for the gateway
 	 *

--- a/src/PaymentGateways/PaymentGateway.php
+++ b/src/PaymentGateways/PaymentGateway.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Give\PaymentGateways;
+
+interface PaymentGateway {
+
+	/**
+	 * Returns a unique ID for the gateway
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return string
+	 */
+	public function getId();
+
+	/**
+	 * Returns a human readable name for the gateway
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return string
+	 */
+	public function getName();
+
+	/**
+	 * Returns a human readable label for use when a donor selects a payment method to use
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return string
+	 */
+	public function getPaymentMethodLabel();
+}

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Give\ServiceProviders;
+
+use Give\PaymentGateways\PaymentGateway;
+use Give\PaymentGateways\PayPalCheckout\PayPalCheckout;
+
+class PaymentGateways implements ServiceProvider {
+	public $gateways = [
+		PayPalCheckout::class,
+	];
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		// Not used, but needed for interface
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function boot() {
+		add_filter( 'give_payment_gateways', [ $this, 'registerGateways' ] );
+	}
+
+	/**
+	 * Registers all of the payment gateways with GiveWP
+	 *
+	 * @param array $gateways
+	 *
+	 * @return array
+	 */
+	public function registerGateways( array $gateways ) {
+		foreach ( $this->gateways as $gateway ) {
+			/** @var PaymentGateway $gateway */
+			$gateway = new $gateway();
+
+			$gateways[ $gateway->getId() ] = [
+				'admin_label'    => $gateway->getName(),
+				'checkout_label' => $gateway->getPaymentMethodLabel(),
+			];
+		}
+
+		return $gateways;
+	}
+}

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -5,7 +5,19 @@ namespace Give\ServiceProviders;
 use Give\PaymentGateways\PaymentGateway;
 use Give\PaymentGateways\PayPalCheckout\PayPalCheckout;
 
+/**
+ * Class PaymentGateways
+ *
+ * The Service Provider for loading the Payment Gateways
+ *
+ * @since 2.8.0
+ */
 class PaymentGateways implements ServiceProvider {
+	/**
+	 * Array of PaymentGateway classes to be bootstrapped
+	 *
+	 * @var string[]
+	 */
 	public $gateways = [
 		PayPalCheckout::class,
 	];
@@ -26,6 +38,8 @@ class PaymentGateways implements ServiceProvider {
 
 	/**
 	 * Registers all of the payment gateways with GiveWP
+	 *
+	 * @since 2.8.0
 	 *
 	 * @param array $gateways
 	 *

--- a/src/ServiceProviders/ServiceProvider.php
+++ b/src/ServiceProviders/ServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Give\ServiceProviders;
+
+interface ServiceProvider {
+
+	/**
+	 * Registers the Service Provider within the application. Use this to bind anything to the
+	 * Service Container. This prepares the service.
+	 *
+	 * @return void
+	 */
+	public function register();
+
+	/**
+	 * The bootstraps the service after all of the services have been registered. The importance of this
+	 * is that any cross service dependencies should be resolved by this point, so it should be safe to
+	 * bootstrap the service.
+	 *
+	 * @return void
+	 */
+	public function boot();
+}

--- a/src/ServiceProviders/ServiceProvider.php
+++ b/src/ServiceProviders/ServiceProvider.php
@@ -2,8 +2,14 @@
 
 namespace Give\ServiceProviders;
 
+/**
+ * Interface ServiceProvider
+ *
+ * For use when defining Service Providers, see the method docs for when to use them
+ *
+ * @since 2.8.0
+ */
 interface ServiceProvider {
-
 	/**
 	 * Registers the Service Provider within the application. Use this to bind anything to the
 	 * Service Container. This prepares the service.


### PR DESCRIPTION
## Description
This PR's ultimate goal is to register the PayPal Checkout payment gateways. It's pretty simple as that's all its goal is.

To do this, it also introduces a Service Provider framework within GiveWP. This introduces a means of registering services with the Service Container (i.e. the `Give` class). It also gives means of bootstrapping services efficiently. The gateways, for example, will only be instantiated and set up in the appropriate context, and the `PaymentGateways` provider handles this.

It's _super_ tempting to do more refactoring in `Give` to handle singletons better, but until it's necessary I will refrain. If it seems like it should happen, then we'll do it on the `develop` branch and merge that branch into this one (or another PR in this epic).

Resolves #4887 

## Affects
Doesn't affect anything existing, but the PayPal Checkout gateways does show up in the gateways list, now, and can be enabled.

## What to test
Whether or not the PayPal Checkout gateways shows up in the gateways list.

## Screenshots:
<img width="1535" alt="PayPal Checkout Gateway" src="https://user-images.githubusercontent.com/2024145/86302194-d7622280-bbbc-11ea-988f-c55bfb1d2c0e.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
- [x] Acceptance criteria satisfied and marked in issue
