### PR TITLE
Trailing comma in function call is removed for PHP 5.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Removed trailing comma in function call for PHP 5.6 support. (#)
+-   Trailing comma in function call is removed for PHP 5.6 support. (#5195)
 
 ## [2.8.0-beta.1] - 2020-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Changes made since the last release are stored here until a release is ready. -->
 
+### Fixed
+
+-   Removed trailing comma in function call for PHP 5.6 support. (#)
+
 ## [2.8.0-beta.1] - 2020-08-24
 
 ### Changed

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-checkout.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-checkout.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'Give_Stripe_Checkout' ) ) {
 					',
 				esc_html__( 'Make your donations quickly and securely with Stripe', 'give' ),
 				esc_html__( 'How it works:', 'give' ),
-				esc_html__( 'A Stripe window will open after you click the Donate Now button where you can securely make your donation. You will then be brought back to this page to view your receipt.', 'give' ),
+				esc_html__( 'A Stripe window will open after you click the Donate Now button where you can securely make your donation. You will then be brought back to this page to view your receipt.', 'give' )
 			);
 
 			return Stripe::canShowBillingAddress( $formId, $args );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5194

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Trailing commas in function calls weren't added until PHP `7.3`, see [rfc/trailing-comma-function-calls](https://wiki.php.net/rfc/trailing-comma-function-calls).

This removes the trailing comma to support PHP `5.6`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

See #5194
