### PR TITLE
When creating a new payment, set the gateway based on payment_data, instead of hardcode

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -250,7 +250,7 @@ function give_create_payment( $payment_data ) {
 		'currency'        => give_get_currency( $form_id, $payment_data ),
 		'user_info'       => $payment_data['user_info'],
 		'status'          => 'pending',
-		'gateway'         => 'paypal',
+		'gateway'         => $payment_data['gateway'],
 	);
 
 	/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->
As can be seen in the changes tab, 'paypal' was hardcoded as the payment gateway for any and all payments.

The workaround to use the `give_create_payment` filter, but seems a bit backwards ..

So, tadaa 😃 

