### PR TITLE
License activation is restored by resolving JS translation error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Set a specific placeholder for the base country select setting, no longer reads "Select a form". (#5163)
 -   Form preview within the Onboarding Wizard now remains centered on larger viewports. (#5180)
+-   Fixed translation of common text to support WordPress 5.5, with backwards compatibility for `commonL10n`. (#5186)
 
 ## [2.8.0-alpha.2] - 2020-08-19
 

--- a/assets/src/js/plugins/give-api/notice.js
+++ b/assets/src/js/plugins/give-api/notice.js
@@ -90,6 +90,8 @@ export default {
 		 * Note: use only in WP Backend
 		 *
 		 * @since 2.5.0
+		 * @since 2.8.0 Localization updated to support changes in WordPress 5.5.
+		 *
 		 * @param {string} notice Notice description.
 		 * @param {string} type   Notice type.
 		 * @param {object} args   Notice type.
@@ -97,7 +99,13 @@ export default {
 		 * @return {string} Notice HTML.
 		 */
 		getAdminNoticeHTML: function( notice, type = 'info', args = { dismissible: true } ) {
-			const btnText = commonL10n.dismiss || '';
+			/**
+			 * WordPress 5.5 removed the localized `commonL10n` in favor of translation in JavaScript.
+			 */
+			const btnText = ( 'undefined' !== typeof commonL10n ) ?
+				commonL10n.dismiss :
+				wp.i18n.__( 'Dismiss this notice.' );
+
 			return `<div class="give-notice notice notice-${ type }${ args.dismissible ? ' is-dismissible' : '' }"><p>${ notice }${ args.dismissible ? ` <button type="button" class="notice-dismiss"><span class="screen-reader-text">${ btnText }</span></button>` : '' }</p</div>`;
 		},
 	},


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5185

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Implemented `wp.i18n.__` for translating common text in WordPress `>=5.5` with backwards compatibility for `commonL10n` for WordPress `<=5.4.2`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Navigate to Donations -> Settings -> Licenses, add a license key and click "Activate License".

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
