### PR TITLE
Fix/title prefix order 4992

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2931,6 +2931,48 @@ const gravatar = require( 'gravatar' );
 		},
 	};
 
+	/**
+	 * Keep multi select options order.
+	 *
+	 * @since 2.7.3
+	 */
+	const GiveMultiSelectOptions = {
+		init: function() {
+			$( '.give-select-chosen[multiple]' ).each( function( i, selectDropdown ) {
+				$( selectDropdown ).chosen().change( function( e, currentOption ) {
+					const $dropdown = $( this );
+					const dropDownId = $dropdown.attr( 'id' );
+					const orderedOptions = [];
+
+					$( `#${ dropDownId }_chosen li.search-choice span` ).each( function( j, element ) {
+						const value = element.textContent;
+						if ( value !== currentOption.deselected ) {
+							orderedOptions.push( { value, selected: true } );
+						}
+					} );
+
+					Array.from( e.target.options ).map( option => {
+						const included = orderedOptions.filter( orderedOption => orderedOption.value === option.value ).length;
+						if ( ! included ) {
+							orderedOptions.push( {
+								value: option.value,
+								selected: option.selected,
+							} );
+						}
+					} );
+
+					// Rebuild the dropdown
+					$dropdown.empty();
+					orderedOptions.map( option => $dropdown.append( $( '<option>', {
+						value: option.value,
+						text: option.value,
+						selected: option.selected,
+					} ) ) );
+				} );
+			} );
+		},
+	};
+
 	// On DOM Ready.
 	$( function() {
 		give_dismiss_notice();
@@ -2950,6 +2992,7 @@ const gravatar = require( 'gravatar' );
 		Edit_Form_Screen.init();
 		GivePaymentHistory.init();
 		GiveShortcodeButtonObj.init();
+		GiveMultiSelectOptions.init();
 
 		// Footer.
 		$( 'a.give-rating-link' ).click( function() {

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2934,7 +2934,7 @@ const gravatar = require( 'gravatar' );
 	/**
 	 * Keep multi select options order.
 	 *
-	 * @since 2.7.3
+	 * @since 2.8.0
 	 */
 	const GiveMultiSelectOptions = {
 		init: function() {

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -902,8 +902,8 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 
 					// Add dynamically added values to options
 					// we can add option dynamically to chosen select field. For example: "Title Prefixes"
-					if ( $allow_new_values && $option_value && ( $missing_options = array_diff( $option_value, array_keys( $choices ) ) ) ) {
-						$choices = array_merge( $value['options'], array_combine( $missing_options, $missing_options ) );
+					if ( $allow_new_values && $option_value ) {
+						$choices = array_merge( array_combine( $option_value, $option_value ), $value['options'] );
 					}
 					?>
 					<tr valign="top" <?php echo $wrapper_class; ?>>

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -341,8 +341,8 @@ function give_chosen_input( $field ) {
 		$fieldName     .= '[]';
 	}
 
-	if ( $allow_new_values && $field['value'] && ( $missing = array_diff( $field['value'], array_keys( $choices ) ) ) ) {
-		$choices = array_merge( $choices, array_combine( $missing, $missing ) );
+	if ( $allow_new_values && $field['value'] ) {
+		$choices = array_merge( array_combine( $field['value'], $field['value'] ), $choices );
 	}
 	?>
 	<p class="give-field-wrap <?php echo esc_attr( $field['id'] ); ?>_field <?php echo esc_attr( $field['wrapper_class'] ); ?>">


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4992 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The order of **Title Prefix** options was not kept after saving the settings. This PR solves this issue by reordering the hidden selected options on options update. This PR affects all multi-select fields.

## Affects

Edit Donation form screen -> Form Fields tab -> Title Prefixes multi-select dropdown
Settings screen -> Default Options tab -> Title Prefixes multi-select dropdown
Any future multi-select settings field

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Add global Title Prefixes options
Add Form Fields Title Prefixes options
