### PR TITLE
Onboaridng Wizard no longer shows empty submenu under Dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Set a specific placeholder for the base country select setting, no longer reads "Select a form". (#5163)
 -   Form preview within the Onboarding Wizard now remains centered on larger viewports. (#5180)
+-   Onboaridng Wizard no longer shows empty submenu under Dashboard. (#5190)
 
 ## [2.8.0-alpha.2] - 2020-08-19
 

--- a/src/Onboarding/Wizard/FormPreview.php
+++ b/src/Onboarding/Wizard/FormPreview.php
@@ -37,7 +37,7 @@ class FormPreview {
 	 * @since 2.8.0
 	 **/
 	public function add_page() {
-		add_dashboard_page( '', '', 'manage_options', $this->slug, '' );
+		add_submenu_page( '', '', '', 'manage_options', $this->slug );
 	}
 
 	/**

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -58,7 +58,7 @@ class Page {
 	 * @since 2.8.0
 	 **/
 	public function add_page() {
-		add_dashboard_page( '', '', 'manage_options', $this->slug, '' );
+		add_submenu_page( '', '', '', 'manage_options', $this->slug );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5187

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Replaces `add_dashboard_page()` with `add_submenu_page()` which supports an "unattached" submenu item.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
| --- | --- |
| ![empty-submenu](https://user-images.githubusercontent.com/10858303/91093861-037faa00-e628-11ea-8c77-1acabfcb1f19.png) | ![empty-submenu-fixed](https://user-images.githubusercontent.com/10858303/91093863-04184080-e628-11ea-825e-58090f226b8e.png) |


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Checkout `develop`
1. Activate GiveWP plugin.
1. Hover over the "Dashboard" menu item
1. See empty space below "Updates" submenu item.
1. Switch to `chore/empty-menu-item-5187`
1. Hover over the "Dashboard" menu item
1. Empty space below "Updates" is no longer there.
