### PR TITLE
Onboarding Wizard design loose ends are resolved

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
@@ -41,7 +41,7 @@ const Addons = () => {
 				</Card>
 				<Card value="pdf-receipts">
 					<PDFReceiptsIcon />
-					<strong>{ __( 'PDF Reciepts', 'give' ) }</strong>
+					<strong>{ __( 'PDF Receipts', 'give' ) }</strong>
 				</Card>
 				<Card value="custom-form-fields">
 					<CustomFormFieldsIcon />

--- a/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
@@ -15,6 +15,7 @@ import PDFReceiptsIcon from '../../../components/icons/pdf-receipts';
 import CustomFormFieldsIcon from '../../../components/icons/custom-form-fields';
 import MultipleCurrenciesIcon from '../../../components/icons/multiple-currencies';
 import DedicateDonationsIcon from '../../../components/icons/dedicate-donations';
+import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -56,6 +57,7 @@ const Addons = () => {
 				</Card>
 			</CardInput>
 			<ContinueButton />
+			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -5,6 +5,7 @@ const { __ } = wp.i18n;
 import ContinueButton from '../../../components/continue-button';
 import DonationFormComponent from '../../../components/donation-form';
 import GradientChevronIcon from '../../../components/icons/gradient-chevron';
+import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -42,6 +43,7 @@ const DonationForm = () => {
 						</li>
 					</ul>
 					<ContinueButton />
+					<DismissLink />
 				</div>
 			</div>
 		</div>

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -6,6 +6,11 @@
 	grid-gap: 62px;
 }
 
+.give-obw-dismiss-link {
+	margin-top: 32px;
+	display: block;
+}
+
 .give-obw-donation-form__content {
 	display: flex;
 	flex-direction: column;

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -8,7 +8,7 @@
 
 .give-obw-dismiss-link {
 	margin-top: 32px;
-	display: block;
+	display: inline-block;
 }
 
 .give-obw-donation-form__content {

--- a/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
@@ -15,6 +15,7 @@ import DonationCommentsIcon from '../../../components/icons/donation-comments';
 import TermsConditionsIcon from '../../../components/icons/terms-conditions';
 import AnonymousDonationsIcon from '../../../components/icons/anonymous-donations';
 import CompanyDonationsIcon from '../../../components/icons/company-donations';
+import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -56,6 +57,7 @@ const Features = () => {
 				</Card>
 			</CardInput>
 			<ContinueButton />
+			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
@@ -1,18 +1,15 @@
 // Import vendor dependencies
 const { __ } = wp.i18n;
 
-// Import utilities
-import { getWindowData } from '../../../utils';
-
 // Import styles
 import './style.scss';
 
 import Card from '../../../components/card';
 import GiveLogo from '../../../components/give-logo';
 import ContinueButton from '../../../components/continue-button';
+import DismissLink from '../../../components/dismiss-link';
 
 const Introduction = () => {
-	const setupUrl = getWindowData( 'setupUrl' );
 	return (
 		<div className="give-obw-introduction">
 			<Card>
@@ -27,7 +24,7 @@ const Introduction = () => {
 					<ContinueButton label={ __( 'Start Setup', 'give' ) } />
 				</div>
 			</Card>
-			<a href={ setupUrl }>{ __( 'Dismiss Setup Wizard', 'give' ) }</a>
+			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/style.scss
@@ -10,6 +10,13 @@
 		font-size: 16px;
 		line-height: 22px;
 		margin-top: 42px;
+		padding: 6px;
+		border-radius: 3px;
+
+		&:focus {
+			box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+			outline: none;
+		}
 	}
 }
 

--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/style.scss
@@ -2,22 +2,6 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-
-	> a {
-		font-family: 'Open Sans', Arial, Helvetica, sans-serif;
-		color: #666;
-		font-weight: 500;
-		font-size: 16px;
-		line-height: 22px;
-		margin-top: 42px;
-		padding: 6px;
-		border-radius: 3px;
-
-		&:focus {
-			box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
-			outline: none;
-		}
-	}
 }
 
 .give-obw-introduction__content {

--- a/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
@@ -11,6 +11,7 @@ import Card from '../../../components/card';
 import ContinueButton from '../../../components/continue-button';
 import SelectInput from '../../../components/select-input';
 import BackgroundImage from './background';
+import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -38,6 +39,7 @@ const Location = () => {
 				<SelectInput label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
 			</Card>
 			<ContinueButton />
+			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
@@ -45,7 +45,6 @@ const YourCause = () => {
 				</Card>
 			</CardInput>
 			<h2>{ __( 'What is your cause?', 'give' ) }</h2>
-			<p>{ __( '(select all that apply)', 'give' ) }</p>
 			<span className="screen-reader-text">{ __( 'What is your cause?', 'give' ) }</span>
 			<SelectInput value={ causeType } onChange={ ( value ) => dispatch( setCauseType( value ) ) } options={
 				[

--- a/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
@@ -13,6 +13,7 @@ import ContinueButton from '../../../components/continue-button';
 import IndividualIcon from '../../../components/icons/individual';
 import OrganizationIcon from '../../../components/icons/organization';
 import OtherIcon from '../../../components/icons/other';
+import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -59,6 +60,7 @@ const YourCause = () => {
 				]
 			} />
 			<ContinueButton />
+			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/style.scss
@@ -1,7 +1,8 @@
 #onboarding-wizard-app {
-	height: 100vh;
-	width: 100vw;
+	height: auto;
+	width: 100%;
 	position: absolute;
 	top: 0;
 	left: 0;
+	overflow-x: hidden;
 }

--- a/assets/src/js/admin/onboarding-wizard/components/button/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/button/style.scss
@@ -18,4 +18,9 @@
 	box-shadow: 0 2px 10px rgba(105, 184, 107, 0.6);
 	border-radius: 4px;
 	border: none;
+
+	&:focus {
+		box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+		outline: none;
+	}
 }

--- a/assets/src/js/admin/onboarding-wizard/components/button/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/button/style.scss
@@ -10,10 +10,10 @@
 	align-items: center;
 	text-align: center;
 	letter-spacing: 1px;
-	text-transform: uppercase;
+	text-transform: capitalize;
 	color: #fff;
 
-	padding: 14px 32px;
+	padding: 14px 34px;
 	background: #4fa651;
 	box-shadow: 0 2px 10px rgba(105, 184, 107, 0.6);
 	border-radius: 4px;

--- a/assets/src/js/admin/onboarding-wizard/components/card-input/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/card-input/style.scss
@@ -17,14 +17,10 @@
 		z-index: 1;
 	}
 
-	.give-obw-card {
-		&:hover {
-			border-color: #888;
+	&:hover {
+		.give-obw-card {
+			box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
 		}
-	}
-
-	&:focus-within .give-obw-card {
-		outline: -webkit-focus-ring-color auto 1px;
 	}
 }
 
@@ -33,8 +29,7 @@ input:focus + .give-obw-card-input__option .give-obw-card {
 	// Using a border as a selected state with border-box box-sizing,
 	// creates a change in available content space within the box.
 	// Instead, a box-shadow maintains width and border-radius.
-	//box-shadow: 0 0 0 3px rgb(105, 184, 107);
-	box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+	box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651, 0 3px 8px rgba(0, 0, 0, 0.25);
 }
 
 input[type='checkbox'] {

--- a/assets/src/js/admin/onboarding-wizard/components/card-input/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/card-input/style.scss
@@ -33,7 +33,8 @@ input:focus + .give-obw-card-input__option .give-obw-card {
 	// Using a border as a selected state with border-box box-sizing,
 	// creates a change in available content space within the box.
 	// Instead, a box-shadow maintains width and border-radius.
-	box-shadow: 0 0 0 3px rgb(105, 184, 107);
+	//box-shadow: 0 0 0 3px rgb(105, 184, 107);
+	box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
 }
 
 input[type='checkbox'] {

--- a/assets/src/js/admin/onboarding-wizard/components/card/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/card/style.scss
@@ -10,6 +10,8 @@
 	flex-direction: column;
 	justify-content: center;
 
+	transition: box-shadow 0.2s ease;
+
 	> svg {
 		margin-bottom: 20px;
 	}

--- a/assets/src/js/admin/onboarding-wizard/components/dismiss-link/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/dismiss-link/index.js
@@ -1,0 +1,19 @@
+// Import vendor dependencies
+const { __ } = wp.i18n;
+
+// Import utilities
+import { getWindowData } from '../../utils';
+
+// Import styles
+import './style.scss';
+
+const DismissLink = () => {
+	const setupUrl = getWindowData( 'setupUrl' );
+	return (
+		<a className="give-obw-dismiss-link" href={ setupUrl }>
+			{ __( 'Dismiss Setup Wizard', 'give' ) }
+		</a>
+	);
+};
+
+export default DismissLink;

--- a/assets/src/js/admin/onboarding-wizard/components/dismiss-link/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/dismiss-link/style.scss
@@ -1,0 +1,15 @@
+.give-obw-dismiss-link {
+	font-family: 'Open Sans', Arial, Helvetica, sans-serif;
+	color: #666;
+	font-weight: 500;
+	font-size: 16px;
+	line-height: 22px;
+	margin-top: 42px;
+	padding: 6px;
+	border-radius: 3px;
+
+	&:focus {
+		box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+		outline: none;
+	}
+}

--- a/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
@@ -26,7 +26,7 @@ const SelectInput = ( { label, value, isLoading, onChange, options } ) => {
 			boxSizing: 'border-box',
 			marginTop: '10px',
 			border: '1px solid #b8b8b8',
-			boxShadow: state.isFocused ? '0 0 0 3px #4fa651' : '0 1px 4px rgba(0, 0, 0, 0.158927)',
+			boxShadow: state.isFocused ? 	'0 0 0 2px #7ec980, 0 0 0 3px #4fa651' : '0 1px 4px rgba(0, 0, 0, 0.158927)',
 			borderRadius: '4px',
 		} ),
 		input: ( provided ) => ( {

--- a/assets/src/js/admin/onboarding-wizard/components/step-link/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step-link/style.scss
@@ -13,11 +13,17 @@
 	align-items: center;
 
 	border: none;
+	border-radius: 3px;
 	background: none;
 	padding: 10px 0;
 
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0);
 	transition: box-shadow 0.2s ease;
+
+	&:focus {
+		box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+		outline: none;
+	}
 }
 
 .give-obw-step-icon {

--- a/assets/src/js/admin/onboarding-wizard/components/step/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/step/style.scss
@@ -5,4 +5,5 @@
 	justify-content: center;
 	padding-right: 30px;
 	padding-left: 30px;
+	padding-bottom: 52px;
 }

--- a/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
@@ -1,5 +1,5 @@
 // Import vendor dependencies
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 // Import store dependencies
@@ -15,6 +15,10 @@ import './style.scss';
 const Wizard = ( { children } ) => {
 	const [ { currentStep } ] = useStoreValue();
 	const steps = children;
+
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [ currentStep ] );
 
 	const app = useRef( null );
 

--- a/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
@@ -1,8 +1,7 @@
 .give-obw {
-	min-height: 100%;
+	min-height: 100vh;
 	height: auto;
 	width: 100%;
-	overflow-x: hidden;
 
 	color: #424242;
 	font-family: Montserrat, arial, sans-serif;

--- a/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/style.scss
@@ -2,6 +2,7 @@
 	min-height: 100%;
 	height: auto;
 	width: 100%;
+	overflow-x: hidden;
 
 	color: #424242;
 	font-family: Montserrat, arial, sans-serif;

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -42,7 +42,12 @@ export const getAPINonce = () => {
 };
 
 export const getCountryList = () => {
-	return getWindowData( 'countries' );
+	return getWindowData( 'countries' ).map( ( country ) => {
+		return {
+			value: country.value,
+			label: decodeHTMLEntity( country.label ),
+		};
+	} );
 };
 
 export const getDefaultStateList = () => {


### PR DESCRIPTION
Resolves #5068 

## Description
This PR addresses a punchlist of design loose ends associated with the Onboarding Wizard. See the affects and visuals sections below for a complete list, and representation of changes this PR covers.

## Affects
Changes introduced in this PR:
- Consistent focus state for all inputs/elements (SelectInput, CardInput, Buttons, StepLinks, DismissLink)
- Focus state design improved to use dualtone green box-shadow (which ensures that focus state pops on Buttons)
- Focus state design improved to incorporate existing box shadows on Cards in CardInput
- Dismiss Setup Wizard link added to bottom of each step
- CardInput hover state modified to use a material inspired shadow to highligh, rather than setting border color
- HTML Entities in Country list are decoded
- Added padding below steps to match padding above steps
- Button case is consistent with Multi-Step form button case
- Typo in Step 4 is resolved ("PDF Receipts")
- Sets horizontal overflow to hidden for the Wizard, to prevent horizontal scrollbars from appearing
- Removes 'select all that apply' subtitle from cause selection input

## Visuals
Improved focus states, added Dismiss Setup link, and new CardInput hover states (see far right card):
<img width="1112" alt="Screen Shot 2020-08-12 at 3 13 39 PM" src="https://user-images.githubusercontent.com/5186078/90073643-7004bb80-dcae-11ea-8643-1161ed9cc064.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [x] Keyboard accessible
-   [x] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Navigate to the Onboarding Wizard (`wp-admin/?page=give-onboarding-wizard`) and proceed through Wizard steps to see/interact with changes implmented in this PR.
