### PR TITLE
First-time activation now redirects users to the Onboarding Wizard

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -159,7 +159,7 @@ function give_do_automatic_upgrades() {
 	}
 
 	if ( $did_upgrade || version_compare( $give_version, GIVE_VERSION, '<' ) ) {
-		update_option( 'give_version', preg_replace( '/[^0-9.].*/', '', GIVE_VERSION ), false );
+		update_option( 'give_version', GIVE_VERSION, false );
 	}
 }
 
@@ -692,7 +692,7 @@ function give_v152_cleanup_users() {
 		$roles->add_caps();
 
 		// The Update Ran.
-		update_option( 'give_version', preg_replace( '/[^0-9.].*/', '', GIVE_VERSION ), false );
+		update_option( 'give_version', GIVE_VERSION, false );
 		give_set_upgrade_complete( 'upgrade_give_user_caps_cleanup' );
 		delete_option( 'give_doing_upgrade' );
 


### PR DESCRIPTION
Resolves #5159 

## Description
This PR resolves an issue where, when using an alpha release, users were not redirected to the Onboarding Wizard, and the Setup Page was being disabled. After some investigation, it was determined to be the fault of the give_do_automatic_updates and give_run_install functions. Both of these functions were using preg_match to strip the version number defined as a constant of any non-numeric characters before storing it as the give_version site option. This PR removes the preg_match, allowing version numbers to use non-numeric tags (ex: alpha) as part of the numbering convention.

## Affects
This PR affects upgrade and installation logic for GiveWP. Specifically, how storing the current version number is handled. 

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Setup a fresh WP install
2. Install GiveWP
3. Activate GiveWP
4. See that you are now redirected to the Onboaridng Wizard, and the Setup page is visible in the Donations admin menu
