### PR TITLE
PHP Notices no longer break multi-step form receipt step.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   PHP Notices no longer break multi-step form receipt step. (#5219)
+
 ## [2.8.0-beta.3] - 2020-08-27
 
 ### Fixed

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -202,8 +202,16 @@ function give_process_donation_form() {
 	// Used for showing data to non logged-in users after donation, and for other plugins needing donation data.
 	give_set_purchase_session( $session_data );
 
+	/**
+	 * Prevent PHP notices from breaking receipt display.
+	 * This is specifically an issue with the Stripe SDK.
+	 *
+	 * @link https://github.com/impress-org/givewp/issues/5199
+	 */
+	ob_start();
 	// Send info to the gateway for payment processing.
 	give_send_to_gateway( $donation_data['gateway'], $donation_data );
+	ob_get_clean();
 	give_die();
 }
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5199

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The Stripe SDK is throwing PHP deprecation notices when `WP_DEBUG` is enabled, which breaks the receipt step of the multi-step form template.

This prevents the notices from breaking the display using an output buffer to control the output and prevent the notices from displaying.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Enabled `WP_DEBUG`
- Connect to Stripe account
- Make a donation using a credit card (Stripe).