### PR TITLE
upgrading database will not break WP admin interface

### DIFF
--- a/includes/admin/upgrades/class-give-updates.php
+++ b/includes/admin/upgrades/class-give-updates.php
@@ -32,7 +32,7 @@ class Give_Updates {
 	 * @access private
 	 * @var array
 	 */
-	private $updates = array();
+	private $updates = [];
 
 	/**
 	 * Current update percentage number
@@ -81,11 +81,11 @@ class Give_Updates {
 	 * @param array $args
 	 */
 	public function register( $args ) {
-		$args_default = array(
+		$args_default = [
 			'id'       => '',
 			'version'  => '',
 			'callback' => '',
-		);
+		];
 
 		$args = wp_parse_args( $args, $args_default );
 
@@ -104,7 +104,7 @@ class Give_Updates {
 
 		// Change depend param to array.
 		if ( isset( $args['depend'] ) && is_string( $args['depend'] ) ) {
-			$args['depend'] = array( $args['depend'] );
+			$args['depend'] = [ $args['depend'] ];
 		}
 
 		$this->updates[ $args['type'] ][] = $args;
@@ -144,19 +144,19 @@ class Give_Updates {
 		/**
 		 * Setup hooks.
 		 */
-		add_action( 'init', array( $this, '__register_upgrade' ), 9999 );
-		add_action( 'give_set_upgrade_completed', array( $this, '__flush_resume_updates' ), 9999 );
-		add_action( 'wp_ajax_give_db_updates_info', array( $this, '__give_db_updates_info' ) );
-		add_action( 'wp_ajax_give_run_db_updates', array( $this, '__give_start_updating' ) );
-		add_action( 'admin_init', array( $this, '__redirect_admin' ) );
-		add_action( 'admin_init', array( $this, '__pause_db_update' ), - 1 );
-		add_action( 'admin_init', array( $this, '__restart_db_update' ), - 1 );
-		add_action( 'admin_notices', array( $this, '__show_notice' ) );
-		add_action( 'give_restart_db_upgrade', array( $this, '__health_background_update' ) );
+		add_action( 'init', [ $this, '__register_upgrade' ], 9999 );
+		add_action( 'give_set_upgrade_completed', [ $this, '__flush_resume_updates' ], 9999 );
+		add_action( 'wp_ajax_give_db_updates_info', [ $this, '__give_db_updates_info' ] );
+		add_action( 'wp_ajax_give_run_db_updates', [ $this, '__give_start_updating' ] );
+		add_action( 'admin_init', [ $this, '__redirect_admin' ] );
+		add_action( 'admin_init', [ $this, '__pause_db_update' ], - 1 );
+		add_action( 'admin_init', [ $this, '__restart_db_update' ], - 1 );
+		add_action( 'admin_notices', [ $this, '__show_notice' ] );
+		add_action( 'give_restart_db_upgrade', [ $this, '__health_background_update' ] );
 
 		if ( is_admin() ) {
-			add_action( 'admin_init', array( $this, '__change_donations_label' ), 9999 );
-			add_action( 'admin_menu', array( $this, '__register_menu' ), 9999 );
+			add_action( 'admin_init', [ $this, '__change_donations_label' ], 9999 );
+			add_action( 'admin_menu', [ $this, '__register_menu' ], 9999 );
 		}
 	}
 
@@ -167,7 +167,7 @@ class Give_Updates {
 	 * @access public
 	 */
 	public function __register_plugin_addon_updates() {
-		$addons         = give_get_plugins( array( 'only_premium_add_ons' => true ) );
+		$addons         = give_get_plugins( [ 'only_premium_add_ons' => true ] );
 		$plugin_updates = get_plugin_updates();
 
 		foreach ( $addons as $key => $info ) {
@@ -254,7 +254,7 @@ class Give_Updates {
 					__( 'Updates', 'give' ),
 					'manage_give_settings',
 					'give-updates',
-					array( $this, 'render_complete_page' )
+					[ $this, 'render_complete_page' ]
 				);
 			}
 
@@ -278,7 +278,7 @@ class Give_Updates {
 			),
 			'manage_give_settings',
 			'give-updates',
-			array( $this, 'render_page' )
+			[ $this, 'render_page' ]
 		);
 	}
 
@@ -294,7 +294,7 @@ class Give_Updates {
 		if (
 			! wp_doing_ajax() &&
 			current_user_can( 'manage_give_settings' ) &&
-			Give_Cache_Setting::get_option( 'give_show_db_upgrade_complete_notice' ) &&
+			get_option( 'give_show_db_upgrade_complete_notice' ) &&
 			! isset( $_GET['give-db-update-completed'] )
 		) {
 			delete_option( 'give_show_db_upgrade_complete_notice' );
@@ -429,10 +429,10 @@ class Give_Updates {
 
 		/* @var stdClass $batch */
 		$batch                = self::$background_updater->get_all_batch();
-		$old_batch_update_ids = is_array( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : array();
+		$old_batch_update_ids = is_array( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : [];
 		$all_updates          = $give_updates->get_updates( 'database', 'all' );
 		$all_update_ids       = wp_list_pluck( $all_updates, 'id' );
-		$all_batch_update_ids = ! empty( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : array();
+		$all_batch_update_ids = ! empty( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : [];
 		$log_data             = '';
 		$doing_upgrade_args   = get_option( 'give_doing_upgrade' );
 
@@ -478,7 +478,7 @@ class Give_Updates {
 		 * Add new upgrade to batch
 		 */
 		if ( $new_updates = $this->get_updates( 'database', 'new' ) ) {
-			$all_batch_update_ids = ! empty( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : array();
+			$all_batch_update_ids = ! empty( $batch->data ) ? wp_list_pluck( $batch->data, 'id' ) : [];
 
 			foreach ( $new_updates as $index => $new_update ) {
 				if ( give_has_upgrade_completed( $new_update['id'] ) || in_array( $new_update['id'], $all_batch_update_ids ) ) {
@@ -583,11 +583,11 @@ class Give_Updates {
 	 */
 	public function __show_notice() {
 		$current_screen = get_current_screen();
-		$hide_on_pages  = array(
+		$hide_on_pages  = [
 			'give_forms_page_give-updates',
 			'update-core',
 			'give_forms_page_give-addons',
-		);
+		];
 
 		// Bailout.
 		if ( ! current_user_can( 'manage_give_settings' ) ) {
@@ -614,7 +614,7 @@ class Give_Updates {
 				&nbsp;&#8211;&nbsp;<?php _e( 'GiveWP needs to update your database to the latest version. The following process will make updates to your site\'s database. Please create a backup before proceeding.', 'give' ); ?>
 				<br>
 				<br>
-				<a href="<?php echo esc_url( add_query_arg( array( 'give-restart-db-upgrades' => 1 ), admin_url( 'edit.php?post_type=give_forms&page=give-updates' ) ) ); ?>" class="button button-primary give-restart-updater-btn">
+				<a href="<?php echo esc_url( add_query_arg( [ 'give-restart-db-upgrades' => 1 ], admin_url( 'edit.php?post_type=give_forms&page=give-updates' ) ) ); ?>" class="button button-primary give-restart-updater-btn">
 					<?php _e( 'Restart the updater', 'give' ); ?>
 				</a>
 			<?php else : ?>
@@ -626,12 +626,12 @@ class Give_Updates {
 			$desc_html = ob_get_clean();
 
 			Give()->notices->register_notice(
-				array(
+				[
 					'id'          => 'give_upgrade_db',
 					'type'        => 'error',
 					'dismissible' => false,
 					'description' => $desc_html,
-				)
+				]
 			);
 		}
 
@@ -643,12 +643,12 @@ class Give_Updates {
 		// Show db upgrade completed notice.
 		if ( ! empty( $_GET['give-db-update-completed'] ) ) {
 			Give()->notices->register_notice(
-				array(
+				[
 					'id'          => 'give_db_upgrade_completed',
 					'type'        => 'updated',
 					'description' => __( 'GiveWP database updates completed successfully. Thank you for updating to the latest version!', 'give' ),
 					'show'        => true,
-				)
+				]
 			);
 
 			// Start update.
@@ -664,7 +664,7 @@ class Give_Updates {
 				&nbsp;&#8211;&nbsp;<?php _e( 'GiveWP needs to update your database to the latest version. The following process will make updates to your site\'s database. Please create a complete backup before proceeding.', 'give' ); ?>
 			</p>
 			<p class="submit">
-				<a href="<?php echo esc_url( add_query_arg( array( 'give-run-db-update' => 1 ), admin_url( 'edit.php?post_type=give_forms&page=give-updates' ) ) ); ?>" class="button button-primary give-run-update-now">
+				<a href="<?php echo esc_url( add_query_arg( [ 'give-run-db-update' => 1 ], admin_url( 'edit.php?post_type=give_forms&page=give-updates' ) ) ); ?>" class="button button-primary give-run-update-now">
 					<?php _e( 'Run the updater', 'give' ); ?>
 				</a>
 			</p>
@@ -672,12 +672,12 @@ class Give_Updates {
 			$desc_html = ob_get_clean();
 
 			Give()->notices->register_notice(
-				array(
+				[
 					'id'          => 'give_upgrade_db',
 					'type'        => 'updated',
 					'dismissible' => false,
 					'description' => $desc_html,
-				)
+				]
 			);
 		}
 	}
@@ -724,14 +724,14 @@ class Give_Updates {
 
 		add_option(
 			'give_doing_upgrade',
-			array(
+			[
 				'update_info'      => $updates[0],
 				'step'             => 1,
 				'update'           => 1,
 				'heading'          => sprintf( 'Update %s of %s', 1, count( $updates ) ),
 				'percentage'       => 0,
 				'total_percentage' => 0,
-			),
+			],
 			'',
 			false
 		);
@@ -805,11 +805,11 @@ class Give_Updates {
 		$response_type = '';
 
 		if ( self::$background_updater->is_paused_process() ) {
-			$update_info = array(
+			$update_info = [
 				'message'    => __( 'The updates have been paused.', 'give' ),
 				'heading'    => '',
 				'percentage' => 0,
-			);
+			];
 
 			if ( get_option( 'give_upgrade_error' ) ) {
 				$update_info['message'] = __( 'An unexpected issue occurred during the database update which caused it to stop automatically. Please contact support for assistance.', 'give' );
@@ -818,11 +818,11 @@ class Give_Updates {
 			$response_type = 'error';
 
 		} elseif ( empty( $update_info ) || ! $this->get_total_new_db_update_count( true ) ) {
-			$update_info   = array(
+			$update_info   = [
 				'message'    => __( 'GiveWP database updates completed successfully. Thank you for updating to the latest version!', 'give' ),
 				'heading'    => __( 'Updates Completed.', 'give' ),
 				'percentage' => 0,
-			);
+			];
 			$response_type = 'success';
 
 			delete_option( 'give_show_db_upgrade_complete_notice' );
@@ -841,13 +841,13 @@ class Give_Updates {
 	 * @param string $type
 	 */
 	public function send_ajax_response( $data, $type = '' ) {
-		$default = array(
+		$default = [
 			'message'    => '',
 			'heading'    => '',
 			'percentage' => 0,
 			'step'       => 0,
 			'update'     => 0,
-		);
+		];
 
 		// Set data.
 		$data = wp_parse_args( $data, $default );
@@ -866,9 +866,9 @@ class Give_Updates {
 
 			default:
 				wp_send_json(
-					array(
+					[
 						'data' => $data,
-					)
+					]
 				);
 				break;
 		}
@@ -980,7 +980,7 @@ class Give_Updates {
 		}
 
 		// Get specific update.
-		$updates = ! empty( $this->updates[ $update_type ] ) ? $this->updates[ $update_type ] : array();
+		$updates = ! empty( $this->updates[ $update_type ] ) ? $this->updates[ $update_type ] : [];
 
 		// Bailout.
 		if ( empty( $updates ) ) {


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Resolves https://github.com/impress-org/givewp/issues/4900

I find out that we are using `Give_Cache_Setting` class to get cache value which updates after any [whitelist options ](https://github.com/impress-org/givewp/blob/b2f77d5a096f13a47a3fabd95fed3310e123ab96/includes/class-give-cache-setting.php#L58) add/update/delete. I think a few servers hijack action fired inside this function and which cause of cache settings does not flush.  As per discussion with @JasonTheAdams and @DevinWalker It is good to use WordPress core function in this case to prevent any future conflict like this.

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
This pr affect admin redirect logic which setup after database upgrade completes in background and admin, was not on the database upgrade page.

## What to test
<!-- Provide a comprehensive list of what should be tested to confirm this works and not break anything. -->
We are unable to test it because only a few people get affected by this and we do not know exact steps to reproduce this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
