### PR TITLE
"donation_id" and "form_id" set as foreign key which reference to "wp_posts.ID"

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -3,7 +3,7 @@
  * Admin View: System Info
  */
 
-use Give\Database\RunMigrations;
+use Give\Framework\Migrations\MigrationsRunner;
 use Give\Helpers\Table;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -523,7 +523,16 @@ $give_updates = Give_Updates::get_instance();
 	<tr>
 		<td data-export-label="Database Updates"><?php _e( 'Database Migrations', 'give' ); ?>:</td>
 		<td class="help"><?php echo Give()->tooltips->render_help( __( 'This will inform you whether database migration completed or not.', 'give' ) ); ?></td>
-		<td><?php echo give( RunMigrations::class )->hasMigrationToRun() ? esc_html__( 'Few Database Migrations still need to run.', 'give' ) : esc_html__( 'All Database Migrations Completed.', 'give' ); ?></td>
+		<td>
+			<?php
+			/* @var MigrationsRunner $migrationRunner */
+			$migrationRunner = give( MigrationsRunner::class );
+
+			echo $migrationRunner->hasMigrationToRun() ?
+				esc_html__( 'Few Database Migrations still need to run.', 'give' ) :
+				esc_html__( 'All Database Migrations Completed.', 'give' );
+			?>
+			</td>
 	</tr>
 	<tr>
 		<td data-export-label="Database Tables"><?php _e( 'Database Tables', 'give' ); ?>:</td>

--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -59,12 +59,13 @@ class MigrationsRunner {
 
 		foreach ( $this->migrationRegister->getMigrations() as $migrationClass ) {
 			/* @var Migration $migrationClass */
-			$migrations[ $migrationClass::timestamp() ] = $migrationClass;
+			$migrations[ $migrationClass ] = $migrationClass::timestamp();
 		}
 
-		ksort( $migrations );
+		asort( $migrations );
 
 		// Process migrations.
+		$migrations    = array_keys( $migrations );
 		$newMigrations = [];
 
 		foreach ( $migrations as $migrationClass ) {

--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -34,7 +34,7 @@ class MigrationsRunner {
 	private $migrationRegister;
 
 	/**
-	 *  RunMigrations constructor.
+	 *  MigrationsRunner constructor.
 	 *
 	 * @param MigrationsRegister $migrationRegister
 	 */
@@ -99,7 +99,7 @@ class MigrationsRunner {
 	 *
 	 * @return bool
 	 */
-	private function hasMigrationToRun() {
+	public function hasMigrationToRun() {
 		return (bool) array_diff( $this->migrationRegister->getRegisteredIds(), $this->completedMigrations );
 	}
 }

--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -59,13 +59,12 @@ class MigrationsRunner {
 
 		foreach ( $this->migrationRegister->getMigrations() as $migrationClass ) {
 			/* @var Migration $migrationClass */
-			$migrations[ $migrationClass ] = $migrationClass::timestamp();
+			$migrations[ $migrationClass::timestamp() . '_' . $migrationClass::id() ] = $migrationClass;
 		}
 
-		asort( $migrations );
+		ksort( $migrations );
 
 		// Process migrations.
-		$migrations    = array_keys( $migrations );
 		$newMigrations = [];
 
 		foreach ( $migrations as $migrationClass ) {

--- a/src/Revenue/Migrations/CreateRevenueTable.php
+++ b/src/Revenue/Migrations/CreateRevenueTable.php
@@ -38,11 +38,11 @@ class CreateRevenueTable extends Migration {
 
 		$sql = "CREATE TABLE {$tableName} (
   			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  			donation_id bigint(20) NOT NULL,
-  			form_id bigint(20) NOT NULL,
+  			donation_id bigint(20) UNSIGNED NOT NULL,
+  			form_id bigint(20) UNSIGNED NOT NULL,
   			amount int UNSIGNED NOT NULL,
-  			PRIMARY KEY  (id)
-  			FOREIGN KEY (donation_id) REFERENCES {$referencedTableName}(ID)
+  			PRIMARY KEY  (id),
+  			FOREIGN KEY (donation_id) REFERENCES {$referencedTableName}(ID),
   			FOREIGN KEY (form_id) REFERENCES {$referencedTableName}(ID)
 		) {$charset_collate};";
 

--- a/src/Revenue/Migrations/CreateRevenueTable.php
+++ b/src/Revenue/Migrations/CreateRevenueTable.php
@@ -32,8 +32,9 @@ class CreateRevenueTable extends Migration {
 	public function run() {
 		global $wpdb;
 
-		$charset_collate = $wpdb->get_charset_collate();
-		$tableName       = "{$wpdb->prefix}give_revenue";
+		$charset_collate     = $wpdb->get_charset_collate();
+		$tableName           = "{$wpdb->prefix}give_revenue";
+		$referencedTableName = "{$wpdb->prefix}posts";
 
 		$sql = "CREATE TABLE {$tableName} (
   			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -41,6 +42,8 @@ class CreateRevenueTable extends Migration {
   			form_id bigint(20) NOT NULL,
   			amount int UNSIGNED NOT NULL,
   			PRIMARY KEY  (id)
+  			FOREIGN KEY (donation_id) REFERENCES {$referencedTableName}(ID)
+  			FOREIGN KEY (form_id) REFERENCES {$referencedTableName}(ID)
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5272

## Description
`donation_id` and `form_id`  set as foreign key which reference to `wp_posts.ID`.

## Affects
- I fixed a PHP error that generates on the system info page because of referencing old class.
- Update logic to prevent migration overwrite if has the same timestamp.

## Visuals
![image](https://user-images.githubusercontent.com/1784821/93483851-e2f0fa00-f91e-11ea-8155-7eb5b09079ff.png)

## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
If you want to rerun Migration then make sure you complete below steps:
- [ ] Remove `wp_give_reveneue` table
- [ ] Remove `give_database_migrations` from `wp_options`.
