### PR TITLE
fix: extract give_receipt shortcode from post content

### DIFF
--- a/src/Helpers/Frontend/Shortcode.php
+++ b/src/Helpers/Frontend/Shortcode.php
@@ -10,17 +10,15 @@ class Shortcode {
 	 * @since 2.7.0
 	 */
 	public static function getReceiptShortcodeFromConfirmationPage() {
-		$pattern = get_shortcode_regex();
 		$post    = get_post( give_get_option( 'success_page', 0 ) );
 		$content = $post->post_content;
 
-		if (
-			! empty( $content ) &&
-			preg_match_all( '/' . $pattern . '/s', $content, $matches ) &&
-			array_key_exists( 2, $matches ) &&
-			in_array( 'give_receipt', $matches[2], true )
-		) {
-			return $matches[0][0];
+		if ( ! empty( $content ) ) {
+			preg_match( '/\[give_receipt(.*?)]/', $content, $matches );
+
+			if ( isset( $matches[0] ) ) {
+				return $matches[0];
+			}
 		}
 
 		return '';

--- a/src/Helpers/Frontend/Shortcode.php
+++ b/src/Helpers/Frontend/Shortcode.php
@@ -14,7 +14,7 @@ class Shortcode {
 		$content = $post->post_content;
 
 		if ( ! empty( $content ) ) {
-			preg_match( '/\[give_receipt(.*?)]/', $content, $matches );
+			preg_match( '/\[give_receipt(.*?)]/i', $content, $matches );
 
 			if ( isset( $matches[0] ) ) {
 				return $matches[0];


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5042

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The current [method](https://github.com/impress-org/givewp/blob/3bb91d25819daf834d6f5212de48e9a1fe854810/src/Helpers/Frontend/Shortcode.php#L12) for extracting **give_receipt** shortcode from the post content, sometimes cannot extract the shortcode if the multiple shortcodes are being used ( i.e when using Divi page builder ). This PR solves this issue by using a regex pattern focused on **give_receipt** string which will be more efficient and possibly less prone to errors.
## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions


   1. Install and activate Divi page builder plugin
   2. Go to the Donation Success page and edit page with Divi editor
   3. Insert `[give_receipt]` shortcode into Divi Code Module and hit save
   4. View page on the front-end



<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
