### PR TITLE
Setup Stripe Webhooks URL is now based on test mode setting.

### DIFF
--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -97,6 +97,20 @@ class PageView {
 	}
 
 	/**
+	 * @return string
+	 *
+	 * @since 2.8.0
+	 */
+	public function getStripeWebhooksURL() {
+		$testMode = give_get_option( 'test_mode' );
+		$url      = ( give_is_setting_enabled( $testMode ) )
+			? 'https://dashboard.stripe.com/test/webhooks'
+			: 'https://dashboard.stripe.com/webhooks';
+
+		return esc_url_raw( $url );
+	}
+
+	/**
 	 * Returns a qualified image URL.
 	 *
 	 * @param string $src

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -106,7 +106,7 @@
 							'title'       => esc_html__( 'Please configure your Stripe webhook to finalize the setup.', 'give' ),
 							'description' => esc_html__( 'In order for Stripe to function properly, you must add a new Stripe webhook endpoint. To do this please visit the Webhooks Section of your Stripe Dashboard and click the Add endpoint button and paste the following URL: ', 'give' ) . '<br /><span id="stripeWebhooksCopyHandler" class="stripe-webhooks-url"><input disabled="disabled" id="stripeWebhooksCopy" value="' . add_query_arg( 'give-listener', 'stripe', site_url() ) . '" /> &nbsp; <i id="stripeWebhooksCopyIcon" class="fa fa-clipboard"></i></input>',
 							'action'      =>
-								sprintf( '<a id="stripeWebhooksConfigureButton" href="%s" target="_blank">%s</a>', esc_url_raw( 'https://dashboard.stripe.com/webhooks' ), __( 'Configure Webhooks', 'give' ) ),
+								sprintf( '<a id="stripeWebhooksConfigureButton" href="%s" target="_blank">%s</a>', $this->getStripeWebhooksURL(), __( 'Configure Webhooks', 'give' ) ),
 						]
 					) : '',
 					$this->render_template(


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5095

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The Stripe URL to configure webhooks is now based on whether or not test mode is enabled.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
