### PR TITLE
State/Province input now uses loading state when fetching options from API

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/index.js
@@ -51,6 +51,7 @@ const App = () => {
 		countriesList: getCountryList(),
 		currenciesList: getCurrencyList(),
 		statesList: getDefaultStateList(),
+		fetchingStatesList: false,
 	};
 
 	const steps = [

--- a/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
@@ -15,7 +15,7 @@ import BackgroundImage from './background';
 import './style.scss';
 
 const Location = () => {
-	const [ { configuration, currenciesList, statesList, countriesList }, dispatch ] = useStoreValue();
+	const [ { configuration, currenciesList, statesList, fetchingStatesList, countriesList }, dispatch ] = useStoreValue();
 
 	const country = configuration.country;
 	const state = configuration.state;
@@ -32,7 +32,7 @@ const Location = () => {
 			<h1>{ __( 'Where are you fundraising?', 'give' ) }</h1>
 			<Card>
 				<SelectInput label={ __( 'Country', 'give' ) } value={ country } onChange={ onChangeCountry } options={ countriesList } />
-				<SelectInput label={ __( 'State / Province', 'give' ) } value={ state } onChange={ ( value ) => dispatch( setState( value ) ) } options={ statesList } />
+				<SelectInput label={ __( 'State / Province', 'give' ) } value={ state } onChange={ ( value ) => dispatch( setState( value ) ) } options={ statesList } isLoading={ fetchingStatesList } />
 				<SelectInput label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
 			</Card>
 			<ContinueButton />

--- a/assets/src/js/admin/onboarding-wizard/app/store/actions.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/actions.js
@@ -48,6 +48,16 @@ export const fetchStateList = ( country, dispatch ) => {
 	};
 };
 
+// Dispatch SET_FETCHING_STATES_LIST action
+export const setFetchingStatesList = ( status ) => {
+	return {
+		type: 'SET_FETCHING_STATES_LIST',
+		payload: {
+			status,
+		},
+	};
+};
+
 // Dispatch SET_STATE_LIST action
 export const setStateList = ( stateList ) => {
 	return {

--- a/assets/src/js/admin/onboarding-wizard/app/store/reducer.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/reducer.js
@@ -44,6 +44,11 @@ export const reducer = ( state, action ) => {
 				...state,
 				statesList: action.payload.stateList,
 			};
+		case 'SET_FETCHING_STATES_LIST':
+			return {
+				...state,
+				fetchingStatesList: action.payload.status,
+			};
 		case 'SET_STATE':
 			saveSettingWithOnboardingAPI( 'base_state', action.payload.state );
 			return {

--- a/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
@@ -9,7 +9,8 @@ import { toKebabCase } from '../../utils';
 import './style.scss';
 
 const SelectInput = ( { label, value, onChange, options } ) => {
-	const selectedOptionValue = options.filter( option => option.value === value );
+	const selectedOptionValue = options !== null ? options.filter( option => option.value === value ) : null;
+	const isLoading = options === null ? true : false;
 	const selectStyles = {
 		control: ( provided, state ) => ( {
 			...provided,
@@ -54,13 +55,14 @@ const SelectInput = ( { label, value, onChange, options } ) => {
 		<div className="give-obw-select-input">
 			{ label && ( <label className="give-obw-select-input__label" htmlFor={ toKebabCase( label ) }>{ label }</label> ) }
 			<Select
+				isLoading={ isLoading }
 				inputId={ label && toKebabCase( label ) }
 				value={ selectedOptionValue }
 				onChange={ ( selectedOption ) => onChange( selectedOption.value ) }
 				options={ options }
 				styles={ selectStyles }
 				maxMenuHeight="200px"
-				isDisabled={ options.length < 2 }
+				isDisabled={ isLoading }
 				theme={ ( theme ) => ( {
 					...theme,
 					colors: {

--- a/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
@@ -8,9 +8,12 @@ import { toKebabCase } from '../../utils';
 // Import styles
 import './style.scss';
 
-const SelectInput = ( { label, value, onChange, options } ) => {
+const SelectInput = ( { label, value, isLoading, onChange, options } ) => {
+	if ( options && options.length < 2 ) {
+		return null;
+	}
+
 	const selectedOptionValue = options !== null ? options.filter( option => option.value === value ) : null;
-	const isLoading = options === null ? true : false;
 	const selectStyles = {
 		control: ( provided, state ) => ( {
 			...provided,

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -124,6 +124,7 @@ export const saveSettingWithOnboardingAPI = ( setting, value ) => {
  * @since 2.8.0
  */
 export const fetchStatesListWithOnboardingAPI = ( country, dispatch ) => {
+	dispatch( setStateList( null ) );
 	axios.get( getAPIRoot() + 'give-api/v2/onboarding/location', {
 		params: {
 			countryCode: country,
@@ -133,7 +134,9 @@ export const fetchStatesListWithOnboardingAPI = ( country, dispatch ) => {
 		},
 	} )
 		.then( ( response ) => response.data )
-		.then( ( data ) => dispatch( setStateList( data.states ) ) );
+		.then( ( data ) => {
+			dispatch( setStateList( data.states ) );
+		} );
 };
 
 /**

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -2,7 +2,7 @@
 // Note: no-unused-vars rule is disabled while axios logic is not enabled
 
 import axios from 'axios';
-import { setStateList } from '../app/store/actions';
+import { setStateList, setFetchingStatesList } from '../app/store/actions';
 
 export const getWindowData = ( value ) => {
 	const data = window.giveOnboardingWizardData;
@@ -124,7 +124,7 @@ export const saveSettingWithOnboardingAPI = ( setting, value ) => {
  * @since 2.8.0
  */
 export const fetchStatesListWithOnboardingAPI = ( country, dispatch ) => {
-	dispatch( setStateList( null ) );
+	dispatch( setFetchingStatesList( true ) );
 	axios.get( getAPIRoot() + 'give-api/v2/onboarding/location', {
 		params: {
 			countryCode: country,
@@ -136,6 +136,7 @@ export const fetchStatesListWithOnboardingAPI = ( country, dispatch ) => {
 		.then( ( response ) => response.data )
 		.then( ( data ) => {
 			dispatch( setStateList( data.states ) );
+			dispatch( setFetchingStatesList( false ) );
 		} );
 };
 


### PR DESCRIPTION
Resolves #4980 

## Description
This issue introduces a disabled loading state to the State/Province select input when it is fetching options from the API. Previously, when a user updated their country selection, there was no indication that the state/province options were being updated. Additionally, this PR implements logic that hides a SelectInput component if fewer than 2 options are available to it.

## Affects
This PR affects frontend rendering logic for the SelectInput component in the Onboarding Wizard, and specifically introduces a loading state that is displayed on the State/Province input of the "Location" step.

## Visuals
![SelectLoading](https://user-images.githubusercontent.com/5186078/89929748-87647b80-dbbe-11ea-8d68-bdc8b8826299.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [x] Keyboard accessible
-   [x] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Navigate to the second ("Location") step of the Onboarding Wizard. When you modify your Country selection, are you shown a loading indicator for the State/Province input? When a country is selected that does not use State/Provinces, is the select input hidden?
