### PR TITLE
Improve Webhook extensibility and PayPal updating

### DIFF
--- a/src/Controller/PayPalWebhooks.php
+++ b/src/Controller/PayPalWebhooks.php
@@ -31,13 +31,6 @@ class PayPalWebhooks {
 	/**
 	 * @since 2.8.0
 	 *
-	 * @var Webhooks
-	 */
-	private $webhooksRepository;
-
-	/**
-	 * @since 2.8.0
-	 *
 	 * @var MerchantDetails
 	 */
 	private $merchantRepository;
@@ -45,14 +38,11 @@ class PayPalWebhooks {
 	/**
 	 * PayPalWebhooks constructor.
 	 *
-	 * @param  Webhooks  $webhooksRepository
-	 * @param  MerchantDetails  $merchantRepository
-	 *
 	 * @since 2.8.0
 	 *
+	 * @param MerchantDetails $merchantRepository
 	 */
-	public function __construct( Webhooks $webhooksRepository, MerchantDetails $merchantRepository ) {
-		$this->webhooksRepository = $webhooksRepository;
+	public function __construct( MerchantDetails $merchantRepository ) {
 		$this->merchantRepository = $merchantRepository;
 	}
 
@@ -102,7 +92,10 @@ class PayPalWebhooks {
 			return;
 		}
 
-		if ( ! $this->webhooksRepository->verifyEventSignature( $merchantDetails->accessToken, $event, getallheaders() ) ) {
+		/** @var Webhooks $webhooksRepository */
+		$webhooksRepository = give( Webhooks::class );
+
+		if ( ! $webhooksRepository->verifyEventSignature( $merchantDetails->accessToken, $event, getallheaders() ) ) {
 			throw new Exception( 'Failed event verification' );
 		}
 
@@ -110,5 +103,16 @@ class PayPalWebhooks {
 		$handler = give( $this->eventHandlers[ $event->event_type ] );
 
 		$handler->processEvent( $event );
+	}
+
+	/**
+	 * Returns an array of the registered events
+	 *
+	 * @since 2.9.0
+	 *
+	 * @return string[]
+	 */
+	public function getRegisteredEvents() {
+		return array_keys( $this->eventHandlers );
 	}
 }

--- a/src/Controller/PayPalWebhooks.php
+++ b/src/Controller/PayPalWebhooks.php
@@ -5,29 +5,9 @@ namespace Give\Controller;
 use Exception;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
-use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\EventListener;
-use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureCompleted;
-use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureDenied;
-use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureRefunded;
-use InvalidArgumentException;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookRegister;
 
 class PayPalWebhooks {
-	/**
-	 * Array of the PayPal webhook event handlers. Add-ons can use the registerEventHandler method
-	 * to add additional events/handlers.
-	 *
-	 * Structure: PayPalEventName => EventHandlerClass
-	 *
-	 * @since 2.8.0
-	 *
-	 * @var string[]
-	 */
-	private $eventHandlers = [
-		'PAYMENT.CAPTURE.REFUNDED'  => PaymentCaptureRefunded::class,
-		'PAYMENT.CAPTURE.COMPLETED' => PaymentCaptureCompleted::class,
-		'PAYMENT.CAPTURE.DENIED'    => PaymentCaptureDenied::class,
-	];
-
 	/**
 	 * @since 2.8.0
 	 *
@@ -36,38 +16,30 @@ class PayPalWebhooks {
 	private $merchantRepository;
 
 	/**
+	 * @var Webhooks
+	 */
+	private $webhookRepository;
+
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var WebhookRegister
+	 */
+	private $webhookRegister;
+
+	/**
 	 * PayPalWebhooks constructor.
 	 *
 	 * @since 2.8.0
 	 *
 	 * @param MerchantDetails $merchantRepository
+	 * @param WebhookRegister $register
+	 * @param Webhooks        $webhookRepository
 	 */
-	public function __construct( MerchantDetails $merchantRepository ) {
+	public function __construct( MerchantDetails $merchantRepository, WebhookRegister $register, Webhooks $webhookRepository ) {
 		$this->merchantRepository = $merchantRepository;
-	}
-
-	/**
-	 * Use this to register additional events and handlers
-	 *
-	 * @since 2.8.0
-	 *
-	 * @param string $payPalEvent PayPal event to listen for, i.e. CHECKOUT.ORDER.APPROVED
-	 * @param string $eventHandler The FQCN of the event handler
-	 *
-	 * @return $this
-	 */
-	public function registerEventHandler( $payPalEvent, $eventHandler ) {
-		if ( isset( $this->eventHandlers[ $payPalEvent ] ) ) {
-			throw new InvalidArgumentException( 'Cannot register an already registered event' );
-		}
-
-		if ( ! is_subclass_of( $eventHandler, EventListener::class ) ) {
-			throw new InvalidArgumentException( 'Listener must be a subclass of ' . EventListener::class );
-		}
-
-		$this->eventHandlers[ $payPalEvent ] = $eventHandler;
-
-		return $this;
+		$this->webhookRegister    = $register;
+		$this->webhookRepository  = $webhookRepository;
 	}
 
 	/**
@@ -88,31 +60,16 @@ class PayPalWebhooks {
 		$event = json_decode( file_get_contents( 'php://input' ), false );
 
 		// If we receive an event that we're not expecting, just ignore it
-		if ( ! isset( $this->eventHandlers[ $event->event_type ] ) ) {
+		if ( ! $this->webhookRegister->hasEventRegistered( $event->event_type ) ) {
 			return;
 		}
 
-		/** @var Webhooks $webhooksRepository */
-		$webhooksRepository = give( Webhooks::class );
-
-		if ( ! $webhooksRepository->verifyEventSignature( $merchantDetails->accessToken, $event, getallheaders() ) ) {
+		if ( ! $this->webhookRepository->verifyEventSignature( $merchantDetails->accessToken, $event, getallheaders() ) ) {
 			throw new Exception( 'Failed event verification' );
 		}
 
-		/** @var EventListener $handler */
-		$handler = give( $this->eventHandlers[ $event->event_type ] );
-
-		$handler->processEvent( $event );
-	}
-
-	/**
-	 * Returns an array of the registered events
-	 *
-	 * @since 2.9.0
-	 *
-	 * @return string[]
-	 */
-	public function getRegisteredEvents() {
-		return array_keys( $this->eventHandlers );
+		$this->webhookRegister
+			->getEventHandler( $event->event_type )
+			->processEvent( $event );
 	}
 }

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -182,9 +182,9 @@ class AjaxRequestHandler {
 		$this->validateAdminRequest();
 
 		// Remove the webhook from PayPal if there is one
-		if ( $webhookId = $this->webhooksRepository->getWebhookId() ) {
-			$this->webhooksRepository->deleteWebhook( $this->merchantDetails->accessToken, $webhookId );
-			$this->webhooksRepository->deleteWebhookId();
+		if ( $webhookConfig = $this->webhooksRepository->getWebhookConfig() ) {
+			$this->webhooksRepository->deleteWebhook( $this->merchantDetails->accessToken, $webhookConfig->id );
+			$this->webhooksRepository->deleteWebhookConfig();
 		}
 
 		$this->merchantRepository->delete();

--- a/src/PaymentGateways/PayPalCommerce/Models/WebhookConfig.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/WebhookConfig.php
@@ -4,22 +4,30 @@ namespace Give\PaymentGateways\PayPalCommerce\Models;
 
 class WebhookConfig {
 	/**
+	 * @since 2.9.0
+	 *
 	 * @var string
 	 */
 	public $id;
 
 	/**
+	 * @since 2.9.0
+	 *
 	 * @var string
 	 */
 	public $returnUrl;
 
 	/**
+	 * @since 2.9.0
+	 *
 	 * @var string[]
 	 */
 	public $events;
 
 	/**
 	 * WebhookConfig constructor.
+	 *
+	 * @since 2.9.0
 	 *
 	 * @param string   $id
 	 * @param string   $returnUrl
@@ -34,6 +42,8 @@ class WebhookConfig {
 	/**
 	 * Generates an instance from serialized data
 	 *
+	 * @since 2.9.0
+	 *
 	 * @param array $data
 	 *
 	 * @return WebhookConfig
@@ -44,6 +54,8 @@ class WebhookConfig {
 
 	/**
 	 * Generates an array for serialization
+	 *
+	 * @since 2.9.0
 	 *
 	 * @return array
 	 */

--- a/src/PaymentGateways/PayPalCommerce/Models/WebhookConfig.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/WebhookConfig.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCommerce\Models;
+
+class WebhookConfig {
+	/**
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * @var string
+	 */
+	public $returnUrl;
+
+	/**
+	 * @var string[]
+	 */
+	public $events;
+
+	/**
+	 * WebhookConfig constructor.
+	 *
+	 * @param string   $id
+	 * @param string   $returnUrl
+	 * @param string[] $events
+	 */
+	public function __construct( $id, $returnUrl, $events ) {
+		$this->id        = $id;
+		$this->returnUrl = $returnUrl;
+		$this->events    = $events;
+	}
+
+	/**
+	 * Generates an instance from serialized data
+	 *
+	 * @param array $data
+	 *
+	 * @return WebhookConfig
+	 */
+	public static function fromArray( array $data ) {
+		return new self( $data['id'], $data['returnUrl'], $data['events'] );
+	}
+
+	/**
+	 * Generates an array for serialization
+	 *
+	 * @return array
+	 */
+	public function toArray() {
+		return [
+			'id'        => $this->id,
+			'returnUrl' => $this->returnUrl,
+			'events'    => $this->events,
+		];
+	}
+}

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -5,6 +5,7 @@ namespace Give\PaymentGateways\PayPalCommerce;
 use Give\Helpers\Hooks;
 use Give\PaymentGateways\PaymentGateway;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookChecker;
 
 /**
  * Class PayPalCommerce
@@ -109,5 +110,7 @@ class PayPalCommerce implements PaymentGateway {
 		Hooks::addAction( 'give_update_edited_donation', RefundPaymentHandler::class, 'refundPayment' );
 		Hooks::addAction( 'admin_notices', RefundPaymentHandler::class, 'showPaymentRefundFailureNotice' );
 		Hooks::addAction( 'give_view_donation_details_totals_after', RefundPaymentHandler::class, 'optInForRefundFormField' );
+
+		Hooks::addAction( 'admin_init', WebhookChecker::class, 'checkWebhookCriteria' );
 	}
 }

--- a/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
@@ -4,10 +4,8 @@ namespace Give\PaymentGateways\PayPalCommerce\Repositories;
 
 use Give\Helpers\ArrayDataSet;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
-use Give\PaymentGateways\PayPalCommerce\OptionId;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Traits\HasMode;
-use InvalidArgumentException;
 
 /**
  * Class MerchantDetails

--- a/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/MerchantDetails.php
@@ -6,6 +6,7 @@ use Give\Helpers\ArrayDataSet;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\OptionId;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
+use Give\PaymentGateways\PayPalCommerce\Repositories\Traits\HasMode;
 use InvalidArgumentException;
 
 /**
@@ -14,33 +15,7 @@ use InvalidArgumentException;
  * @since 2.8.0
  */
 class MerchantDetails {
-	/**
-	 * The current working mode: live or sandbox
-	 *
-	 * @since 2.8.0
-	 *
-	 * @var string
-	 */
-	private $mode;
-
-	/**
-	 * Sets the mode for the repository for handling operations
-	 *
-	 * @since 2.8.0
-	 *
-	 * @param $mode
-	 *
-	 * @return MerchantDetails
-	 */
-	public function setMode( $mode ) {
-		if ( ! in_array( $mode, [ 'live', 'sandbox' ], true ) ) {
-			throw new InvalidArgumentException( "Must be either 'live' or 'sandbox', received: $mode" );
-		}
-
-		$this->mode = $mode;
-
-		return $this;
-	}
+	use HasMode;
 
 	/**
 	 * Returns whether or not the account has been connected

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types=1 );
+
+namespace Give\PaymentGateways\PayPalCommerce\Repositories\Traits;
+
+use InvalidArgumentException;
+
+trait HasMode {
+	/**
+	 * The current working mode: live or sandbox
+	 *
+	 * @since 2.8.0
+	 *
+	 * @var string
+	 */
+	protected $mode;
+
+	/**
+	 * Sets the mode for the repository for handling operations
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param $mode
+	 *
+	 * @return $this
+	 */
+	public function setMode( $mode ) {
+		if ( ! in_array( $mode, [ 'live', 'sandbox' ], true ) ) {
+			throw new InvalidArgumentException( "Must be either 'live' or 'sandbox', received: $mode" );
+		}
+
+		$this->mode = $mode;
+
+		return $this;
+	}
+}

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
@@ -7,7 +7,7 @@ trait HasMode {
 	/**
 	 * The current working mode: live or sandbox
 	 *
-	 * @since 2.8.0
+	 * @since 2.9.0
 	 *
 	 * @var string
 	 */
@@ -16,7 +16,7 @@ trait HasMode {
 	/**
 	 * Sets the mode for the repository for handling operations
 	 *
-	 * @since 2.8.0
+	 * @since 2.9.0
 	 *
 	 * @param $mode
 	 *

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
@@ -1,6 +1,4 @@
 <?php
-declare( strict_types=1 );
-
 namespace Give\PaymentGateways\PayPalCommerce\Repositories\Traits;
 
 use InvalidArgumentException;

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
@@ -159,32 +159,34 @@ class Webhooks {
 
 		$response = wp_remote_request(
 			$apiUrl,
-			[
-				'method'  => 'PATCH',
-				'headers' => [
-					'Content-Type'  => 'application/json',
-					'Authorization' => "Bearer $token",
-				],
-				'body'    => [
-					[
-						'op'    => 'replace',
-						'path'  => '/url',
-						'value' => $webhookUrl,
+			json_encode(
+				[
+					'method'  => 'PATCH',
+					'headers' => [
+						'Content-Type'  => 'application/json',
+						'Authorization' => "Bearer $token",
 					],
-					[
-						'op'    => 'replace',
-						'path'  => '/event_types',
-						'value' => array_map(
-							static function ( $eventType ) {
-								return [
-									'name' => $eventType,
-								];
-							},
-							$this->webhookController->getRegisteredEvents()
-						),
+					'body'    => [
+						[
+							'op'    => 'replace',
+							'path'  => '/url',
+							'value' => $webhookUrl,
+						],
+						[
+							'op'    => 'replace',
+							'path'  => '/event_types',
+							'value' => array_map(
+								static function ( $eventType ) {
+									 return [
+										 'name' => $eventType,
+									 ];
+								},
+								$this->webhookController->getRegisteredEvents()
+							),
+						],
 					],
-				],
-			]
+				]
+			)
 		);
 
 		$response = json_decode( wp_remote_retrieve_body( $response ), true );

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
@@ -5,8 +5,8 @@ namespace Give\PaymentGateways\PayPalCommerce\Repositories;
 use Exception;
 use Give\PaymentGateways\PayPalCommerce\Models\WebhookConfig;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
-use Give\Controller\PayPalWebhooks as WebhooksController;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Traits\HasMode;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookRegister;
 use Give\Route\PayPalWebhooks as WebhooksRoute;
 
 class Webhooks {
@@ -20,9 +20,9 @@ class Webhooks {
 	private $webhookRoute;
 
 	/**
-	 * @var WebhooksController
+	 * @var WebhookRegister
 	 */
-	private $webhookController;
+	private $webhooksRegister;
 
 	/**
 	 * @var PayPalClient
@@ -34,14 +34,14 @@ class Webhooks {
 	 *
 	 * @since 2.8.0
 	 *
-	 * @param WebhooksRoute      $webhookRoute
-	 * @param PayPalClient       $payPalClient
-	 * @param WebhooksController $webhookController
+	 * @param WebhooksRoute   $webhookRoute
+	 * @param PayPalClient    $payPalClient
+	 * @param WebhookRegister $webhooksRegister
 	 */
-	public function __construct( WebhooksRoute $webhookRoute, PayPalClient $payPalClient, WebhooksController $webhookController ) {
-		$this->webhookRoute      = $webhookRoute;
-		$this->payPalClient      = $payPalClient;
-		$this->webhookController = $webhookController;
+	public function __construct( WebhooksRoute $webhookRoute, PayPalClient $payPalClient, WebhookRegister $webhooksRegister ) {
+		$this->webhookRoute     = $webhookRoute;
+		$this->payPalClient     = $payPalClient;
+		$this->webhooksRegister = $webhooksRegister;
 	}
 
 	/**
@@ -105,7 +105,7 @@ class Webhooks {
 	public function createWebhook( $token ) {
 		$apiUrl = $this->payPalClient->getApiUrl( 'v1/notifications/webhooks' );
 
-		$events     = $this->webhookController->getRegisteredEvents();
+		$events     = $this->webhooksRegister->getRegisteredEvents();
 		$webhookUrl = $this->webhookRoute->getRouteUrl();
 
 		$response = wp_remote_post(
@@ -124,7 +124,7 @@ class Webhooks {
 									'name' => $eventType,
 								];
 							},
-							$this->webhookController->getRegisteredEvents()
+							$events
 						),
 					]
 				),
@@ -177,11 +177,11 @@ class Webhooks {
 							'path'  => '/event_types',
 							'value' => array_map(
 								static function ( $eventType ) {
-									 return [
-										 'name' => $eventType,
-									 ];
+									return [
+										'name' => $eventType,
+									];
 								},
-								$this->webhookController->getRegisteredEvents()
+								$this->webhooksRegister->getRegisteredEvents()
 							),
 						],
 					],

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCommerce\Webhooks;
+
+use Give\Controller\PayPalWebhooks;
+use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
+use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
+use Give\Route\PayPalWebhooks as WebhooksRoute;
+
+class WebhookChecker {
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var Webhooks
+	 */
+	private $webhooksRepository;
+
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var PayPalWebhooks
+	 */
+	private $webhooksController;
+
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var WebhooksRoute
+	 */
+	private $webhooksRoute;
+
+	/**
+	 * @since 2.9.0
+	 *
+	 * @var MerchantDetail
+	 */
+	private $merchantDetails;
+
+	/**
+	 * WebhookChecker constructor.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param Webhooks       $webhooksRepository
+	 * @param PayPalWebhooks $webhooksController
+	 * @param MerchantDetail $merchantDetails
+	 * @param WebhooksRoute  $webhooksRoute
+	 */
+	public function __construct( Webhooks $webhooksRepository, PayPalWebhooks $webhooksController, MerchantDetail $merchantDetails, WebhooksRoute $webhooksRoute ) {
+		$this->webhooksRepository = $webhooksRepository;
+		$this->webhooksController = $webhooksController;
+		$this->merchantDetails    = $merchantDetails;
+		$this->webhooksRoute      = $webhooksRoute;
+	}
+
+	/**
+	 * Checks whether the webhook configuration has changed. If it has, then update the webhook with PayPal.
+	 *
+	 * @since 2.9.0
+	 */
+	public function checkWebhookCriteria() {
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+
+		if ( ! $this->merchantDetails->accessToken ) {
+			return;
+		}
+
+		$webhookConfig = $this->webhooksRepository->getWebhookConfig();
+
+		if ( $webhookConfig === null ) {
+			return;
+		}
+
+		$webhookUrl       = $this->webhooksRoute->getRouteUrl();
+		$registeredEvents = $this->webhooksController->getRegisteredEvents();
+
+		$hasMissingEvents = ! empty(
+			array_merge(
+				array_diff( $registeredEvents, $webhookConfig->events ),
+				array_diff( $webhookConfig->events, $registeredEvents )
+			)
+		);
+
+		// Update the webhook if the return url or events have changed
+		if ( $webhookUrl !== $webhookConfig->returnUrl || $hasMissingEvents ) {
+			$this->webhooksRepository->updateWebhook( $this->merchantDetails->accessToken, $webhookConfig->id );
+
+			$webhookConfig->returnUrl = $webhookUrl;
+			$webhookConfig->events    = $registeredEvents;
+
+			$this->webhooksRepository->saveWebhookConfig( $webhookConfig );
+		}
+	}
+}

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
@@ -24,6 +24,8 @@ class WebhookChecker {
 	private $webhooksRoute;
 
 	/**
+	 * @since 2.9.0
+	 *
 	 * @var WebhookRegister
 	 */
 	private $webhookRegister;

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookChecker.php
@@ -59,7 +59,7 @@ class WebhookChecker {
 	 * @since 2.9.0
 	 */
 	public function checkWebhookCriteria() {
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		if ( wp_doing_ajax() || wp_doing_cron() ) {
 			return;
 		}
 

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCommerce\Webhooks;
+
+use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\EventListener;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureCompleted;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureDenied;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureRefunded;
+use InvalidArgumentException;
+
+class WebhookRegister {
+	/**
+	 * Array of the PayPal webhook event handlers. Add-ons can use the registerEventHandler method
+	 * to add additional events/handlers.
+	 *
+	 * Structure: PayPalEventName => EventHandlerClass
+	 *
+	 * @since 2.9.0
+	 *
+	 * @var string[]
+	 */
+	private $eventHandlers = [
+		'PAYMENT.CAPTURE.REFUNDED'  => PaymentCaptureRefunded::class,
+		'PAYMENT.CAPTURE.COMPLETED' => PaymentCaptureCompleted::class,
+		'PAYMENT.CAPTURE.DENIED'    => PaymentCaptureDenied::class,
+	];
+
+	/**
+	 * Use this to register additional events and handlers
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $payPalEvent PayPal event to listen for, i.e. CHECKOUT.ORDER.APPROVED
+	 * @param string $eventHandler The FQCN of the event handler
+	 *
+	 * @return $this
+	 */
+	public function registerEventHandler( $payPalEvent, $eventHandler ) {
+		if ( isset( $this->eventHandlers[ $payPalEvent ] ) ) {
+			throw new InvalidArgumentException( 'Cannot register an already registered event' );
+		}
+
+		if ( ! is_subclass_of( $eventHandler, EventListener::class ) ) {
+			throw new InvalidArgumentException( 'Listener must be a subclass of ' . EventListener::class );
+		}
+
+		$this->eventHandlers[ $payPalEvent ] = $eventHandler;
+
+		return $this;
+	}
+
+	/**
+	 * Returns Event Listener instance for given event
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $event
+	 *
+	 * @return EventListener
+	 */
+	public function getEventHandler( $event ) {
+		return give( $this->eventHandlers[ $event ] );
+	}
+
+	/**
+	 * Checks whether the given event is registered
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param string $event
+	 *
+	 * @return bool
+	 */
+	public function hasEventRegistered( $event ) {
+		return isset( $this->eventHandlers[ $event ] );
+	}
+
+	/**
+	 * Returns an array of the registered events
+	 *
+	 * @since 2.9.0
+	 *
+	 * @return string[]
+	 */
+	public function getRegisteredEvents() {
+		return array_keys( $this->eventHandlers );
+	}
+}

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
@@ -50,6 +50,19 @@ class WebhookRegister {
 	}
 
 	/**
+	 * Registers multiple event handlers using an array where the key is the
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param array $handlers = [ 'PAYPAL.EVENT' => EventHandler::class ]
+	 */
+	public function registerEventHandlers( array $handlers ) {
+		foreach ( $handlers as $event => $handler ) {
+			$this->registerEventHandler( $event, $handler );
+		}
+	}
+
+	/**
 	 * Returns Event Listener instance for given event
 	 *
 	 * @since 2.9.0

--- a/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
@@ -148,9 +148,9 @@ class onBoardingRedirectHandler {
 			return;
 		}
 
-		$webhookId = $this->webhooksRepository->createWebhook( $merchant_details->accessToken );
+		$webhookConfig = $this->webhooksRepository->createWebhook( $merchant_details->accessToken );
 
-		$this->webhooksRepository->saveWebhookId( $webhookId );
+		$this->webhooksRepository->saveWebhookConfig( $webhookConfig );
 	}
 
 	/**
@@ -414,7 +414,7 @@ class onBoardingRedirectHandler {
 	 * @since 2.8.0
 	 */
 	private function registerPayPalSSLNotice() {
-		if ( is_ssl() && empty( $this->webhooksRepository->getWebhookId() ) ) {
+		if ( is_ssl() && empty( $this->webhooksRepository->getWebhookConfig() ) ) {
 			Give_Admin_Settings::add_error(
 				'paypal-webhook-error',
 				esc_html__(

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -16,6 +16,7 @@ use Give\PaymentGateways\PayPalCommerce\onBoardingRedirectHandler;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
 use Give\PaymentGateways\PayPalCommerce\PayPalCommerce;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
+use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookRegister;
 use Give\PaymentGateways\PayPalStandard\PayPalStandard;
 use Give\PaymentGateways\PaypalSettingPage;
 
@@ -121,6 +122,7 @@ class PaymentGateways implements ServiceProvider {
 		give()->singleton( RefreshToken::class );
 		give()->singleton( AjaxRequestHandler::class );
 		give()->singleton( ScriptLoader::class );
+		give()->singleton( WebhookRegister::class );
 		give()->singleton( Webhooks::class );
 		give()->singleton( MerchantDetails::class );
 		give()->singleton( PayPalAuth::class );

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -120,13 +120,8 @@ class PaymentGateways implements ServiceProvider {
 		give()->singleton( RefreshToken::class );
 		give()->singleton( AjaxRequestHandler::class );
 		give()->singleton( ScriptLoader::class );
-		give()->singleton(
-			MerchantDetails::class,
-			static function () {
-				return ( new MerchantDetails() )
-				->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
-			}
-		);
+		give()->singleton( Webhooks::class );
+		give()->singleton( MerchantDetails::class );
 
 		give()->singleton(
 			MerchantDetail::class,
@@ -135,6 +130,20 @@ class PaymentGateways implements ServiceProvider {
 				$repository = give( MerchantDetails::class );
 
 				return $repository->getDetails();
+			}
+		);
+
+		give()->resolving(
+			MerchantDetails::class,
+			static function ( MerchantDetails $details ) {
+				$details->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
+			}
+		);
+
+		give()->resolving(
+			Webhooks::class,
+			static function ( Webhooks $repository ) {
+				$repository->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
 			}
 		);
 	}

--- a/src/ServiceProviders/Routes.php
+++ b/src/ServiceProviders/Routes.php
@@ -2,7 +2,6 @@
 
 namespace Give\ServiceProviders;
 
-use Give\Route\Form;
 use Give\Route\PayPalWebhooks;
 use Give\Route\Route;
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5176 

## Description

This PR greatly improves what it takes to extend the PayPal Commerce webhook and also adds checking to silently update the webhook with PayPal if what's registered ever changes (i.e. an add-on is installed that adds more events, or the return url changes).

For registration, a `WebhookRegister` class has been added and stored as a singleton within the Container. This allows for the following extensibility from any other theme or plugin:
```php
// Register a single event
give(WebhookRegister::class)->registerEventHandler('PAYMENT.SALES.COMPLETED', PaymentSalesCompleted::class);

// Register a bunch of events
give(WebhookRegister::class)->registerEventHandlers([
    'PAYMENT.SALES.COMPLETED' => PaymentSalesCompleted::class,
]);
```

## Affects

Setting up webhooks upon onboarding, adding/removing events within core, and adding events from add-ons.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

You will need to disconnect and connect an account since the shape of how webhooks are stored has changed.

Try registering with an add-on.

Go to the `WebhookRegister::class` method and comment out one of the events. Put breakpoint in the `WebhookChecker` class to see if the webhook gets updated. Then load page again to makes sure it doesn't. Also load a page on the front-end to make sure nothing happens in the checker.

