### PR TITLE
WP Errors are no longer logged when using the block editor

### DIFF
--- a/includes/api/class-give-api-v2.php
+++ b/includes/api/class-give-api-v2.php
@@ -79,9 +79,9 @@ class Give_API_V2 {
 	 */
 	private function init() {
 		// Setup hooks.
-		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'localize_script' ), 999 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'localize_script' ), 999 );
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'localize_script' ], 999 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'localize_script' ], 999 );
 	}
 
 
@@ -98,28 +98,31 @@ class Give_API_V2 {
 		register_rest_route(
 			$this->rest_base,
 			'/form/(?P<id>[\d]+)',
-			array(
-				'methods'  => 'GET',
-				'callback' => array( $this, 'get_forms_data' ),
-			)
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_forms_data' ],
+				'permission_callback' => __return_true(),
+			]
 		);
 
 		register_rest_route(
 			$this->rest_base,
 			'/form-grid',
-			array(
-				'methods'  => 'GET',
-				'callback' => array( $this, 'get_donation_grid' ),
-			)
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_donation_grid' ],
+				'permission_callback' => __return_true(),
+			]
 		);
 
 		register_rest_route(
 			$this->rest_base,
 			'/donor-wall',
-			array(
-				'methods'  => 'GET',
-				'callback' => array( $this, 'get_donor_wall' ),
-			)
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'get_donor_wall' ],
+				'permission_callback' => __return_true(),
+			]
 		);
 	}
 
@@ -130,10 +133,10 @@ class Give_API_V2 {
 	 * @access public
 	 */
 	public function localize_script() {
-		$data = array(
+		$data = [
 			'root'      => esc_url_raw( self::get_rest_api() ),
 			'rest_base' => $this->rest_base,
-		);
+		];
 
 		if ( is_admin() ) {
 			wp_localize_script( 'give-admin-scripts', 'giveApiSettings', $data );
@@ -155,7 +158,7 @@ class Give_API_V2 {
 
 		// Bailout
 		if ( ! isset( $parameters['id'] ) || empty( $parameters['id'] ) ) {
-			return array( 'error' => 'no_parameter_given' );
+			return [ 'error' => 'no_parameter_given' ];
 		}
 
 		return give_form_shortcode( $parameters );

--- a/includes/api/class-give-api-v2.php
+++ b/includes/api/class-give-api-v2.php
@@ -101,7 +101,7 @@ class Give_API_V2 {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_forms_data' ],
-				'permission_callback' => __return_true(),
+				'permission_callback' => '__return_true',
 			]
 		);
 
@@ -111,7 +111,7 @@ class Give_API_V2 {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_donation_grid' ],
-				'permission_callback' => __return_true(),
+				'permission_callback' => '__return_true',
 			]
 		);
 
@@ -121,7 +121,7 @@ class Give_API_V2 {
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_donor_wall' ],
-				'permission_callback' => __return_true(),
+				'permission_callback' => '__return_true',
 			]
 		);
 	}


### PR DESCRIPTION
Resolves #5114 

## Description
This PR resolves WP Errors which were logged for users when loading the block editor in WP 5.5. Specifically, the errors made reference to a failure on GiveWP's part to clarify a `permission_callback` when registering rest routes. These errors were first introduced in WP 5.5. In accordance with WP recommendations, these endpoints which are meant to be public now include `permission_callback`s which simply return true. 

## Affects
This PR affects API route registration in the `Give_API_v2` class. In particular, it addresses the lack of a defined permission callback for a number of GiveWP core routes.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
In a WP 5.5 Install, running GiveWP 2.7.5:
- Enable WP Debug log
- Create a new page
- Check for errors in log