### PR TITLE
Use give_ function to read form metadata

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -103,7 +103,7 @@ function give_get_donation_form( $args = array() ) {
 			$form_title = ! is_singular( 'give_forms' ) ? apply_filters( 'give_form_title', '<h2 class="give-form-title">' . get_the_title( $form->ID ) . '</h2>' ) : '';
 
 			// Get Goal thank you message.
-			$goal_achieved_message = get_post_meta( $form->ID, '_give_form_goal_achieved_message', true );
+			$goal_achieved_message = give_get_meta( $form->ID, '_give_form_goal_achieved_message', true );
 			$goal_achieved_message = ! empty( $goal_achieved_message ) ? $form_title . apply_filters( 'the_content', $goal_achieved_message ) : '';
 
 			// Print thank you message.


### PR DESCRIPTION
## Description

Give metadata (i.e. keys prefixed with `_give_`) is almost always read with `give_get_metadata`. That means if you need to modfiy any of this, you can do it all with the `give_get_meta` filter. There is one place where `_give_form_goal_achieved_message` is read with `get_post_meta` instead, which means you need another filter for just this one place. I've changed this to be consistent (because there doesn't seem to be a reason why it shouldn't be).

## Affects

You can now modify `_give_form_goal_achieved_message` like other Give fields in the `give_get_meta` filter.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Define a `give_get_meta` filter like this:

```php
function test($meta_value, $id, $meta_key) {
    if ($meta_key === '_give_form_goal_achieved_message') {
        return 'FOUND IT!!';
    }
    return $meta_value;
}
add_filter('give_get_meta', 'test', 10, 3);
```

Open a form view in the browser (where the goal is achieved). After this change, you should see `FOUND IT!!` instead of the regular message

