### PR TITLE
add support for sub group in setting tab

### DIFF
--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -298,8 +298,6 @@ jQuery( document ).ready( function( $ ) {
 
 // Vertical tabs feature.
 document.addEventListener( 'DOMContentLoaded', () => {
-	const currentUrl = window.location.href.split( '#' );
-	const currentGroup = currentUrl[ 1 ];
 	const mainContentWrap = document.querySelector( '.give-settings-section-content' );
 
 	// Bailout, if main content wrap not exists.
@@ -308,14 +306,16 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	const menuContentWrap = mainContentWrap.querySelector( '.give-settings-section-group-menu' );
-	const allContent = Array.prototype.slice.call( mainContentWrap.querySelectorAll( '.give-settings-section-group' ) );
 
 	// Bailout, if menu content wrap not exists.
 	if ( null === menuContentWrap ) {
 		return;
 	}
 
-	const menuButtons = Array.prototype.slice.call( menuContentWrap.querySelectorAll( 'ul li a' ) );
+	const allContent = Array.prototype.slice.call( mainContentWrap.querySelectorAll( '.give-settings-section-group' ) );
+
+	const menuButtons = Array.from( menuContentWrap.querySelectorAll( 'ul li a' ) )
+		.concat( Array.from( mainContentWrap.querySelectorAll( 'ul.give-subsubsub li a' ) ) );
 
 	// Bailout, if menu content wrap not exists.
 	if ( null === menuButtons ) {
@@ -324,19 +324,40 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	menuButtons.forEach( ( element ) => {
 		element.addEventListener( 'click', ( e ) => {
-			const selectedGroup = e.target.getAttribute( 'data-group' );
-			const selectedContent = mainContentWrap.querySelector( '#give-settings-section-group-' + selectedGroup );
+			const hasSubGroup = e.target.hasAttribute( 'data-subgroup' );
+			let selectedGroup, selectedContent;
 
-			// Loop through menu button and remove `active` class.
-			menuButtons.forEach( ( element ) => {
-				element.classList.remove( 'active' );
-			} );
+			if ( hasSubGroup ) {
+				const menuContainer = e.target.parentElement.parentElement;
+				const sectionGroup = menuContainer.parentElement;
+				selectedGroup = e.target.getAttribute( 'data-subgroup' );
+				selectedContent = mainContentWrap.querySelector( `#give-settings-section-subgroup-${ selectedGroup }` );
 
-			// Loop through content sections and add `give-hidden` class.
-			allContent.map( contentElement => contentElement.classList.add( 'give-hidden' ) );
+				// Loop through menu button and remove `current` class.
+				menuContainer.querySelectorAll( 'a' ).forEach( ( element ) => {
+					element.classList.remove( 'current' );
+				} );
 
-			// Add `active` class to menu buttons of selected element.
-			e.target.classList.add( 'active' );
+				// Loop through content sections and add `give-hidden` class.
+				sectionGroup.querySelectorAll( '.give-settings-section-subgroup ' ).forEach( contentElement => contentElement.classList.add( 'give-hidden' ) );
+
+				// Add `active` class to menu buttons of selected element.
+				e.target.classList.add( 'current' );
+			} else {
+				selectedGroup = e.target.getAttribute( 'data-group' );
+				selectedContent = mainContentWrap.querySelector( `#give-settings-section-group-${ selectedGroup }` );
+
+				// Loop through menu button and remove `active` class.
+				menuButtons.forEach( ( element ) => {
+					element.classList.remove( 'active' );
+				} );
+
+				// Loop through content sections and add `give-hidden` class.
+				allContent.map( contentElement => contentElement.classList.add( 'give-hidden' ) );
+
+				// Add `active` class to menu buttons of selected element.
+				e.target.classList.add( 'active' );
+			}
 
 			// Remove `give-hidden` class from content section of selected element.
 			selectedContent.classList.remove( 'give-hidden' );


### PR DESCRIPTION
## Description
As part of the PayPal Pro addon issue: https://github.com/impress-org/give-paypal-pro/issues/83, we get the need  of showing setting in the group under tabs as you can see in visual. this pr updates existing logic to allow register subgroups to tab settings.

## Affects
This PR does not affect existing logic but it extends existing logic.

## Visuals
![image](https://user-images.githubusercontent.com/1784821/90275554-1eac2600-de80-11ea-9c91-8809e912f5a9.png)

## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
You can test this pr with PayPal Pro addon pr: https://github.com/impress-org/give-paypal-pro/pull/84

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
