### PR TITLE
Users are now warned before accidentally leaving the Onboarding Wizard

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
@@ -13,11 +13,23 @@ import Step from '../step';
 import './style.scss';
 
 const Wizard = ( { children } ) => {
-	const [ { currentStep } ] = useStoreValue();
+	const [ { currentStep, lastStep } ] = useStoreValue();
 	const steps = children;
 
 	useEffect( () => {
 		window.scrollTo( 0, 0 );
+		const handleUnload = ( event ) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+		if ( currentStep > 0 && currentStep !== lastStep ) {
+			window.addEventListener( 'beforeunload', handleUnload );
+		}
+		return () => {
+			if ( currentStep > 0 ) {
+				window.removeEventListener( 'beforeunload', handleUnload );
+			}
+		};
 	}, [ currentStep ] );
 
 	const app = useRef( null );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5074 

## Description
This PR prevents accidental unloading of the Onboarding Wizard (if a user accidentally backs out, presses refresh etc) by showing the user a browser modal alerted them that their changes may not be saved. The modal asks them to confirm their desire to navigate away from the Onboarding Wizard mid-setup.

The modal does not appear on the first or last steps. It does not appear on the first step because at this point users have not actually added any input to the Wizard. It does not appear on that last step because, at this point, all options have been configured. 

## Affects
This PR affects frontend rendering logic of the Onboarding Wizard, specifically setting up window listeners that prevent unloading events from happening on all steps other than the first or last step.

## Visuals
<img width="607" alt="Screen Shot 2020-08-17 at 11 32 21 AM" src="https://user-images.githubusercontent.com/5186078/90431087-5c29d280-e07d-11ea-8af9-046ba6452a39.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Navigate to the Onboarding Wizard, then select start setup. Try refreshing or using the back button on any step other than the last - are you asked to confirm your intent to leave the page? 
