### PR TITLE
Hide "Donate Now" button when only PayPal Smart Buttons available for paymant

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -1,6 +1,7 @@
 /* globals paypal, Give, givePayPalCommerce, Event */
 import DonationForm from './DonationForm';
 import PaymentMethod from './PaymentMethod';
+import CustomCardFields from './CustomCardFields';
 
 class AdvancedCardFields extends PaymentMethod {
 	/**
@@ -78,6 +79,9 @@ class AdvancedCardFields extends PaymentMethod {
 
 		if ( this.customCardFields.recurringChoiceHiddenField ) {
 			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceHiddenField, this.toggleFields.bind( this ) );
+			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceHiddenField, () => {
+				DonationForm.toggleDonateNowButton( this.form );
+			} );
 		}
 	}
 
@@ -557,7 +561,7 @@ class AdvancedCardFields extends PaymentMethod {
 	 */
 	toggleFields() {
 		const display = DonationForm.isRecurringDonation( this.form ) ? 'none' : 'block';
-		const canHideParentContainer = 'none' === display && ! this.customCardFields.canShow();
+		const canHideParentContainer = 'none' === display && ! CustomCardFields.canShow( this.form );
 
 		this.toggleCardNameField( canHideParentContainer );
 

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -23,7 +23,7 @@ class CustomCardFields extends PaymentMethod {
 	}
 
 	/**
-	 * @inheritDocregisterEvents
+	 * @inheritDoc
 	 */
 	registerEvents() {
 		if ( this.recurringChoiceHiddenField ) {

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -18,7 +18,6 @@ class CustomCardFields extends PaymentMethod {
 	 * @since 2.9.0
 	 */
 	setUpProperties() {
-		this.payPalSupportedCountriesForCardSubscription = [ 'US', 'AU' ];
 		this.cardFields = this.getCardFields();
 		this.recurringChoiceHiddenField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 	}
@@ -83,7 +82,7 @@ class CustomCardFields extends PaymentMethod {
 	 * @since 2.9.0
 	 */
 	toggleFields() {
-		const display = this.canShow() ? 'block' : 'none';
+		const display = CustomCardFields.canShow( this.form ) ? 'block' : 'none';
 
 		for ( const type in this.cardFields ) {
 			this.cardFields[ type ].el.style.display = display;
@@ -96,12 +95,14 @@ class CustomCardFields extends PaymentMethod {
 	 *
 	 * @since 2.9.0
 	 *
+	 * @param {object} form Form javascript selector
+	 *
 	 * @return {boolean} Return whether or not display custom card fields.
 	 */
-	canShow() {
+	static canShow( form ) {
 		return AdvancedCardFields.canShow() &&
-			DonationForm.isRecurringDonation( this.form ) &&
-			this.payPalSupportedCountriesForCardSubscription.includes( window.givePayPalCommerce.accountCountry );
+			DonationForm.isRecurringDonation( form ) &&
+			[ 'US', 'AU' ].includes( window.givePayPalCommerce.accountCountry );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -1,4 +1,7 @@
 /* globals Give, Promise  */
+import AdvancedCardFields from './AdvancedCardFields';
+import CustomCardFields from './CustomCardFields';
+
 class DonationForm {
 	/**
 	 * Get form Data.
@@ -109,6 +112,25 @@ class DonationForm {
 			attributeFilter: [ 'value' ],
 			attributeOldValue: true,
 		} );
+	}
+
+	/**
+	 * Hide donate now button if only PayPal smart buttons payment method available.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param {object} form form javascript selector.
+	 */
+	static toggleDonateNowButton( form ) {
+		let display = '';
+
+		if ( ! AdvancedCardFields.canShow() ) {
+			display = 'none';
+		} else if ( DonationForm.isRecurringDonation( form ) && ! CustomCardFields.canShow( form ) ) {
+			display = 'none';
+		}
+
+		form.querySelector( 'input[name="give-purchase"]' ).style.display = display;
 	}
 }
 

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -124,9 +124,8 @@ class DonationForm {
 	static toggleDonateNowButton( form ) {
 		let display = '';
 
-		if ( ! AdvancedCardFields.canShow() ) {
-			display = 'none';
-		} else if ( DonationForm.isRecurringDonation( form ) && ! CustomCardFields.canShow( form ) ) {
+		// Hide the buttons if there are no custom credit card fields
+		if ( ! AdvancedCardFields.canShow() || ( DonationForm.isRecurringDonation( form ) && ! CustomCardFields.canShow( form ) ) ) {
 			display = 'none';
 		}
 

--- a/assets/src/js/frontend/paypal-commerce/SmartButtons.js
+++ b/assets/src/js/frontend/paypal-commerce/SmartButtons.js
@@ -60,6 +60,8 @@ class SmartButtons extends PaymentMethod {
 				tagline: false,
 			},
 		} ).render( this.smartButtonContainer );
+
+		DonationForm.toggleDonateNowButton( this.form );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -14,19 +14,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	$formWraps.forEach( $formWrap => {
 		const $form = $formWrap.querySelector( '.give-form' );
 		const smartButtons = new SmartButtons( $form );
+		const customCardFields = new CustomCardFields( $form );
 
 		smartButtons.boot();
 
 		// Boot CustomCardFields class before AdvancedCardFields because of internal dependencies.
 		if ( AdvancedCardFields.canShow() ) {
-			const customCardFields = new CustomCardFields( $form );
 			const advancedCardFields = new AdvancedCardFields( customCardFields );
 
 			customCardFields.boot();
 			advancedCardFields.boot();
 		} else {
-			const customCardFields = new CustomCardFields( $form );
-			customCardFields.removeFields();
+			if ( DonationForm.isPayPalCommerceSelected( jQuery( $form ) ) ) {
+				customCardFields.removeFields();
+			}
+
 			customCardFields.removeFieldsOnGatewayLoad();
 		}
 	} );

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -191,7 +191,8 @@ EOT;
 				// List of style properties support by PayPal for advanced card fields: https://developer.paypal.com/docs/business/checkout/reference/style-guide/#style-the-card-payments-fields
 				'hostedCardFieldStyles'                 => apply_filters( 'give_paypal_commerce_hosted_field_style', [] ),
 				'supportsCustomPayments'                => $merchant->supportsCustomPayments ? 1 : '',
-				'accountCountry'                        => $merchant->accountCountry,
+				// 'accountCountry'                        => $merchant->accountCountry,
+				'accountCountry'                        => 'IN',
 				'separatorLabel'                        => esc_html__( 'Or pay with card', 'give' ),
 			]
 		);

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -191,8 +191,7 @@ EOT;
 				// List of style properties support by PayPal for advanced card fields: https://developer.paypal.com/docs/business/checkout/reference/style-guide/#style-the-card-payments-fields
 				'hostedCardFieldStyles'                 => apply_filters( 'give_paypal_commerce_hosted_field_style', [] ),
 				'supportsCustomPayments'                => $merchant->supportsCustomPayments ? 1 : '',
-				// 'accountCountry'                        => $merchant->accountCountry,
-				'accountCountry'                        => 'IN',
+				'accountCountry'                        => $merchant->accountCountry,
 				'separatorLabel'                        => esc_html__( 'Or pay with card', 'give' ),
 			]
 		);


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5255

## Description
If only PayPal smart buttons available for payment then the "Donate Now" button can confuse the donor. We decided to hide this button when only the smart button available for the "PayPal Donations" payment gateway.

## Affects
This PR does not affect existing logic but implement additional logic to hide the "Donate Now" button.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
- Run  `npm i && npm run dev` before testing.
