### PR TITLE
Onboarding Wizard no longer changes width when the scrollbar is toggled.

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/store/observers.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/observers.js
@@ -16,8 +16,14 @@ export function observeAction( action ) {
 }
 
 /**
- * Example
+ * The Preview step creates horizontal movement due to
+ * the change in form height. In order to normalize
+ * visual movement, set the overflow-y to scroll.
+ *
+ * After the first step, after the introduction, set the overflow to scroll.
  */
 subscribe( 'GO_TO_STEP', ( action ) => {
-	console.log( action.payload.step );
+	if ( action.payload.step === 1 ) {
+		document.body.style[ 'overflow-y' ] = 'scroll';
+	}
 } );

--- a/assets/src/js/admin/onboarding-wizard/app/store/observers.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/observers.js
@@ -20,7 +20,7 @@ export function observeAction( action ) {
  * the change in form height. In order to normalize
  * visual movement, set the overflow-y to scroll.
  *
- * After the first step, after the introduction, set the overflow to scroll.
+ * Starting with the first step, after the introduction, set the overflow to scroll.
  */
 subscribe( 'GO_TO_STEP', ( action ) => {
 	if ( action.payload.step === 1 ) {

--- a/assets/src/js/admin/onboarding-wizard/app/store/observers.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/observers.js
@@ -1,0 +1,23 @@
+const observers = [];
+
+function subscribe( action, callback ) {
+	observers.push( {
+		action,
+		callback,
+	} );
+}
+
+export function observeAction( action ) {
+	observers.filter( ( observer ) => {
+		return observer.action === action.type;
+	} ).map( ( observer ) => {
+		observer.callback( action );
+	} );
+}
+
+/**
+ * Example
+ */
+subscribe( 'GO_TO_STEP', ( action ) => {
+	console.log( action.payload.step );
+} );

--- a/assets/src/js/admin/onboarding-wizard/app/store/reducer.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/reducer.js
@@ -3,7 +3,11 @@ import {
 	fetchStatesListWithOnboardingAPI,
 } from '../../utils';
 
+import { observeAction } from './observers';
+
 export const reducer = ( state, action ) => {
+	observeAction( action );
+
 	switch ( action.type ) {
 		case 'GO_TO_STEP':
 			return {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5104

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Sets the `body.style[ 'overflow-y' ]` to `scroll` to prevent shifting in viewport size when the preview form changes height.

I tried doing this for only the Preview step, but that created a shift when changing to and from the Preview step, which was actually more noticeable than the shifting that I was trying to address.

Note: This is applied on `GO_TO_STEP` after the introduction screen, because a visible scrollbar area in the introduction was very noticeable, so this isn't a simple CSS change.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Introduces `observeAction( action )`, which is used to act upon an action for side effects not directly related to state. My goal with this is to not clutter the reducer with non-state code, like DOM styling.

```js
// reducer.js
export const reducer = ( state, action ) => {
    observeAction( action );
    // ...  
}
```

```js
// observer.js
subscribe( 'GO_TO_STEP', ( action ) => {
    if ( action.payload.step === 1 ) {
        document.body.style[ 'overflow-y' ] = 'scroll';
    }
} );
```

This may also be a good option for organizing API calls, code that doesn't directly alter the state being reduced.

```js
// observer.js
subscribe( 'SET_USER_TYPE', ( action ) => {
    saveSettingWithOnboardingAPI( 'user_type', action.payload.type );
} );
```

```js
// reducer.js
case 'SET_USER_TYPE':
    return {
        ...state,
        configuration: { ...state.configuration,
            userType: action.payload.type,
        },
    };
// ...
```

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Note the scrollbar space being held when not scrollable.

![Screenshot from 2020-08-14 18-30-10](https://user-images.githubusercontent.com/10858303/90297398-51dcbe00-de5c-11ea-9e98-a137fe76ab40.png)
![Screenshot from 2020-08-14 18-29-56](https://user-images.githubusercontent.com/10858303/90297405-55704500-de5c-11ea-81de-4706da4d6371.png)
![Screenshot from 2020-08-14 18-30-24](https://user-images.githubusercontent.com/10858303/90297409-573a0880-de5c-11ea-956f-d736a26e1862.png)
![Screenshot from 2020-08-14 18-30-42](https://user-images.githubusercontent.com/10858303/90297413-599c6280-de5c-11ea-83e8-a541ffd1f6a0.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
