### PR TITLE
Dismiss Link is now only present in the first step

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
@@ -15,7 +15,6 @@ import PDFReceiptsIcon from '../../../components/icons/pdf-receipts';
 import CustomFormFieldsIcon from '../../../components/icons/custom-form-fields';
 import MultipleCurrenciesIcon from '../../../components/icons/multiple-currencies';
 import DedicateDonationsIcon from '../../../components/icons/dedicate-donations';
-import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -57,7 +56,6 @@ const Addons = () => {
 				</Card>
 			</CardInput>
 			<ContinueButton />
-			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -5,7 +5,6 @@ const { __ } = wp.i18n;
 import ContinueButton from '../../../components/continue-button';
 import DonationFormComponent from '../../../components/donation-form';
 import GradientChevronIcon from '../../../components/icons/gradient-chevron';
-import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -43,7 +42,6 @@ const DonationForm = () => {
 						</li>
 					</ul>
 					<ContinueButton />
-					<DismissLink />
 				</div>
 			</div>
 		</div>

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -6,11 +6,6 @@
 	grid-gap: 62px;
 }
 
-.give-obw-dismiss-link {
-	margin-top: 32px;
-	display: inline-block;
-}
-
 .give-obw-donation-form__content {
 	display: flex;
 	flex-direction: column;

--- a/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
@@ -15,7 +15,6 @@ import DonationCommentsIcon from '../../../components/icons/donation-comments';
 import TermsConditionsIcon from '../../../components/icons/terms-conditions';
 import AnonymousDonationsIcon from '../../../components/icons/anonymous-donations';
 import CompanyDonationsIcon from '../../../components/icons/company-donations';
-import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -57,7 +56,6 @@ const Features = () => {
 				</Card>
 			</CardInput>
 			<ContinueButton />
-			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
@@ -11,7 +11,6 @@ import Card from '../../../components/card';
 import ContinueButton from '../../../components/continue-button';
 import SelectInput from '../../../components/select-input';
 import BackgroundImage from './background';
-import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -39,7 +38,6 @@ const Location = () => {
 				<SelectInput label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
 			</Card>
 			<ContinueButton />
-			<DismissLink />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
@@ -13,7 +13,6 @@ import ContinueButton from '../../../components/continue-button';
 import IndividualIcon from '../../../components/icons/individual';
 import OrganizationIcon from '../../../components/icons/organization';
 import OtherIcon from '../../../components/icons/other';
-import DismissLink from '../../../components/dismiss-link';
 
 // Import styles
 import './style.scss';
@@ -59,7 +58,6 @@ const YourCause = () => {
 				]
 			} />
 			<ContinueButton />
-			<DismissLink />
 		</div>
 	);
 };


### PR DESCRIPTION
Resolves #5089 

## Description
This PR removes the Dismiss Link from all steps except the Introduction step, and clears up styles introduced to the Donation Form step meant specifically to style the Dismiss Link.

## Affects
Step composition logic in the Onboarding Wizard app.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed