### PR TITLE
Form Preview no longer renders all steps at once

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -10,7 +10,7 @@
 	const { wp: parentWp } = window.parent;
 
 	// Make donation form block selectable in editor
-	if ( !! parentWp.data ) {
+	if ( parentWp && parentWp.data ) {
 		$container.on( 'click', function() {
 			const blockId = window.frameElement.closest( '.wp-block' ).getAttribute( 'data-block' );
 			parentWp.data.dispatch( 'core/block-editor' ).selectBlock( blockId );


### PR DESCRIPTION
Resolves #5080

## Description
This issue resolves an error that surfaces when viewing the Multi-Step form from the Form Preview. Previously, when a form was loaded in the Form Preview step, it displayed all steps simultaneously. Now, it behaves as expected and without producing JS blocking errors.

## Affects
This PR affects Multi Step form frontend rendering logic, specifically how it checks to see if it is being viewed from within the Gutenberg editor. Previously, it referenced the wp object, without first checking that the wp object is defined on the window.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Testing form preview:
1. Go to the Onboarding Wizard (`wp-admin/?page=give-onboarding-wizard`)
2. Navigate to the Form Preview step
3. See how Form Preview loads now loads correctly (one step visible at a time)
4. Open JS console, check for errors

Testing Gutenberg:
1. Go to Gutenberg editor
2. Add donation form block, select an existing form
3. Is the block selectable as expected

Testing Frontend:
1. View a page with the Multi-Step form on it
2. Does the form load as expected?

