### PR TITLE
fix: anonymous donation opt-in is now visible in Multi-Step forms

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -170,6 +170,9 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			#give_terms_agreement input[type='checkbox'] + label::after {
 				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\") !important;
 			}
+			#give-anonymous-donation-wrap label::after {
+				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\") !important;
+			}
 		";
 
 		if ( Utils::isPluginActive( 'give-recurring/give-recurring.php' ) ) {

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -173,6 +173,9 @@ class Sequoia extends Template implements Hookable, Scriptable {
 			#give-anonymous-donation-wrap label::after {
 				background-image: url(\"data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%23{$rawColor}'/%3E%3C/svg%3E%0A\") !important;
 			}
+			#give-anonymous-donation-wrap label:focus-within::before {
+				border-color: {$primaryColor} !important;
+			}
 		";
 
 		if ( Utils::isPluginActive( 'give-recurring/give-recurring.php' ) ) {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -600,6 +600,56 @@ p {
 		width: 100%;
 	}
 
+	#give-anonymous-donation-wrap {
+		.give-label {
+			display: block !important;
+			font-weight: 400;
+			font-size: 14px;
+			line-height: 1.4;
+			padding: 0 0 0 32px;
+			width: calc(100% - 82px);
+			margin-left: 0;
+			color: #696969;
+			display: inline-block;
+
+			&::before {
+				content: ' ';
+				position: absolute;
+				top: calc(50% - 12px);
+				left: 0;
+				width: 20px;
+				height: 20px;
+				border: 1px solid #b4b9be;
+				background-color: #fff;
+				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+			}
+
+			&::after {
+				transition: clip-path 0.2s ease, -webkit-clip-path 0.2s ease;
+				border-radius: 11px;
+				width: 20px;
+				height: 20px;
+				position: absolute;
+				top: calc(50% - 12px);
+				left: 0;
+				content: ' ';
+				display: block;
+				background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%231E8CBE'/%3E%3C/svg%3E%0A");
+				background-repeat: no-repeat;
+				background-position: center;
+				clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+				-webkit-clip-path: polygon(0 0, 11% 0, 0 100%, 0 55%);
+			}
+
+			&.active {
+				&::after {
+					clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+					-webkit-clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+				}
+			}
+		}
+	}
+
 	#give_terms_agreement {
 		order: 3;
 		background: #fff;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -607,7 +607,7 @@ p {
 			font-size: 14px;
 			line-height: 1.4;
 			padding: 0 0 0 32px;
-			width: calc(100% - 82px);
+			width: calc(100% - 40px);
 			margin-left: 0;
 			color: #696969;
 			display: inline-block;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -224,6 +224,13 @@
 					moveErrorNotice( $( this ) );
 				} );
 
+				// Setup anonymouse donations opt-in event listeners
+				setupCheckbox( {
+					container: '#give-anonymous-donation-wrap label',
+					label: '#give-anonymous-donation-wrap label',
+					input: '#give-anonymous-donation',
+				} );
+
 				// Setup recurring donations opt-in event listeners
 				setupCheckbox( {
 					container: '.give-recurring-donors-choice',
@@ -627,7 +634,11 @@
 		}
 
 		// Persist checkbox input border when selected
-		$( label ).on( 'click touchend', function() {
+		$( label ).on( 'click touchend', function( evt ) {
+			if ( container === label ) {
+				evt.stopPropagation();
+				evt.preventDefault();
+			}
 			$( container ).toggleClass( 'active' );
 		} );
 	}


### PR DESCRIPTION
## Description
Resolves #4888 
This PR introduces frontend form rending logic and styles to the Multi-Step form template to ensure that the anonymous donation checkbox is visible when enabled. Previously, when an admin enabled anonymous donations for a form using the multi-step form template, the markup for the checkbox would render, but the field itself was not visible.

## Affects
This PR affects form rending logic in the Multi-Step form, specifically regarding how the Anonymous Donation checkbox is displayed, when Anonymous Donations are enabled.

## What to test
In a form using the Multi-Step form template, enable Anonymous Donations.
- [x] Does the anonymous donation checkbox appear below payment information fields?
- [x] Does the anonymous donation checkbox use form colors for focus and the checkmark?
- [x] Is the opt-in responsive on mobile devices?

## Screenshots:
<img width="590" alt="Screen Shot 2020-07-02 at 1 43 11 PM" src="https://user-images.githubusercontent.com/5186078/86409380-9f66e800-bc6d-11ea-8d90-ea4effba64fa.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
