### PR TITLE
Setup Page now connects to Stripe without a deprecated notice.

### DIFF
--- a/src/Onboarding/Setup/Handlers/StripeConnectHandler.php
+++ b/src/Onboarding/Setup/Handlers/StripeConnectHandler.php
@@ -48,6 +48,9 @@ class StripeConnectHandler implements RequestHandler {
 		\Stripe\Stripe::setApiKey( $access_token );
 
 		$this->stripe_accounts = give_stripe_get_all_accounts();
+
+		// The Stripe SDK throws a depracted notice in PHP7.4+,
+		// so we are suppressing the notice in this request.
 		$this->account_details = @give_stripe_get_account_details( $vars['stripe_user_id'] );
 
 		$this->liveSecretKey      = $vars['stripe_access_token'];

--- a/src/Onboarding/Setup/Handlers/StripeConnectHandler.php
+++ b/src/Onboarding/Setup/Handlers/StripeConnectHandler.php
@@ -48,7 +48,7 @@ class StripeConnectHandler implements RequestHandler {
 		\Stripe\Stripe::setApiKey( $access_token );
 
 		$this->stripe_accounts = give_stripe_get_all_accounts();
-		$this->account_details = give_stripe_get_account_details( $vars['stripe_user_id'] );
+		$this->account_details = @give_stripe_get_account_details( $vars['stripe_user_id'] );
 
 		$this->liveSecretKey      = $vars['stripe_access_token'];
 		$this->testSecretKey      = $vars['stripe_access_token_test'];


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Related #4868

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Suppresses the deprecated notice thrown by the Stripe SDK when connecting to Stripe from the Setup Page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This does NOT address the issue when connecting to Stripe from the settings page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
