### PR TITLE
Onboarding selected Features and Addons are now pre-loaded

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -20,7 +20,13 @@ import Features from './steps/features';
 import DonationForm from './steps/donation-form';
 import Addons from './steps/addons';
 
-import { getCountryList, getDefaultStateList, getCurrencyList, getFeaturesEnabledDefault } from '../utils';
+import {
+	getCountryList,
+	getDefaultStateList,
+	getCurrencyList,
+	getFeaturesEnabledDefault,
+	getAddonsSelectedDefault,
+} from '../utils';
 
 /**
  * Onboarding Wizard app component
@@ -40,7 +46,7 @@ const App = () => {
 			state: null,
 			currency: 'USD',
 			features: getFeaturesEnabledDefault(),
-			addons: [],
+			addons: getAddonsSelectedDefault(),
 		},
 		countriesList: getCountryList(),
 		currenciesList: getCurrencyList(),

--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -20,7 +20,7 @@ import Features from './steps/features';
 import DonationForm from './steps/donation-form';
 import Addons from './steps/addons';
 
-import { getCountryList, getDefaultStateList, getCurrencyList } from '../utils';
+import { getCountryList, getDefaultStateList, getCurrencyList, getFeaturesEnabledDefault } from '../utils';
 
 /**
  * Onboarding Wizard app component
@@ -39,7 +39,7 @@ const App = () => {
 			country: 'US',
 			state: null,
 			currency: 'USD',
-			features: [ 'one-time-donations' ],
+			features: getFeaturesEnabledDefault(),
 			addons: [],
 		},
 		countriesList: getCountryList(),

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -58,6 +58,15 @@ export const getCurrencyList = () => {
 	} );
 };
 
+export const getFeaturesEnabledDefault = () => {
+	const features = getWindowData( 'features' );
+	return features.filter( ( feature ) => {
+		return feature.value;
+	} ).map( ( feature ) => {
+		return feature.label;
+	} );
+};
+
 export const decodeHTMLEntity = ( entity ) => {
 	const div = document.createElement( 'div' );
 	div.innerHTML = entity;

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -67,6 +67,10 @@ export const getFeaturesEnabledDefault = () => {
 	} );
 };
 
+export const getAddonsSelectedDefault = () => {
+	return getWindowData( 'addons' );
+};
+
 export const decodeHTMLEntity = ( entity ) => {
 	const div = document.createElement( 'div' );
 	div.innerHTML = entity;

--- a/src/Onboarding/Helpers/FormatList.php
+++ b/src/Onboarding/Helpers/FormatList.php
@@ -10,6 +10,8 @@ namespace Give\Onboarding\Helpers;
 class FormatList {
 
 	/**
+	 * Format a JS value/label object where the $key is the `value` and the $value is the `label`.
+	 *
 	 * @param array $data
 	 *
 	 * @return array
@@ -19,27 +21,46 @@ class FormatList {
 	public static function fromKeyValue( $data ) {
 		return self::format(
 			$data,
-			function( $key, $label ) {
+			function( $key, $value ) {
 				return [
 					'value' => $key,
-					'label' => $label,
+					'label' => $value,
 				];
 			}
 		);
 	}
 
+	/**
+	 * Format a JS value/label object where the $key is the `label` and the $value is the `value`.
+	 *
+	 * @param array $data
+	 *
+	 * @return array
+	 *
+	 * @since 2.8.0
+	 */
 	public static function fromValueKey( $data ) {
 		return self::format(
 			$data,
-			function( $label, $key ) {
+			function( $key, $value ) {
 				return [
-					'value' => $key,
-					'label' => $label,
+					'value' => $value,
+					'label' => $key,
 				];
 			}
 		);
 	}
 
+	/**
+	 * A higher-order function to format a JS value/label object.
+	 *
+	 * @param array $data
+	 * @param callable $function
+	 *
+	 * @return array
+	 *
+	 * @since 2.8.0
+	 */
 	protected static function format( $data, $function ) {
 		return array_map(
 			$function,

--- a/src/Onboarding/Helpers/FormatList.php
+++ b/src/Onboarding/Helpers/FormatList.php
@@ -17,16 +17,34 @@ class FormatList {
 	 * @since 2.8.0
 	 */
 	public static function fromKeyValue( $data ) {
-		$keys = array_keys( $data );
-		return array_map(
+		return self::format(
+			$data,
 			function( $key, $label ) {
 				return [
 					'value' => $key,
 					'label' => $label,
 				];
-			},
-			$keys,
-			$data
+			}
+		);
+	}
+
+	public static function fromValueKey( $data ) {
+		return self::format(
+			$data,
+			function( $label, $key ) {
+				return [
+					'value' => $key,
+					'label' => $label,
+				];
+			}
+		);
+	}
+
+	protected static function format( $data, $function ) {
+		return array_map(
+			$function,
+			array_keys( $data ),
+			array_values( $data )
 		);
 	}
 }

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -118,6 +118,13 @@ class Page {
 
 		wp_set_script_translations( 'give-admin-onboarding-wizard-app', 'give' );
 
+		$formID           = $this->formRepository->getOrMake();
+		$featureGoal      = get_post_meta( $formID, '_give_goal_option', true );
+		$featureComments  = get_post_meta( $formID, '_give_donor_comment', true );
+		$featureTerms     = get_post_meta( $formID, '_give_terms_option', true );
+		$featureAnonymous = get_post_meta( $formID, '_give_anonymous_donation', true );
+		$featureCompany   = get_post_meta( $formID, '_give_company_field', true );
+
 		wp_localize_script(
 			'give-admin-onboarding-wizard-app',
 			'giveOnboardingWizardData',
@@ -129,6 +136,15 @@ class Page {
 				'currencies'     => FormatList::fromKeyValue( give_get_currencies_list() ),
 				'countries'      => FormatList::fromKeyValue( give_get_country_list() ),
 				'states'         => FormatList::fromKeyValue( give_get_states( 'US' ) ),
+				'features'       => FormatList::fromValueKey(
+					[
+						'donation-goal'       => ( 'enabled' == $featureGoal ),
+						'donation-comments'   => ( 'enabled' == $featureComments ),
+						'terms-conditions'    => ( 'enabled' == $featureTerms ),
+						'anonymous-donations' => ( 'enabled' == $featureAnonymous ),
+						'company-donations'   => in_array( $featureCompany, [ 'required', 'optional' ] ), // Note: The company field has two values for enabled, "required" and "optional".
+					]
+				),
 			]
 		);
 

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -6,6 +6,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Give\Onboarding\Helpers\FormatList;
 use Give\Onboarding\FormRepository;
+use Give\Onboarding\SettingsRepositoryFactory;
 
 /**
  * Onboarding Wizard admin page class
@@ -23,8 +24,16 @@ class Page {
 	/** @var FormRepository */
 	protected $formRepository;
 
-	public function __construct( FormRepository $formRepository ) {
-		$this->formRepository = $formRepository;
+	/** @var SettingsRepository */
+	protected $settingsRepository;
+
+	/**
+	 * @param FormRepository $formRepository
+	 * @param SettingsRepositoryFactory $settingsRepositoryFactory
+	 */
+	public function __construct( FormRepository $formRepository, SettingsRepositoryFactory $settingsRepositoryFactory ) {
+		$this->formRepository     = $formRepository;
+		$this->settingsRepository = $settingsRepositoryFactory->make( 'give_onboarding' );
 	}
 
 	/**
@@ -145,6 +154,7 @@ class Page {
 						'company-donations'   => in_array( $featureCompany, [ 'required', 'optional' ] ), // Note: The company field has two values for enabled, "required" and "optional".
 					]
 				),
+				'addons'         => $this->settingsRepository->get( 'addons' ),
 			]
 		);
 

--- a/tests/src/Onboarding/Helpers/FormatListTest.php
+++ b/tests/src/Onboarding/Helpers/FormatListTest.php
@@ -15,4 +15,16 @@ final class FormatListTest extends TestCase {
 		];
 		$this->assertEquals( $expectedList, $formattedList );
 	}
+
+	public function testFromValueKey(): void {
+		$data          = [ 'foo' => 'bar' ];
+		$formattedList = FormatList::fromValueKey( $data );
+		$expectedList  = [
+			[
+				'value' => 'bar',
+				'label' => 'foo',
+			],
+		];
+		$this->assertEquals( $expectedList, $formattedList );
+	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5040 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Selected Features and Add-ons are pre-loaded into the initial state when the Wizard is re-launched.

- Adds new util `getFeaturesEnabledDefault()`.
- Adds new util `getAddonsSelectedDefault()`.
- Extracts a higher-order function to extend the `FormatList` helper.
- Injects a `SettingsRepositoryFactory` into the `Wizard/Page` to `get` selected add-ons.
- Builds a `features` array from post meta.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
