### PR TITLE
Setup shows only the gateway being configured.

### DIFF
--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -49,6 +49,24 @@ class PageView {
 	}
 
 	/**
+	 * @return bool
+	 *
+	 * @since 2.8.0
+	 */
+	public function isStripeSetup() {
+		return \Give\Helpers\Gateways\Stripe::isAccountConfigured();
+	}
+
+	/**
+	 * @return bool
+	 *
+	 * @since 2.8.0
+	 */
+	public function isPayPalSetup() {
+		return false;
+	}
+
+	/**
 	 * Returns a qualified image URL.
 	 *
 	 * @param string $src

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -47,7 +47,7 @@
 			[
 				'title'    => sprintf( '%s 2: %s', __( 'Step', 'give' ), __( 'Connect a payment gateway', 'give' ) ),
 				'contents' => [
-					$this->render_template(
+					! $this->isStripeSetup() ? $this->render_template(
 						'row-item',
 						[
 							'class'       => 'paypal',
@@ -68,8 +68,8 @@
 								)
 							),
 						]
-					),
-					! \Give\Helpers\Gateways\Stripe::isAccountConfigured() ? $this->render_template(
+					) : '',
+					! $this->isStripeSetup() && ! $this->isPayPalSetup() ? $this->render_template(
 						'row-item',
 						[
 							'class'       => 'stripe',
@@ -91,8 +91,8 @@
 								)
 							),
 						]
-					)
-					: $this->render_template(
+					) : '',
+					$this->isStripeSetup() && ! $this->isPayPalSetup() ? $this->render_template(
 						'row-item',
 						[
 							'class'       => 'stripe stripe-webhooks',
@@ -104,7 +104,7 @@
 								sprintf( '<a id="stripeWebhooksConfigureButton" href="%s" target="_blank">%s</a>', esc_url_raw( 'https://dashboard.stripe.com/webhooks' ), __( 'Configure Webhooks', 'give' ) )
 								. sprintf( '<button class="hidden" disabled="disable" id="stripeWebhooksConfigureConfirmed">%s</button>', __( 'Webhooks Configured!', 'give' ) ),
 						]
-					),
+					) : '',
 				],
 				'footer'   => $this->render_template(
 					'footer',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

 #5015

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

If Stripe is configured, hides PayPal (and vica versa).

This is based on the assumption that the new user is only setting up one payment gateway, which is a decision made to focus and simplify the Setup Page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/89938543-a413aa00-dbe4-11ea-9f06-35b05a9636a7.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
