### PR TITLE
Social sharing section is now hidden in Form Preview

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -24,7 +24,19 @@ const DonationForm = () => {
 	}, [] );
 
 	const receiveMessage = ( event ) => {
-		setIframeHeight( event.data.payload.height );
+		switch ( event.data.action ) {
+			case 'resize': {
+				setIframeHeight( event.data.payload.height );
+				break;
+			}
+			case 'loaded': {
+				onIframeLoaded();
+				break;
+			}
+			default: {
+
+			}
+		}
 	};
 
 	const iframeStyle = {
@@ -38,11 +50,17 @@ const DonationForm = () => {
 
 	const onIframeLoaded = () => {
 		setIframeLoaded( true );
+		hideInIframe( '#give_error_test_mode' );
+		hideInIframe( '.social-sharing' );
+	};
 
-		document.getElementById( 'donationFormPreview' ).contentDocument
+	const hideInIframe = ( selector ) => {
+		const element = document.getElementById( 'donationFormPreview' ).contentDocument
 			.getElementById( 'iFrameResizer0' ).contentDocument
-			.getElementById( 'give_error_test_mode' )
-			.style.display = 'none';
+			.querySelector( selector );
+		if ( element ) {
+			element.style.display = 'none';
+		}
 	};
 
 	return (
@@ -53,7 +71,7 @@ const DonationForm = () => {
 					{ __( 'Building Form Preview...', 'give' ) }
 				</h3>
 			</div>
-			<iframe id="donationFormPreview" onLoad={ onIframeLoaded } className="give-obw-donation-form-preview__iframe" scrolling="no" src={ formPreviewUrl } style={ iframeStyle } />
+			<iframe id="donationFormPreview" className="give-obw-donation-form-preview__iframe" scrolling="no" src={ formPreviewUrl } style={ iframeStyle } />
 		</div>
 	);
 };

--- a/src/Onboarding/Wizard/templates/form-preview.php
+++ b/src/Onboarding/Wizard/templates/form-preview.php
@@ -73,4 +73,16 @@ set_current_screen();
 			window.requestAnimationFrame(checkBodySizeChange);
 		})();
 	</script>
+	<script>
+		(function listenForFormLoaded() {
+			function handleFormLoaded(width, height)
+			{
+				window.parent.postMessage({
+					action: 'loaded',
+					payload: {}
+				});
+			}
+			document.querySelector('iframe').addEventListener('load', handleFormLoaded );
+		})();
+	</script>
 </html>


### PR DESCRIPTION
Resolves #5087

## Description
This PR introduces logic to hide the Social Sharing section of the receipt in the Form Preview. In order to do so, some additional logic was added to the Form Preview frontend template to send a message to the parent window whenever the Form's iframe is loaded, which occurs first when the form is loaded, then again when the receipt is loaded. Using PostMessage to send this event to the parent window enables the DonationForm component to hide the Social Sharing div when the receipt loads, and the test notice div when the form loads.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed