### PR TITLE
Onboarding wizard is now scaffolded

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -1,0 +1,12 @@
+// Onboarding Wizard App
+
+import './style.scss';
+
+const App = () => {
+	return (
+		<div className="give-onboarding-wizard">
+			<h1>Onboardng Wizard!</h1>
+		</div>
+	);
+};
+export default App;

--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -1,6 +1,8 @@
 // Import styles
 import './style.scss';
 
+const { __ } = wp.i18n;
+
 /**
  * Onboarding Wizard app component
  *
@@ -12,15 +14,15 @@ const App = () => {
 		<div className="give-obw">
 			<div className="give-obw-step">
 				<h2>
-					Welcome To
+					{ __( 'Welcome To', 'give' ) }
 				</h2>
-				<div className="give-obw-logo">GiveWP</div>
+				<div className="give-obw-logo">{ __( 'GiveWP', 'give' ) }</div>
 				<p>
-					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed in mi a leo convallis consequat. Sed ornare tellus vel justo porttitor, eu bibendum lorem vulputate.
+					{ __( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed in mi a leo convallis consequat. Sed ornare tellus vel justo porttitor, eu bibendum lorem vulputate.', 'give' ) }
 				</p>
 				<div className="give-obw-buttons">
-					<a className="give-obw-button give-obw-button--primary" href="#">Get Started</a>
-					<a className="give-obw-button" href={ window.giveOnboardingWizardData.setupUrl }>Not right now.</a>
+					<a className="give-obw-button give-obw-button--primary" href="#">{ __( 'Get Started', 'give' ) }</a>
+					<a className="give-obw-button" href={ window.giveOnboardingWizardData.setupUrl }>{ __( 'Not right now.', 'give' ) }</a>
 				</div>
 			</div>
 		</div>

--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -1,7 +1,12 @@
-// Onboarding Wizard App
-
+// Import styles
 import './style.scss';
 
+/**
+ * Onboarding Wizard app component
+ *
+ * @since 2.8.0
+ * @returns {array} Array of React elements, comprising the Onboarding Wizard app
+ */
 const App = () => {
 	return (
 		<div className="give-obw">

--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -4,8 +4,20 @@ import './style.scss';
 
 const App = () => {
 	return (
-		<div className="give-onboarding-wizard">
-			<h1>Onboardng Wizard!</h1>
+		<div className="give-obw">
+			<div className="give-obw-step">
+				<h2>
+					Welcome To
+				</h2>
+				<div className="give-obw-logo">GiveWP</div>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed in mi a leo convallis consequat. Sed ornare tellus vel justo porttitor, eu bibendum lorem vulputate.
+				</p>
+				<div className="give-obw-buttons">
+					<a className="give-obw-button give-obw-button--primary" href="#">Get Started</a>
+					<a className="give-obw-button" href={ window.giveOnboardingWizardData.setupUrl }>Not right now.</a>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/style.scss
@@ -1,0 +1,3 @@
+.give-onboarding-wizard {
+	color: rgb(255, 0, 0);
+}

--- a/assets/src/js/admin/onboarding-wizard/app/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/style.scss
@@ -1,3 +1,51 @@
-.give-onboarding-wizard {
-	color: rgb(255, 0, 0);
+body {
+	font-family: Montserrat, arial, sans-serif;
+	color: #222;
+}
+
+.give-obw {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100vh;
+	width: 100vw;
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+.give-obw-step {
+	text-align: center;
+	max-width: 600px;
+}
+
+.give-obw-logo {
+	font-size: 88px;
+	font-weight: 600;
+	color: #69b868;
+}
+
+.give-obw-buttons {
+	display: inline-flex;
+	flex-direction: column;
+	margin-top: 36px;
+}
+
+.give-obw-button {
+	text-decoration: none;
+	color: #000;
+	border: 1px solid #ccc;
+	padding: 12px 12px;
+	background: #eee;
+	font-size: 14px;
+	margin: 6px;
+	border-radius: 4px;
+}
+
+.give-obw-button--primary {
+	background: #333;
+	border: 1px solid #000;
+	color: #fff;
+	font-size: 18px;
+	padding: 16px 46px;
 }

--- a/assets/src/js/admin/onboarding-wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/index.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-unused-vars */
+
+// Entry point for Onboarind Wizard app
+
+// Vendor dependencies
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+// Reports app
+import App from './app/index.js';
+
+ReactDOM.render(
+	<App />,
+	document.getElementById( 'onboarding-wizard-app' )
+);

--- a/assets/src/js/admin/onboarding-wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/index.js
@@ -6,9 +6,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-// Reports app
+// Onboarding Wizard app
 import App from './app/index.js';
 
+// Render application
 ReactDOM.render(
 	<App />,
 	document.getElementById( 'onboarding-wizard-app' )

--- a/includes/admin/class-give-welcome.php
+++ b/includes/admin/class-give-welcome.php
@@ -641,7 +641,7 @@ class Give_Welcome {
 
 		if ( ! $upgrade ) {
 			// First time install
-			wp_safe_redirect( admin_url( 'index.php?page=give-getting-started' ) );
+			wp_safe_redirect( admin_url( 'index.php?page=give-onboarding-wizard' ) );
 			exit;
 		} elseif ( ! give_is_setting_enabled( give_get_option( 'welcome' ) ) ) {
 			// Welcome is disabled in settings

--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -131,11 +131,11 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 							],
 						],
 						[
-							'name'    => __( 'Welcome Screen', 'give' ),
+							'name'    => __( 'What\'s New Screen', 'give' ),
 							/* translators: %s: about page URL */
 							'desc'    => sprintf(
 								wp_kses(
-									__( 'Enable this option if you would like to disable the <a href="%s" target="_blank">GiveWP Welcome screen</a> that displays each time GiveWP is activated or updated.', 'give' ),
+									__( 'Enable this option if you would like to disable the <a href="%s" target="_blank">GiveWP What\'s New screen</a> that displays each time GiveWP is updated.', 'give' ),
 									[
 										'a' => [
 											'href'   => [],
@@ -143,7 +143,7 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 										],
 									]
 								),
-								esc_url( admin_url( 'index.php?page=give-getting-started' ) )
+								esc_url( admin_url( 'index.php?page=give-changelog' ) )
 							),
 							'id'      => 'welcome',
 							'type'    => 'radio_inline',

--- a/includes/install.php
+++ b/includes/install.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Runs on plugin install by setting up the post types, custom taxonomies, flushing rewrite rules to initiate the new
  * 'donations' slug and also creates the plugin and populates the settings fields for those plugin pages. After
- * successful install, the user is redirected to the Give Welcome screen.
+ * successful install, the user is redirected to the Give Onboarding Wizard.
  *
  * @since 1.0
  *

--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 
 == Changelog ==
 
+= 2.8.0: ??? =
+* Fix: On a fresh install, users are now directed to the new Onboarding Wizard!
+
 = 2.7.2: July 6th, 2020 =
 * Fix: The 2.7.0 upgrade routine could cause WP-Admin to be incorrectly redirected to the update success screen for certain hosting environments after completion. [#4900](https://github.com/impress-org/givewp/issues/4900)
 * Fix: The Donor Wall shortcode now allows you to properly only display certain donors by their donor IDs. [#4864](https://github.com/impress-org/givewp/issues/4864)

--- a/src/Views/Admin.php
+++ b/src/Views/Admin.php
@@ -42,6 +42,10 @@ class Admin {
 		// Load Reports page
 		$reports = new Admin\Pages\Reports();
 		$reports->init();
+
+		// Load Onboarding Wizard page
+		$onboarding_wizard = new Admin\Pages\OnboardingWizard();
+		$onboarding_wizard->init();
 	}
 
 }

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -5,23 +5,45 @@ namespace Give\Views\Admin\Pages;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * undocumented class
+ * Onboarding Wizard admin page class
+ *
+ * Responsible for setting up and rendering Onboarding Wizard page at
+ * wp-admin/?page=give-onboarding-wizard
  */
 class OnboardingWizard {
 
 
+	/** @var string $slug Page slug used for displaying onboarding wizard */
 	protected $slug = 'give-onboarding-wizard';
 
+	/**
+	 * Adds Onboarding Wizard hooks
+	 *
+	 * Handles setting up hooks relates to the Onboarding Wizard admin page.
+	 *
+	 **/
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_page' ] );
 		add_action( 'admin_init', [ $this, 'setup_wizard' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}
 
+	/**
+	 * Adds Onboarding Wizard as dashboard page
+	 *
+	 * Register Onboarding Wizard as an admin page route
+	 *
+	 **/
 	public function add_page() {
-		add_dashboard_page( '', '', 'manage_options', 'give-onboarding-wizard', '' );
+		add_dashboard_page( '', '', 'manage_options', $this->slug, '' );
 	}
 
+	/**
+	 * Conditionally renders Onboarding Wizard
+	 *
+	 * If the current page query matches the onboarding wizard's slug, method renders the onboarding wizard.
+	 *
+	 **/
 	public function setup_wizard() {
 		if ( empty( $_GET['page'] ) || $this->slug !== $_GET['page'] ) { // WPCS: CSRF ok, input var ok.
 			return;
@@ -30,6 +52,12 @@ class OnboardingWizard {
 		}
 	}
 
+	/**
+	 * Renders onboarding wizard markup
+	 *
+	 * Uses an object buffer to display the onboarding wizard template
+	 *
+	 **/
 	public function render_page() {
 		ob_start();
 		include_once GIVE_PLUGIN_DIR . 'src/Views/Admin/Pages/templates/onboarding-wizard-template.php';
@@ -37,6 +65,13 @@ class OnboardingWizard {
 
 	}
 
+	/**
+	 * Enqueues onboarding wizard scripts/styles
+	 *
+	 * Enqueues scripts/styles necessary for loading the Onboarding Wizard React app,
+	 * and localizes some additional data for the app to access.
+	 *
+	 **/
 	public function enqueue_scripts() {
 		wp_enqueue_style(
 			'give-admin-onboarding-wizard',

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -14,7 +14,7 @@ class OnboardingWizard {
 
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_page' ] );
-		add_action( 'admin_init', [ $this, 'render_page' ] );
+		add_action( 'admin_init', [ $this, 'setup_wizard' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}
 
@@ -22,10 +22,19 @@ class OnboardingWizard {
 		add_dashboard_page( '', '', 'manage_options', 'give-onboarding-wizard', '' );
 	}
 
+	public function setup_wizard() {
+		if ( empty( $_GET['page'] ) || $this->slug !== $_GET['page'] ) { // WPCS: CSRF ok, input var ok.
+			return;
+		} else {
+			$this->render_page();
+		}
+	}
+
 	public function render_page() {
 		ob_start();
 		include_once GIVE_PLUGIN_DIR . 'src/Views/Admin/Pages/templates/onboarding-wizard-template.php';
 		exit;
+
 	}
 
 	public function enqueue_scripts() {
@@ -48,9 +57,18 @@ class OnboardingWizard {
 			'give-admin-onboarding-wizard-app',
 			'giveOnboardingWizardData',
 			[
+				'setupUrl'   => admin_url( '?page=give-getting-started' ),
 				'currencies' => array_keys( give_get_currencies_list() ),
 			]
 		);
+
+		wp_enqueue_style(
+			'give-google-font-montserrat',
+			'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap',
+			[],
+			GIVE_VERSION
+		);
+
 	}
 
 }

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -29,7 +29,28 @@ class OnboardingWizard {
 	}
 
 	public function enqueue_scripts() {
+		wp_enqueue_style(
+			'give-admin-onboarding-wizard',
+			GIVE_PLUGIN_URL . 'assets/dist/css/admin-onboarding-wizard.css',
+			[],
+			'0.0.1'
+		);
+		wp_enqueue_script(
+			'give-admin-onboarding-wizard-app',
+			GIVE_PLUGIN_URL . 'assets/dist/js/admin-onboarding-wizard.js',
+			[ 'wp-element', 'wp-api', 'wp-i18n' ],
+			'0.0.1',
+			true
+		);
+		wp_set_script_translations( 'give-admin-onboarding-wizard-app', 'give' );
 
+		wp_localize_script(
+			'give-admin-onboarding-wizard-app',
+			'giveOnboardingWizardData',
+			[
+				'currencies' => array_keys( give_get_currencies_list() ),
+			]
+		);
 	}
 
 }

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Give\Views\Admin\Pages;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * undocumented class
+ */
+class OnboardingWizard {
+
+
+	protected $slug = 'give-onboarding-wizard';
+
+	public function init() {
+		add_action( 'admin_menu', [ $this, 'add_page' ] );
+		add_action( 'admin_init', [ $this, 'render_page' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+	}
+
+	public function add_page() {
+		add_dashboard_page( '', '', 'manage_options', 'give-onboarding-wizard', '' );
+	}
+
+	public function render_page() {
+		ob_start();
+		include_once GIVE_PLUGIN_DIR . 'src/Views/Admin/Pages/templates/onboarding-wizard-template.php';
+		exit;
+	}
+
+	public function enqueue_scripts() {
+
+	}
+
+}

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -84,13 +84,13 @@ class OnboardingWizard {
 			'give-admin-onboarding-wizard',
 			GIVE_PLUGIN_URL . 'assets/dist/css/admin-onboarding-wizard.css',
 			[],
-			'0.0.1'
+			GIVE_VERSION
 		);
 		wp_enqueue_script(
 			'give-admin-onboarding-wizard-app',
 			GIVE_PLUGIN_URL . 'assets/dist/js/admin-onboarding-wizard.js',
 			[ 'wp-element', 'wp-api', 'wp-i18n' ],
-			'0.0.1',
+			GIVE_VERSION,
 			true
 		);
 		wp_set_script_translations( 'give-admin-onboarding-wizard-app', 'give' );

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -9,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * Responsible for setting up and rendering Onboarding Wizard page at
  * wp-admin/?page=give-onboarding-wizard
+ *
+ * @since 2.8.0
  */
 class OnboardingWizard {
 
@@ -21,6 +23,7 @@ class OnboardingWizard {
 	 *
 	 * Handles setting up hooks relates to the Onboarding Wizard admin page.
 	 *
+	 * @since 2.8.0
 	 **/
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_page' ] );
@@ -33,6 +36,7 @@ class OnboardingWizard {
 	 *
 	 * Register Onboarding Wizard as an admin page route
 	 *
+	 * @since 2.8.0
 	 **/
 	public function add_page() {
 		add_dashboard_page( '', '', 'manage_options', $this->slug, '' );
@@ -43,6 +47,7 @@ class OnboardingWizard {
 	 *
 	 * If the current page query matches the onboarding wizard's slug, method renders the onboarding wizard.
 	 *
+	 * @since 2.8.0
 	 **/
 	public function setup_wizard() {
 		if ( empty( $_GET['page'] ) || $this->slug !== $_GET['page'] ) { // WPCS: CSRF ok, input var ok.
@@ -57,6 +62,7 @@ class OnboardingWizard {
 	 *
 	 * Uses an object buffer to display the onboarding wizard template
 	 *
+	 * @since 2.8.0
 	 **/
 	public function render_page() {
 		ob_start();
@@ -71,6 +77,7 @@ class OnboardingWizard {
 	 * Enqueues scripts/styles necessary for loading the Onboarding Wizard React app,
 	 * and localizes some additional data for the app to access.
 	 *
+	 * @since 2.8.0
 	 **/
 	public function enqueue_scripts() {
 		wp_enqueue_style(

--- a/src/Views/Admin/Pages/OnboardingWizard.php
+++ b/src/Views/Admin/Pages/OnboardingWizard.php
@@ -108,7 +108,7 @@ class OnboardingWizard {
 			'give-google-font-montserrat',
 			'https://fonts.googleapis.com/css?family=Montserrat:100,100i,200,200i,300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i&display=swap',
 			[],
-			GIVE_VERSION
+			null
 		);
 
 	}

--- a/src/Views/Admin/Pages/templates/onboarding-wizard-template.php
+++ b/src/Views/Admin/Pages/templates/onboarding-wizard-template.php
@@ -1,0 +1,23 @@
+<?php
+
+// same as default WP from wp-admin/admin-header.php.
+$wp_version_class = 'branch-' . str_replace( [ '.', ',' ], '-', floatval( get_bloginfo( 'version' ) ) );
+
+set_current_screen();
+?>
+
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta name="viewport" content="width=device-width" />
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title><?php esc_html_e( 'GiveWP &rsaquo; Onboarding Wizard', 'give' ); ?></title>
+	<?php do_action( 'admin_enqueue_scripts' ); ?>
+	<?php do_action( 'admin_print_styles' ); ?>
+	<?php do_action( 'admin_head' ); ?>
+</head>
+	<body class="<?php echo esc_attr( $wp_version_class ); ?>">
+		<h1>GiveWP Onboarding Wizard!</h1>
+		<?php do_action( 'give_onboarding_wizard_footer' ); ?>
+	</body>
+</html>

--- a/src/Views/Admin/Pages/templates/onboarding-wizard-template.php
+++ b/src/Views/Admin/Pages/templates/onboarding-wizard-template.php
@@ -14,10 +14,11 @@ set_current_screen();
 	<title><?php esc_html_e( 'GiveWP &rsaquo; Onboarding Wizard', 'give' ); ?></title>
 	<?php do_action( 'admin_enqueue_scripts' ); ?>
 	<?php do_action( 'admin_print_styles' ); ?>
+	<?php do_action( 'admin_print_scripts' ); ?>
 	<?php do_action( 'admin_head' ); ?>
 </head>
 	<body class="<?php echo esc_attr( $wp_version_class ); ?>">
-		<h1>GiveWP Onboarding Wizard!</h1>
-		<?php do_action( 'give_onboarding_wizard_footer' ); ?>
+		<div id="onboarding-wizard-app"></div>
+		<?php do_action( 'admin_print_footer_scripts' ); ?>
 	</body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ const config = {
 		'admin-reports': [ './assets/src/js/admin/reports/app.js' ],
 		'admin-reports-widget': [ './assets/src/js/admin/reports/widget.js' ],
 		'admin-widgets': [ './assets/src/js/admin/admin-widgets.js', './assets/src/css/admin/widgets.scss' ],
+		'admin-onboarding-wizard': [ './assets/src/js/admin/onboarding-wizard/index.js' ],
 	},
 	output: {
 		path: path.join( __dirname, './assets/dist/' ),


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->
Resolves #4915 
This PR scaffolds the Onboarding Wizard page, which is now shown to users on first install, or at the admin url `wp-admin/?page=give-onboarding-wizard`. Previously, on a new install users were directed to the Welcome Page (at `wp-admin/?page=give-getting-started`). This PR instead directs users to the new Onboarding Wizard, and loads necessary styles/scripts.

## Description
This PR introduces the OnboardingWizard class in the src/Views/Admin/Pages namespace. Inline with other admin page view classes, the  OnboardingWizard class includes an init() method, which is called in the Admin views load_pages function. The init() method registers a dashboard page ('give-onboarding-wizard), outputs the wizard template, and enqueues necessary scripts/styles to load the onboarding wizard.

Additionally, this PR scaffolds the Onboarding Wizard React app. Currently, the app is minimal, and simply renders some dummy content and a link to skip the onboarding wizard. The URL for this link is localized by the OnboardingWizard class on page load, and directs users to the Welcome Page. In the future, this will direct users to the Setup page instead.

## Affects
This PR affects the new install process, redirecting new users to the Onboarding Wizard first, instead of the Welcome Page. The PR also makes the Onboarding Wizard available to users via the admin url: `wp-admin/?page=give-onboarding-wizard`.

## Visuals
<img width="1204" alt="Screen Shot 2020-07-09 at 2 30 12 PM" src="https://user-images.githubusercontent.com/5186078/87094075-1b73a980-c1f3-11ea-9766-db891ff134ca.png">

## Pre-review Checklist
- [x] Acceptance criteria satisfied and marked in issue
- [x] Tests included
- [x] Keyboard accessible
- [x] Screen reader accessible
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changelog updated
- [x] Labels applied if user testing/docs are needed 
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) completed

## User Testing
On an entirely fresh install of GiveWP. 
- [x] Are you redirected to the new onboarding wizard, instead of the Welcome page?

On any GiveWP install, navigate to admin url: `wp-admin/?page=give-onboarding-wizard`.
- [x] Are you taken to the new onboarding wizard?
- [x] When you click "Not right now", are you redirected to the Welcome page?

## User Documentation
- [ ] On new install, users are now directed to the Onboarding Wizard, instead of the Welcome page
