### PR TITLE
Remove default selected state.

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
@@ -1,12 +1,9 @@
 // Import vendor dependencies
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 
 // Import store dependencies
 import { useStoreValue } from '../../app/store';
-
-// Import utilities
-import { setStepFocus } from '../../utils';
 
 // Import components
 import StepNavigation from '../step-navigation';
@@ -20,10 +17,6 @@ const Wizard = ( { children } ) => {
 	const steps = children;
 
 	const app = useRef( null );
-
-	useEffect( () => {
-		setStepFocus();
-	}, [ currentStep ] );
 
 	return (
 		<div className="give-obw" ref={ app }>

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -23,16 +23,6 @@ export const toKebabCase = ( str ) => {
 		.toLowerCase();
 };
 
-/**
- * Sets browser focus to first input/iframe element in current step
- *
- * @since 2.8.0
- */
-export const setStepFocus = () => {
-	const stepInputs = document.querySelectorAll( '.give-obw-step button, .give-obw-step input, .give-obw-step select, .give-obw-step iframe' );
-	stepInputs[ 0 ].focus();
-};
-
 export const getAPIRoot = () => {
 	return getWindowData( 'apiRoot' );
 };


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5072

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Removes the `setStepFocus` utility so that the first element on each step is not auto-focused.

For each step, tabbing starts on the first element (which would have otherwise been auto-focused) - as expected.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/90071836-52dae780-dcc4-11ea-8814-e0b1d2bf66da.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
