### PR TITLE
Show custom card field for "Admin Defined" subscription

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -77,8 +77,8 @@ class AdvancedCardFields extends PaymentMethod {
 		this.addEventToHostedFields( hostedCardFields );
 		this.jQueryForm.on( 'submit', { hostedCardFields }, onSubmitHandlerForDonationForm );
 
-		if ( this.customCardFields.recurringChoiceField ) {
-			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceField, this.toggleFields.bind( this ) );
+		if ( this.customCardFields.recurringChoiceHiddenField ) {
+			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceHiddenField, this.toggleFields.bind( this ) );
 		}
 	}
 

--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -78,7 +78,7 @@ class AdvancedCardFields extends PaymentMethod {
 		this.jQueryForm.on( 'submit', { hostedCardFields }, onSubmitHandlerForDonationForm );
 
 		if ( this.customCardFields.recurringChoiceField ) {
-			this.customCardFields.recurringChoiceField.addEventListener( 'change', this.toggleFields.bind( this ) );
+			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceField, this.toggleFields.bind( this ) );
 		}
 	}
 

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -38,7 +38,7 @@ class CustomCardFields extends PaymentMethod {
 	 * @inheritDoc
 	 */
 	onGatewayLoadBoot( evt, self ) {
-		if ( evt.detail.formIdAttribute === self.form.getAttribute( 'id' ) && DonationForm.isPayPalCommerceSelected( self.jQueryForm ) ) {
+		if ( this.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
 			self.setUpProperties();
 			self.registerEvents();
 		}
@@ -115,7 +115,22 @@ class CustomCardFields extends PaymentMethod {
 		}
 
 		this.form.querySelector( 'input[name="card_name"]' ).parentElement.remove();
-		this.form.querySelector( '[id*="give_cc_fields-"] .separator-with-text' ).parentElement.remove();
+	}
+
+	/**
+	 * Remove custom card fields on gateway load.
+	 *
+	 * @since 2.9.0
+	 */
+	removeFieldsOnGatewayLoad() {
+		const self = this;
+
+		document.addEventListener( 'give_gateway_loaded', evt => {
+			if ( this.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
+				self.setUpProperties();
+				self.removeFields.bind( self ).call();
+			}
+		} );
 	}
 
 	/**
@@ -132,6 +147,18 @@ class CustomCardFields extends PaymentMethod {
 		div.innerHTML = `<div class="dashed-line"></div><div class="label">${ window.givePayPalCommerce.separatorLabel }</div><div class="dashed-line"></div>`;
 
 		return div;
+	}
+
+	/**
+	 * Return wther or not process donation form same donation form.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param {string} formId Donation form id attribute value.
+	 * @return {boolean|boolean} Retrun true if processing same form otherwise false.
+	 */
+	isProcessingEventForForm( formId ) {
+		return formId === this.form.getAttribute( 'id' ) && DonationForm.isPayPalCommerceSelected( this.jQueryForm );
 	}
 }
 

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -20,15 +20,15 @@ class CustomCardFields extends PaymentMethod {
 	setUpProperties() {
 		this.payPalSupportedCountriesForCardSubscription = [ 'US', 'AU' ];
 		this.cardFields = this.getCardFields();
-		this.recurringChoiceField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
+		this.recurringChoiceHiddenField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 	}
 
 	/**
 	 * @inheritDocregisterEvents
 	 */
 	registerEvents() {
-		if ( this.recurringChoiceField ) {
-			DonationForm.trackRecurringHiddenFieldChange( this.recurringChoiceField, this.renderPaymentMethodOption.bind( this ) );
+		if ( this.recurringChoiceHiddenField ) {
+			DonationForm.trackRecurringHiddenFieldChange( this.recurringChoiceHiddenField, this.renderPaymentMethodOption.bind( this ) );
 		}
 
 		this.separator = this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() );

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -20,7 +20,7 @@ class CustomCardFields extends PaymentMethod {
 	setUpProperties() {
 		this.payPalSupportedCountriesForCardSubscription = [ 'US', 'AU' ];
 		this.cardFields = this.getCardFields();
-		this.recurringChoiceField = this.form.querySelector( 'input[name="give-recurring-period"]' );
+		this.recurringChoiceField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class CustomCardFields extends PaymentMethod {
 	 */
 	registerEvents() {
 		if ( this.recurringChoiceField ) {
-			this.recurringChoiceField.addEventListener( 'change', this.renderPaymentMethodOption.bind( this ) );
+			DonationForm.trackRecurringHiddenFieldChange( this.recurringChoiceField, this.renderPaymentMethodOption.bind( this ) );
 		}
 
 		this.separator = this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() );

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -92,13 +92,22 @@ class DonationForm {
 	 */
 	static trackRecurringHiddenFieldChange( element, handler ) {
 		const MutationObserver = new window.MutationObserver( function( mutations ) {
-			if ( 'value' === mutations[ 0 ].attributeName ) {
-				handler.call();
+			// Exit if value does not change.
+			if ( mutations[ 0 ].oldValue === mutations[ 0 ].target.value ) {
+				return;
 			}
+
+			// Exit if paypal-commerce is not selected.
+			if ( ! DonationForm.isPayPalCommerceSelected( jQuery( mutations[ 0 ].target ).closest( '.give-form' ) ) ) {
+				return;
+			}
+
+			handler.call();
 		} );
 
 		MutationObserver.observe( element, {
 			attributeFilter: [ 'value' ],
+			attributeOldValue: true,
 		} );
 	}
 }

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -98,7 +98,7 @@ class DonationForm {
 		} );
 
 		MutationObserver.observe( element, {
-			attributes: true,
+			attributeFilter: [ 'value' ],
 		} );
 	}
 }

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -44,7 +44,7 @@ class DonationForm {
 	 *
 	 * @since 2.9.0
 	 *
-	 * @param {object} $form Form object.
+	 * @param {object} $form Form jQuery object.
 	 *
 	 * @return {boolean} Return whether or not donor selected PayPal Commerce payment gateway.
 	 */

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -75,17 +75,31 @@ class DonationForm {
 	 * @return {boolean}  Return whether or not donor opted in for subscription.
 	 */
 	static isRecurringDonation( form ) {
-		const recurringChoiceField = form.querySelector( 'input[name="give-recurring-period"]' );
-
-		if ( recurringChoiceField ) {
-			return recurringChoiceField && recurringChoiceField.checked;
-		}
-
 		// Recurring choice field will be not available if donation form set to "Admin Defined" Recurring Donations.
 		// In that case we can still find type of donation by checking "_give_is_donation_recurring" field value.
 		const recurringChoiceHiddenField = form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 
 		return recurringChoiceHiddenField && '1' === recurringChoiceHiddenField.value;
+	}
+
+	/**
+	 * Call function when change field attribute.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param {object} element Javascript selector
+	 * @param {object} handler Function
+	 */
+	static trackRecurringHiddenFieldChange( element, handler ) {
+		const MutationObserver = new window.MutationObserver( function( mutations ) {
+			if ( 'value' === mutations[ 0 ].attributeName ) {
+				handler.call();
+			}
+		} );
+
+		MutationObserver.observe( element, {
+			attributes: true,
+		} );
 	}
 }
 

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -27,6 +27,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		} else {
 			const customCardFields = new CustomCardFields( $form );
 			customCardFields.removeFields();
+			customCardFields.removeFieldsOnGatewayLoad();
 		}
 	} );
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

@JasonTheAdams comment https://github.com/impress-org/give-recurring/pull/982#pullrequestreview-481162902

## Description

I figure out that the custom card field does not show correctly when the donation form set to `Admin Defined` recurring donation and the default donation level set to non recurring level. I update the code to show the custom card fields correctly when the donor opted in for recurring donation by there choice or by admin.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Previously we are listening to change on the checkbox provided by a recurring add-on for the donor but that field does not show in all cases. To solve issue we now using `window.MutationObserver` to listen to changes on `input[name="_give_is_donation_recurring"]` which will give more accurate results.

## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing guidelines
- Run the command `npm run dev` after fetching this pr.
- Update recurring addon https://github.com/impress-org/give-recurring/tree/epic/paypal-commerce-integration

