### PR TITLE
Configuring Stripe webhooks now has a note about test mode.

### DIFF
--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -124,7 +124,12 @@
 							'icon'        => $this->image( 'stripe-connect@2x.min.png' ),
 							'icon_alt'    => esc_html__( 'Stripe', 'give' ),
 							'title'       => esc_html__( 'Please configure your Stripe webhook to finalize the setup.', 'give' ),
-							'description' => esc_html__( 'In order for Stripe to function properly, you must add a new Stripe webhook endpoint. To do this please visit the Webhooks Section of your Stripe Dashboard and click the Add endpoint button and paste the following URL: ', 'give' ) . '<br /><span id="stripeWebhooksCopyHandler" class="stripe-webhooks-url"><input disabled="disabled" id="stripeWebhooksCopy" value="' . add_query_arg( 'give-listener', 'stripe', site_url() ) . '" /> &nbsp; <i id="stripeWebhooksCopyIcon" class="fa fa-clipboard"></i></input>',
+							'description' => sprintf(
+								'%s<br /><br />%s<br /><br /><em>%s</em>',
+								esc_html__( 'In order for Stripe to function properly, you must add a new Stripe webhook endpoint. To do this please visit the Webhooks Section of your Stripe Dashboard and click the Add endpoint button and paste the following URL: ', 'give' ),
+								'<span id="stripeWebhooksCopyHandler" class="stripe-webhooks-url"><input disabled="disabled" id="stripeWebhooksCopy" value="' . add_query_arg( 'give-listener', 'stripe', site_url() ) . '" /> &nbsp; <i id="stripeWebhooksCopyIcon" class="fa fa-clipboard"></i></input>',
+								esc_html__( 'Note: If you plan on testing Stripe you will need to set the webhook for both live and test mode.', 'give' )
+							),
 							'action'      =>
 								sprintf( '<a id="stripeWebhooksConfigureButton" href="%s" target="_blank">%s</a>', esc_url_raw( 'https://dashboard.stripe.com/webhooks' ), __( 'Configure Webhooks', 'give' ) ),
 						]


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5095

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Add a note about testing Stripe and webhooks.

Related: https://github.com/impress-org/givewp/pull/5098#pullrequestreview-469620709

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Note: There is a Stripe color change in a separate PR that isn't reflected here.

![Screenshot_2020-08-18 Setup GiveWP ‹ WordPress — WordPress(17)](https://user-images.githubusercontent.com/10858303/90578570-a7cda080-e191-11ea-936b-0ffef02eb434.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
