### PR TITLE
Milestone now supports filtering forms by tag/category and displaying specific metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now displays aggregated earnings based on associated forms (#5236)
 -   Milestone now supports a deadline (#5239)
 -   Milestone now supports a custom goal (#5237)
+-   Milestone now supports sorting forms by tag and category (#5244)
 
 ## [2.8.0] - 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now supports a deadline (#5239)
 -   Milestone now supports a custom goal (#5237)
 -   Milestone now supports sorting forms by tag and category (#5244)
+-   Milestone now supports aggregating different metrics (Revenue, Donations, Donors) (#5244)
 
 ## [2.8.0] - 2020-08-31
 

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -174,6 +174,7 @@ function give_setup_taxonomies() {
 			'hierarchical' => true,
 			'labels'       => apply_filters( 'give_forms_category_labels', $category_labels ),
 			'show_ui'      => true,
+			'show_in_rest' => true,
 			'query_var'    => 'give_forms_category',
 			'rewrite'      => [
 				'slug'         => $slug . '/category',
@@ -211,6 +212,7 @@ function give_setup_taxonomies() {
 			'hierarchical' => false,
 			'labels'       => apply_filters( 'give_forms_tag_labels', $tag_labels ),
 			'show_ui'      => true,
+			'show_in_rest' => true,
 			'query_var'    => 'give_forms_tag',
 			'rewrite'      => [
 				'slug'         => $slug . '/tag',

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -33,6 +33,14 @@ class Block {
 						'type'    => 'array',
 						'default' => [],
 					],
+					'categories'  => [
+						'type'    => 'array',
+						'default' => [],
+					],
+					'tags'        => [
+						'type'    => 'array',
+						'default' => [],
+					],
 					'deadline'    => [
 						'type'    => 'string',
 						'default' => '',
@@ -59,6 +67,8 @@ class Block {
 				'description' => $attributes['description'],
 				'image'       => $attributes['image'],
 				'ids'         => $attributes['ids'],
+				'tags'        => $attributes['tags'],
+				'categories'  => $attributes['categories'],
 				'deadline'    => $attributes['deadline'],
 				'goal'        => $attributes['goal'],
 			]

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -41,6 +41,10 @@ class Block {
 						'type'    => 'array',
 						'default' => [],
 					],
+					'metric'      => [
+						'type'    => 'string',
+						'default' => 'revenue',
+					],
 					'deadline'    => [
 						'type'    => 'string',
 						'default' => '',
@@ -69,6 +73,7 @@ class Block {
 				'ids'         => $attributes['ids'],
 				'tags'        => $attributes['tags'],
 				'categories'  => $attributes['categories'],
+				'metric'      => $attributes['metric'],
 				'deadline'    => $attributes['deadline'],
 				'goal'        => $attributes['goal'],
 			]

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -10,6 +10,8 @@ class Model {
 	protected $description;
 	protected $image;
 	protected $ids;
+	protected $tags;
+	protected $categories;
 	protected $deadline;
 	protected $goal;
 
@@ -27,6 +29,8 @@ class Model {
 		isset( $args['description'] ) ? $this->description = $args['description'] : $this->description = __( 'This is a sample description.', 'give' );
 		isset( $args['image'] ) ? $this->image             = $args['image'] : $this->image = '';
 		isset( $args['ids'] ) ? $this->ids                 = $args['ids'] : $this->ids = [];
+		isset( $args['tags'] ) ? $this->tags               = $args['tags'] : $this->tags = [];
+		isset( $args['categories'] ) ? $this->categories   = $args['categories'] : $this->categories = [];
 		isset( $args['deadline'] ) ? $this->deadline       = $args['deadline'] : $this->deadline = '';
 		isset( $args['goal'] ) ? $this->goal               = $args['goal'] : $this->goal = '';
 	}
@@ -53,7 +57,22 @@ class Model {
 				'relation' => 'AND',
 			],
 		];
-		$query      = new \WP_Query( $query_args );
+
+		if ( ! empty( $this->tags ) ) {
+			$query_args['tax_query'][] = [
+				'taxonomy' => 'give_forms_tag',
+				'terms'    => $this->tags,
+			];
+		}
+
+		if ( ! empty( $this->categories ) ) {
+			$query_args['tax_query'][] = [
+				'taxonomy' => 'give_forms_category',
+				'terms'    => $this->categories,
+			];
+		}
+
+		$query = new \WP_Query( $query_args );
 
 		if ( $query->posts ) {
 			$this->forms = $query->posts;

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -85,24 +85,15 @@ class Model {
 	}
 
 	protected function getDonations() {
-
-		$forms    = $this->getForms();
-		$form_ids = [];
-		foreach ( $forms as $form ) {
-			$form_ids += $form['ID'];
-		}
-
 		$query_args = [
 			'post_status' => [
 				'publish',
 				'give_subscription',
 			],
 			'number'      => -1,
-			'paged'       => 1,
-			'give_forms'  => $form_ids,
+			'give_forms'  => $this->getForms(),
 		];
-
-		$query = new \Give_Payments_Query( $query_args );
+		$query      = new \Give_Payments_Query( $query_args );
 		return $query->get_payments();
 	}
 
@@ -146,7 +137,7 @@ class Model {
 		$donations = $this->getDonations();
 		$donors    = [];
 		foreach ( $donations as $donation ) {
-			$donors += ! empty( $donation->donor_id ) ? $donation->donor_id : 0;
+			$donors[] = ! empty( $donation->donor_id ) ? $donation->donor_id : 0;
 		}
 		$unique = array_unique( $donors );
 		return count( $unique );

--- a/src/Milestones/resources/js/components/multi-select-control/index.js
+++ b/src/Milestones/resources/js/components/multi-select-control/index.js
@@ -14,7 +14,7 @@ const MultiSelectControl = ( { name, label, help, className, value, hideLabelFro
 	const instanceId = useInstanceId( MultiSelectControl );
 	const id = `give-multi-select-control-${ name }-${ instanceId }`;
 
-	if ( options && options.length < 2 ) {
+	if ( options && options.length < 1 ) {
 		return null;
 	}
 	return (

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -32,6 +32,10 @@ const blockAttributes = {
 		type: 'array',
 		default: [],
 	},
+	metric: {
+		type: 'string',
+		default: 'revenue',
+	},
 	deadline: {
 		type: 'string',
 		default: '',

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -24,6 +24,14 @@ const blockAttributes = {
 		type: 'array',
 		default: [],
 	},
+	categories: {
+		type: 'array',
+		default: [],
+	},
+	tags: {
+		type: 'array',
+		default: [],
+	},
 	deadline: {
 		type: 'string',
 		default: '',

--- a/src/Milestones/resources/js/data/utils.js
+++ b/src/Milestones/resources/js/data/utils.js
@@ -1,0 +1,50 @@
+const { useSelect } = wp.data;
+const { __ } = wp.i18n;
+
+export const useFormOptions = () => {
+	const formOptions = useSelect( ( select ) => {
+		const records = select( 'core' ).getEntityRecords( 'postType', 'give_forms' );
+		if ( records ) {
+			return records.map( ( record ) => {
+				return {
+					label: record.title.rendered ? record.title.rendered : __( '(no title)' ),
+					value: record.id,
+				};
+			} );
+		}
+		return [];
+	}, [] );
+	return formOptions;
+};
+
+export const useTagOptions = () => {
+	const tagOptions = useSelect( ( select ) => {
+		const records = select( 'core' ).getEntityRecords( 'taxonomy', 'give_forms_tag', { per_page: 100 } );
+		if ( records ) {
+			return records.map( ( record ) => {
+				return {
+					label: record.name ? record.name : __( '(no title)' ),
+					value: record.id,
+				};
+			} );
+		}
+		return [];
+	}, [] );
+	return tagOptions;
+};
+
+export const useCategoryOptions = () => {
+	const categoryOptions = useSelect( ( select ) => {
+		const records = select( 'core' ).getEntityRecords( 'taxonomy', 'give_forms_category', { per_page: 100 } );
+		if ( records ) {
+			return records.map( ( record ) => {
+				return {
+					label: record.name ? record.name : __( '(no title)' ),
+					value: record.id,
+				};
+			} );
+		}
+		return [];
+	}, [] );
+	return categoryOptions;
+};

--- a/src/Milestones/resources/js/data/utils.js
+++ b/src/Milestones/resources/js/data/utils.js
@@ -1,6 +1,12 @@
 const { useSelect } = wp.data;
 const { __ } = wp.i18n;
 
+/**
+ * Get array of form options for a select control
+ *
+ * @since 2.9.0
+ * @return {array} Array of options for a select control
+ */
 export const useFormOptions = () => {
 	const formOptions = useSelect( ( select ) => {
 		const records = select( 'core' ).getEntityRecords( 'postType', 'give_forms' );
@@ -17,6 +23,12 @@ export const useFormOptions = () => {
 	return formOptions;
 };
 
+/**
+ * Get array of form tag options for a select control
+ *
+ * @since 2.9.0
+ * @return {array} Array of options for a select control
+ */
 export const useTagOptions = () => {
 	const tagOptions = useSelect( ( select ) => {
 		const records = select( 'core' ).getEntityRecords( 'taxonomy', 'give_forms_tag', { per_page: 100 } );
@@ -33,6 +45,12 @@ export const useTagOptions = () => {
 	return tagOptions;
 };
 
+/**
+ * Get array of form category options for a select control
+ *
+ * @since 2.9.0
+ * @return {array} Array of options for a select control
+ */
 export const useCategoryOptions = () => {
 	const categoryOptions = useSelect( ( select ) => {
 		const records = select( 'core' ).getEntityRecords( 'taxonomy', 'give_forms_category', { per_page: 100 } );

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -4,7 +4,6 @@
 const { __ } = wp.i18n;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody, TextControl } = wp.components;
-const { useSelect } = wp.data;
 
 /**
  * Internal dependencies
@@ -12,25 +11,17 @@ const { useSelect } = wp.data;
 
 import ImageControl from '../components/image-control';
 import MultiSelectControl from '../components/multi-select-control';
+import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils';
 
 /**
  * Render Inspector Controls
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, goal, deadline } = attributes;
-	const formOptions = useSelect( ( select ) => {
-		const records = select( 'core' ).getEntityRecords( 'postType', 'give_forms' );
-		if ( records ) {
-			return records.map( ( record ) => {
-				return {
-					label: record.title.rendered ? record.title.rendered : __( '(no title)' ),
-					value: record.id,
-				};
-			} );
-		}
-		return [];
-	}, [] );
+	const { title, description, image, ids, categories, tags, goal, deadline } = attributes;
+	const formOptions = useFormOptions();
+	const tagOptions = useTagOptions();
+	const categoryOptions = useCategoryOptions();
 	const saveSetting = ( name, value ) => {
 		setAttributes( {
 			[ name ]: value,
@@ -60,6 +51,18 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<MultiSelectControl
+					name="tags"
+					label={ __( 'Filter by Tags', 'give' ) }
+					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
+					options={ tagOptions }
+					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<MultiSelectControl
+					name="categories"
+					label={ __( 'Filter by Categories', 'give' ) }
+					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
+					options={ categoryOptions }
+					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<TextControl
 					name="goal"
 					label={ __( 'Goal', 'give' ) }

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -3,7 +3,7 @@
  */
 const { __ } = wp.i18n;
 const { InspectorControls } = wp.blockEditor;
-const { PanelBody, TextControl } = wp.components;
+const { PanelBody, TextControl, SelectControl } = wp.components;
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, categories, tags, goal, deadline } = attributes;
+	const { title, description, image, ids, categories, tags, metric, goal, deadline } = attributes;
 	const formOptions = useFormOptions();
 	const tagOptions = useTagOptions();
 	const categoryOptions = useCategoryOptions();
@@ -63,6 +63,16 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
 					options={ categoryOptions }
 					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<SelectControl
+					label={ __( 'Metric', 'give' ) }
+					value={ metric }
+					options={ [
+						{ label: __( 'Revenue', 'give' ), value: 'revenue' },
+						{ label: __( 'Donors', 'give' ), value: 'donor-count' },
+						{ label: __( 'Number of Donations', 'give' ), value: 'donation-count' },
+					] }
+					onChange={ ( value ) => saveSetting( 'metric', value ) }
+				/>
 				<TextControl
 					name="goal"
 					label={ __( 'Goal', 'give' ) }

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -68,7 +68,7 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					value={ metric }
 					options={ [
 						{ label: __( 'Revenue', 'give' ), value: 'revenue' },
-						{ label: __( 'Donors', 'give' ), value: 'donor-count' },
+						{ label: __( 'Number of Donors', 'give' ), value: 'donor-count' },
 						{ label: __( 'Number of Donations', 'give' ), value: 'donation-count' },
 					] }
 					onChange={ ( value ) => saveSetting( 'metric', value ) }

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -41,7 +41,13 @@
 			</span>
 			<?php if ( ! empty( $this->getDeadline() ) ) : ?>
 			<span>
-				<?php echo $this->getDaysToGo(); ?> Days To Go
+				<?php
+					$days = $this->getDaysToGo();
+				if ( $days > 0 ) {
+					$format = _n( '%s Day to Go', '%s Days to Go', $days, 'give' );
+					echo sprintf( $format, $days );
+				}
+				?>
 			</span>
 			<?php endif; ?>
 		</div>

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -44,7 +44,7 @@
 				<?php
 					$days = $this->getDaysToGo();
 				if ( $days > 0 ) {
-					$format = _n( '%s Day to Go', '%s Days to Go', $days, 'give' );
+					$format = _n( '%s Day To Go', '%s Days To Go', $days, 'give' );
 					echo sprintf( $format, $days );
 				}
 				?>

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -23,35 +23,19 @@
 		</div>
 		<?php if ( ! empty( $this->getGoal() ) ) : ?>
 		<div class="give-milestone__progress">
-			<?php $percent = ( $this->getEarnings() / $this->getGoal() ) * 100; ?>
+			<?php $percent = ( $this->getTotal() / $this->getGoal() ) * 100; ?>
 			<div class="give-milestone__progress-bar" style="width: <?php echo $percent < 100 ? $percent : 100; ?>%"></div>
 		</div>
 		<?php endif; ?>
 		<div class="give-milestone__context">
 			<span> 
 				<?php
-				echo give_currency_filter(
-					give_format_amount(
-						$this->getEarnings(),
-						[
-							'sanitize' => false,
-							'decimal'  => false,
-						]
-					)
-				);
+				echo $this->getFormattedTotal();
 				?>
 				<?php
 				if ( ! empty( $this->getGoal() ) ) {
 					echo __( 'of ', 'give' );
-					echo give_currency_filter(
-						give_format_amount(
-							$this->getGoal(),
-							[
-								'sanitize' => false,
-								'decimal'  => false,
-							]
-						)
-					);
+					echo $this->getFormattedGoal();
 				}
 				?>
 			</span>


### PR DESCRIPTION
Resolves #5243 

## Description
This PR introduces logic to support filter the forms that feed into a Milestone block by their tag and category. With MultiSelectControls, an admin can search registered form tags or categories and select which ones to filter forms that feed into the Milestone by. For example: If an admin selects no specific forms, but chooses a specific category, then all forms with that category will be factored into Milestone progress.

This PR also introduces metric selections beyond simply revenue. The metric dropdown was added to the inspector, which allows an admin to display progress according to revenue, donations, or donors. 

## Affects
This PR affects Milestone block editor rendering logic, and how the Milestone model queries forms and aggregates data.

## Visuals
<img width="269" alt="Screen Shot 2020-09-14 at 11 13 07 AM" src="https://user-images.githubusercontent.com/5186078/93104009-507cfc00-f67b-11ea-9b12-dc1046994bbd.png">


## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Enable Form Tags/Categories (Give Settings > Default Options > Taxonomies)
2. Create a form, and give it a tag or category
3. Create a new post or page
4. Add a milestone block, and select the tag or category you gave the form
5. Check that the form is queried as expected by its given category or tag
6. Change the metric used to display progress
7. Check that the Milestone metric changes as expected