### PR TITLE
don't pass $meta_value twice and pass $meta_type rather for use

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -980,7 +980,7 @@ function give_get_meta( $id, $meta_key = '', $single = false, $default = false, 
 	 *
 	 * @since 1.8.8
 	 */
-	$meta_value = apply_filters( 'give_get_meta', $meta_value, $id, $meta_key, $default, $meta_value );
+	$meta_value = apply_filters( 'give_get_meta', $meta_value, $id, $meta_key, $default, $meta_type );
 
 	if ( ( empty( $meta_key ) || empty( $meta_value ) ) && $default ) {
 		$meta_value = $default;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4464

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I updated the `give_get_meta` filter to pass the correct param rather than a duplicate of another one already passed.
