### PR TITLE
Prevent javascript notices which appears when default payment gateway (except paypal commerce) which does not need card field for payment

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -45,7 +45,6 @@ class AdvancedCardFields extends PaymentMethod {
 		};
 
 		this.setFocusStyle();
-		this.computedStyles();
 	}
 
 	/**
@@ -425,8 +424,6 @@ class AdvancedCardFields extends PaymentMethod {
 						...	this.styles[ 'input:focus' ],
 					};
 				} );
-
-				this.setHostedFieldContainerHeight();
 			}, { once: true } );
 		} );
 	}

--- a/assets/src/js/frontend/paypal-commerce/SmartButtons.js
+++ b/assets/src/js/frontend/paypal-commerce/SmartButtons.js
@@ -22,7 +22,7 @@ class SmartButtons extends PaymentMethod {
 	 */
 	getButtonContainer() {
 		const smartButtonWrap = document.createElement( 'div' );
-		this.ccFieldsContainer = this.ccFieldsContainer.length ? this.ccFieldsContainer : this.form.querySelector( '[id^="give_cc_fields-"]' ); // Refresh cc field container selector.
+		this.ccFieldsContainer = this.form.querySelector( '[id^="give_cc_fields-"]' ); // Refresh cc field container selector.
 
 		smartButtonWrap.setAttribute( 'id', '#give-paypal-commerce-smart-buttons-wrap' );
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves javascript issue reported by @kevinwhoffman: https://github.com/impress-org/givewp/pull/5079#issuecomment-689881823

## Description

I figure out that a few javascript logic runs even PayPal Commerce payment gateway is not selected by the donor. I updated logic to setup card field height and calculate height only if PayPal Commerce payment gateway selected.

## Affects
It does not affect donor donation flow.


## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
- run `npm i && npm run dev` before testing this pr.
