### PR TITLE
HTML entities in State labels are now decoded

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -144,7 +144,13 @@ export const fetchStatesListWithOnboardingAPI = ( country, dispatch ) => {
 	} )
 		.then( ( response ) => response.data )
 		.then( ( data ) => {
-			dispatch( setStateList( data.states ) );
+			const stateList = data.states.map( ( state ) => {
+				return {
+					value: state.value,
+					label: decodeHTMLEntity( state.label ),
+				};
+			} );
+			dispatch( setStateList( stateList ) );
 			dispatch( setFetchingStatesList( false ) );
 		} );
 };

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -41,7 +41,12 @@ export const getCountryList = () => {
 };
 
 export const getDefaultStateList = () => {
-	return getWindowData( 'states' );
+	return getWindowData( 'states' ).map( ( state ) => {
+		return {
+			value: state.value,
+			label: decodeHTMLEntity( state.label ),
+		};
+	} );
 };
 
 export const getCurrencyList = () => {


### PR DESCRIPTION
Resolves #5151

## Description
This issue addresses an error whereby HTML entities within state labels (in the State/Province input) were not being decoded. Using the decodeHTMLEntity utility already utilized to decode labels for other select inputs, this PR resolves the issue by decoding labels in both the default state list, and fetched state lists.

## Affects
This PR affects state fetching logic associated with the State/Provinces input of the Onboarding Wizard.

## Visuals
<img width="484" alt="Screen Shot 2020-08-19 at 10 52 38 AM" src="https://user-images.githubusercontent.com/5186078/90672191-9d032200-e20a-11ea-855e-c11a728b272d.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
In the Onboarding Wizard:
1. Navigate to the Location step
2. Select a country with States/Provinces that require HTML entities to display correctly (ex: Spain)
3. Check that HTML entities are decoded in the State options