### PR TITLE
Add Hooks helper for creating auto-instantiated hooks

### DIFF
--- a/src/Helpers/Hooks.php
+++ b/src/Helpers/Hooks.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Give\Helpers;
+
+use BadMethodCallException;
+
+class Hooks {
+	/**
+	 * A function which extends the WordPress add_action method to handle the instantiation of a class
+	 * once the action is fired. This prevents the need to instantiate a class before adding it to hook.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $tag
+	 * @param string $class
+	 * @param string $method
+	 * @param int    $priority
+	 * @param int    $acceptedArgs
+	 *
+	 * @return void
+	 */
+	public static function addAction( $tag, $class, $method = '__invoke', $priority = 10, $acceptedArgs = 1 ) {
+		add_action(
+			$tag,
+			static function () use ( $tag, $class, $method ) {
+				// Provide a way of disabling the hook
+				if ( apply_filters( "give_disable_hook-{$tag}", false ) || apply_filters( "give_disable_hook-{$tag}:{$class}@{$method}", false ) ) {
+					return;
+				}
+
+				$instance = give( $class );
+
+				if ( ! method_exists( $instance, $method ) ) {
+					throw new BadMethodCallException( "The method $method does not exist on $class" );
+				}
+
+				call_user_func_array( [ $instance, $method ], func_get_args() );
+			},
+			$priority,
+			$acceptedArgs
+		);
+	}
+
+	/**
+	 * A function which extends the WordPress add_filter method to handle the instantiation of a class
+	 * once the filter is fired. This prevents the need to instantiate a class before adding it to hook.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $tag
+	 * @param string $class
+	 * @param string $method
+	 * @param int    $priority
+	 * @param int    $acceptedArgs
+	 *
+	 * @return void
+	 */
+	public static function addFilter( $tag, $class, $method = '__invoke', $priority = 10, $acceptedArgs = 1 ) {
+		add_filter(
+			$tag,
+			static function () use ( $tag, $class, $method ) {
+				// Provide a way of disabling the hook
+				if ( apply_filters( "give_disable_hook-{$tag}", false ) || apply_filters( "give_disable_hook-{$tag}:{$class}@{$method}", false ) ) {
+					return func_get_arg( 0 );
+				}
+
+				$instance = give()->make( $class );
+
+				if ( ! method_exists( $instance, $method ) ) {
+					throw new BadMethodCallException( "The method $method does not exist on $class" );
+				}
+
+				return call_user_func_array( [ $instance, $method ], func_get_args() );
+			},
+			$priority,
+			$acceptedArgs
+		);
+	}
+}

--- a/src/Helpers/Hooks.php
+++ b/src/Helpers/Hooks.php
@@ -2,7 +2,7 @@
 
 namespace Give\Helpers;
 
-use BadMethodCallException;
+use InvalidArgumentException;
 
 class Hooks {
 	/**
@@ -20,6 +20,10 @@ class Hooks {
 	 * @return void
 	 */
 	public static function addAction( $tag, $class, $method = '__invoke', $priority = 10, $acceptedArgs = 1 ) {
+		if ( ! method_exists( $class, $method ) ) {
+			throw new InvalidArgumentException( "The method $method does not exist on $class" );
+		}
+
 		add_action(
 			$tag,
 			static function () use ( $tag, $class, $method ) {
@@ -29,10 +33,6 @@ class Hooks {
 				}
 
 				$instance = give( $class );
-
-				if ( ! method_exists( $instance, $method ) ) {
-					throw new BadMethodCallException( "The method $method does not exist on $class" );
-				}
 
 				call_user_func_array( [ $instance, $method ], func_get_args() );
 			},
@@ -56,6 +56,10 @@ class Hooks {
 	 * @return void
 	 */
 	public static function addFilter( $tag, $class, $method = '__invoke', $priority = 10, $acceptedArgs = 1 ) {
+		if ( ! method_exists( $class, $method ) ) {
+			throw new InvalidArgumentException( "The method $method does not exist on $class" );
+		}
+
 		add_filter(
 			$tag,
 			static function () use ( $tag, $class, $method ) {
@@ -64,11 +68,7 @@ class Hooks {
 					return func_get_arg( 0 );
 				}
 
-				$instance = give()->make( $class );
-
-				if ( ! method_exists( $instance, $method ) ) {
-					throw new BadMethodCallException( "The method $method does not exist on $class" );
-				}
+				$instance = give( $class );
 
 				return call_user_func_array( [ $instance, $method ], func_get_args() );
 			},


### PR DESCRIPTION
Resolves #4938 

## Description

The targeted purpose for this PR is to provide a more memory efficient means of using WordPress hooks that also helps to organize our code.

Right now, every class that has hooks that need to be applied needs to be instantiated in order to have its hooks set up. This would be like leaving your house with everything you own _just in case_ you need anything while you're out. This provides a means of specifying the class and method to be called _if_ the action/filter ends up being used. So if the hook isn't used, the class isn't instantiated — which uses less memory.

This also gives us the ability to better centralize our hooks. So instead of hooks being scattered through hundreds of classes, they can instead be primarily set up within the Service Providers. So this...
```php
class FrontEndAssets {
    public function init() {
        add_action('wp_enqueue_scripts', [$this, 'loadScripts']);
    }

    public function loadScript() {
        // load scripts
    }
}

class BackEndAssets {
    public function init() {
        add_action('admin_enqueue_scripts', [$this, 'loadScripts']);
    }

    public function loadScript() {
        // load scripts
    }
}

$frontEnd = new FrontEndAssets();
$frontEnd->init();

$backEnd = new BackEndAssets();
$backEnd->init();
```

becomes this

```php
class AssetsServiceProvider {
    public function boot() {
        Hooks::add_action('wp_enqueue_scripts', FrontEndAssets::class, 'loadScript');
        Hooks::add_action('admin_enqueue_scripts', BackEndAssets::class, 'loadScript');
    }
}

class FrontEndAssets {
    public function loadScript() {
        // load scripts
    }
}

class BackEndAssets {
    public function loadScript() {
        // load scripts
    }
}
```

As you can see it's less code, easier to follow, and more memory efficient. Huzzah! 🎊 

## Affects

This does not affect any existing code. It's just new utilities.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
