### PR TITLE
Milestone title and description now support {} tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now displays aggregated earnings based on associated forms (#5236)
 -   Milestone now supports a deadline (#5239)
 -   Milestone now supports a custom goal (#5237)
+-   Milestone title and description now support {} tags (#5242)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -19,11 +19,11 @@ class Block {
 				'attributes'      => [
 					'title'       => [
 						'type'    => 'string',
-						'default' => __( 'Back to School Fundraiser', 'give' ),
+						'default' => __( 'We\'ve raised {total} so far!', 'give' ),
 					],
 					'description' => [
 						'type'    => 'string',
-						'default' => __( 'This is a sample description.', 'give' ),
+						'default' => __( 'But we still need {total_remaining} to reach our goal!', 'give' ),
 					],
 					'image'       => [
 						'type'    => 'string',

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -100,7 +100,7 @@ class Model {
 	 * @since 2.9.0
 	 **/
 	protected function getTitle() {
-		return $this->title;
+		return $this->formatMessage( $this->title );
 	}
 
 	/**
@@ -132,7 +132,61 @@ class Model {
 	 * @since 2.9.0
 	 **/
 	protected function getDescription() {
-		return $this->description;
+		return $this->formatMessage( $this->description );
+	}
+
+	protected function getFormattedTotal() {
+		return give_currency_filter(
+			give_format_amount(
+				$this->getEarnings(),
+				[
+					'sanitize' => false,
+					'decimal'  => false,
+				]
+			)
+		);
+	}
+
+	protected function getFormattedTotalRemaining() {
+		$total_remaining = ( $this->getGoal() - $this->getEarnings() ) > 0 ? ( $this->getGoal() - $this->getEarnings() ) : 0;
+		return give_currency_filter(
+			give_format_amount(
+				$total_remaining,
+				[
+					'sanitize' => false,
+					'decimal'  => false,
+				]
+			)
+		);
+	}
+
+	protected function getFormattedGoal() {
+		return give_currency_filter(
+			give_format_amount(
+				$this->getGoal(),
+				[
+					'sanitize' => false,
+					'decimal'  => false,
+				]
+			)
+		);
+	}
+
+	protected function formatMessage( $message ) {
+		$codes = [
+			[ 'total', $this->getFormattedTotal() ],
+			[ 'total_goal', $this->getFormattedGoal() ],
+			[ 'total_remaining', $this->getFormattedTotalRemaining() ],
+			[ 'days_remaining', $this->getDaysToGo() ],
+		];
+		foreach ( $codes as $code ) {
+			$message = str_replace(
+				"{{$code[0]}}",
+				$code[1],
+				esc_html( $message )
+			);
+		}
+		return $message;
 	}
 
 	/**

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -135,6 +135,11 @@ class Model {
 		return $this->formatMessage( $this->description );
 	}
 
+	/**
+	 * Get formatted total (ex: $100)
+	 *
+	 * @since 2.9.0
+	 */
 	protected function getFormattedTotal() {
 		return give_currency_filter(
 			give_format_amount(
@@ -147,6 +152,11 @@ class Model {
 		);
 	}
 
+	/**
+	 * Get formatted total remaining (ex: $75)
+	 *
+	 * @since 2.9.0
+	 */
 	protected function getFormattedTotalRemaining() {
 		$total_remaining = ( $this->getGoal() - $this->getEarnings() ) > 0 ? ( $this->getGoal() - $this->getEarnings() ) : 0;
 		return give_currency_filter(
@@ -160,6 +170,9 @@ class Model {
 		);
 	}
 
+	/**
+	 * Get formatted goal (ex: $175)
+	 */
 	protected function getFormattedGoal() {
 		return give_currency_filter(
 			give_format_amount(
@@ -172,6 +185,11 @@ class Model {
 		);
 	}
 
+	/**
+	 * Format message containing special {} tags (ex: {total})
+	 *
+	 * @since 2.9.0
+	 */
 	protected function formatMessage( $message ) {
 		$codes = [
 			[ 'total', $this->getFormattedTotal() ],

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -23,8 +23,8 @@ class Model {
 	 * @since 2.9.0
 	 **/
 	public function __construct( array $args ) {
-		isset( $args['title'] ) ? $this->title             = $args['title'] : $this->title = __( 'Sample Milestone Title', 'give' );
-		isset( $args['description'] ) ? $this->description = $args['description'] : $this->description = __( 'This is a sample description.', 'give' );
+		isset( $args['title'] ) ? $this->title             = $args['title'] : $this->title = __( 'We\'ve raised {total} so far!', 'give' );
+		isset( $args['description'] ) ? $this->description = $args['description'] : $this->description = __( 'But we still need {total_remaining} to reach our goal!', 'give' );
 		isset( $args['image'] ) ? $this->image             = $args['image'] : $this->image = '';
 		isset( $args['ids'] ) ? $this->ids                 = $args['ids'] : $this->ids = [];
 		isset( $args['deadline'] ) ? $this->deadline       = $args['deadline'] : $this->deadline = '';

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -10,11 +10,11 @@ const { __ } = wp.i18n;
 const blockAttributes = {
 	title: {
 		type: 'string',
-		default: __( 'Back to School Fundraiser', 'give' ),
+		default: __( 'We\'ve raised {total} so far!', 'give' ),
 	},
 	description: {
 		type: 'string',
-		default: __( 'This is a sample description.', 'give' ),
+		default: __( 'But we still need {total_remaining} to reach our goal!', 'give' ),
 	},
 	image: {
 		type: 'string',

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -3,7 +3,7 @@
  */
 const { __ } = wp.i18n;
 const { InspectorControls } = wp.blockEditor;
-const { PanelBody, TextControl } = wp.components;
+const { PanelBody, TextControl, TextareaControl } = wp.components;
 const { useSelect } = wp.data;
 
 /**
@@ -44,7 +44,7 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					label={ __( 'Title', 'give' ) }
 					value={ title }
 					onChange={ ( value ) => saveSetting( 'title', value ) } />
-				<TextControl
+				<TextareaControl
 					name="description"
 					label={ __( 'Description', 'give' ) }
 					value={ description }

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -28,15 +28,15 @@
 		</div>
 		<?php endif; ?>
 		<div class="give-milestone__context">
-			<?php if ( ! empty( $this->getGoal() ) ) : ?>
 			<span> 
+				<?php echo $this->getFormattedTotal(); ?>
 				<?php
-					echo $this->getFormattedTotal();
+				if ( ! empty( $this->getGoal() ) ) {
 					echo __( ' of ', 'give' );
 					echo $this->getFormattedGoal();
+				}
 				?>
 			</span>
-			<?php endif; ?>
 			<?php if ( ! empty( $this->getDeadline() ) ) : ?>
 			<span>
 				<?php echo $this->getDaysToGo(); ?> Days To Go

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -28,33 +28,15 @@
 		</div>
 		<?php endif; ?>
 		<div class="give-milestone__context">
+			<?php if ( ! empty( $this->getGoal() ) ) : ?>
 			<span> 
 				<?php
-				echo give_currency_filter(
-					give_format_amount(
-						$this->getEarnings(),
-						[
-							'sanitize' => false,
-							'decimal'  => false,
-						]
-					)
-				);
-				?>
-				<?php
-				if ( ! empty( $this->getGoal() ) ) {
-					echo __( 'of ', 'give' );
-					echo give_currency_filter(
-						give_format_amount(
-							$this->getGoal(),
-							[
-								'sanitize' => false,
-								'decimal'  => false,
-							]
-						)
-					);
-				}
+					echo $this->getFormattedTotal();
+					echo __( ' of ', 'give' );
+					echo $this->getFormattedGoal();
 				?>
 			</span>
+			<?php endif; ?>
 			<?php if ( ! empty( $this->getDeadline() ) ) : ?>
 			<span>
 				<?php echo $this->getDaysToGo(); ?> Days To Go


### PR DESCRIPTION
Resolves #5240 

## Description
This PR introduces logic to format special {} tags in Milestone title or description, so that admin can use dynamic information like {total_remaining} or {days_remaining} in their Milestone messaging. Additionally, the PR uses a `textarea` input in the block inspector to handle Milestone descriptions.

The special {} tags introduced in this PR are:
- {total}
- {total_goal}
- {total_remaining}
- {days_remaining}

A future issue should be opened to handle actually informing users about what specific tags are available to them, and what they do. Because this specific requirement relies on unspecified design decisions, I opted not to include it as part of this PR.

## Affects
This PR affects the Milestone model, as well as frontend rendering logic for Milestones.

## Visuals
<img width="1005" alt="Screen Shot 2020-09-04 at 12 26 19 PM" src="https://user-images.githubusercontent.com/5186078/92263443-a2b76380-eeaa-11ea-9ef6-2153cedeb2bb.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Create a new post or page
2. Add a Milestone block
3. Change the title or description to include {total}, {total_goal}, {total_remaining} or {days_remaining}
4. Check that dynamic information is correctly populated in editor and frontend

## User Documentation
- Documentation explaining each of the {} tags available