### PR TITLE
Onboarding form preview does not display Test Mode notice

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -22,6 +22,15 @@ const DonationForm = () => {
 		opacity: iframeLoaded === false ? '1' : '0',
 	};
 
+	const onIframeLoaded = () => {
+		setIframeLoaded( true );
+
+		document.getElementById( 'donationFormPreview' ).contentDocument
+			.getElementById( 'iFrameResizer0' ).contentDocument
+			.getElementById( 'give_error_test_mode' )
+			.style.display = 'none';
+	};
+
 	return (
 		<div className="give-obw-donation-form-preview">
 			<div className="give-obw-donation-form-preview__loading-message" style={ messageStyle }>
@@ -30,7 +39,7 @@ const DonationForm = () => {
 					{ __( 'Building Form Preview...', 'give' ) }
 				</h3>
 			</div>
-			<iframe onLoad={ () => setIframeLoaded( true ) } className="give-obw-donation-form-preview__iframe" src={ formPreviewUrl } style={ iframeStyle } />
+			<iframe id="donationFormPreview" onLoad={ onIframeLoaded } className="give-obw-donation-form-preview__iframe" src={ formPreviewUrl } style={ iframeStyle } />
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4987

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Programatically hides the Test Mode notice when the iframe is loaded. I took this approach assuming that the iframe didn't have context of its location and was better for the Wizard to know about the iFrame than for the iFrame to know about the Wizard.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Only effects the Onboarding Wizard Form Preview and not the public display of the form.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/89473682-81e7db00-d751-11ea-9cde-465e2da0f351.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
