### PR TITLE
FFM Inputs now works in Multi-Step forms with a one gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
--   Improved Mutli-Step form's placement of Fee Recovery checkbox to match location setting (#5205)
+-   Fee Recovery checkbox placement in Multi-Step forms now respects the Fee Recovery input location setting (#5205)
+-   FFM inputs are now setup on init of the Multi-Step form, to ensure they work with only a single gateway enabled (#5216)
 
 ## [2.8.0-beta.3] - 2020-08-27
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -18,7 +18,7 @@
 		font-weight: 500;
 		font-size: 16px;
 		line-height: 1.4;
-		padding: 0 0 15px 32px;
+		padding: 0 0 2px 32px;
 		width: 100%;
 		margin-left: 0;
 		color: #333;
@@ -147,14 +147,11 @@
 	}
 }
 
-
 /*---------------------------------
 RTL styles
 -----------------------------------*/
 
-html[dir="rtl"] {
-
-
+html[dir='rtl'] {
 	.ffm-checkbox-field {
 		label {
 			top: 6px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/ffm.scss
@@ -42,7 +42,7 @@
 			width: 20px;
 			height: 20px;
 			position: absolute;
-			top: calc(50% - 12px);
+			top: calc(50% - 10px);
 			left: 0;
 			content: ' ';
 			display: block;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -320,6 +320,12 @@
 				// Setup gateway icons
 				setupGatewayIcons();
 
+				// Setup Form Field Manager input listeners
+				setupFFMInputs();
+
+				// Setup Icons for inputs
+				setupInputIcons();
+
 				const observer = new window.MutationObserver( function( mutations ) {
 					mutations.forEach( function( mutation ) {
 						if ( ! mutation.addedNodes ) {
@@ -763,13 +769,12 @@
 	}
 
 	/**
-	 * Setup select inputs
+	 * Check if document is RTL
 	 *
 	 * @since 2.8.0
-	 * @return {boolean}
+	 * @return {boolean} Whether or not document is RTL
 	 */
 	function isRTL() {
 		return $( 'html' ).attr( 'dir' ) === 'rtl';
 	}
-
 }( jQuery ) );


### PR DESCRIPTION
Resolves #5212 

## Description
This PR addresses an issue which caused FFM inputs in the Multi-Step form to render incorrectly. Previously, when you created a Multi-Step which included FFM inputs, but only enabled one payment gateway, the inputs were not visually reactive to selections you made. This PR resolves the bug by ensuring that `setupFFMInputs` is called on initialization of the Multi-Step form, and not only when a payment gateway is changed.

As another easy win, this PR improves FFM checkbox styles to ensure that labels are aligned correctly with the visual checkbox, and that checkmarks appear centered inside the checkbox.

## Affects
This PR affects frontend logic of the Multi-Step form. Specifically, it affects the init method of the form itself, ensuring that `setupFFMInputs` is called there, as well as on payment gateway changes.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Create a Donation Form with FFM checkboxes and radio options
2. Disable all but 1 payment gateway
3. View form on the front end
4. Notice how FFM inputs are now reactive to choices you make