### PR TITLE
Fix/countries without postcodes 5006

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -124,7 +124,7 @@ jQuery( function( $ ) {
 					}
 
 					// Check whether the post code fields should be required
-					const zipRequired = !! response.zip_required;
+					const zipRequired = !! response.zip_require;
 					$form.find( 'input#card_zip' ).toggleClass( 'required', zipRequired )
 						.attr( 'required', zipRequired )
 						.attr( 'aria-required', zipRequired );

--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -124,20 +124,11 @@ jQuery( function( $ ) {
 					}
 
 					// Check whether the post code fields should be required
-					if (
-						'undefined' !== typeof ( response.zip_require ) &&
-						false === response.zip_require
-					) {
-						$form.find( 'input#card_zip' ).removeClass( 'required' );
-						$form.find( 'input#card_zip' ).attr( 'required', false );
-						$form.find( 'input#card_zip' ).attr( 'aria-required', false );
-						$form.find( 'label[for="card_zip"] span.give-required-indicator' ).addClass( 'give-hidden' );
-					} else {
-						$form.find( 'input#card_zip' ).addClass( 'required' );
-						$form.find( 'input#card_zip' ).attr( 'required', true );
-						$form.find( 'input#card_zip' ).attr( 'aria-required', true );
-						$form.find( 'label[for="card_zip"] span.give-required-indicator' ).removeClass( 'give-hidden' );
-					}
+					const zipRequired = !! response.zip_required;
+					$form.find( 'input#card_zip' ).toggleClass( 'required', zipRequired )
+						.attr( 'required', zipRequired )
+						.attr( 'aria-required', zipRequired );
+					$form.find( 'label[for="card_zip"] span.give-required-indicator' ).toggleClass( 'give-hidden', zipRequired );
 
 					doc.trigger( 'give_checkout_billing_address_updated', [ response, $form.attr( 'id' ) ] );
 				},

--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -123,6 +123,22 @@ jQuery( function( $ ) {
 						$form.find( 'p#give-card-zip-wrap' ).removeClass( 'form-row-last' );
 					}
 
+					// Check whether the post code fields should be required
+					if (
+						'undefined' !== typeof ( response.zip_require ) &&
+						false === response.zip_require
+					) {
+						$form.find( 'input#card_zip' ).removeClass( 'required' );
+						$form.find( 'input#card_zip' ).attr( 'required', false );
+						$form.find( 'input#card_zip' ).attr( 'aria-required', false );
+						$form.find( 'label[for="card_zip"] span.give-required-indicator' ).addClass( 'give-hidden' );
+					} else {
+						$form.find( 'input#card_zip' ).addClass( 'required' );
+						$form.find( 'input#card_zip' ).attr( 'required', true );
+						$form.find( 'input#card_zip' ).attr( 'aria-required', true );
+						$form.find( 'label[for="card_zip"] span.give-required-indicator' ).removeClass( 'give-hidden' );
+					}
+
 					doc.trigger( 'give_checkout_billing_address_updated', [ response, $form.attr( 'id' ) ] );
 				},
 			} ).fail( function( data ) {

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -265,6 +265,7 @@ function give_ajax_get_states_field() {
 		'data'           => $data,
 		'default_state'  => $default_state,
 		'city_require'   => ! array_key_exists( $country, give_city_not_required_country_list() ),
+		'zip_require'    => ! array_key_exists( $country, give_get_country_list_without_postcodes() ),
 	);
 	wp_send_json( $response );
 }

--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -2363,3 +2363,86 @@ function give_get_spain_states_list() {
 
 	return apply_filters( 'give_spain_states', $states );
 }
+
+/**
+ * Get Country List without postcodes
+ *
+ * @since 2.8.0
+ * @return array $countries A list of countries without postcodes.
+ */
+function give_get_country_list_without_postcodes() {
+	$countries = [
+		'AO' => esc_html__( 'Angola', 'give' ),
+		'AG' => esc_html__( 'Antigua and Barbuda', 'give' ),
+		'AW' => esc_html__( 'Aruba', 'give' ),
+		'BS' => esc_html__( 'Bahamas', 'give' ),
+		'BZ' => esc_html__( 'Belize', 'give' ),
+		'BJ' => esc_html__( 'Benin', 'give' ),
+		'BW' => esc_html__( 'Botswana', 'give' ),
+		'BF' => esc_html__( 'Burkina Faso', 'give' ),
+		'BI' => esc_html__( 'Burundi', 'give' ),
+		'CM' => esc_html__( 'Cameroon', 'give' ),
+		'CF' => esc_html__( 'Central African Republic', 'give' ),
+		'KM' => esc_html__( 'Comoros', 'give' ),
+		'CD' => esc_html__( 'Congo, Democratic People\'s Republic', 'give' ),
+		'CG' => esc_html__( 'Congo, Republic of', 'give' ),
+		'CK' => esc_html__( 'Cook Islands', 'give' ),
+		'CI' => esc_html__( 'Cote d\'Ivoire', 'give' ),
+		'DJ' => esc_html__( 'Djibouti', 'give' ),
+		'DM' => esc_html__( 'Dominica', 'give' ),
+		'GQ' => esc_html__( 'Equatorial Guinea', 'give' ),
+		'ER' => esc_html__( 'Eritrea', 'give' ),
+		'FJ' => esc_html__( 'Fiji', 'give' ),
+		'TF' => esc_html__( 'French Southern Territories', 'give' ),
+		'GM' => esc_html__( 'Gambia', 'give' ),
+		'GH' => esc_html__( 'Ghana', 'give' ),
+		'GD' => esc_html__( 'Grenada', 'give' ),
+		'GN' => esc_html__( 'Guinea', 'give' ),
+		'GY' => esc_html__( 'Guyana', 'give' ),
+		'HK' => esc_html__( 'Hong Kong', 'give' ),
+		'IE' => esc_html__( 'Ireland', 'give' ),
+		'JM' => esc_html__( 'Jamaica', 'give' ),
+		'KE' => esc_html__( 'Kenya', 'give' ),
+		'KI' => esc_html__( 'Kiribati', 'give' ),
+		'MO' => esc_html__( 'Macau', 'give' ),
+		'MW' => esc_html__( 'Malawi', 'give' ),
+		'ML' => esc_html__( 'Mali', 'give' ),
+		'MR' => esc_html__( 'Mauritania', 'give' ),
+		'MU' => esc_html__( 'Mauritius', 'give' ),
+		'MS' => esc_html__( 'Montserrat', 'give' ),
+		'NR' => esc_html__( 'Nauru', 'give' ),
+		'AN' => esc_html__( 'Netherlands Antilles', 'give' ),
+		'NU' => esc_html__( 'Niue', 'give' ),
+		'KP' => esc_html__( 'North Korea', 'give' ),
+		'PA' => esc_html__( 'Panama', 'give' ),
+		'QA' => esc_html__( 'Qatar', 'give' ),
+		'RW' => esc_html__( 'Rwanda', 'give' ),
+		'KN' => esc_html__( 'Saint Kitts and Nevis', 'give' ),
+		'LC' => esc_html__( 'Saint Lucia', 'give' ),
+		'ST' => esc_html__( 'Sao Tome and Principe', 'give' ),
+		'SC' => esc_html__( 'Seychelles', 'give' ),
+		'SL' => esc_html__( 'Sierra Leone', 'give' ),
+		'SB' => esc_html__( 'Solomon Islands', 'give' ),
+		'SO' => esc_html__( 'Somalia', 'give' ),
+		'ZA' => esc_html__( 'South Africa', 'give' ),
+		'SR' => esc_html__( 'Suriname', 'give' ),
+		'SY' => esc_html__( 'Syrian Arab Republic', 'give' ),
+		'TZ' => esc_html__( 'Tanzania', 'give' ),
+		'TK' => esc_html__( 'Tokelau', 'give' ),
+		'TO' => esc_html__( 'Tonga', 'give' ),
+		'TT' => esc_html__( 'Trinidad and Tobago', 'give' ),
+		'TV' => esc_html__( 'Tuvalu', 'give' ),
+		'UG' => esc_html__( 'Uganda', 'give' ),
+		'AE' => esc_html__( 'United Arab Emirates', 'give' ),
+		'VU' => esc_html__( 'Vanuatu', 'give' ),
+		'YE' => esc_html__( 'Yemen', 'give' ),
+		'ZW' => esc_html__( 'Zimbabwe', 'give' ),
+	];
+
+	/**
+	 * Filter list of countries without postcodes
+	 *
+	 * @since 2.8.0
+	 */
+	return (array) apply_filters( 'give_countries_without_postcodes', $countries );
+}

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1253,7 +1253,10 @@ function give_default_cc_address_fields( $form_id ) {
 		$require_state = ! array_key_exists( $selected_country, $no_states_country ) && give_field_is_required( 'card_state', $form_id );
 		// Used to determine is state input should be marked as required.
 		$validate_state = ! array_key_exists( $selected_country, $states_not_required_country_list ) && give_field_is_required( 'card_state', $form_id );
-
+		// Check if post code is required
+		$postcode_required = $selected_country
+			? ! array_key_exists( $selected_country, give_get_country_list_without_postcodes() ) && give_field_is_required( 'card_zip', $form_id )
+			: give_field_is_required( 'card_zip', $form_id );
 		?>
 		<p id="give-card-state-wrap"
 		   class="form-row form-row-first form-row-responsive <?php echo ( ! empty( $selected_country ) && ! $require_state ) ? 'give-hidden' : ''; ?> ">
@@ -1291,9 +1294,7 @@ function give_default_cc_address_fields( $form_id ) {
 		<p id="give-card-zip-wrap" class="form-row <?php echo $require_state ? 'form-row-last' : ''; ?> form-row-responsive">
 			<label for="card_zip" class="give-label">
 				<?php _e( 'Zip / Postal Code', 'give' ); ?>
-				<?php if ( give_field_is_required( 'card_zip', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
-				<?php endif; ?>
+				<span class="give-required-indicator<?php echo ( $postcode_required ? '' : ' give-hidden' ); ?>">*</span>
 				<?php echo Give()->tooltips->render_help( __( 'The zip or postal code for your billing address.', 'give' ) ); ?>
 			</label>
 
@@ -1303,10 +1304,10 @@ function give_default_cc_address_fields( $form_id ) {
 				id="card_zip"
 				name="card_zip"
 				autocomplete="postal-code"
-				class="card-zip give-input<?php echo( give_field_is_required( 'card_zip', $form_id ) ? ' required' : '' ); ?>"
+				class="card-zip give-input<?php echo( $postcode_required ? ' required' : '' ); ?>"
 				placeholder="<?php _e( 'Zip / Postal Code', 'give' ); ?>"
 				value="<?php echo isset( $give_user_info['card_zip'] ) ? $give_user_info['card_zip'] : ''; ?>"
-				<?php echo( give_field_is_required( 'card_zip', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
+				<?php echo( $postcode_required ? ' required aria-required="true" ' : '' ); ?>
 			/>
 		</p>
 		<?php

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -689,6 +689,12 @@ function give_get_required_fields( $form_id ) {
 				// If states is empty remove the required fields of city in billing cart.
 				unset( $required_fields['card_city'] );
 			}
+
+			// Check if country is without post codes.
+			if ( array_key_exists( $country, give_get_country_list_without_postcodes() ) ) {
+				// If country is on the list, zip code is not required.
+				unset( $required_fields['card_zip'] );
+			}
 		}
 	} // End if().
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5006

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

GiveWP donation forms currently require a postal code for countries without postcodes. 
This PR solves this issue by checking the donor country. If the country is without postcodes, the Zip/Postal Code field will be optional.  
## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Donation Form Billing Details

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![deepin-screen-recorder_Select area_20200805182942](https://user-images.githubusercontent.com/4222590/89438983-d1c2a400-d749-11ea-8f29-dd424b4cd493.gif)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Enable Offline Donation gateway
2. Enable Collect Billing Details setting for Offline Donation gateway
3. Go to the donation page and select country ( Aruba, Ireland, Hong Kong, Jamaica, etc. )
4. Try to make donations with different countries selected

