### PR TITLE
Fix typo in third step of wizard subtitle.

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
@@ -27,7 +27,7 @@ const Features = () => {
 		<div className="give-obw-fundraising-needs">
 			<h1>{ __( 'What do you need in your first donation form?', 'give' ) }</h1>
 			<p>
-				{ __( 'Don\t worry, these settings can always be changed later.', 'give' ) }
+				{ __( 'Don\'t worry, these settings can always be changed later.', 'give' ) }
 			</p>
 			<CardInput values={ features } onChange={ ( value ) => dispatch( setFeatures( value ) ) } >
 				<Card value="one-time-donations">


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The `t` in `don't` was escaped instead of the apostrophe.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/89940613-c8bd5100-dbe7-11ea-9df6-5475084657ce.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
