### PR TITLE
On a fresh install, the `/donations/` form archive now works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Onboarding Form Preview default image has been updated. (#5203)
 -   Stripe Checkout modal max-width has been increased to fit-content (#5209)
 -   If the Setup Page is disabled, Onboarding Wizard now directs users to the All Forms page (#5211)
+-   On a fresh install, the donation forms archive is now enabled by default (#5214)
 
 ## [2.8.0-beta.2] - 2020-08-25
 

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function give_setup_post_types() {
 
 	// Give Forms single post and archive options.
-	$give_forms_singular = give_is_setting_enabled( give_get_option( 'forms_singular' ) );
+	$give_forms_singular = give_is_setting_enabled( give_get_option( 'forms_singular', 'enabled' ) );
 	$give_forms_archives = give_is_setting_enabled( give_get_option( 'forms_archives', 'enabled' ) );
 
 	// Enable/Disable give_forms links if form is saving.

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -24,7 +24,7 @@ function give_setup_post_types() {
 
 	// Give Forms single post and archive options.
 	$give_forms_singular = give_is_setting_enabled( give_get_option( 'forms_singular' ) );
-	$give_forms_archives = give_is_setting_enabled( give_get_option( 'forms_archives' ) );
+	$give_forms_archives = give_is_setting_enabled( give_get_option( 'forms_archives', 'enabled' ) );
 
 	// Enable/Disable give_forms links if form is saving.
 	if ( Give_Admin_Settings::is_saving_settings() ) {
@@ -45,14 +45,14 @@ function give_setup_post_types() {
 		$give_forms_slug = GIVE_FORMS_SLUG;
 	}
 
-	$give_forms_rewrite = defined( 'GIVE_DISABLE_FORMS_REWRITE' ) && GIVE_DISABLE_FORMS_REWRITE ? false : array(
+	$give_forms_rewrite = defined( 'GIVE_DISABLE_FORMS_REWRITE' ) && GIVE_DISABLE_FORMS_REWRITE ? false : [
 		'slug'       => $give_forms_slug,
 		'with_front' => false,
-	);
+	];
 
 	$give_forms_labels = apply_filters(
 		'give_forms_labels',
-		array(
+		[
 			'name'               => __( 'Donation Forms', 'give' ),
 			'singular_name'      => __( 'Form', 'give' ),
 			'add_new'            => __( 'Add Form', 'give' ),
@@ -67,17 +67,17 @@ function give_setup_post_types() {
 			'parent_item_colon'  => '',
 			'menu_name'          => apply_filters( 'give_menu_name', __( 'Donations', 'give' ) ),
 			'name_admin_bar'     => apply_filters( 'give_name_admin_bar_name', __( 'Donation Form', 'give' ) ),
-		)
+		]
 	);
 
 	// Default give_forms supports.
-	$give_form_supports = array(
+	$give_form_supports = [
 		'title',
 		'thumbnail',
 		'excerpt',
 		'revisions',
 		'author',
-	);
+	];
 
 	// Has the user disabled the excerpt?
 	if ( ! give_is_setting_enabled( give_get_option( 'forms_excerpt' ) ) ) {
@@ -90,7 +90,7 @@ function give_setup_post_types() {
 		remove_action( 'give_before_single_form_summary', 'give_show_form_images' );
 	}
 
-	$give_forms_args = array(
+	$give_forms_args = [
 		'labels'          => $give_forms_labels,
 		'public'          => $give_forms_singular,
 		'show_ui'         => true,
@@ -104,11 +104,11 @@ function give_setup_post_types() {
 		'menu_icon'       => 'dashicons-give',
 		'hierarchical'    => false,
 		'supports'        => apply_filters( 'give_forms_supports', $give_form_supports ),
-	);
+	];
 	register_post_type( 'give_forms', apply_filters( 'give_forms_post_type_args', $give_forms_args ) );
 
 	/** Donation Post Type */
-	$payment_labels = array(
+	$payment_labels = [
 		'name'               => _x( 'Donations', 'post type general name', 'give' ),
 		'singular_name'      => _x( 'Donation', 'post type singular name', 'give' ),
 		'add_new'            => __( 'Add New', 'give' ),
@@ -122,18 +122,18 @@ function give_setup_post_types() {
 		'not_found_in_trash' => __( 'No donations found in Trash.', 'give' ),
 		'parent_item_colon'  => '',
 		'menu_name'          => __( 'Donations', 'give' ),
-	);
+	];
 
-	$payment_args = array(
+	$payment_args = [
 		'labels'          => apply_filters( 'give_payment_labels', $payment_labels ),
 		'public'          => false,
 		'query_var'       => false,
 		'rewrite'         => false,
 		'map_meta_cap'    => true,
 		'capability_type' => 'give_payment',
-		'supports'        => array( 'title' ),
+		'supports'        => [ 'title' ],
 		'can_export'      => true,
-	);
+	];
 	register_post_type( 'give_payment', $payment_args );
 
 }
@@ -154,7 +154,7 @@ function give_setup_taxonomies() {
 	$slug = defined( 'GIVE_FORMS_SLUG' ) ? GIVE_FORMS_SLUG : 'donations';
 
 	/** Categories */
-	$category_labels = array(
+	$category_labels = [
 		'name'              => _x( 'Form Categories', 'taxonomy general name', 'give' ),
 		'singular_name'     => _x( 'Category', 'taxonomy singular name', 'give' ),
 		'search_items'      => __( 'Search Categories', 'give' ),
@@ -166,31 +166,31 @@ function give_setup_taxonomies() {
 		'add_new_item'      => __( 'Add New Category', 'give' ),
 		'new_item_name'     => __( 'New Category Name', 'give' ),
 		'menu_name'         => __( 'Categories', 'give' ),
-	);
+	];
 
 	$category_args = apply_filters(
 		'give_forms_category_args',
-		array(
+		[
 			'hierarchical' => true,
 			'labels'       => apply_filters( 'give_forms_category_labels', $category_labels ),
 			'show_ui'      => true,
 			'query_var'    => 'give_forms_category',
-			'rewrite'      => array(
+			'rewrite'      => [
 				'slug'         => $slug . '/category',
 				'with_front'   => false,
 				'hierarchical' => true,
-			),
-			'capabilities' => array(
+			],
+			'capabilities' => [
 				'manage_terms' => 'manage_give_form_terms',
 				'edit_terms'   => 'edit_give_form_terms',
 				'assign_terms' => 'assign_give_form_terms',
 				'delete_terms' => 'delete_give_form_terms',
-			),
-		)
+			],
+		]
 	);
 
 	/** Tags */
-	$tag_labels = array(
+	$tag_labels = [
 		'name'                  => _x( 'Form Tags', 'taxonomy general name', 'give' ),
 		'singular_name'         => _x( 'Tag', 'taxonomy singular name', 'give' ),
 		'search_items'          => __( 'Search Tags', 'give' ),
@@ -203,27 +203,27 @@ function give_setup_taxonomies() {
 		'new_item_name'         => __( 'New Tag Name', 'give' ),
 		'menu_name'             => __( 'Tags', 'give' ),
 		'choose_from_most_used' => __( 'Choose from most used tags.', 'give' ),
-	);
+	];
 
 	$tag_args = apply_filters(
 		'give_forms_tag_args',
-		array(
+		[
 			'hierarchical' => false,
 			'labels'       => apply_filters( 'give_forms_tag_labels', $tag_labels ),
 			'show_ui'      => true,
 			'query_var'    => 'give_forms_tag',
-			'rewrite'      => array(
+			'rewrite'      => [
 				'slug'         => $slug . '/tag',
 				'with_front'   => false,
 				'hierarchical' => true,
-			),
-			'capabilities' => array(
+			],
+			'capabilities' => [
 				'manage_terms' => 'manage_give_form_terms',
 				'edit_terms'   => 'edit_give_form_terms',
 				'assign_terms' => 'assign_give_form_terms',
 				'delete_terms' => 'delete_give_form_terms',
-			),
-		)
+			],
+		]
 	);
 
 	// Does the user want category?
@@ -246,12 +246,12 @@ function give_setup_taxonomies() {
 	}
 
 	if ( $enable_category ) {
-		register_taxonomy( 'give_forms_category', array( 'give_forms' ), $category_args );
+		register_taxonomy( 'give_forms_category', [ 'give_forms' ], $category_args );
 		register_taxonomy_for_object_type( 'give_forms_category', 'give_forms' );
 	}
 
 	if ( $enable_tag ) {
-		register_taxonomy( 'give_forms_tag', array( 'give_forms' ), $tag_args );
+		register_taxonomy( 'give_forms_tag', [ 'give_forms' ], $tag_args );
 		register_taxonomy_for_object_type( 'give_forms_tag', 'give_forms' );
 	}
 }
@@ -266,10 +266,10 @@ add_action( 'init', 'give_setup_taxonomies', 0 );
  * @since 1.0
  */
 function give_get_default_form_labels() {
-	$defaults = array(
+	$defaults = [
 		'singular' => __( 'Form', 'give' ),
 		'plural'   => __( 'Forms', 'give' ),
-	);
+	];
 
 	return apply_filters( 'give_default_form_name', $defaults );
 }
@@ -337,81 +337,81 @@ function give_register_post_type_statuses() {
 	// Payment Statuses
 	register_post_status(
 		'refunded',
-		array(
+		[
 			'label'                     => __( 'Refunded', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Refunded <span class="count">(%s)</span>', 'Refunded <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 	register_post_status(
 		'failed',
-		array(
+		[
 			'label'                     => __( 'Failed', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 	register_post_status(
 		'revoked',
-		array(
+		[
 			'label'                     => __( 'Revoked', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Revoked <span class="count">(%s)</span>', 'Revoked <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 	register_post_status(
 		'cancelled',
-		array(
+		[
 			'label'                     => __( 'Cancelled', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Cancelled <span class="count">(%s)</span>', 'Cancelled <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 	register_post_status(
 		'abandoned',
-		array(
+		[
 			'label'                     => __( 'Abandoned', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Abandoned <span class="count">(%s)</span>', 'Abandoned <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 	register_post_status(
 		'processing',
-		array(
+		[
 			'label'                     => _x( 'Processing', 'Processing payment status', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Processing <span class="count">(%s)</span>', 'Processing <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 
 	register_post_status(
 		'preapproval',
-		array(
+		[
 			'label'                     => _x( 'Preapproval', 'Preapproval payment status', 'give' ),
 			'public'                    => true,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,
 			'label_count'               => _n_noop( 'Preapproval <span class="count">(%s)</span>', 'Preapproval <span class="count">(%s)</span>', 'give' ),
-		)
+		]
 	);
 
 }
@@ -433,23 +433,23 @@ function give_updated_messages( $messages ) {
 
 	if ( ! give_is_setting_enabled( give_get_option( 'forms_singular' ) ) ) {
 
-		$messages['give_forms'] = array(
+		$messages['give_forms'] = [
 			1 => __( 'Form updated.', 'give' ),
 			4 => __( 'Form updated.', 'give' ),
 			6 => __( 'Form published.', 'give' ),
 			7 => __( 'Form saved.', 'give' ),
 			8 => __( 'Form submitted.', 'give' ),
-		);
+		];
 
 	} else {
 
-		$messages['give_forms'] = array(
+		$messages['give_forms'] = [
 			1 => sprintf( '%1$s <a href="%2$s">%3$s</a>', __( 'Form updated.', 'give' ), get_permalink( $post_ID ), __( 'View Form', 'give' ) ),
 			4 => sprintf( '%1$s <a href="%2$s">%3$s</a>', __( 'Form updated.', 'give' ), get_permalink( $post_ID ), __( 'View Form', 'give' ) ),
 			6 => sprintf( '%1$s <a href="%2$s">%3$s</a>', __( 'Form published.', 'give' ), get_permalink( $post_ID ), __( 'View Form', 'give' ) ),
 			7 => sprintf( '%1$s <a href="%2$s">%3$s</a>', __( 'Form saved.', 'give' ), get_permalink( $post_ID ), __( 'View Form', 'give' ) ),
 			8 => sprintf( '%1$s <a href="%2$s">%3$s</a>', __( 'Form submitted.', 'give' ), get_permalink( $post_ID ), __( 'View Form', 'give' ) ),
-		);
+		];
 
 	}
 
@@ -491,7 +491,7 @@ function give_widgets_init() {
 		register_sidebar(
 			apply_filters(
 				'give_forms_single_sidebar',
-				array(
+				[
 					'name'          => __( 'GiveWP Single Form Sidebar', 'give' ),
 					'id'            => 'give-forms-sidebar',
 					'description'   => __( 'Widgets in this area will be shown on the single GiveWP forms aside area. This sidebar will not display for embedded forms.', 'give' ),
@@ -499,7 +499,7 @@ function give_widgets_init() {
 					'after_widget'  => '</div>',
 					'before_title'  => '<h3 class="widgettitle widget-title">',
 					'after_title'   => '</h3>',
-				)
+				]
 			)
 		);
 
@@ -518,7 +518,7 @@ add_action( 'widgets_init', 'give_widgets_init', 999 );
  * @return array
  * @since 2.3.0
  */
-function give_forms_disable_quick_edit( $actions = array(), $post = null ) {
+function give_forms_disable_quick_edit( $actions = [], $post = null ) {
 
 	// Abort if the post type is not "give_forms".
 	if ( ! is_post_type_archive( 'give_forms' ) ) {


### PR DESCRIPTION
Resolves #5207 

## Description
This PR resolves an issue whereby the users were met with a 404 notice when trying to view donation form archives via `mysite.com/donations/`. This PR resolves the issue by defaulting to `enabled` when checking for the `form_archives` site option in the `give_setup_post_types()` method. 

## Affects
This PR affects how post types are registered and setup during initial installation of the plugin.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Fresh install at example.local
2. either go through the setup wizard to create a test form, or skip it and create a new form.
3. Navigate to example.local/donations/
