### PR TITLE
Milestone now supports a custom link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Milestone now supports sorting forms by tag and category (#5244)
 -   Milestone now supports aggregating different metrics (Revenue, Donations, Donors) (#5244)
 -   Milestone title and description now support {} tags (#5242)
+-   Milestone now supports a custom Call To Action URL and text (#5262)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -53,15 +53,15 @@ class Block {
 						'type'    => 'string',
 						'default' => '',
 					],
-					'cta'         => [
+					'linkText'    => [
 						'type'    => 'string',
 						'default' => __( 'Learn More', 'give' ),
 					],
-					'url'         => [
+					'linkUrl'     => [
 						'type'    => 'string',
 						'default' => '',
 					],
-					'target'      => [
+					'linkTarget'  => [
 						'type'    => 'string',
 						'default' => '_self',
 					],
@@ -88,9 +88,9 @@ class Block {
 				'metric'      => $attributes['metric'],
 				'deadline'    => $attributes['deadline'],
 				'goal'        => $attributes['goal'],
-				'cta'         => $attributes['cta'],
-				'url'         => $attributes['url'],
-				'target'      => $attributes['target'],
+				'linkText'    => $attributes['linkText'],
+				'linkUrl'     => $attributes['linkUrl'],
+				'linkTarget'  => $attributes['linkTarget'],
 			]
 		);
 		return $milestone->getOutput();

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -53,6 +53,10 @@ class Block {
 						'type'    => 'string',
 						'default' => '',
 					],
+					'link'        => [
+						'type'    => 'string',
+						'default' => '',
+					],
 				],
 
 			]

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -53,7 +53,11 @@ class Block {
 						'type'    => 'string',
 						'default' => '',
 					],
-					'link'        => [
+					'cta'         => [
+						'type'    => 'string',
+						'default' => __( 'Learn More', 'give' ),
+					],
+					'url'         => [
 						'type'    => 'string',
 						'default' => '',
 					],
@@ -80,6 +84,8 @@ class Block {
 				'metric'      => $attributes['metric'],
 				'deadline'    => $attributes['deadline'],
 				'goal'        => $attributes['goal'],
+				'cta'         => $attributes['cta'],
+				'url'         => $attributes['url'],
 			]
 		);
 		return $milestone->getOutput();

--- a/src/Milestones/Block.php
+++ b/src/Milestones/Block.php
@@ -61,6 +61,10 @@ class Block {
 						'type'    => 'string',
 						'default' => '',
 					],
+					'target'      => [
+						'type'    => 'string',
+						'default' => '_self',
+					],
 				],
 
 			]
@@ -86,6 +90,7 @@ class Block {
 				'goal'        => $attributes['goal'],
 				'cta'         => $attributes['cta'],
 				'url'         => $attributes['url'],
+				'target'      => $attributes['target'],
 			]
 		);
 		return $milestone->getOutput();

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -15,6 +15,8 @@ class Model {
 	protected $metric;
 	protected $deadline;
 	protected $goal;
+	protected $cta;
+	protected $url;
 
 	// Internal
 	protected $forms = [];
@@ -35,6 +37,8 @@ class Model {
 		isset( $args['metric'] ) ? $this->metric           = $args['metric'] : $this->metric = 'revenue';
 		isset( $args['deadline'] ) ? $this->deadline       = $args['deadline'] : $this->deadline = '';
 		isset( $args['goal'] ) ? $this->goal               = $args['goal'] : $this->goal = '';
+		isset( $args['url'] ) ? $this->url                 = $args['url'] : $this->url = '';
+		isset( $args['cta'] ) ? $this->cta                 = $args['cta'] : $this->cta = __( 'Learn More', 'give' );
 	}
 
 	/**
@@ -172,6 +176,26 @@ class Model {
 	 **/
 	protected function getDeadline() {
 		return $this->deadline;
+	}
+
+	/**
+	 * Get call to action url for Milestone
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	protected function getUrl() {
+		return $this->url;
+	}
+
+	/**
+	 * Get call to action text for Milestone
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	protected function getCta() {
+		return $this->cta;
 	}
 
 	/**

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -15,9 +15,9 @@ class Model {
 	protected $metric;
 	protected $deadline;
 	protected $goal;
-	protected $cta;
-	protected $url;
-	protected $target;
+	protected $linkText;
+	protected $linkUrl;
+	protected $linkTarget;
 
 	// Internal
 	protected $forms = [];
@@ -38,9 +38,9 @@ class Model {
 		isset( $args['metric'] ) ? $this->metric           = $args['metric'] : $this->metric = 'revenue';
 		isset( $args['deadline'] ) ? $this->deadline       = $args['deadline'] : $this->deadline = '';
 		isset( $args['goal'] ) ? $this->goal               = $args['goal'] : $this->goal = '';
-		isset( $args['url'] ) ? $this->url                 = $args['url'] : $this->url = '';
-		isset( $args['cta'] ) ? $this->cta                 = $args['cta'] : $this->cta = __( 'Learn More', 'give' );
-		isset( $args['target'] ) ? $this->target           = $args['target'] : $this->target = '_self';
+		isset( $args['linkUrl'] ) ? $this->linkUrl         = $args['linkUrl'] : $this->linkUrl = '';
+		isset( $args['linkText'] ) ? $this->linkText       = $args['linkText'] : $this->linkText = __( 'Learn More', 'give' );
+		isset( $args['linkTarget'] ) ? $this->linkTarget   = $args['linkTarget'] : $this->linkTarget = '_self';
 	}
 
 	/**
@@ -186,8 +186,8 @@ class Model {
 	 * @return string
 	 * @since 2.9.0
 	 **/
-	protected function getUrl() {
-		return $this->url;
+	protected function getLinkUrl() {
+		return $this->linkUrl;
 	}
 
 	/**
@@ -196,8 +196,8 @@ class Model {
 	 * @return string
 	 * @since 2.9.0
 	 **/
-	protected function getTarget() {
-		return $this->target;
+	protected function getLinkTarget() {
+		return $this->linkTarget;
 	}
 
 	/**
@@ -206,8 +206,8 @@ class Model {
 	 * @return string
 	 * @since 2.9.0
 	 **/
-	protected function getCta() {
-		return $this->cta;
+	protected function getLinkText() {
+		return $this->linkText;
 	}
 
 	/**

--- a/src/Milestones/Model.php
+++ b/src/Milestones/Model.php
@@ -17,6 +17,7 @@ class Model {
 	protected $goal;
 	protected $cta;
 	protected $url;
+	protected $target;
 
 	// Internal
 	protected $forms = [];
@@ -39,6 +40,7 @@ class Model {
 		isset( $args['goal'] ) ? $this->goal               = $args['goal'] : $this->goal = '';
 		isset( $args['url'] ) ? $this->url                 = $args['url'] : $this->url = '';
 		isset( $args['cta'] ) ? $this->cta                 = $args['cta'] : $this->cta = __( 'Learn More', 'give' );
+		isset( $args['target'] ) ? $this->target           = $args['target'] : $this->target = '_self';
 	}
 
 	/**
@@ -186,6 +188,16 @@ class Model {
 	 **/
 	protected function getUrl() {
 		return $this->url;
+	}
+
+	/**
+	 * Get call to action url for Milestone
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	protected function getTarget() {
+		return $this->target;
 	}
 
 	/**

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -52,6 +52,10 @@ const blockAttributes = {
 		type: 'string',
 		default: '',
 	},
+	target: {
+		type: 'string',
+		default: '_self',
+	},
 };
 
 export default blockAttributes;

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -44,6 +44,10 @@ const blockAttributes = {
 		type: 'string',
 		default: '',
 	},
+	link: {
+		type: 'string',
+		default: '',
+	},
 };
 
 export default blockAttributes;

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -44,15 +44,15 @@ const blockAttributes = {
 		type: 'string',
 		default: '',
 	},
-	cta: {
+	linkText: {
 		type: 'string',
 		default: __( 'Learn More', 'give' ),
 	},
-	url: {
+	linkUrl: {
 		type: 'string',
 		default: '',
 	},
-	target: {
+	linkTarget: {
 		type: 'string',
 		default: '_self',
 	},

--- a/src/Milestones/resources/js/data/attributes.js
+++ b/src/Milestones/resources/js/data/attributes.js
@@ -44,7 +44,11 @@ const blockAttributes = {
 		type: 'string',
 		default: '',
 	},
-	link: {
+	cta: {
+		type: 'string',
+		default: __( 'Learn More', 'give' ),
+	},
+	url: {
 		type: 'string',
 		default: '',
 	},

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -19,7 +19,7 @@ import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, categories, tags, metric, goal, deadline, cta, url, target } = attributes;
+	const { title, description, image, ids, categories, tags, metric, goal, deadline, linkText, linkUrl, linkTarget } = attributes;
 	const formOptions = useFormOptions();
 	const tagOptions = useTagOptions();
 	const categoryOptions = useCategoryOptions();
@@ -28,13 +28,13 @@ const Inspector = ( { attributes, setAttributes } ) => {
 			[ name ]: value,
 		} );
 	};
-	const [ openInNewTab, setOpenInNewTab ] = useState( target === '_self' ? false : true );
-	const toggleTarget = ( value ) => {
+	const [ openInNewTab, setOpenInNewTab ] = useState( linkTarget === '_self' ? false : true );
+	const toggleLinkTarget = ( value ) => {
 		setOpenInNewTab( value );
 		if ( value === true ) {
-			saveSetting( 'target', '_blank' );
+			saveSetting( 'linkTarget', '_blank' );
 		} else {
-			saveSetting( 'target', '_self' );
+			saveSetting( 'linkTarget', '_self' );
 		}
 	};
 	return (
@@ -98,22 +98,22 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					onChange={ ( value ) => saveSetting( 'deadline', value ) }
 				/>
 				<TextControl
-					name="cta"
-					label={ __( 'Call To Action', 'give' ) }
-					onChange={ ( value ) => saveSetting( 'cta', value ) }
-					value={ cta }
+					name="linkText"
+					label={ __( 'Link Text', 'give' ) }
+					onChange={ ( value ) => saveSetting( 'linkText', value ) }
+					value={ linkText }
 				/>
 				<TextControl
-					name="url"
+					name="linkUrl"
 					type="url"
-					label={ __( 'Call To Action URL', 'give' ) }
-					onChange={ ( value ) => saveSetting( 'url', value ) }
-					value={ url }
+					label={ __( 'Link URL', 'give' ) }
+					onChange={ ( value ) => saveSetting( 'linkUrl', value ) }
+					value={ linkUrl }
 				/>
 				<ToggleControl
-					name="target"
-					label={ __( 'Open Call To Action in a new tab?', 'give' ) }
-					onChange={ ( value ) => toggleTarget( value ) }
+					name="linkTarget"
+					label={ __( 'Open link in a new tab?', 'give' ) }
+					onChange={ ( value ) => toggleLinkTarget( value ) }
 					checked={ openInNewTab }
 				/>
 			</PanelBody>

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -4,7 +4,6 @@
 const { __ } = wp.i18n;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody, TextControl, SelectControl, TextareaControl } = wp.components;
-const { useSelect } = wp.data;
 
 /**
  * Internal dependencies
@@ -19,7 +18,7 @@ import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, categories, tags, metric, goal, deadline } = attributes;
+	const { title, description, image, ids, categories, tags, metric, goal, deadline, link } = attributes;
 	const formOptions = useFormOptions();
 	const tagOptions = useTagOptions();
 	const categoryOptions = useCategoryOptions();
@@ -87,6 +86,13 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					type="date"
 					value={ deadline }
 					onChange={ ( value ) => saveSetting( 'deadline', value ) }
+				/>
+				<TextControl
+					name="link"
+					type="url"
+					label={ __( 'Custom Link', 'give' ) }
+					onChange={ ( value ) => saveSetting( 'link', value ) }
+					value={ link }
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -18,7 +18,7 @@ import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, categories, tags, metric, goal, deadline, link } = attributes;
+	const { title, description, image, ids, categories, tags, metric, goal, deadline, cta, url } = attributes;
 	const formOptions = useFormOptions();
 	const tagOptions = useTagOptions();
 	const categoryOptions = useCategoryOptions();
@@ -88,11 +88,17 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					onChange={ ( value ) => saveSetting( 'deadline', value ) }
 				/>
 				<TextControl
-					name="link"
+					name="cta"
+					label={ __( 'Call To Action', 'give' ) }
+					onChange={ ( value ) => saveSetting( 'cta', value ) }
+					value={ cta }
+				/>
+				<TextControl
+					name="url"
 					type="url"
-					label={ __( 'Custom Link', 'give' ) }
-					onChange={ ( value ) => saveSetting( 'link', value ) }
-					value={ link }
+					label={ __( 'Call To Action URL', 'give' ) }
+					onChange={ ( value ) => saveSetting( 'url', value ) }
+					value={ url }
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/src/Milestones/resources/js/edit/inspector.js
+++ b/src/Milestones/resources/js/edit/inspector.js
@@ -3,7 +3,8 @@
  */
 const { __ } = wp.i18n;
 const { InspectorControls } = wp.blockEditor;
-const { PanelBody, TextControl, SelectControl, TextareaControl } = wp.components;
+const { PanelBody, TextControl, SelectControl, TextareaControl, ToggleControl } = wp.components;
+const { useState } = wp.element;
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import { useFormOptions, useTagOptions, useCategoryOptions } from '../data/utils
 */
 
 const Inspector = ( { attributes, setAttributes } ) => {
-	const { title, description, image, ids, categories, tags, metric, goal, deadline, cta, url } = attributes;
+	const { title, description, image, ids, categories, tags, metric, goal, deadline, cta, url, target } = attributes;
 	const formOptions = useFormOptions();
 	const tagOptions = useTagOptions();
 	const categoryOptions = useCategoryOptions();
@@ -26,6 +27,15 @@ const Inspector = ( { attributes, setAttributes } ) => {
 		setAttributes( {
 			[ name ]: value,
 		} );
+	};
+	const [ openInNewTab, setOpenInNewTab ] = useState( target === '_self' ? false : true );
+	const toggleTarget = ( value ) => {
+		setOpenInNewTab( value );
+		if ( value === true ) {
+			saveSetting( 'target', '_blank' );
+		} else {
+			saveSetting( 'target', '_self' );
+		}
 	};
 	return (
 		<InspectorControls key="inspector">
@@ -99,6 +109,12 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					label={ __( 'Call To Action URL', 'give' ) }
 					onChange={ ( value ) => saveSetting( 'url', value ) }
 					value={ url }
+				/>
+				<ToggleControl
+					name="target"
+					label={ __( 'Open Call To Action in a new tab?', 'give' ) }
+					onChange={ ( value ) => toggleTarget( value ) }
+					checked={ openInNewTab }
 				/>
 			</PanelBody>
 		</InspectorControls>

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -21,6 +21,11 @@
 		<div class="give-milestone__description">
 			<?php echo $this->getDescription(); ?>
 		</div>
+		<?php if ( ! empty( $this->getUrl() ) && ! empty( $this->getCta() ) ) : ?>
+			<div class="give-milestone__cta">
+				<a href="<?php echo $this->getUrl(); ?>"><?php echo $this->getCta(); ?></a>
+			</div>
+		<?php endif; ?>
 		<?php if ( ! empty( $this->getGoal() ) ) : ?>
 		<div class="give-milestone__progress">
 			<?php $percent = ( $this->getTotal() / $this->getGoal() ) * 100; ?>

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -21,9 +21,9 @@
 		<div class="give-milestone__description">
 			<?php echo $this->getDescription(); ?>
 		</div>
-		<?php if ( ! empty( $this->getUrl() ) && ! empty( $this->getCta() ) ) : ?>
-			<div class="give-milestone__cta">
-				<a href="<?php echo $this->getUrl(); ?>" target="<?php echo $this->getTarget(); ?>"><?php echo $this->getCta(); ?></a>
+		<?php if ( ! empty( $this->getLinkUrl() ) && ! empty( $this->getLinkText() ) ) : ?>
+			<div class="give-milestone__link">
+				<a href="<?php echo $this->getLinkUrl(); ?>" target="<?php echo $this->getLinkTarget(); ?>"><?php echo $this->getLinkText(); ?></a>
 			</div>
 		<?php endif; ?>
 		<?php if ( ! empty( $this->getGoal() ) ) : ?>

--- a/src/Milestones/resources/views/milestone.php
+++ b/src/Milestones/resources/views/milestone.php
@@ -23,7 +23,7 @@
 		</div>
 		<?php if ( ! empty( $this->getUrl() ) && ! empty( $this->getCta() ) ) : ?>
 			<div class="give-milestone__cta">
-				<a href="<?php echo $this->getUrl(); ?>"><?php echo $this->getCta(); ?></a>
+				<a href="<?php echo $this->getUrl(); ?>" target="<?php echo $this->getTarget(); ?>"><?php echo $this->getCta(); ?></a>
 			</div>
 		<?php endif; ?>
 		<?php if ( ! empty( $this->getGoal() ) ) : ?>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5241 

## Description
This PR introduces logic to support a custom Call To Action URL and text associated with the Milestone block. Admin can now customize link text and URL through the Milestone block inspector. 

## Affects
This PR affects frontend Milestone rendering logic as well as admin block editing JS.

## Visuals
<img width="274" alt="Screen Shot 2020-09-14 at 12 19 15 PM" src="https://user-images.githubusercontent.com/5186078/93111801-229cb500-f685-11ea-85f0-e63c3cf21537.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Create a new post or page
2. Add the Milestone block
3. Add a custom Call To Action URL
4. Change the Call To Action text
5. Check that these changes are reflected both in the block preview and on the frontend