### PR TITLE
fix: make donation form block selectable in editor

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -7,6 +7,15 @@
 	const $navigatorTitle = $( '.give-form-navigator .title' );
 	const $paymentGatewayContainer = $( '#give-payment-mode-select' );
 	let gatewayAnimating = false;
+	const { wp: parentWp } = window.parent;
+
+	// Make donation form block selectable in editor
+	if ( !! parentWp.data ) {
+		$container.on( 'click', function() {
+			const blockId = window.frameElement.closest( '.wp-block' ).getAttribute( 'data-block' );
+			parentWp.data.dispatch( 'core/block-editor' ).selectBlock( blockId );
+		} );
+	}
 
 	const navigator = {
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5017

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

If you click away from a donation form block in the Gutenberg editor, you can't access it again.
This PR solves the problem by adding an onClick event listener on the multi-step donation form which will dispatch an action ( Gutenberg state update - selected block ) when the user clicks on the form.

It might be that this PR is not the best solution, but I couldn't find anything related to this issue e.g. CSS prop pointer-events set to none.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Multi-step donation form block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

  1. Add a new page
  2. Select donation form block
  3. Click away from a donation form block.
  4. Click again on a donation block

