### PR TITLE
fix: renewal donations are now factored into Reports

### DIFF
--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -40,7 +40,10 @@ class AverageDonation extends Endpoint {
 				$interval = round( $diff->days / 12 );
 				$data     = $this->get_data( $start, $end, 'P' . $interval . 'D' );
 				break;
-			case ( $diff->days > 7 ):
+			case ( $diff->days > 5 ):
+				$data = $this->get_data( $start, $end, 'P1D' );
+				break;
+			case ( $diff->days > 4 ):
 				$data = $this->get_data( $start, $end, 'PT12H' );
 				break;
 			case ( $diff->days > 2 ):
@@ -54,10 +57,11 @@ class AverageDonation extends Endpoint {
 		return $data;
 	}
 
+
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$income   = [];
 		$tooltips = [];
+		$income   = [];
 
 		$interval = new \DateInterval( $intervalStr );
 
@@ -69,62 +73,75 @@ class AverageDonation extends Endpoint {
 
 		while ( $periodStart < $end ) {
 
-			$averageForPeriod = $this->get_average_donation( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$avgIncomeForPeriod = $this->get_average_income( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$time               = $periodEnd->format( 'Y-m-d H:i:s' );
 
-			if ( $intervalStr == 'PT1H' ) {
-				$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-			} else {
-				$periodLabel = $periodStart->format( 'M j, Y' ) . ' - ' . $periodEnd->format( 'M j, Y' );
+			switch ( $intervalStr ) {
+				case 'P1D':
+					$periodLabel = $periodStart->format( 'l' );
+					break;
+				case 'PT12H':
+				case 'PT3H':
+				case 'PT1H':
+					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
+					break;
+				default:
+					$periodLabel = $periodStart->format( 'M j, Y' ) . ' - ' . $periodEnd->format( 'M j, Y' );
 			}
 
 			$income[] = [
-				'x' => $periodEnd->format( 'Y-m-d H:i:s' ),
-				'y' => $averageForPeriod,
+				'x' => $time,
+				'y' => $avgIncomeForPeriod,
 			];
 
 			$tooltips[] = [
 				'title'  => give_currency_filter(
-					give_format_amount( $averageForPeriod ),
+					give_format_amount( $avgIncomeForPeriod ),
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
 					]
 				),
-				'body'   => __( 'Avg Donation', 'give' ),
+				'body'   => __( 'Avg Income', 'give' ),
 				'footer' => $periodLabel,
 			];
 
-				// Add interval to set up next period
-				date_add( $periodStart, $interval );
-				date_add( $periodEnd, $interval );
+			// Add interval to set up next period
+			date_add( $periodStart, $interval );
+			date_add( $periodEnd, $interval );
 		}
 
-			$averageIncomeForPeriod = $this->get_average_donation( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
-			$trend                  = $this->get_trend( $start, $end, $income );
+		if ( $intervalStr === 'P1D' ) {
+			$income   = array_slice( $income, 1 );
+			$tooltips = array_slice( $tooltips, 1 );
+		}
 
-			$diff = date_diff( $start, $end );
-			$info = $diff->days > 1 ? __( 'VS previous', 'give' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day', 'give' );
+		$totalAvgIncomeForPeriod = $this->get_average_income( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
+		$trend                   = $this->get_trend( $start, $end, $income );
 
-			// Create data objec to be returned, with 'highlights' object containing total and average figures to display
-			$data = [
-				'datasets' => [
-					[
-						'data'      => $income,
-						'tooltips'  => $tooltips,
-						'trend'     => $trend,
-						'info'      => $info,
-						'highlight' => give_currency_filter(
-							give_format_amount( $averageIncomeForPeriod ),
-							[
-								'currency_code'   => $this->currency,
-								'decode_currency' => true,
-							]
-						),
-					],
+		$diff = date_diff( $start, $end );
+		$info = $diff->days > 1 ? __( 'VS previous', 'give' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day', 'give' );
+
+		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		$data = [
+			'datasets' => [
+				[
+					'data'      => $income,
+					'tooltips'  => $tooltips,
+					'trend'     => $trend,
+					'info'      => $info,
+					'highlight' => give_currency_filter(
+						give_format_amount( $totalAvgIncomeForPeriod ),
+						[
+							'currency_code'   => $this->currency,
+							'decode_currency' => true,
+						]
+					),
 				],
-			];
+			],
+		];
 
-			return $data;
+		return $data;
 
 	}
 
@@ -137,8 +154,8 @@ class AverageDonation extends Endpoint {
 
 		$prevEnd = clone $start;
 
-		$prevAverage    = $this->get_average_donation( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
-		$currentAverage = $this->get_average_donation( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
+		$prevAverage    = $this->get_average_income( $prevStart->format( 'Y-m-d H:i:s' ), $prevEnd->format( 'Y-m-d H:i:s' ) );
+		$currentAverage = $this->get_average_income( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
 
 		// Set default trend to 0
 		$trend = 0;
@@ -159,7 +176,7 @@ class AverageDonation extends Endpoint {
 		return $trend;
 	}
 
-	public function get_average_donation( $startStr, $endStr ) {
+	public function get_average_income( $startStr, $endStr ) {
 
 		$paymentObjects = $this->get_payments( $startStr, $endStr );
 
@@ -167,7 +184,7 @@ class AverageDonation extends Endpoint {
 		$paymentCount = 0;
 
 		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+			if ( $paymentObject->date >= $startStr && $paymentObject->date < $endStr ) {
 				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
 					$earnings     += $paymentObject->total;
 					$paymentCount += 1;
@@ -175,9 +192,9 @@ class AverageDonation extends Endpoint {
 			}
 		}
 
-		$average = $paymentCount > 0 ? $earnings / $paymentCount : 0;
+		$averageIncome = $paymentCount > 0 ? $earnings / $paymentCount : 0;
 
 		// Return rounded average (avoid displaying figures with many decimal places)
-		return round( $average, 2 );
+		return round( $averageIncome, 2 );
 	}
 }

--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -354,14 +354,18 @@ abstract class Endpoint {
 		$gateway = array_keys( $gatewayObjects );
 
 		$args = [
-			'number'     => $number,
-			'paged'      => 1,
-			'orderby'    => $orderBy,
-			'order'      => 'DESC',
-			'start_date' => strtotime( $startStr ),
-			'end_date'   => strtotime( $endStr ),
-			'gateway'    => $gateway,
-			'meta_query' => [
+			'post_status' => [
+				'publish',
+				'give_subscription',
+			],
+			'number'      => $number,
+			'paged'       => 1,
+			'orderby'     => $orderBy,
+			'order'       => 'DESC',
+			'start_date'  => strtotime( $startStr ),
+			'end_date'    => strtotime( $endStr ),
+			'gateway'     => $gateway,
+			'meta_query'  => [
 				[
 					'key'     => '_give_payment_currency',
 					'value'   => $this->currency,

--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -358,8 +358,8 @@ abstract class Endpoint {
 			'paged'      => 1,
 			'orderby'    => $orderBy,
 			'order'      => 'DESC',
-			'start_date' => $startStr,
-			'end_date'   => $endStr,
+			'start_date' => strtotime( $startStr ),
+			'end_date'   => strtotime( $endStr ),
 			'gateway'    => $gateway,
 			'meta_query' => [
 				[

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -67,7 +67,7 @@ class Income extends Endpoint {
 
 			switch ( $intervalStr ) {
 				case 'P1D':
-					$time        = $periodStart->format( 'Y-m-d H:i:s' );
+					$time        = $periodStart->format( 'Y-m-d' );
 					$periodLabel = $periodStart->format( 'l' );
 					break;
 				case 'PT12H':
@@ -128,7 +128,7 @@ class Income extends Endpoint {
 		$donors   = [];
 
 		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+			if ( $paymentObject->date >= $startStr && $paymentObject->date < $endStr ) {
 				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
 					$earnings += $paymentObject->total;
 					$donors[]  = $paymentObject->donor_id;

--- a/src/API/Endpoints/Reports/IncomeBreakdown.php
+++ b/src/API/Endpoints/Reports/IncomeBreakdown.php
@@ -43,8 +43,7 @@ class IncomeBreakdown extends Endpoint {
 
 	public function get_data( $start, $end, $intervalStr ) {
 
-		$tooltips = [];
-		$income   = [];
+		$data = [];
 
 		$interval = new \DateInterval( $intervalStr );
 
@@ -56,7 +55,8 @@ class IncomeBreakdown extends Endpoint {
 
 		while ( $periodStart < $end ) {
 
-			$values           = $this->get_values( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$values = $this->get_values( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+
 			$incomeForPeriod  = $values['income'];
 			$donorsForPeriod  = $values['donors'];
 			$refundsForPeriod = $values['refunds'];
@@ -76,7 +76,7 @@ class IncomeBreakdown extends Endpoint {
 					$periodLabel = $periodEnd->format( 'F j, Y' );
 			}
 
-			$income[] = [
+			$data[] = [
 				__( 'Date', 'give' )      => $periodLabel,
 				__( 'Donors', 'give' )    => $donorsForPeriod,
 				__( 'Donations', 'give' ) => $incomeForPeriod,
@@ -89,8 +89,6 @@ class IncomeBreakdown extends Endpoint {
 			date_add( $periodEnd, $interval );
 		}
 
-		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
-		$data = $income;
 		return $data;
 
 	}
@@ -105,7 +103,7 @@ class IncomeBreakdown extends Endpoint {
 		$donors      = [];
 
 		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+			if ( $paymentObject->date > $startStr && $paymentObject->date <= $endStr ) {
 				switch ( $paymentObject->status ) {
 					case 'give_subscription':
 					case 'publish': {

--- a/src/API/Endpoints/Reports/TotalDonors.php
+++ b/src/API/Endpoints/Reports/TotalDonors.php
@@ -28,7 +28,10 @@ class TotalDonors extends Endpoint {
 				$interval = round( $diff->days / 12 );
 				$data     = $this->get_data( $start, $end, 'P' . $interval . 'D' );
 				break;
-			case ( $diff->days > 7 ):
+			case ( $diff->days > 5 ):
+				$data = $this->get_data( $start, $end, 'P1D' );
+				break;
+			case ( $diff->days > 4 ):
 				$data = $this->get_data( $start, $end, 'PT12H' );
 				break;
 			case ( $diff->days > 2 ):
@@ -58,14 +61,15 @@ class TotalDonors extends Endpoint {
 		while ( $periodStart < $end ) {
 
 			$donorsForPeriod = $this->get_donors( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$time            = $periodEnd->format( 'Y-m-d H:i:s' );
 
 			switch ( $intervalStr ) {
+				case 'P1D':
+					$time        = $periodStart->format( 'Y-m-d' );
+					$periodLabel = $periodStart->format( 'l' );
+					break;
 				case 'PT12H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT3H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT1H':
 					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
 					break;
@@ -74,12 +78,12 @@ class TotalDonors extends Endpoint {
 			}
 
 			$donors[] = [
-				'x' => $periodEnd->format( 'Y-m-d H:i:s' ),
+				'x' => $time,
 				'y' => $donorsForPeriod,
 			];
 
 			$tooltips[] = [
-				'title'  => $donorsForPeriod . ' ' . __( 'Donors', 'give' ),
+				'title'  => sprintf( _n( '%d Donor', '%d Donors', $donorsForPeriod, 'give' ), $donorsForPeriod ),
 				'body'   => __( 'Total Donors', 'give' ),
 				'footer' => $periodLabel,
 			];
@@ -87,6 +91,11 @@ class TotalDonors extends Endpoint {
 			// Add interval to set up next period
 			date_add( $periodStart, $interval );
 			date_add( $periodEnd, $interval );
+		}
+
+		if ( $intervalStr === 'P1D' ) {
+			$donors   = array_slice( $donors, 1 );
+			$tooltips = array_slice( $tooltips, 1 );
 		}
 
 		$totalDonorsForPeriod = $this->get_donors( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
@@ -150,7 +159,7 @@ class TotalDonors extends Endpoint {
 		$donors = [];
 
 		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+			if ( $paymentObject->date >= $startStr && $paymentObject->date < $endStr ) {
 				if ( $paymentObject->status == 'publish' || $paymentObject->status == 'give_subscription' ) {
 					$donors[] = $paymentObject->donor_id;
 				}

--- a/src/API/Endpoints/Reports/TotalIncome.php
+++ b/src/API/Endpoints/Reports/TotalIncome.php
@@ -28,7 +28,10 @@ class TotalIncome extends Endpoint {
 				$interval = round( $diff->days / 12 );
 				$data     = $this->get_data( $start, $end, 'P' . $interval . 'D' );
 				break;
-			case ( $diff->days > 7 ):
+			case ( $diff->days > 5 ):
+				$data = $this->get_data( $start, $end, 'P1D' );
+				break;
+			case ( $diff->days > 4 ):
 				$data = $this->get_data( $start, $end, 'PT12H' );
 				break;
 			case ( $diff->days > 2 ):
@@ -55,17 +58,18 @@ class TotalIncome extends Endpoint {
 		// Subtract interval to set up period start
 		date_sub( $periodStart, $interval );
 
-		while ( $periodStart <= $end ) {
+		while ( $periodStart < $end ) {
 
 			$incomeForPeriod = $this->get_income( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$time            = $periodEnd->format( 'Y-m-d H:i:s' );
 
 			switch ( $intervalStr ) {
+				case 'P1D':
+					$time        = $periodStart->format( 'Y-m-d' );
+					$periodLabel = $periodStart->format( 'l' );
+					break;
 				case 'PT12H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT3H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT1H':
 					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
 					break;
@@ -74,7 +78,7 @@ class TotalIncome extends Endpoint {
 			}
 
 			$income[] = [
-				'x' => $periodEnd->format( 'Y-m-d H:i:s' ),
+				'x' => $time,
 				'y' => $incomeForPeriod,
 			];
 
@@ -90,37 +94,42 @@ class TotalIncome extends Endpoint {
 				'footer' => $periodLabel,
 			];
 
-				// Add interval to set up next period
-				date_add( $periodStart, $interval );
-				date_add( $periodEnd, $interval );
+			// Add interval to set up next period
+			date_add( $periodStart, $interval );
+			date_add( $periodEnd, $interval );
 		}
 
-			$totalIncomeForPeriod = $this->get_earnings( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
-			$trend                = $this->get_trend( $start, $end, $income );
+		if ( $intervalStr === 'P1D' ) {
+			$income   = array_slice( $income, 1 );
+			$tooltips = array_slice( $tooltips, 1 );
+		}
 
-			$diff = date_diff( $start, $end );
-			$info = $diff->days > 1 ? __( 'VS previous', 'give' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day', 'give' );
+		$totalIncomeForPeriod = $this->get_income( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
+		$trend                = $this->get_trend( $start, $end, $income );
 
-			// Create data objec to be returned, with 'highlights' object containing total and average figures to display
-			$data = [
-				'datasets' => [
-					[
-						'data'      => $income,
-						'tooltips'  => $tooltips,
-						'trend'     => $trend,
-						'info'      => $info,
-						'highlight' => give_currency_filter(
-							give_format_amount( $totalIncomeForPeriod ),
-							[
-								'currency_code'   => $this->currency,
-								'decode_currency' => true,
-							]
-						),
-					],
+		$diff = date_diff( $start, $end );
+		$info = $diff->days > 1 ? __( 'VS previous', 'give' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day', 'give' );
+
+		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
+		$data = [
+			'datasets' => [
+				[
+					'data'      => $income,
+					'tooltips'  => $tooltips,
+					'trend'     => $trend,
+					'info'      => $info,
+					'highlight' => give_currency_filter(
+						give_format_amount( $totalIncomeForPeriod ),
+						[
+							'currency_code'   => $this->currency,
+							'decode_currency' => true,
+						]
+					),
 				],
-			];
+			],
+		];
 
-			return $data;
+		return $data;
 
 	}
 
@@ -133,8 +142,8 @@ class TotalIncome extends Endpoint {
 
 		$prevEnd = clone $start;
 
-		$prevIncome    = $this->get_earnings( $prevStart->format( 'Y-m-d' ), $prevEnd->format( 'Y-m-d' ) );
-		$currentIncome = $this->get_earnings( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
+		$prevIncome    = $this->get_income( $prevStart->format( 'Y-m-d' ), $prevEnd->format( 'Y-m-d' ) );
+		$currentIncome = $this->get_income( $start->format( 'Y-m-d' ), $end->format( 'Y-m-d' ) );
 
 		// Set default trend to 0
 		$trend = 0;
@@ -163,7 +172,7 @@ class TotalIncome extends Endpoint {
 
 		foreach ( $paymentObjects as $paymentObject ) {
 			if ( $paymentObject->currency === $this->currency ) {
-				if ( $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+				if ( $paymentObject->date >= $startStr && $paymentObject->date < $endStr ) {
 					if ( $paymentObject->status === 'publish' || $paymentObject->status === 'give_subscription' ) {
 						$income += $paymentObject->total;
 					}
@@ -174,7 +183,4 @@ class TotalIncome extends Endpoint {
 		return $income;
 	}
 
-	public function get_earnings( $startStr, $endStr ) {
-		return $this->get_income( $startStr, $endStr );
-	}
 }

--- a/src/API/Endpoints/Reports/TotalRefunds.php
+++ b/src/API/Endpoints/Reports/TotalRefunds.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Income over time endpoint
+ * Refunds over time endpoint
  *
  * @package Give
  */
@@ -30,7 +30,10 @@ class TotalRefunds extends Endpoint {
 				$interval = round( $diff->days / 12 );
 				$data     = $this->get_data( $start, $end, 'P' . $interval . 'D' );
 				break;
-			case ( $diff->days > 7 ):
+			case ( $diff->days > 5 ):
+				$data = $this->get_data( $start, $end, 'P1D' );
+				break;
+			case ( $diff->days > 4 ):
 				$data = $this->get_data( $start, $end, 'PT12H' );
 				break;
 			case ( $diff->days > 2 ):
@@ -49,7 +52,7 @@ class TotalRefunds extends Endpoint {
 		$tooltips = [];
 		$refunds  = [];
 
-		$interval = new DateInterval( $intervalStr );
+		$interval = new \DateInterval( $intervalStr );
 
 		$periodStart = clone $start;
 		$periodEnd   = clone $start;
@@ -60,14 +63,15 @@ class TotalRefunds extends Endpoint {
 		while ( $periodStart < $end ) {
 
 			$refundsForPeriod = $this->get_refunds( $periodStart->format( 'Y-m-d H:i:s' ), $periodEnd->format( 'Y-m-d H:i:s' ) );
+			$time             = $periodEnd->format( 'Y-m-d H:i:s' );
 
 			switch ( $intervalStr ) {
+				case 'P1D':
+					$time        = $periodStart->format( 'Y-m-d' );
+					$periodLabel = $periodStart->format( 'l' );
+					break;
 				case 'PT12H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT3H':
-					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
-					break;
 				case 'PT1H':
 					$periodLabel = $periodStart->format( 'D ga' ) . ' - ' . $periodEnd->format( 'D ga' );
 					break;
@@ -76,12 +80,12 @@ class TotalRefunds extends Endpoint {
 			}
 
 			$refunds[] = [
-				'x' => $periodEnd->format( 'Y-m-d H:i:s' ),
+				'x' => $time,
 				'y' => $refundsForPeriod,
 			];
 
 			$tooltips[] = [
-				'title'  => $refundsForPeriod . ' ' . __( 'Refunds', 'give' ),
+				'title'  => sprintf( _n( '%d Donor', '%d Donors', $refundsForPeriod, 'give' ), $refundsForPeriod ),
 				'body'   => __( 'Total Refunds', 'give' ),
 				'footer' => $periodLabel,
 			];
@@ -91,11 +95,16 @@ class TotalRefunds extends Endpoint {
 			date_add( $periodEnd, $interval );
 		}
 
+		if ( $intervalStr === 'P1D' ) {
+			$refunds  = array_slice( $refunds, 1 );
+			$tooltips = array_slice( $tooltips, 1 );
+		}
+
 		$totalRefundsForPeriod = $this->get_refunds( $start->format( 'Y-m-d H:i:s' ), $end->format( 'Y-m-d H:i:s' ) );
 		$trend                 = $this->get_trend( $start, $end, $refunds );
 
 		$diff = date_diff( $start, $end );
-		$info = $diff->days > 1 ? __( 'VS previous' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day' );
+		$info = $diff->days > 1 ? __( 'VS previous', 'give' ) . ' ' . $diff->days . ' ' . __( 'days', 'give' ) : __( 'VS previous day', 'give' );
 
 		// Create data objec to be returned, with 'highlights' object containing total and average figures to display
 		$data = [
@@ -114,7 +123,7 @@ class TotalRefunds extends Endpoint {
 
 	}
 
-	public function get_trend( $start, $end, $income ) {
+	public function get_trend( $start, $end, $refunds ) {
 
 		$interval = $start->diff( $end );
 
@@ -151,7 +160,7 @@ class TotalRefunds extends Endpoint {
 
 		$refunds = 0;
 		foreach ( $paymentObjects as $paymentObject ) {
-			if ( $paymentObject->status == 'refunded' && $paymentObject->date > $startStr && $paymentObject->date < $endStr ) {
+			if ( $paymentObject->status == 'refunded' && $paymentObject->date >= $startStr && $paymentObject->date < $endStr ) {
 				$refunds += 1;
 			}
 		}


### PR DESCRIPTION
## Description
Resolves #4883 
This PR improves the Reports Endpoint base class, and standardizes interval logic across Reports endpoints to ensure that payment objects are consistently queried across all endpoints. Previously, when a user visited the Reports page, it failed to consistently factor renewal donations into totals for the queried period. This PR resolves that issue, and ensures that all endpoints are using consistent logic to query intervals between the specified period range.

## Affects
This PR affects Reports Endpoints querying logic, specifically with regards to how Endpoints pass start and end dates to the Give_Payments_Query object, and how Endpoints determine intervals to query within the greater specified period range.

## What to test
Using an install of GiveWP with processed Renewal donations, visit the Reports page.
- [ ] Looking at a period with known Renewals processed, are they factored into all chart totals?
- [ ] Test different ranges (day, week, month, etc) do charts and tables handle these different ranges consistently?
- [ ] Look at the income chart, then look at each mini chart. Are there an equal number of data points represented on each?
- [ ] With the day view selected, find a date range with known donations processed. Do they appear as expected in the "Income Breakdown" table? Do other charts support the data presented in the "income Breakdown" table?
- [ ] Do known Renewal donations appear in the "Recent Donation Activity" table with the Renewal icon?
- [ ] Check the Reports widget in the admin dashboard, does it reflect the same data available on the Reports dashboard?

## Screenshots:
<img width="524" alt="Screen Shot 2020-07-01 at 5 33 53 PM" src="https://user-images.githubusercontent.com/5186078/86303728-93255100-bbc1-11ea-8091-bf31147ae92e.png">

<img width="218" alt="Screen Shot 2020-07-01 at 5 13 10 PM" src="https://user-images.githubusercontent.com/5186078/86303738-98829b80-bbc1-11ea-8fe6-ec02a564152f.png">

<img width="912" alt="Screen Shot 2020-07-01 at 5 12 58 PM" src="https://user-images.githubusercontent.com/5186078/86303740-9ae4f580-bbc1-11ea-8c11-43b75f9db779.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
