### PR TITLE
Store PayPal order id to donation meta

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/Models/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/PayPalOrder.php
@@ -112,9 +112,7 @@ class PayPalOrder {
 
 		foreach ( $array as $itemName => $value ) {
 			if ( 'purchaseUnits' === $itemName ) {
-				// We will always have single unit in order.
-				$itemName = 'purchaseUnit';
-				$value    = current( $value );
+				$value = current( $value );
 
 				$order->purchaseUnit = $value;
 				$order->payment      = PayPalPayment::fromArray( (array) current( $order->purchaseUnit->payments->captures ) );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4999 

## Description
I find out that PayPal order id is important to keep in database and can be help in the future to trace order details if the seller needs.

## Affects
This PR affect donation meta and note. For the future purpose, we store order id to donation meta and attach order id to donation note with PayPal Payment id.

## Visuals
![image](https://user-images.githubusercontent.com/1784821/89574993-aecbe900-d84a-11ea-854d-e72c807778bc.png)
![image](https://user-images.githubusercontent.com/1784821/89575033-bf7c5f00-d84a-11ea-936b-fe596a930168.png)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Process donation with a smart button or advanced card field. Check meta key `_give_order_id` in `wp_give_donationmeta` table and also review donation note on donation details page.