### PR TITLE
fix: Multi-step forms without 1st step should not auto-focus on page load #5004

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -11,6 +11,7 @@
 	const navigator = {
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
 		animating: false,
+		firstFocus: false,
 		goToStep: ( step ) => {
 			// Adjust body height before animating step, to prevent choppy iframe resizing
 			// Compare next step to current step, and increase body height if next step is taller.
@@ -75,6 +76,10 @@
 			setupTabOrder();
 
 			setTimeout( function() {
+				// Do not auto-focus form on the page load if the first step is disabled
+				if ( ! navigator.firstFocus && templateOptions.introduction.enabled === 'disabled' ) {
+					return navigator.firstFocus = true;
+				}
 				if ( steps[ navigator.currentStep ].firstFocus ) {
 					$( steps[ navigator.currentStep ].firstFocus ).focus();
 				}


### PR DESCRIPTION

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5004

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
If you place a form on a page without the first step, the page auto-scrolls to the form location.
This PR solves this issue by disabling initial auto-focus on the page load only if the 1st step is disabled.
## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Multi-step form auto-focus

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Add multi-step form
2. Disable the 1st step
3. Navigate to the donation page
4. Refresh the page couple of times ( CTRL/CMD + F5 )

