### PR TITLE
Milestone now supports a custom goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now supports a featured image (#5234)
 -   Milestone can now be associated with one or many forms (#5230)
 -   Milestone now displays aggregated earnings based on associated forms (#5236)
+-   Milestone now supports a custom goal (#5237)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -33,6 +33,10 @@ class Block {
 						'type'    => 'array',
 						'default' => [],
 					],
+					'goal'        => [
+						'type'    => 'string',
+						'default' => '',
+					],
 				],
 
 			]
@@ -50,6 +54,7 @@ class Block {
 				'title'       => $attributes['title'],
 				'description' => $attributes['description'],
 				'image'       => $attributes['image'],
+				'goal'        => $attributes['goal'],
 			]
 		);
 		return $milestone->getOutput();

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -9,6 +9,7 @@ class Model {
 	protected $title;
 	protected $description;
 	protected $image;
+	protected $goal;
 
 	/**
 	 * Constructs and sets up setting variables for a new Milestone model
@@ -20,6 +21,7 @@ class Model {
 		isset( $args['title'] ) ? $this->title             = $args['title'] : $this->title = __( 'Sample Milestone Title', 'give' );
 		isset( $args['description'] ) ? $this->description = $args['description'] : $this->description = __( 'This is a sample description.', 'give' );
 		isset( $args['image'] ) ? $this->image             = $args['image'] : $this->image = '';
+		isset( $args['goal'] ) ? $this->goal               = $args['goal'] : $this->goal = '';
 	}
 
 	/**
@@ -65,6 +67,16 @@ class Model {
 	 **/
 	protected function getImage() {
 		return $this->image;
+	}
+
+	/**
+	 * Get goal for Milestone
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	protected function getGoal() {
+		return $this->goal;
 	}
 
 	/**

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -24,6 +24,10 @@ const blockAttributes = {
 		type: 'array',
 		default: [],
 	},
+	goal: {
+		type: 'string',
+		default: '',
+	},
 };
 
 export default blockAttributes;

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -18,7 +18,7 @@ import MultiSelectControl from '../components/multi-select-control';
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids } = attributes;
+	const { title, description, image, ids, goal } = attributes;
 	const formOptions = useSelect( ( select ) => {
 		const records = select( 'core' ).getEntityRecords( 'postType', 'give_forms' );
 		if ( records ) {
@@ -60,6 +60,13 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<TextControl
+					name="goal"
+					label={ __( 'Goal', 'give' ) }
+					type="number"
+					onChange={ ( value ) => saveSetting( 'goal', value ) }
+					value={ goal }
+				/>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -21,12 +21,25 @@
 		<div class="give-milestone__description">
 			<?php echo $this->getDescription(); ?>
 		</div>
+		<?php if ( ! empty( $this->getGoal() ) ) : ?>
 		<div class="give-milestone__progress">
 			<div class="give-milestone__progress-bar" style="width: 60%"></div>
 		</div>
+		<?php endif; ?>
 		<div class="give-milestone__context">
 			<span>
-				$600 of $1,000
+				$600 of 
+				<?php
+				echo give_currency_filter(
+					give_format_amount(
+						$this->getGoal(),
+						[
+							'sanitize' => false,
+							'decimal'  => false,
+						]
+					)
+				)
+				?>
 			</span>
 			<span>
 				15 Days to Go

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -23,7 +23,8 @@
 		</div>
 		<?php if ( ! empty( $this->getGoal() ) ) : ?>
 		<div class="give-milestone__progress">
-			<div class="give-milestone__progress-bar" style="width: 60%"></div>
+			<?php $percent = ( $this->getEarnings() / $this->getGoal() ) * 100; ?>
+			<div class="give-milestone__progress-bar" style="width: <?php echo $percent < 100 ? $percent : 100; ?>%"></div>
 		</div>
 		<?php endif; ?>
 		<div class="give-milestone__context">
@@ -31,7 +32,7 @@
 				<?php
 				echo give_currency_filter(
 					give_format_amount(
-						$this->getGoal(),
+						$this->getEarnings(),
 						[
 							'sanitize' => false,
 							'decimal'  => false,
@@ -43,7 +44,7 @@
 				<?php
 				echo give_currency_filter(
 					give_format_amount(
-						$this->getEarnings(),
+						$this->getGoal(),
 						[
 							'sanitize' => false,
 							'decimal'  => false,


### PR DESCRIPTION
Resolves #5231 

## Description
This PR introduces functionality for Milestones to support a basic custom goal. It registers the `goal` attributes which can be modified via the block inspector, and conditionally hides/shows the progress bar, adjusts the progress bar width, and updates the goal figure shown in the Milestone.

## Affects
This PR affects Milestone block registration, frontend Milestone rendering logic and the Milestone model.

## Visuals
![Goal](https://user-images.githubusercontent.com/5186078/92163174-3e8c9500-ee01-11ea-942d-5118202ce1b5.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new post or page
2. Add a Milestone block
3. Add forms which have already collected donations
4. Change the goal amount, check that it is reflected in the editor
5. Save, check that the goal is reflected on the frontend