### PR TITLE
Milestone now supports a deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now supports a featured image (#5234)
 -   Milestone can now be associated with one or many forms (#5230)
 -   Milestone now displays aggregated earnings based on associated forms (#5236)
+-   Milestone now supports a deadline (#5239)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -33,6 +33,10 @@ class Block {
 						'type'    => 'array',
 						'default' => [],
 					],
+					'deadline'    => [
+						'type'    => 'string',
+						'default' => '',
+					],
 				],
 
 			]
@@ -51,6 +55,7 @@ class Block {
 				'description' => $attributes['description'],
 				'image'       => $attributes['image'],
 				'ids'         => $attributes['ids'],
+				'deadline'    => $attributes['deadline'],
 			]
 		);
 		return $milestone->getOutput();

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -10,6 +10,7 @@ class Model {
 	protected $description;
 	protected $image;
 	protected $ids;
+	protected $deadline;
 
 	// Internal
 	protected $forms = [];
@@ -25,6 +26,7 @@ class Model {
 		isset( $args['description'] ) ? $this->description = $args['description'] : $this->description = __( 'This is a sample description.', 'give' );
 		isset( $args['image'] ) ? $this->image             = $args['image'] : $this->image = '';
 		isset( $args['ids'] ) ? $this->ids                 = $args['ids'] : $this->ids = [];
+		isset( $args['deadline'] ) ? $this->deadline       = $args['deadline'] : $this->deadline = '';
 	}
 
 	/**
@@ -97,6 +99,22 @@ class Model {
 	 **/
 	protected function getTitle() {
 		return $this->title;
+	}
+
+	/**
+	 * Get deadline for Milestone
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	protected function getDeadline() {
+		return $this->deadline;
+	}
+
+	protected function getDaysToGo() {
+		$now      = new \DateTime();
+		$deadline = new \DateTime( $this->getDeadline() );
+		return $now < $deadline ? $deadline->diff( $now )->format( '%a' ) + 1 : 0;
 	}
 
 	/**

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -111,6 +111,12 @@ class Model {
 		return $this->deadline;
 	}
 
+	/**
+	 * Get days remaining before Milestone deadline
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
 	protected function getDaysToGo() {
 		$now      = new \DateTime();
 		$deadline = new \DateTime( $this->getDeadline() );

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -24,6 +24,10 @@ const blockAttributes = {
 		type: 'array',
 		default: [],
 	},
+	deadline: {
+		type: 'string',
+		default: '',
+	},
 };
 
 export default blockAttributes;

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -18,7 +18,7 @@ import MultiSelectControl from '../components/multi-select-control';
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids } = attributes;
+	const { title, description, image, ids, deadline } = attributes;
 	const formOptions = useSelect( ( select ) => {
 		const records = select( 'core' ).getEntityRecords( 'postType', 'give_forms' );
 		if ( records ) {
@@ -60,6 +60,12 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<TextControl
+					name="deadline"
+					label={ __( 'Deadline', 'give' ) }
+					type="date"
+					value={ deadline }
+					onChange={ ( value ) => saveSetting( 'deadline', value ) } />
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -39,9 +39,11 @@
 				?>
 				 of $1,000
 			</span>
+			<?php if ( ! empty( $this->getDeadline() ) ) : ?>
 			<span>
-				15 Days to Go
+				<?php echo $this->getDaysToGo(); ?> Days To Go
 			</span>
+			<?php endif; ?>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Resolves #5238 

## Description
This PR introduces functionality for Milestones to support a `deadline` attribute, and display days remaining until that deadline. 

## Affects
This PR affects Milestone block registration, frontend display logic for Milestones, and the Milestone model. 

## Visuals
![Deadline](https://user-images.githubusercontent.com/5186078/92167001-a3e38480-ee07-11ea-8fd7-f483462f3804.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new page or post
2. Add a Milestone block
3. Change the deadline input
4. See that changes are reflected in the editor, and on the frontend