### PR TITLE
Admin notices are no longer animated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added hover styles to the Wizard buttons to match the form preview. (#5167)
 -   Setup Page now initiates the connection to Stripe, but defers webhook configuration to the gateway settings. (#5171)
 -   Removed preg_match that prevented version numbers with tags from being stored (#5172)
+-   Admin notice animation has been removed. (#5182)
 
 ### Fixed
 

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -27,7 +27,7 @@ class Give_Notices {
 	 * @since  1.8.9
 	 * @access private
 	 */
-	private static $notices = array();
+	private static $notices = [];
 
 
 	/**
@@ -54,22 +54,22 @@ class Give_Notices {
 	 * @since 1.8.9
 	 */
 	public function __construct() {
-		add_action( 'admin_notices', array( $this, 'render_admin_notices' ), 999 );
-		add_action( 'admin_footer', array( $this, '__reveal_notices' ) );
-		add_action( 'give_dismiss_notices', array( $this, 'dismiss_notices' ) );
+		add_action( 'admin_notices', [ $this, 'render_admin_notices' ], 999 );
+		add_action( 'admin_footer', [ $this, '__reveal_notices' ] );
+		add_action( 'give_dismiss_notices', [ $this, 'dismiss_notices' ] );
 
-		add_action( 'give_frontend_notices', array( $this, 'render_frontend_notices' ), 999 );
-		add_action( 'give_pre_form_output', array( $this, 'render_frontend_form_notices' ), 10, 1 );
-		add_action( 'give_ajax_donation_errors', array( $this, 'render_frontend_notices' ) );
+		add_action( 'give_frontend_notices', [ $this, 'render_frontend_notices' ], 999 );
+		add_action( 'give_pre_form_output', [ $this, 'render_frontend_form_notices' ], 10, 1 );
+		add_action( 'give_ajax_donation_errors', [ $this, 'render_frontend_notices' ] );
 
 		/**
 		 * Backward compatibility for deprecated params.
 		 *
 		 * @since 1.8.14
 		 */
-		add_filter( 'give_register_notice_args', array( $this, 'bc_deprecated_params' ) );
-		add_filter( 'give_frontend_errors_args', array( $this, 'bc_deprecated_params' ) );
-		add_filter( 'give_frontend_notice_args', array( $this, 'bc_deprecated_params' ) );
+		add_filter( 'give_register_notice_args', [ $this, 'bc_deprecated_params' ] );
+		add_filter( 'give_frontend_errors_args', [ $this, 'bc_deprecated_params' ] );
+		add_filter( 'give_frontend_notice_args', [ $this, 'bc_deprecated_params' ] );
 	}
 
 	/**
@@ -118,7 +118,7 @@ class Give_Notices {
 
 		$notice_args = wp_parse_args(
 			$notice_args,
-			array(
+			[
 				'id'                    => '',
 				'description'           => '',
 
@@ -152,7 +152,7 @@ class Give_Notices {
 				// Only set it when custom is defined.
 				'dismiss_interval_time' => null,
 
-			)
+			]
 		);
 
 		/**
@@ -172,12 +172,12 @@ class Give_Notices {
 				foreach ( $extra_notice_dismiss_links as $extra_notice_dismiss_link ) {
 					// Create array og key ==> value by parsing query string created after renaming data attributes.
 					$data_attribute_query_str = str_replace(
-						array( 'data-', '-', '"' ),
-						array(
+						[ 'data-', '-', '"' ],
+						[
 							'',
 							'_',
 							'',
-						),
+						],
 						implode( '&', $extra_notice_dismiss_link )
 					);
 
@@ -322,9 +322,9 @@ class Give_Notices {
 		$display_option = give_get_meta( $form_id, '_give_payment_display', true );
 
 		if ( 'modal' === $display_option ) {
-			add_action( 'give_payment_mode_top', array( $this, 'render_frontend_notices' ) );
+			add_action( 'give_payment_mode_top', [ $this, 'render_frontend_notices' ] );
 		} else {
-			add_action( 'give_pre_form', array( $this, 'render_frontend_notices' ), 11 );
+			add_action( 'give_pre_form', [ $this, 'render_frontend_notices' ], 11 );
 		}
 	}
 
@@ -420,16 +420,10 @@ class Give_Notices {
 		<script>
 			jQuery(document).ready(function($){
 				// Fix notice appearance issue.
-				window.setTimeout(
-					function(){
-						var give_notices = $('.give-notice');
-
-						if( give_notices.length ) {
-							give_notices.slideDown();
-						}
-					},
-					1000
-				);
+				var give_notices = $('.give-notice');
+				if( give_notices.length ) {
+					give_notices.show();
+				}
 			});
 		</script>
 		<?php
@@ -517,12 +511,12 @@ class Give_Notices {
 	public function get_dismiss_link( $notice_args ) {
 		$notice_args = wp_parse_args(
 			$notice_args,
-			array(
+			[
 				'title'                 => __( 'Click here', 'give' ),
 				'dismissible_type'      => '',
 				'dismiss_interval'      => '',
 				'dismiss_interval_time' => null,
-			)
+			]
 		);
 
 		return sprintf(
@@ -594,13 +588,13 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = array(
+		$default_notice_args = [
 			'dismissible'      => true,
 			'dismiss_interval' => 5000,
-		);
+		];
 
 		// Note: we will remove give_errors class in future.
-		$classes = apply_filters( 'give_error_class', array( 'give_notices', 'give_errors' ) );
+		$classes = apply_filters( 'give_error_class', [ 'give_notices', 'give_errors' ] );
 
 		echo sprintf( '<div class="%s">', implode( ' ', $classes ) );
 
@@ -608,10 +602,10 @@ class Give_Notices {
 		foreach ( $errors as $error_id => $error ) {
 			// Backward compatibility v<1.8.11
 			if ( is_string( $error ) ) {
-				$error = array(
+				$error = [
 					'message'     => $error,
-					'notice_args' => array(),
-				);
+					'notice_args' => [],
+				];
 			}
 
 			$notice_args = wp_parse_args( $error['notice_args'], $default_notice_args );
@@ -652,7 +646,7 @@ class Give_Notices {
 	 *
 	 * @return  string
 	 */
-	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = array() ) {
+	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = [] ) {
 		if ( empty( $message ) ) {
 			return '';
 		}
@@ -662,11 +656,11 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = array(
+		$default_notice_args = [
 			'dismissible'      => false,
 			'dismiss_type'     => 'auto',
 			'dismiss_interval' => 5000,
-		);
+		];
 
 		$notice_args = wp_parse_args( $notice_args, $default_notice_args );
 
@@ -723,18 +717,18 @@ class Give_Notices {
 	 *
 	 * @return string
 	 */
-	public function print_admin_notices( $notice_args = array() ) {
+	public function print_admin_notices( $notice_args = [] ) {
 		// Bailout.
 		if ( empty( $notice_args['description'] ) ) {
 			return '';
 		}
 
-		$defaults    = array(
+		$defaults    = [
 			'id'          => '',
 			'echo'        => true,
 			'notice_type' => 'warning',
 			'dismissible' => true,
-		);
+		];
 		$notice_args = wp_parse_args( $notice_args, $defaults );
 
 		$output     = '';

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -27,7 +27,7 @@ class Give_Notices {
 	 * @since  1.8.9
 	 * @access private
 	 */
-	private static $notices = [];
+	private static $notices = array();
 
 
 	/**
@@ -54,21 +54,22 @@ class Give_Notices {
 	 * @since 1.8.9
 	 */
 	public function __construct() {
-		add_action( 'admin_notices', [ $this, 'render_admin_notices' ], 999 );
-		add_action( 'give_dismiss_notices', [ $this, 'dismiss_notices' ] );
+		add_action( 'admin_notices', array( $this, 'render_admin_notices' ), 999 );
+		add_action( 'admin_footer', array( $this, '__reveal_notices' ) );
+		add_action( 'give_dismiss_notices', array( $this, 'dismiss_notices' ) );
 
-		add_action( 'give_frontend_notices', [ $this, 'render_frontend_notices' ], 999 );
-		add_action( 'give_pre_form_output', [ $this, 'render_frontend_form_notices' ], 10, 1 );
-		add_action( 'give_ajax_donation_errors', [ $this, 'render_frontend_notices' ] );
+		add_action( 'give_frontend_notices', array( $this, 'render_frontend_notices' ), 999 );
+		add_action( 'give_pre_form_output', array( $this, 'render_frontend_form_notices' ), 10, 1 );
+		add_action( 'give_ajax_donation_errors', array( $this, 'render_frontend_notices' ) );
 
 		/**
 		 * Backward compatibility for deprecated params.
 		 *
 		 * @since 1.8.14
 		 */
-		add_filter( 'give_register_notice_args', [ $this, 'bc_deprecated_params' ] );
-		add_filter( 'give_frontend_errors_args', [ $this, 'bc_deprecated_params' ] );
-		add_filter( 'give_frontend_notice_args', [ $this, 'bc_deprecated_params' ] );
+		add_filter( 'give_register_notice_args', array( $this, 'bc_deprecated_params' ) );
+		add_filter( 'give_frontend_errors_args', array( $this, 'bc_deprecated_params' ) );
+		add_filter( 'give_frontend_notice_args', array( $this, 'bc_deprecated_params' ) );
 	}
 
 	/**
@@ -117,7 +118,7 @@ class Give_Notices {
 
 		$notice_args = wp_parse_args(
 			$notice_args,
-			[
+			array(
 				'id'                    => '',
 				'description'           => '',
 
@@ -151,7 +152,7 @@ class Give_Notices {
 				// Only set it when custom is defined.
 				'dismiss_interval_time' => null,
 
-			]
+			)
 		);
 
 		/**
@@ -171,12 +172,12 @@ class Give_Notices {
 				foreach ( $extra_notice_dismiss_links as $extra_notice_dismiss_link ) {
 					// Create array og key ==> value by parsing query string created after renaming data attributes.
 					$data_attribute_query_str = str_replace(
-						[ 'data-', '-', '"' ],
-						[
+						array( 'data-', '-', '"' ),
+						array(
 							'',
 							'_',
 							'',
-						],
+						),
 						implode( '&', $extra_notice_dismiss_link )
 					);
 
@@ -260,7 +261,7 @@ class Give_Notices {
 
 			$css_class = 'give-notice notice ' . ( empty( $notice['dismissible'] ) ? 'non' : 'is' ) . "-dismissible {$notice['type']} notice-{$notice['type']}";
 			$output   .= sprintf(
-				'<div id="%1$s" class="%2$s" data-dismissible="%3$s" data-dismissible-type="%4$s" data-dismiss-interval="%5$s" data-notice-id="%6$s" data-security="%7$s" data-dismiss-interval-time="%8$s">' . " \n",
+				'<div id="%1$s" class="%2$s" data-dismissible="%3$s" data-dismissible-type="%4$s" data-dismiss-interval="%5$s" data-notice-id="%6$s" data-security="%7$s" data-dismiss-interval-time="%8$s" style="display: none">' . " \n",
 				$css_id,
 				$css_class,
 				give_clean( $notice['dismissible'] ),
@@ -321,9 +322,9 @@ class Give_Notices {
 		$display_option = give_get_meta( $form_id, '_give_payment_display', true );
 
 		if ( 'modal' === $display_option ) {
-			add_action( 'give_payment_mode_top', [ $this, 'render_frontend_notices' ] );
+			add_action( 'give_payment_mode_top', array( $this, 'render_frontend_notices' ) );
 		} else {
-			add_action( 'give_pre_form', [ $this, 'render_frontend_notices' ], 11 );
+			add_action( 'give_pre_form', array( $this, 'render_frontend_notices' ), 11 );
 		}
 	}
 
@@ -409,6 +410,33 @@ class Give_Notices {
 	}
 
 	/**
+	 * Show notices
+	 * Note: only for internal use
+	 *
+	 * @since 2.3.0
+	 */
+	public function __reveal_notices() {
+		?>
+		<script>
+			jQuery(document).ready(function($){
+				// Fix notice appearance issue.
+				window.setTimeout(
+					function(){
+						var give_notices = $('.give-notice');
+
+						if( give_notices.length ) {
+							give_notices.slideDown();
+						}
+					},
+					1000
+				);
+			});
+		</script>
+		<?php
+	}
+
+
+	/**
 	 * Hide notice.
 	 *
 	 * @since  1.8.9
@@ -489,12 +517,12 @@ class Give_Notices {
 	public function get_dismiss_link( $notice_args ) {
 		$notice_args = wp_parse_args(
 			$notice_args,
-			[
+			array(
 				'title'                 => __( 'Click here', 'give' ),
 				'dismissible_type'      => '',
 				'dismiss_interval'      => '',
 				'dismiss_interval_time' => null,
-			]
+			)
 		);
 
 		return sprintf(
@@ -566,13 +594,13 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = [
+		$default_notice_args = array(
 			'dismissible'      => true,
 			'dismiss_interval' => 5000,
-		];
+		);
 
 		// Note: we will remove give_errors class in future.
-		$classes = apply_filters( 'give_error_class', [ 'give_notices', 'give_errors' ] );
+		$classes = apply_filters( 'give_error_class', array( 'give_notices', 'give_errors' ) );
 
 		echo sprintf( '<div class="%s">', implode( ' ', $classes ) );
 
@@ -580,10 +608,10 @@ class Give_Notices {
 		foreach ( $errors as $error_id => $error ) {
 			// Backward compatibility v<1.8.11
 			if ( is_string( $error ) ) {
-				$error = [
+				$error = array(
 					'message'     => $error,
-					'notice_args' => [],
-				];
+					'notice_args' => array(),
+				);
 			}
 
 			$notice_args = wp_parse_args( $error['notice_args'], $default_notice_args );
@@ -624,7 +652,7 @@ class Give_Notices {
 	 *
 	 * @return  string
 	 */
-	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = [] ) {
+	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = array() ) {
 		if ( empty( $message ) ) {
 			return '';
 		}
@@ -634,11 +662,11 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = [
+		$default_notice_args = array(
 			'dismissible'      => false,
 			'dismiss_type'     => 'auto',
 			'dismiss_interval' => 5000,
-		];
+		);
 
 		$notice_args = wp_parse_args( $notice_args, $default_notice_args );
 
@@ -695,18 +723,18 @@ class Give_Notices {
 	 *
 	 * @return string
 	 */
-	public function print_admin_notices( $notice_args = [] ) {
+	public function print_admin_notices( $notice_args = array() ) {
 		// Bailout.
 		if ( empty( $notice_args['description'] ) ) {
 			return '';
 		}
 
-		$defaults    = [
+		$defaults    = array(
 			'id'          => '',
 			'echo'        => true,
 			'notice_type' => 'warning',
 			'dismissible' => true,
-		];
+		);
 		$notice_args = wp_parse_args( $notice_args, $defaults );
 
 		$output     = '';

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -27,7 +27,7 @@ class Give_Notices {
 	 * @since  1.8.9
 	 * @access private
 	 */
-	private static $notices = array();
+	private static $notices = [];
 
 
 	/**
@@ -54,22 +54,21 @@ class Give_Notices {
 	 * @since 1.8.9
 	 */
 	public function __construct() {
-		add_action( 'admin_notices', array( $this, 'render_admin_notices' ), 999 );
-		add_action( 'admin_footer', array( $this, '__reveal_notices' ) );
-		add_action( 'give_dismiss_notices', array( $this, 'dismiss_notices' ) );
+		add_action( 'admin_notices', [ $this, 'render_admin_notices' ], 999 );
+		add_action( 'give_dismiss_notices', [ $this, 'dismiss_notices' ] );
 
-		add_action( 'give_frontend_notices', array( $this, 'render_frontend_notices' ), 999 );
-		add_action( 'give_pre_form_output', array( $this, 'render_frontend_form_notices' ), 10, 1 );
-		add_action( 'give_ajax_donation_errors', array( $this, 'render_frontend_notices' ) );
+		add_action( 'give_frontend_notices', [ $this, 'render_frontend_notices' ], 999 );
+		add_action( 'give_pre_form_output', [ $this, 'render_frontend_form_notices' ], 10, 1 );
+		add_action( 'give_ajax_donation_errors', [ $this, 'render_frontend_notices' ] );
 
 		/**
 		 * Backward compatibility for deprecated params.
 		 *
 		 * @since 1.8.14
 		 */
-		add_filter( 'give_register_notice_args', array( $this, 'bc_deprecated_params' ) );
-		add_filter( 'give_frontend_errors_args', array( $this, 'bc_deprecated_params' ) );
-		add_filter( 'give_frontend_notice_args', array( $this, 'bc_deprecated_params' ) );
+		add_filter( 'give_register_notice_args', [ $this, 'bc_deprecated_params' ] );
+		add_filter( 'give_frontend_errors_args', [ $this, 'bc_deprecated_params' ] );
+		add_filter( 'give_frontend_notice_args', [ $this, 'bc_deprecated_params' ] );
 	}
 
 	/**
@@ -118,7 +117,7 @@ class Give_Notices {
 
 		$notice_args = wp_parse_args(
 			$notice_args,
-			array(
+			[
 				'id'                    => '',
 				'description'           => '',
 
@@ -152,7 +151,7 @@ class Give_Notices {
 				// Only set it when custom is defined.
 				'dismiss_interval_time' => null,
 
-			)
+			]
 		);
 
 		/**
@@ -172,12 +171,12 @@ class Give_Notices {
 				foreach ( $extra_notice_dismiss_links as $extra_notice_dismiss_link ) {
 					// Create array og key ==> value by parsing query string created after renaming data attributes.
 					$data_attribute_query_str = str_replace(
-						array( 'data-', '-', '"' ),
-						array(
+						[ 'data-', '-', '"' ],
+						[
 							'',
 							'_',
 							'',
-						),
+						],
 						implode( '&', $extra_notice_dismiss_link )
 					);
 
@@ -261,7 +260,7 @@ class Give_Notices {
 
 			$css_class = 'give-notice notice ' . ( empty( $notice['dismissible'] ) ? 'non' : 'is' ) . "-dismissible {$notice['type']} notice-{$notice['type']}";
 			$output   .= sprintf(
-				'<div id="%1$s" class="%2$s" data-dismissible="%3$s" data-dismissible-type="%4$s" data-dismiss-interval="%5$s" data-notice-id="%6$s" data-security="%7$s" data-dismiss-interval-time="%8$s" style="display: none">' . " \n",
+				'<div id="%1$s" class="%2$s" data-dismissible="%3$s" data-dismissible-type="%4$s" data-dismiss-interval="%5$s" data-notice-id="%6$s" data-security="%7$s" data-dismiss-interval-time="%8$s">' . " \n",
 				$css_id,
 				$css_class,
 				give_clean( $notice['dismissible'] ),
@@ -322,9 +321,9 @@ class Give_Notices {
 		$display_option = give_get_meta( $form_id, '_give_payment_display', true );
 
 		if ( 'modal' === $display_option ) {
-			add_action( 'give_payment_mode_top', array( $this, 'render_frontend_notices' ) );
+			add_action( 'give_payment_mode_top', [ $this, 'render_frontend_notices' ] );
 		} else {
-			add_action( 'give_pre_form', array( $this, 'render_frontend_notices' ), 11 );
+			add_action( 'give_pre_form', [ $this, 'render_frontend_notices' ], 11 );
 		}
 	}
 
@@ -410,33 +409,6 @@ class Give_Notices {
 	}
 
 	/**
-	 * Show notices
-	 * Note: only for internal use
-	 *
-	 * @since 2.3.0
-	 */
-	public function __reveal_notices() {
-		?>
-		<script>
-			jQuery(document).ready(function($){
-				// Fix notice appearance issue.
-				window.setTimeout(
-					function(){
-						var give_notices = $('.give-notice');
-
-						if( give_notices.length ) {
-							give_notices.slideDown();
-						}
-					},
-					1000
-				);
-			});
-		</script>
-		<?php
-	}
-
-
-	/**
 	 * Hide notice.
 	 *
 	 * @since  1.8.9
@@ -517,12 +489,12 @@ class Give_Notices {
 	public function get_dismiss_link( $notice_args ) {
 		$notice_args = wp_parse_args(
 			$notice_args,
-			array(
+			[
 				'title'                 => __( 'Click here', 'give' ),
 				'dismissible_type'      => '',
 				'dismiss_interval'      => '',
 				'dismiss_interval_time' => null,
-			)
+			]
 		);
 
 		return sprintf(
@@ -594,13 +566,13 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = array(
+		$default_notice_args = [
 			'dismissible'      => true,
 			'dismiss_interval' => 5000,
-		);
+		];
 
 		// Note: we will remove give_errors class in future.
-		$classes = apply_filters( 'give_error_class', array( 'give_notices', 'give_errors' ) );
+		$classes = apply_filters( 'give_error_class', [ 'give_notices', 'give_errors' ] );
 
 		echo sprintf( '<div class="%s">', implode( ' ', $classes ) );
 
@@ -608,10 +580,10 @@ class Give_Notices {
 		foreach ( $errors as $error_id => $error ) {
 			// Backward compatibility v<1.8.11
 			if ( is_string( $error ) ) {
-				$error = array(
+				$error = [
 					'message'     => $error,
-					'notice_args' => array(),
-				);
+					'notice_args' => [],
+				];
 			}
 
 			$notice_args = wp_parse_args( $error['notice_args'], $default_notice_args );
@@ -652,7 +624,7 @@ class Give_Notices {
 	 *
 	 * @return  string
 	 */
-	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = array() ) {
+	public static function print_frontend_notice( $message, $echo = true, $notice_type = 'warning', $notice_args = [] ) {
 		if ( empty( $message ) ) {
 			return '';
 		}
@@ -662,11 +634,11 @@ class Give_Notices {
 		 *
 		 * @since 1.8.14
 		 */
-		$default_notice_args = array(
+		$default_notice_args = [
 			'dismissible'      => false,
 			'dismiss_type'     => 'auto',
 			'dismiss_interval' => 5000,
-		);
+		];
 
 		$notice_args = wp_parse_args( $notice_args, $default_notice_args );
 
@@ -723,18 +695,18 @@ class Give_Notices {
 	 *
 	 * @return string
 	 */
-	public function print_admin_notices( $notice_args = array() ) {
+	public function print_admin_notices( $notice_args = [] ) {
 		// Bailout.
 		if ( empty( $notice_args['description'] ) ) {
 			return '';
 		}
 
-		$defaults    = array(
+		$defaults    = [
 			'id'          => '',
 			'echo'        => true,
 			'notice_type' => 'warning',
 			'dismissible' => true,
-		);
+		];
 		$notice_args = wp_parse_args( $notice_args, $defaults );
 
 		$output     = '';


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5181

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The previously added admin notice animation has been removed.

~Note: This change re-exposes the admin notice flicker, but now the time to interactive is much shorter and reduces mis-clicks.~

Switching to `.show()` without a timeout covers the flicker with minimal disruption to the content.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Flicker (before before)
![giveNoticeFlicker](https://user-images.githubusercontent.com/10858303/90989940-3e6fd800-e56b-11ea-90bf-746b97cf928d.gif)

Animation (before) - content shift causing mis-clicks
![giveNoticeAnimation](https://user-images.githubusercontent.com/10858303/90989938-3c0d7e00-e56b-11ea-9b63-da8375009604.gif)

**Show Toggle, All Forms** (after) - no flicker!
![giveNoticeShow](https://user-images.githubusercontent.com/10858303/91108053-e6a59f80-e644-11ea-88f7-872a291cdbb0.gif)

**Show Toggle, Add Form** (after) - Negligible content shift
![giveNoticeShowAddForm](https://user-images.githubusercontent.com/10858303/91108065-f1f8cb00-e644-11ea-8f09-9dc0ebf3d9cb.gif)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
