### PR TITLE
Setup Page is now disabled when updating GiveWP

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -73,6 +73,11 @@ function give_run_install() {
 	// Fresh Install? Setup Test Mode, Base Country (US), Test Gateway, Currency.
 	if ( empty( $current_version ) ) {
 		$options = array_merge( $options, give_get_default_settings() );
+	} else {
+		// Otherwise, disable the Onboarding experience
+		$options = [
+			'setup_page_enabled' => 'disabled',
+		];
 	}
 
 	// Populate the default values.


### PR DESCRIPTION
Resolves #5155 

## Description
This PR ensures that during install, if the current version is already defined, the Setup Page and onboarding experience are disabled. On fresh installs, the Setup Page is still enabled by default.

## Affects
This PR affects installation logic, in particular how non-fresh installs handle setting default values.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
On an existing install of GiveWP, update to this PR. Check to see if Setup page is accessible via the Donations admin menu.
