### PR TITLE
fix typo in thank you page default message

### DIFF
--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -169,9 +169,9 @@ return [
 				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use any of the available template tags within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
-					'placeholder' => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),
+					'placeholder' => __( '{name}, your contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),
 				],
-				'default'    => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),
+				'default'    => __( '{name}, your contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),
 			],
 			[
 				'name'    => __( 'Social Sharing', 'give' ),


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->
Resolve #4909

This is minor fix to update `you --> your`

## Affects
<!-- Provide a list of areas in the code base affected by this. Not file by file, just descriptively. -->
thank you page placeholder and default message.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
