### PR TITLE
Donor will not see Resource ID notice when process donation with Advanced Card Fields

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -52,6 +52,13 @@ class AjaxRequestHandler {
 	private $connectClient;
 
 	/**
+	 * @since 2.8.0
+	 *
+	 * @var ConnectClient
+	 */
+	private $refreshToken;
+
+	/**
 	 * AjaxRequestHandler constructor.
 	 *
 	 * @since 2.8.0
@@ -61,19 +68,22 @@ class AjaxRequestHandler {
 	 * @param PayPalClient    $paypalClient
 	 * @param ConnectClient   $connectClient
 	 * @param MerchantDetails $merchantRepository
+	 * @param RefreshToken    $refreshToken
 	 */
 	public function __construct(
 		Webhooks $webhooksRepository,
 		MerchantDetail $merchantDetails,
 		PayPalClient $paypalClient,
 		ConnectClient $connectClient,
-		MerchantDetails $merchantRepository
+		MerchantDetails $merchantRepository,
+		RefreshToken $refreshToken
 	) {
 		$this->webhooksRepository = $webhooksRepository;
 		$this->merchantDetails    = $merchantDetails;
 		$this->paypalClient       = $paypalClient;
 		$this->connectClient      = $connectClient;
 		$this->merchantRepository = $merchantRepository;
+		$this->refreshToken       = $refreshToken;
 	}
 
 	/**
@@ -136,7 +146,7 @@ class AjaxRequestHandler {
 				[
 					'body' => [
 						'return_url'   => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal&group=paypal-commerce' ),
-						'country_code' => give_get_option('base_country'),
+						'country_code' => give_get_option( 'base_country' ),
 					],
 				]
 			)
@@ -168,6 +178,8 @@ class AjaxRequestHandler {
 
 		$this->merchantRepository->delete();
 		$this->merchantRepository->deleteAccountErrors();
+		$this->merchantRepository->deleteClientToken();
+		$this->refreshToken->deleteRefreshTokenCronJob();
 
 		wp_send_json_success();
 	}

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -135,7 +135,8 @@ class AjaxRequestHandler {
 				),
 				[
 					'body' => [
-						'return_url' => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal&group=paypal-commerce' ),
+						'return_url'   => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal&group=paypal-commerce' ),
+						'country_code' => give_get_option('base_country'),
 					],
 				]
 			)

--- a/src/PaymentGateways/PayPalCommerce/RefreshToken.php
+++ b/src/PaymentGateways/PayPalCommerce/RefreshToken.php
@@ -32,6 +32,18 @@ class RefreshToken {
 		$this->detailsRepository = $detailsRepository;
 	}
 
+
+	/**
+	 * Return cron json name which uses to refresh token.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return string
+	 */
+	private function getCronJobHookName() {
+		return 'give_paypal_commerce_refresh_token';
+	}
+
 	/**
 	 * Register cron job to refresh access token.
 	 * Note: only for internal use.
@@ -44,8 +56,19 @@ class RefreshToken {
 	public function registerCronJobToRefreshToken( $tokenExpires ) {
 		wp_schedule_single_event(
 			time() + ( $tokenExpires - 1800 ), // Refresh token before half hours of expires date.
-			'give_paypal_commerce_refresh_token'
+			$this->getCronJobHookName()
 		);
+	}
+
+	/**
+	 * Delete cron job which refresh access token.
+	 * Note: only for internal use.
+	 *
+	 * @since 2.8.0
+	 *
+	 */
+	public function deleteRefreshTokenCronJob() {
+		wp_clear_scheduled_hook( $this->getCronJobHookName() );
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
@@ -124,6 +124,17 @@ class MerchantDetails {
 	}
 
 	/**
+	 * Deletes the client token for the account
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return bool
+	 */
+	public function deleteClientToken() {
+		return delete_transient( $this->getClientTokenKey() );
+	}
+
+	/**
 	 * Get client token for hosted credit card fields.
 	 *
 	 * @since 2.8.0
@@ -131,7 +142,7 @@ class MerchantDetails {
 	 * @return string
 	 */
 	public function getClientToken() {
-		$optionName = "give_paypal_commerce_{$this->mode}_client_token";
+		$optionName = $this->getClientTokenKey();
 
 		if ( $optionValue = get_transient( $optionName ) ) {
 			return $optionValue;
@@ -196,5 +207,17 @@ class MerchantDetails {
 	 */
 	private function getAccountErrorsKey() {
 		return "give_paypal_commerce_{$this->mode}_account_errors";
+	}
+
+
+	/**
+	 * Returns the options key for the client token in the give mode
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return string
+	 */
+	private function getClientTokenKey() {
+		return "give_paypal_commerce_{$this->mode}_client_token";
 	}
 }

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -100,7 +100,7 @@ EOT;
 		wp_enqueue_script(
 			$this->paypalSdkScriptHandle,
 			sprintf(
-				'https://www.paypal.com/sdk/js?components=%1$s&client-id=%2$s&merchant-id=%3$s&currency=%4$s&intent=capture',
+				'https://www.paypal.com/sdk/js?components=%1$s&client-id=%2$s&merchant-id=%3$s&currency=%4$s&intent=capture&disable-funding=credit',
 				'hosted-fields,buttons',
 				$merchant->clientId,
 				$merchant->merchantIdInPayPal,


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5061

## Description
I find out that client token plays a crucial role when load PayPal SDK on the frontend and client token expires when we reconnect PayPal account. To fix this issue I delete refresh token cron job and client token.

## Affects
I added required param to get partner rest API query which required to process this request on connect server.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Steps to reproduce:
- Switch to the `epic` branch To test this issue.
- Connect a PayPal account and.
- Visit any donation form page to generate the client token.
- Disconnect and reconnect again.
- Now you will see resource id notice when process donation with Advanced Card Fields.

The process the above step in this pr and you will not face same issue.
