### PR TITLE
Add sub header text for Add-ons Setup section.

### DIFF
--- a/assets/src/css/admin/setup.scss
+++ b/assets/src/css/admin/setup.scss
@@ -200,6 +200,11 @@ article.stripe .action button {
 	}
 }
 
+.setup-item-sub-header {
+	display: block; // Override inherited grid layout.
+	padding-left: 20px;
+}
+
 .setup-item-completed .header {
 	text-decoration: line-through;
 }

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -165,12 +165,12 @@
 			[
 				'title'    => sprintf( '%s 3: %s', __( 'Step', 'give' ), __( 'Level up your fundraising', 'give' ) ),
 				'contents' => [
-					$this->render_template(
+					! empty( $settings['addons'] ) ? $this->render_template(
 						'sub-header',
 						[
 							'text' => 'Based on your selections, Give recommends the following add-ons to support your fundraising.',
 						]
-					),
+					) : '',
 					in_array( 'recurring-donations', $settings['addons'] ) ? $this->render_template(
 						'row-item',
 						[

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -165,6 +165,12 @@
 			[
 				'title'    => sprintf( '%s 3: %s', __( 'Step', 'give' ), __( 'Level up your fundraising', 'give' ) ),
 				'contents' => [
+					$this->render_template(
+						'sub-header',
+						[
+							'text' => 'Based on your selections, Give recommends the following add-ons to support your fundraising.',
+						]
+					),
 					in_array( 'recurring-donations', $settings['addons'] ) ? $this->render_template(
 						'row-item',
 						[

--- a/src/Onboarding/Setup/templates/sub-header.html
+++ b/src/Onboarding/Setup/templates/sub-header.html
@@ -1,0 +1,3 @@
+<article class="setup-item setup-item-sub-header">
+    {{ text }}
+</article>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5142

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Introduces a `sub-header` template for adding descriptive text to a section.
- Adds a sub-header for the Add-ons Section, to communicate that the list of add-ons is based on their selection from the Wizard.
  - The sub-header renders conditionally, only if add-ons are selected.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Without any selected add-ons from the Wizard:
![image](https://user-images.githubusercontent.com/10858303/90573204-dd6b8d00-e183-11ea-8362-db0a37e0fd46.png)

With add-on(s) selected from the Wizard:
![image](https://user-images.githubusercontent.com/10858303/90573236-f2482080-e183-11ea-907d-e6514144eac6.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
