### PR TITLE
fix: prevent decimal issues when using ',' as decimal separator

### DIFF
--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -178,6 +178,18 @@ class AverageDonation extends Endpoint {
 		return $trend;
 	}
 
+	/**
+	 * Calculate average income for a period
+	 *
+	 * Based on provided start and end strings, return the calculated income,
+	 * rounded to the appropriate decimal place for the currently queried currency
+	 *
+	 * @param string $startStr Period start string
+	 * @param string $endStr Period end string
+	 *
+	 * @return float Average income float (rounded to the decimal place of currently queried currency)
+	 * @since 2.6.0
+	 **/
 	public function get_average_income( $startStr, $endStr ) {
 
 		$paymentObjects = $this->get_payments( $startStr, $endStr );

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -100,6 +100,7 @@ class AverageDonation extends Endpoint {
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
+						'sanitize'        => false,
 					]
 				),
 				'body'   => __( 'Avg Income', 'give' ),
@@ -135,6 +136,7 @@ class AverageDonation extends Endpoint {
 						[
 							'currency_code'   => $this->currency,
 							'decode_currency' => true,
+							'sanitize'        => false,
 						]
 					),
 				],

--- a/src/API/Endpoints/Reports/AverageDonation.php
+++ b/src/API/Endpoints/Reports/AverageDonation.php
@@ -197,6 +197,6 @@ class AverageDonation extends Endpoint {
 		$averageIncome = $paymentCount > 0 ? $earnings / $paymentCount : 0;
 
 		// Return rounded average (avoid displaying figures with many decimal places)
-		return round( $averageIncome, 2 );
+		return round( $averageIncome, give_get_price_decimals( $this->currency ) );
 	}
 }

--- a/src/API/Endpoints/Reports/FormPerformance.php
+++ b/src/API/Endpoints/Reports/FormPerformance.php
@@ -64,6 +64,7 @@ class FormPerformance extends Endpoint {
 							[
 								'currency_code'   => $this->currency,
 								'decode_currency' => true,
+								'sanitize'        => false,
 							]
 						),
 						'body'   => $value['donations'] . ' ' . __( 'Donations', 'give' ),
@@ -94,6 +95,7 @@ class FormPerformance extends Endpoint {
 						[
 							'currency_code'   => $this->currency,
 							'decode_currency' => true,
+							'sanitize'        => false,
 						]
 					),
 					'body'   => $value['donations'] . ' ' . __( 'Donations', 'give' ),

--- a/src/API/Endpoints/Reports/Income.php
+++ b/src/API/Endpoints/Reports/Income.php
@@ -90,6 +90,7 @@ class Income extends Endpoint {
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
+						'sanitize'        => false,
 					]
 				),
 				'body'   => $donorsForPeriod . ' ' . __( 'Donors', 'give' ),

--- a/src/API/Endpoints/Reports/IncomeBreakdown.php
+++ b/src/API/Endpoints/Reports/IncomeBreakdown.php
@@ -129,6 +129,7 @@ class IncomeBreakdown extends Endpoint {
 				[
 					'currency_code'   => $this->currency,
 					'decode_currency' => true,
+					'sanitize'        => false,
 				]
 			),
 			'donors'  => count( $unique ),
@@ -138,6 +139,7 @@ class IncomeBreakdown extends Endpoint {
 				[
 					'currency_code'   => $this->currency,
 					'decode_currency' => true,
+					'sanitize'        => false,
 				]
 			),
 		];

--- a/src/API/Endpoints/Reports/PaymentMethods.php
+++ b/src/API/Endpoints/Reports/PaymentMethods.php
@@ -64,6 +64,7 @@ class PaymentMethods extends Endpoint {
 						[
 							'currency_code'   => $this->currency,
 							'decode_currency' => true,
+							'sanitize'        => false,
 						]
 					),
 					'body'   => $gateway['count'] . ' ' . __( 'Payments', 'give' ),

--- a/src/API/Endpoints/Reports/TopDonors.php
+++ b/src/API/Endpoints/Reports/TopDonors.php
@@ -36,6 +36,7 @@ class TopDonors extends Endpoint {
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
+						'sanitize'        => false,
 					]
 				);
 				$donors[ $paymentObject->donor_id ]['donations'] = isset( $donors[ $paymentObject->donor_id ]['donations'] ) ? $donors[ $paymentObject->donor_id ]['donations'] += 1 : 1;

--- a/src/API/Endpoints/Reports/TotalIncome.php
+++ b/src/API/Endpoints/Reports/TotalIncome.php
@@ -88,6 +88,7 @@ class TotalIncome extends Endpoint {
 					[
 						'currency_code'   => $this->currency,
 						'decode_currency' => true,
+						'sanitize'        => false,
 					]
 				),
 				'body'   => __( 'Total Income', 'give' ),
@@ -123,6 +124,7 @@ class TotalIncome extends Endpoint {
 						[
 							'currency_code'   => $this->currency,
 							'decode_currency' => true,
+							'sanitize'        => false,
 						]
 					),
 				],


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->
Resolves #4574 

## Description
This PR improves functionality throughout various Reports endpoint to ensure that amounts which have already been sanitized are not being re-sanitized, causing frontend display errors when using ',' as the decimal separator. Additionally, the PR improves rounding logic in the Average Donation endpoint, to ensure that amounts are rounded to the decimal place specified in the currency settings.

Previously, when using a ',' as the decimal separator for a currency, it produces inconsistent errors in terms of decimal placement for totals displayed on the Reports page. Furthermore, using a ',' for the decimal separator resulted in consistent misplacement of the decimal in the Average Donations totals. This PR resolves both of these issues.

## Affects
This PR affects currency formatting logic in various Reports endpoints, and rounding logic in the average donation calculation method. It ensures that amounts are formatting without re-sanitization, and that average donation amounts are rounded to the appropriate decimal place specified in currency settings.

## Pre-review Checklist
- [x] Acceptance criteria satisfied and marked in issue
- [x] Tests included
- [x] Keyboard accessible
- [x] Screen reader accessible
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changelog updated
- [x] Labels applied if user testing/docs are needed 
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) completed

## User Testing
On an install of GiveWP with donations already processed, set ',' as the decimal separator (in currency settings).
- [ ] Do all donation totals on the Reports page appear as expected (with the current number of decimal places after the ',')?
- [ ] Especially, are the Average Donation totals displayed as expected?

Now, in the currency settings, change the number of decimal places to use.
- [ ] Do all donation totals on the Reports page appear as expected (with the current number of decimal places after the ',')?
- [ ] Especially, are the Average Donation totals displayed as expected?