### PR TITLE
Setup Page admin scripts now load from the dist directory

### DIFF
--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -87,7 +87,7 @@ class Page {
 		);
 		wp_enqueue_script(
 			'give-admin-setup-script',
-			GIVE_PLUGIN_URL . 'assets/src/js/admin/admin-setup.js',
+			GIVE_PLUGIN_URL . 'assets/dist/js/admin-setup.js',
 			[ 'jquery' ],
 			GIVE_VERSION,
 			$in_footer = true
@@ -100,7 +100,7 @@ class Page {
 		);
 		wp_enqueue_script(
 			'give-admin-setup-script',
-			GIVE_PLUGIN_URL . 'assets/src/js/admin/admin-setup.js',
+			GIVE_PLUGIN_URL . 'assets/dist/js/admin-setup.js',
 			[],
 			GIVE_VERSION,
 			$in_footer = true

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -92,19 +92,6 @@ class Page {
 			GIVE_VERSION,
 			$in_footer = true
 		);
-		wp_enqueue_style(
-			'give-admin-setup-google-fonts',
-			'https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&display=swap',
-			[],
-			GIVE_VERSION
-		);
-		wp_enqueue_script(
-			'give-admin-setup-script',
-			GIVE_PLUGIN_URL . 'assets/dist/js/admin-setup.js',
-			[],
-			GIVE_VERSION,
-			$in_footer = true
-		);
 	}
 
 	/**


### PR DESCRIPTION
Resolves #5106 

## Description
This PR resolves a minor bug, whereby the Setup Page scripts were being loaded from the `src` directory, rather than the `dist` directory. This likely didn't show up in development, but in an actual build the `src` directory is removed - which caused errors on page load. This PR resolves those errors by enqueueing the script from the correct place.

## Affects
Affects page rendering/script enqueueing logic for the Onboarding Setup Page.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Go to the Setup Page
1. View source and note the updated asset paths (now using `dist`). 