### PR TITLE
fix: terms and conditions agreement is now responsive

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -636,6 +636,7 @@ p {
 		#give_terms {
 			margin-bottom: 17px;
 			max-height: 300px;
+			padding: 0 10px 0 0;
 			overflow-y: scroll !important;
 		}
 
@@ -651,7 +652,7 @@ p {
 			cursor: pointer;
 
 			@media screen and (max-width: $break-phone) {
-				width: calc(100% - 20px);
+				width: calc(100% - 30px);
 				padding: 0 0 30px 40px;
 			}
 		}

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -638,6 +638,11 @@ p {
 			max-height: 300px;
 			padding: 0 10px 0 0;
 			overflow-y: scroll !important;
+
+			> p:first-of-type {
+				margin-top: 0;
+			}
+
 		}
 
 		label {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -624,6 +624,12 @@ p {
 
 		#give_show_terms {
 			order: 3;
+
+			@media screen and (max-width: $break-phone) {
+				bottom: 20px;
+				left: 60px;
+				position: absolute;
+			}
 		}
 
 		#give_terms {
@@ -642,6 +648,11 @@ p {
 			line-height: 1.4;
 			position: relative;
 			cursor: pointer;
+
+			@media screen and (max-width: $break-phone) {
+				width: calc(100% - 20px);
+				padding: 0 0 30px 40px;
+			}
 		}
 
 		&:hover {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -629,13 +629,14 @@ p {
 				bottom: 20px;
 				left: 60px;
 				position: absolute;
+				z-index: 99;
 			}
 		}
 
 		#give_terms {
 			margin-bottom: 17px;
 			max-height: 300px;
-			overflow-y: scroll;
+			overflow-y: scroll !important;
 		}
 
 		label {


### PR DESCRIPTION
## Description
Resolves #4899 
This PR introduces mobile breakpoint styles for the Terms and Conditions opt-in, so that the label and "Show Terms" button stack on mobile. Previously, when a user viewed a Multi-Step form with Terms and Conditions enabled, the Terms and Conditions opt-in was not responsive on mobile.

## Affects
This PR affects frontend styles of the Multi-Step form template, specifically responsive styling of the Terms Agreement checkbox.

## What to test
Enable Terms and Conditions for a form using the Multi-Step form template. Set the Terms and Conditions label to something longer than the default "Agree to Terms".
- [x] Do the Label and "Show Terms" button stack when viewing the form on a mobile browser?
- [x] Looking at the form in a desktop view, do the styles still behave as expected (checkbox, label and "Show Terms" all in one row)?
- [x] When the Terms are displayed, are you able to scroll through them on a desktop browser?
- [x] When the Terms are displayed, are you able to scroll through them on a mobile browser?


## Screenshots:
<img width="492" alt="Screen Shot 2020-07-02 at 3 18 55 PM" src="https://user-images.githubusercontent.com/5186078/86414252-46508180-bc78-11ea-87d9-56fb8bb0d3bb.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
