### PR TITLE
On German installs, there is now enough room for all labels in the Stripe Checkout modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Onboarding Form Preview default image has been updated. (#5203)
+-   Stripe Checkout modal max-width has been increased to 425px (#5209)
 
 ## [2.8.0-beta.2] - 2020-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Onboarding Form Preview default image has been updated. (#5203)
--   Stripe Checkout modal max-width has been increased to 425px (#5209)
+-   Stripe Checkout modal max-width has been increased to fit-content (#5209)
 
 ## [2.8.0-beta.2] - 2020-08-25
 

--- a/assets/src/css/frontend/give-stripe.scss
+++ b/assets/src/css/frontend/give-stripe.scss
@@ -70,7 +70,8 @@
 		transform: translate(-50%, -50%);
 		background: rgb(255, 255, 255);
 		overflow: hidden;
-		width: 385px;
+		width: 90%;
+		max-width: 425px;
 		border-radius: 0.5rem;
 
 		.give-stripe-checkout-modal-container {
@@ -98,14 +99,14 @@
 					color: #fff;
 					text-transform: uppercase;
 					font-size: 18px;
-					font-weight: bold;
+					font-weight: 600;
 					margin: 0 0 10px 0;
 				}
 
 				.give-stripe-checkout-form-title {
 					color: #f5f5f5;
 					font-size: 18px;
-					font-weight: bold;
+					font-weight: 600;
 					margin: 10px 0 0 0;
 				}
 

--- a/assets/src/css/frontend/give-stripe.scss
+++ b/assets/src/css/frontend/give-stripe.scss
@@ -71,7 +71,7 @@
 		background: rgb(255, 255, 255);
 		overflow: hidden;
 		width: 90%;
-		max-width: 425px;
+		max-width: fit-content;
 		border-radius: 0.5rem;
 
 		.give-stripe-checkout-modal-container {


### PR DESCRIPTION
Resolves #5206 

## Description
This PR resolves a minor style issue that occurred when admin opted to use the Stripe modal in Legacy Forms, on a site with German translation. Previously, when translated to German the "Cardholder Name" label was so long that it wrapped to a new line, which caused issues with the associated tooltip and looked bad. This PR increases the maximum width of the Stripe checkout modal to `425px` and sets a width of `90%`, to ensure that the modal is still responsive when viewed on mobile devices or inside a Multi-Step form iframe.

## Affects
This PR affects styles for the Stripe Checkout modal. 

## Visuals
<img width="546" alt="Screen Shot 2020-08-26 at 9 45 18 AM" src="https://user-images.githubusercontent.com/5186078/91332862-a4ce4380-e781-11ea-969d-943403e8217c.png">

## Pre-review Checklist
- [x] Acceptance criteria satisfied and marked in related issue
- [x] Changelog updated
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. On 2.8.0 create a legacy form.
2. enable stripe checkout modal.
3. change the site language to German.
4. Ensure that the translations all download (Dashboard > Updates > Translations)
5. view the form created in step one, specifically when the form pops up.