### PR TITLE
fix: repeater fields in WP 5.5 should collapse and work like previous WP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   A `register_rest_route` notice no longer displays when creating a new page in the block editor (#5115)
 -   A typo in the Terms & Conditions field description has been fixed (#5110)
 -   Installed version of PHPUnit now supports PHP 5.6 (#5100)
+-   Resolved style and JS issues in WordPress 5.5+ with GiveWP's WP-admin metabox expand / collapse, and repeater elements. (#5118)
 
 [unreleased]: https://github.com/impress-org/givewp/releases/tag/2.8.0-alpha.1...HEAD
 [2.8.0-alpha.1]: https://github.com/impress-org/givewp/releases/tag/2.8.0-alpha.1

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -309,17 +309,6 @@ Shortcode Copy & Paste
 				h2 {
 					text-align: left !important;
 				}
-
-				.give-handlediv {
-					float: right;
-					width: 36px;
-					height: 36px;
-					margin: 0;
-					padding: 0;
-					border: 0;
-					background: none;
-					cursor: pointer;
-				}
 			}
 
 			.give-remove {
@@ -391,6 +380,17 @@ Shortcode Copy & Paste
 
 		.give-row.closed .toggle-indicator::before {
 			content: '\f140';
+		}
+
+		.give-handlediv {
+			float: right;
+			width: 36px;
+			height: 36px;
+			margin: 0;
+			padding: 0;
+			border: 0;
+			background: none;
+			cursor: pointer;
 		}
 	}
 

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -309,6 +309,17 @@ Shortcode Copy & Paste
 				h2 {
 					text-align: left !important;
 				}
+
+				.give-handlediv {
+					float: right;
+					width: 36px;
+					height: 36px;
+					margin: 0;
+					padding: 0;
+					border: 0;
+					background: none;
+					cursor: pointer;
+				}
 			}
 
 			.give-remove {

--- a/assets/src/css/admin/forms.scss
+++ b/assets/src/css/admin/forms.scss
@@ -510,6 +510,7 @@ Shortcode Copy & Paste
 
 				> .give-row-head {
 					background-color: #f1f1f1;
+					border-bottom: 1px solid #ccd0d4;
 				}
 			}
 		}

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2514,7 +2514,7 @@ const gravatar = require( 'gravatar' );
 				$body = $( 'body' );
 
 			// Auto toggle repeater group
-			$body.on( 'click', '.give-row-head button', function() {
+			$body.on( 'click', '.give-row-head .give-handlediv', function() {
 				const $parent = $( this ).closest( '.give-row' );
 				$parent.toggleClass( 'closed' );
 				$( '.give-row-body', $parent ).toggle();
@@ -2794,10 +2794,10 @@ const gravatar = require( 'gravatar' );
 	var handle_metabox_repeater_field_row_remove = function( container ) {
 		let $container = $( container ),
 			$parent = $container.parents( '.give-repeatable-field-section' ),
-			row_count = $( container ).attr( 'data-rf-row-count' );
+			row_count = $( container ).prop( 'data-rf-row-count' );
 
 		// Reduce row count.
-		$container.attr( 'data-rf-row-count', --row_count );
+		$container.prop( 'data-rf-row-count', --row_count );
 
 		// Fire event: Row deleted.
 		$parent.trigger( 'repeater_field_row_deleted' );

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -1324,7 +1324,7 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 			<tr class="give-template give-row">
 				<td class="give-repeater-field-wrap give-column" colspan="2">
 					<div class="give-row-head give-move">
-						<button type="button" class="handlediv button-link"><span class="toggle-indicator"></span>
+						<button type="button" class="give-handlediv button-link"><span class="toggle-indicator"></span>
 						</button>
 						<span class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-</span>
 						<h2>
@@ -1359,7 +1359,7 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 					<tr class="give-row">
 						<td class="give-repeater-field-wrap give-column" colspan="2">
 							<div class="give-row-head give-move">
-								<button type="button" class="handlediv button-link">
+								<button type="button" class="give-handlediv button-link">
 									<span class="toggle-indicator"></span></button>
 								<span class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-
 								</span>
@@ -1398,7 +1398,7 @@ function _give_metabox_form_data_repeater_fields( $fields ) {
 				<tr class="give-row">
 					<td class="give-repeater-field-wrap give-column" colspan="2">
 						<div class="give-row-head give-move">
-							<button type="button" class="handlediv button-link">
+							<button type="button" class="give-handlediv button-link">
 								<span class="toggle-indicator"></span></button>
 							<span class="give-remove" title="<?php esc_html_e( 'Remove Group', 'give' ); ?>">-
 							</span>

--- a/src/Helpers/Form/Template/Utils/Admin.php
+++ b/src/Helpers/Form/Template/Utils/Admin.php
@@ -34,7 +34,7 @@ class Admin {
 
 			printf(
 				'<div class="give-row-head">
-							<button type="button" class="handlediv" aria-expanded="true">
+							<button type="button" class="give-handlediv" aria-expanded="true">
 								<span class="toggle-indicator"/>
 							</button>
 							<h2 class="hndle"><span>%1$s</span></h2>

--- a/src/Helpers/Form/Template/Utils/Admin.php
+++ b/src/Helpers/Form/Template/Utils/Admin.php
@@ -37,7 +37,7 @@ class Admin {
 							<button type="button" class="give-handlediv" aria-expanded="true">
 								<span class="toggle-indicator"/>
 							</button>
-							<h2 class="hndle"><span>%1$s</span></h2>
+							<h2><span>%1$s</span></h2>
 						</div>',
 				$group->name
 			);


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5118

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
GiveWP's repeater fields toggle button didn't work in the latest version (5.5) of WordPress. 
The collapse feature didn't actually collapse the group anymore but rather the entire tabbed metabox.
Also, the metabox header was in another line. 

This issue is related to recent WP [changeset](https://core.trac.wordpress.org/changeset/48373) 

This PR solves the issue by changing the jQuery toggle selector name for the metabox toggle button and by re-adding removed button styles. 



## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Donation level repeater fields.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add new Donation form
2. Add new Donation level
3. Toggle Donation level metabox
4. Delete Donation level metabox
5. Save Donation form and repeat steps 2., 3., and 4.


<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
