### PR TITLE
Correct onboarding to store client credential authenticated token

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -2,7 +2,6 @@
 
 namespace Give\PaymentGateways\PayPalCommerce;
 
-use Give\Helpers\ArrayDataSet;
 use Give\ConnectClient\ConnectClient;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
@@ -49,20 +48,6 @@ class AjaxRequestHandler {
 	/**
 	 * @since 2.8.0
 	 *
-	 * @var PayPalClient
-	 */
-	private $paypalClient;
-
-	/**
-	 * @since 2.8.0
-	 *
-	 * @var ConnectClient
-	 */
-	private $connectClient;
-
-	/**
-	 * @since 2.8.0
-	 *
 	 * @var ConnectClient
 	 */
 	private $refreshToken;
@@ -81,8 +66,6 @@ class AjaxRequestHandler {
 	 *
 	 * @param Webhooks        $webhooksRepository
 	 * @param MerchantDetail  $merchantDetails
-	 * @param PayPalClient    $paypalClient
-	 * @param ConnectClient   $connectClient
 	 * @param MerchantDetails $merchantRepository
 	 * @param RefreshToken    $refreshToken
 	 * @param Settings        $settings
@@ -90,16 +73,12 @@ class AjaxRequestHandler {
 	public function __construct(
 		Webhooks $webhooksRepository,
 		MerchantDetail $merchantDetails,
-		PayPalClient $paypalClient,
-		ConnectClient $connectClient,
 		MerchantDetails $merchantRepository,
 		RefreshToken $refreshToken,
 		Settings $settings
 	) {
 		$this->webhooksRepository = $webhooksRepository;
 		$this->merchantDetails    = $merchantDetails;
-		$this->paypalClient       = $paypalClient;
-		$this->connectClient      = $connectClient;
 		$this->merchantRepository = $merchantRepository;
 		$this->refreshToken       = $refreshToken;
 		$this->settings           = $settings;

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -69,19 +69,22 @@ class AjaxRequestHandler {
 	 * @param MerchantDetails $merchantRepository
 	 * @param RefreshToken    $refreshToken
 	 * @param Settings        $settings
+	 * @param PayPalAuth      $payPalAuth
 	 */
 	public function __construct(
 		Webhooks $webhooksRepository,
 		MerchantDetail $merchantDetails,
 		MerchantDetails $merchantRepository,
 		RefreshToken $refreshToken,
-		Settings $settings
+		Settings $settings,
+		PayPalAuth $payPalAuth
 	) {
 		$this->webhooksRepository = $webhooksRepository;
 		$this->merchantDetails    = $merchantDetails;
 		$this->merchantRepository = $merchantRepository;
 		$this->refreshToken       = $refreshToken;
 		$this->settings           = $settings;
+		$this->payPalAuth         = $payPalAuth;
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalAuth.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalAuth.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCommerce\Repositories;
+
+use Give\ConnectClient\ConnectClient;
+use Give\Helpers\ArrayDataSet;
+use Give\PaymentGateways\PayPalCommerce\PayPalClient;
+
+class PayPalAuth {
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var PayPalClient
+	 */
+	private $payPalClient;
+
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var ConnectClient
+	 */
+	private $connectClient;
+
+	/**
+	 * PayPalAuth constructor.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param PayPalClient  $payPalClient
+	 * @param ConnectClient $connectClient
+	 */
+	public function __construct( PayPalClient $payPalClient, ConnectClient $connectClient ) {
+		$this->payPalClient  = $payPalClient;
+		$this->connectClient = $connectClient;
+	}
+
+	/**
+	 * Retrieves a token for the Client ID and Secret
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $client_id
+	 * @param string $client_secret
+	 *
+	 * @return array
+	 */
+	public function getTokenFromClientCredentials( $client_id, $client_secret ) {
+		$auth = base64_encode( "$client_id:$client_secret" );
+
+		$request = wp_remote_post(
+			$this->payPalClient->getApiUrl( 'v1/oauth2/token' ),
+			[
+				'headers' => [
+					'Authorization' => "Basic $auth",
+					'Content-Type'  => 'application/x-www-form-urlencoded',
+				],
+				'body'    => [
+					'grant_type' => 'client_credentials',
+				],
+			]
+		);
+
+		return ArrayDataSet::camelCaseKeys( json_decode( wp_remote_retrieve_body( $request ), true ) );
+	}
+
+	/**
+	 * Retrieves a token from the authorization code
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $authCode
+	 * @param string $sharedId
+	 * @param string $nonce
+	 *
+	 * @return array|null
+	 */
+	public function getTokenFromAuthorizationCode( $authCode, $sharedId, $nonce ) {
+		$response = wp_remote_retrieve_body(
+			wp_remote_post(
+				$this->connectClient->getApiUrl( 'v1/oauth2/token' ),
+				[
+					'headers' => [
+						'Authorization' => sprintf(
+							'Basic %1$s',
+							base64_encode( $sharedId )
+						),
+						'Content-Type'  => 'application/x-www-form-urlencoded',
+					],
+					'body'    => [
+						'grant_type'    => 'authorization_code',
+						'code'          => $authCode,
+						'code_verifier' => $nonce, // Seller nonce.
+					],
+				]
+			)
+		);
+
+		return empty( $response ) ? null : ArrayDataSet::camelCaseKeys( json_decode( $response, true ) );
+	}
+
+	/**
+	 * Retrieves a Partner Link for on-boarding
+	 *
+	 * @param $returnUrl
+	 * @param $country
+	 *
+	 * @return array|null
+	 */
+	public function getSellerPartnerLink( $returnUrl, $country ) {
+		$response = wp_remote_retrieve_body(
+			wp_remote_post(
+				sprintf(
+					$this->connectClient->getApiUrl( 'paypal?mode=%1$s&request=partner-link' ),
+					$this->payPalClient->mode
+				),
+				[
+					'body' => [
+						'return_url'   => $returnUrl,
+						'country_code' => $country,
+					],
+				]
+			)
+		);
+
+		return empty( $response ) ? null : json_decode( $response, true );
+	}
+
+	/**
+	 * Get seller on-boarding details from seller.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $accessToken
+	 *
+	 * @param string $merchantId
+	 *
+	 * @return array
+	 */
+	public function getSellerOnBoardingDetailsFromPayPal( $merchantId, $accessToken ) {
+		$request = wp_remote_post(
+			$this->connectClient->getApiUrl(
+				sprintf(
+					'paypal?mode=%1$s&request=seller-status',
+					$this->payPalClient->mode
+				)
+			),
+			[
+				'body' => [
+					'merchant_id' => $merchantId,
+					'token'       => $accessToken,
+				],
+			]
+		);
+
+		return json_decode( wp_remote_retrieve_body( $request ), true );
+	}
+
+	/**
+	 * Get seller rest API credentials
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $accessToken
+	 *
+	 * @return array
+	 */
+	public function getSellerRestAPICredentials( $accessToken ) {
+		$request = wp_remote_post(
+			$this->connectClient->getApiUrl(
+				sprintf(
+					'paypal?mode=%1$s&request=seller-credentials',
+					$this->payPalClient->mode
+				)
+			),
+			[
+				'body' => [
+					'token' => $accessToken,
+				],
+			]
+		);
+
+		return json_decode( wp_remote_retrieve_body( $request ), true );
+	}
+}

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalAuth.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalAuth.php
@@ -77,7 +77,7 @@ class PayPalAuth {
 	public function getTokenFromAuthorizationCode( $authCode, $sharedId, $nonce ) {
 		$response = wp_remote_retrieve_body(
 			wp_remote_post(
-				$this->connectClient->getApiUrl( 'v1/oauth2/token' ),
+				$this->payPalClient->getApiUrl( 'v1/oauth2/token' ),
 				[
 					'headers' => [
 						'Authorization' => sprintf(

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -10,6 +10,7 @@ use Give\PaymentGateways\PayPalCommerce\DonationProcessor;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\RefreshToken;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
+use Give\PaymentGateways\PayPalCommerce\Repositories\PayPalAuth;
 use Give\PaymentGateways\PayPalCommerce\ScriptLoader;
 use Give\PaymentGateways\PayPalCommerce\onBoardingRedirectHandler;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
@@ -120,11 +121,12 @@ class PaymentGateways implements ServiceProvider {
 		give()->singleton( RefreshToken::class );
 		give()->singleton( AjaxRequestHandler::class );
 		give()->singleton( ScriptLoader::class );
+		give()->singleton( PayPalAuth::class );
 		give()->singleton(
 			MerchantDetails::class,
 			static function () {
 				return ( new MerchantDetails() )
-				->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
+					->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
 			}
 		);
 


### PR DESCRIPTION
## Description

~~PayPal has a known issue they're working on wherein an access token generated from the `authorization_code` grant type does not have the proper permissions to generate a Subscription. Unfortunately, this is the exact grant type used during the onboarding process.~~

~~This PR provides a workaround where it uses the client credentials retrieved during onboarding to replace the stored token details with a token generated from the `client_credentials` grant type. This token has the correct permissions.~~

After talking with Swati, it turns out that this is actually the _intended_ flow for gathering credentials. Apparently the token retrieved via the `authorization_code` grant is supposed to be limited to only retrieving the credentials. In fact, she was surprised we were able to use the Orders API with it at all. 🤦‍♂️ 

## Affects

The PayPal Commerce onboarding process, refreshing the token, and usage of the token for donations.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed