### PR TITLE
Add link to the email tags doc

### DIFF
--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -166,7 +166,7 @@ return [
 			[
 				'id'         => 'description',
 				'name'       => __( 'Description', 'give' ),
-				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags target="_blank">any of the available template tags</a> within this message.', 'give' ),
+				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="http://docs.givewp.com/email-tags target="_blank">any of the available template tags</a> within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
 					'placeholder' => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -166,7 +166,7 @@ return [
 			[
 				'id'         => 'description',
 				'name'       => __( 'Description', 'give' ),
-				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags">any of the available template tags</a> within this message.', 'give' ),
+				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags target="_blank">any of the available template tags</a> within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
 					'placeholder' => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -166,7 +166,7 @@ return [
 			[
 				'id'         => 'description',
 				'name'       => __( 'Description', 'give' ),
-				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use any of the available template tags within this message.', 'give' ),
+				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use  <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags">any of the available template tags</a> within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
 					'placeholder' => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -166,7 +166,7 @@ return [
 			[
 				'id'         => 'description',
 				'name'       => __( 'Description', 'give' ),
-				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use  <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags">any of the available template tags</a> within this message.', 'give' ),
+				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="https://givewp.com/documentation/core/settings/emails/email-tags/?utm_source=GiveWPPlugin&utm_medium=admin&utm_campaign=Plugin_Links&utm_content=Email_Tags">any of the available template tags</a> within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
 					'placeholder' => __( '{name}, you contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),


### PR DESCRIPTION
## Description
Adds a link to the email tags doc. Resolves https://github.com/impress-org/givewp/issues/4906.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.
