### PR TITLE
Onboarding Wizard is now responsive for small desktop displays

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -12,7 +12,9 @@ import './style.scss';
 const DonationForm = () => {
 	return (
 		<div className="give-obw-donation-form">
-			<DonationFormComponent />
+			<div className="give-obw-donation-form__preview">
+				<DonationFormComponent />
+			</div>
 			<div className="give-obw-donation-form__content">
 				<h1>{ __( 'Check out your first donation form!', 'give' ) }</h1>
 				<p>

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -16,31 +16,33 @@ const DonationForm = () => {
 				<DonationFormComponent />
 			</div>
 			<div className="give-obw-donation-form__content">
-				<h1>{ __( 'Check out your first donation form!', 'give' ) }</h1>
-				<p>
-					{ __( 'We\'ve created a donation form for you based on your responses.', 'give' ) }
-				</p>
+				<div className="give-obw-donation-form__fixed">
+					<h1>{ __( 'Check out your first donation form!', 'give' ) }</h1>
+					<p>
+						{ __( 'We\'ve created a donation form for you based on your responses.', 'give' ) }
+					</p>
 
-				<h2>{ __( 'After setup you can:', 'give' ) }</h2>
-				<ul>
-					<li>
-						<GradientChevronIcon index={ 1 } />
-						{ __( 'Customize the text, color and image', 'give' ) }
-					</li>
-					<li>
-						<GradientChevronIcon index={ 2 } />
-						{ __( 'Modify donation amounts and add a fundraising goal', 'give' ) }
-					</li>
-					<li>
-						<GradientChevronIcon index={ 3 } />
-						{ __( 'Add or remove payment options', 'give' ) }
-					</li>
-					<li>
-						<GradientChevronIcon index={ 4 } />
-						{ __( 'Extend with add-ons and more!', 'give' ) }
-					</li>
-				</ul>
-				<ContinueButton />
+					<h2>{ __( 'After setup you can:', 'give' ) }</h2>
+					<ul>
+						<li>
+							<GradientChevronIcon index={ 1 } />
+							{ __( 'Customize the text, color and image', 'give' ) }
+						</li>
+						<li>
+							<GradientChevronIcon index={ 2 } />
+							{ __( 'Modify donation amounts and add a fundraising goal', 'give' ) }
+						</li>
+						<li>
+							<GradientChevronIcon index={ 3 } />
+							{ __( 'Add or remove payment options', 'give' ) }
+						</li>
+						<li>
+							<GradientChevronIcon index={ 4 } />
+							{ __( 'Extend with add-ons and more!', 'give' ) }
+						</li>
+					</ul>
+					<ContinueButton />
+				</div>
 			</div>
 		</div>
 	);

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -1,5 +1,6 @@
 .give-obw-donation-form {
 	display: grid;
+	position: relative;
 	grid-template-columns: repeat(2, 1fr);
 	width: 1200px;
 	grid-gap: 62px;
@@ -12,7 +13,11 @@
 	align-items: flex-start;
 	height: calc(100vh - 190px);
 
-	> h1 {
+	.give-obw-donation-form__fixed {
+		position: fixed;
+	}
+
+	h1 {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
 		font-weight: 600;
 		font-size: 24px;
@@ -21,7 +26,7 @@
 		margin: 0 0 8px 0;
 	}
 
-	> p {
+	p {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
 		font-weight: 500;
 		font-size: 16px;
@@ -30,7 +35,7 @@
 		margin: 0 0 38px;
 	}
 
-	> h2 {
+	h2 {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
 		font-weight: 600;
 		font-size: 16px;
@@ -39,7 +44,7 @@
 		margin: 0 0 4px 0;
 	}
 
-	> ul {
+	ul {
 		padding: 0;
 		margin: 0 0 36px 0;
 		list-style: none;

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -10,6 +10,7 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: flex-start;
+	height: calc(100vh - 190px);
 
 	> h1 {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;

--- a/assets/src/js/admin/onboarding-wizard/components/button/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/button/style.scss
@@ -6,6 +6,7 @@
 	line-height: 26px;
 
 	display: flex;
+	position: relative;
 	align-items: center;
 	text-align: center;
 	letter-spacing: 1px;

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -14,7 +14,7 @@ import './style.scss';
 const DonationForm = () => {
 	const formPreviewUrl = getWindowData( 'formPreviewUrl' );
 	const [ iframeLoaded, setIframeLoaded ] = useState( false );
-	const [ iframeHeight, setIframeHeight ] = useState( 800 );
+	const [ iframeHeight, setIframeHeight ] = useState( 749 );
 
 	useEffect( () => {
 		window.addEventListener( 'message', receiveMessage, false );

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -1,5 +1,5 @@
 // Import vendor dependencies
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 const { __ } = wp.i18n;
 
 // Import utilities
@@ -14,11 +14,25 @@ import './style.scss';
 const DonationForm = () => {
 	const formPreviewUrl = getWindowData( 'formPreviewUrl' );
 	const [ iframeLoaded, setIframeLoaded ] = useState( false );
+	const [ iframeHeight, setIframeHeight ] = useState( 800 );
+
+	useEffect( () => {
+		window.addEventListener( 'message', receiveMessage, false );
+		return () => {
+			window.removeEventListener( 'message', receiveMessage, false );
+		};
+	}, [] );
+
+	const receiveMessage = ( event ) => {
+		setIframeHeight( event.data.payload.height );
+	};
 
 	const iframeStyle = {
+		height: iframeHeight,
 		opacity: iframeLoaded === false ? '0' : '1',
 	};
 	const messageStyle = {
+		height: iframeHeight,
 		opacity: iframeLoaded === false ? '1' : '0',
 	};
 
@@ -39,7 +53,7 @@ const DonationForm = () => {
 					{ __( 'Building Form Preview...', 'give' ) }
 				</h3>
 			</div>
-			<iframe id="donationFormPreview" onLoad={ onIframeLoaded } className="give-obw-donation-form-preview__iframe" src={ formPreviewUrl } style={ iframeStyle } />
+			<iframe id="donationFormPreview" onLoad={ onIframeLoaded } className="give-obw-donation-form-preview__iframe" scrolling="no" src={ formPreviewUrl } style={ iframeStyle } />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/style.scss
@@ -5,7 +5,7 @@
 .give-obw-donation-form-preview__iframe {
 	border: none;
 	width: 560px;
-	height: 800px;
+	overflow: hidden;
 	transition: opacity 0.2s ease;
 }
 
@@ -15,7 +15,6 @@
 	left: 10px;
 	border: none;
 	width: 542px;
-	height: 748px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/style.scss
@@ -6,7 +6,7 @@
 	border: none;
 	width: 560px;
 	overflow: hidden;
-	transition: opacity 0.2s ease;
+	transition: opacity 0.2s ease, height 0.2s ease;
 }
 
 .give-obw-donation-form-preview__loading-message {

--- a/assets/src/js/admin/onboarding-wizard/components/step-link/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step-link/style.scss
@@ -2,6 +2,10 @@
 	flex: 1;
 	display: inline-flex;
 	align-items: center;
+
+	&:last-of-type {
+		flex: 0;
+	}
 }
 
 .give-obw-step-button {
@@ -48,6 +52,7 @@
 	font-size: 16px;
 	color: #333;
 	font-weight: 600;
+	white-space: nowrap;
 }
 
 .give-obw-step-progress {

--- a/assets/src/js/admin/onboarding-wizard/components/step-navigation/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step-navigation/style.scss
@@ -3,6 +3,7 @@
 	top: 0;
 	left: 0;
 	width: 100%;
+	z-index: 99;
 
 	background: #fff;
 	border-bottom: 1px solid #dbdbdb;

--- a/assets/src/js/admin/onboarding-wizard/components/step-navigation/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step-navigation/style.scss
@@ -1,4 +1,7 @@
 .give-obw-step-navigation {
+	position: fixed;
+	top: 0;
+	left: 0;
 	width: 100%;
 
 	background: #fff;

--- a/assets/src/js/admin/onboarding-wizard/components/step/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/step/index.js
@@ -4,19 +4,26 @@ import PropTypes from 'prop-types';
 // Import styles
 import './style.scss';
 
-const Step = ( { children } ) => {
+const Step = ( { showInNavigation, children } ) => {
+	const stepStyles = {
+		paddingTop: showInNavigation ? '128px' : '52px',
+		minHeight: showInNavigation ? 'calc(100vh - 190px)' : 'calc(100vh - 110px)',
+	};
+
 	return (
-		<div className="give-obw-step" role="main">
+		<div className="give-obw-step" role="main" style={ stepStyles }>
 			{ children }
 		</div>
 	);
 };
 
 Step.propTypes = {
+	showInNavigation: PropTypes.bool,
 	children: PropTypes.node.isRequired,
 };
 
 Step.defaultProps = {
+	showInNavigation: true,
 	children: null,
 };
 

--- a/assets/src/js/admin/onboarding-wizard/components/step/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step/style.scss
@@ -3,4 +3,6 @@
 	height: auto;
 	align-items: center;
 	justify-content: center;
+	padding-right: 30px;
+	padding-left: 30px;
 }

--- a/assets/src/js/admin/onboarding-wizard/components/step/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step/style.scss
@@ -1,6 +1,8 @@
 .give-obw-step {
+	padding: 128px 0 52px 0;
 	display: flex;
-	flex: 1;
+	height: auto;
+	min-height: calc(100vh - 190px);
 	align-items: center;
 	justify-content: center;
 }

--- a/assets/src/js/admin/onboarding-wizard/components/step/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step/style.scss
@@ -1,8 +1,6 @@
 .give-obw-step {
-	padding: 128px 0 52px 0;
 	display: flex;
 	height: auto;
-	min-height: calc(100vh - 190px);
 	align-items: center;
 	justify-content: center;
 }

--- a/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
@@ -1,9 +1,6 @@
 .give-obw {
-	display: flex;
-	flex-direction: column-reverse;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
+	min-height: 100%;
+	height: auto;
 	width: 100%;
 
 	color: #424242;

--- a/src/Onboarding/Wizard/templates/form-preview.php
+++ b/src/Onboarding/Wizard/templates/form-preview.php
@@ -35,4 +35,42 @@ set_current_screen();
 			?>
 			<?php wp_print_scripts( [ 'give' ] ); ?>
 	</body>
+	<script>
+		(function checkForBodySizeChange() {
+			var last_body_size = {
+				width: document.body.clientWidth,
+				height: document.body.clientHeight
+			};
+
+			function checkBodySizeChange()
+			{
+				var width_changed = last_body_size.width !== document.body.clientWidth,
+					height_changed = last_body_size.height !== document.body.clientHeight;
+
+
+				if(width_changed || height_changed) {
+					handleBodySizeChange(document.body.clientWidth, document.body.clientHeight);
+					last_body_size = {
+						width: document.body.clientWidth,
+						height: document.body.clientHeight
+					};
+				}
+
+				window.requestAnimationFrame(checkBodySizeChange);
+			}
+
+			function handleBodySizeChange(width, height)
+			{
+				window.parent.postMessage({
+					action: 'resize',
+					payload: {
+						height,
+						width
+					}
+				});
+			}
+
+			window.requestAnimationFrame(checkBodySizeChange);
+		})();
+	</script>
 </html>


### PR DESCRIPTION
Resolves #5045

## Description
This PR improves the responsive behavior of the Onboarding Wizard on smaller desktop displays. Notably, the PR fixes the navigation bar to the top of the screen, causes the entire step to scroll when squished, equips the DonationForm component to resize when the embedded form resizes, and fixes the Form Preview step content to the center of the screen.

## Affects
This PR affects frontend rendering logic of various Onboarding Wizard components (primary Step, StepNavigation, Wizard and DonationForm), and adds JS to the form-preview.php template to pass updates about changes in body height to the DonationForm component.

## Visuals

Scrolling demo:
![OnboardingResponsive](https://user-images.githubusercontent.com/5186078/89955830-bb549680-dbe8-11ea-89f2-882fd1333150.gif)

Line removed from step navigation after last step:
<img width="1299" alt="Screen Shot 2020-08-11 at 3 51 24 PM" src="https://user-images.githubusercontent.com/5186078/89956798-a5e06c00-dbea-11ea-87f4-f31e40aeda8b.png">


## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [x] Keyboard accessible
-   [x] Screen reader accessible
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Explore the Onboarding Wizard at various desktop resolutions, mimicking both large and small screens if possible.
