### PR TITLE
If the Setup Page is disabled, Onboarding Wizard now directs users to the All Forms page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Onboarding Form Preview default image has been updated. (#5203)
 -   Stripe Checkout modal max-width has been increased to fit-content (#5209)
+-   If the Setup Page is disabled, Onboarding Wizard now directs users to the All Forms page (#5211)
 
 ## [2.8.0-beta.2] - 2020-08-25
 

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -9,6 +9,7 @@ use Give\Onboarding\FormRepository;
 use Give\Onboarding\SettingsRepositoryFactory;
 use Give\Onboarding\LocaleCollection;
 use Give\Onboarding\Helpers\LocationList;
+use Give\Onboarding\Setup\Page as SetupPage;
 
 /**
  * Onboarding Wizard admin page class
@@ -157,7 +158,7 @@ class Page {
 			[
 				'apiRoot'          => esc_url_raw( rest_url() ),
 				'apiNonce'         => wp_create_nonce( 'wp_rest' ),
-				'setupUrl'         => admin_url( 'edit.php?post_type=give_forms&page=give-setup' ),
+				'setupUrl'         => SetupPage::getSetupPageEnabledOrDisabled() === SetupPage::ENABLED ? admin_url( 'edit.php?post_type=give_forms&page=give-setup' ) : admin_url( 'edit.php?post_type=give_forms' ),
 				'formPreviewUrl'   => admin_url( '?page=give-form-preview' ),
 				'localeCurrency'   => $this->localeCollection->pluck( 'currency_code' ),
 				'currencies'       => FormatList::fromKeyValue( give_get_currencies_list() ),


### PR DESCRIPTION
Resolves #5210 

## Description
This PR resolves an issue whereby users who visited the Onboarding Wizard after previously dismissing the Setup Page (via the back button), were still being directed to the Setup Page despite it not being accessible to them. As a fix, this PR dynamically sets the setupUrl variable that is localized for the Onboarding Wizard to either send users to the Setup Page or to the All Forms page, depending on whether the Setup Page is enabled.

## Affects
This PR affects localized variable logic for the Onboarding Wizard, specifically the url that users are directed to after completing or dismissing the Onboarding Wizard.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Install the zip/activate
2. Dismiss Wizard
3. Dismiss Set Up page
4. Land on the Create Form Page
5. Hit the Back Button on the Browser
6. Enter the Wizard from the Set Up Page
7. Complete or Dismiss the Wizard, you should be directed to the All Forms page
