### PR TITLE
Improve country handling in onboarding

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -593,6 +593,8 @@ a.give-delete {
 // Paypal setting page
 //--------------------------------------------------------------
 .give-settings-paypal-section {
+	// Hide with position helps element to keep browser computed styling like width.
+	// Few javascript extensions use browser computed styling. for example: chosen uses browser computed style to style custom select field.
 	.hide-with-position {
 		position: absolute;
 		top: -9999px;

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -592,6 +592,14 @@ a.give-delete {
 //--------------------------------------------------------------
 // Paypal setting page
 //--------------------------------------------------------------
+.give-settings-paypal-section {
+	.hide-with-position {
+		position: absolute;
+		top: -9999px;
+		left: -9999px;
+	}
+}
+
 #give-paypal-commerce-account-manager-field-wrap {
 	.connect-button-wrap {
 		display: flex;

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -421,7 +421,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				successConfirm: () => {
 					connectionSettingContainer.classList.remove( 'give-hidden' );
 					disConnectionSettingContainer.classList.add( 'give-hidden' );
-					countryFieldContainer.classList.remove( 'give-hidden' );
+					countryFieldContainer.classList.remove( 'hide-with-position' );
 
 					fetch( ajaxurl + '?action=give_paypal_commerce_disconnect_account' );
 				},

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -388,6 +388,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		onBoardingButton.addEventListener( 'click', function( evt ) {
 			evt.preventDefault();
 
+			onBoardingButton.disabled = true;
+
 			evt.target.innerText = Give.fn.getGlobalVar( 'loader_translation' ).processing;
 
 			const countryCode = countryField.value;

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -29,8 +29,8 @@ jQuery( document ).ready( function( $ ) {
 	const give_settings_position = '#give-mainform #currency_position';
 	$( 'body' ).on( 'change', give_settings_currency, function() {
 		const $currency = $( give_settings_currency + ' option:selected' ),
-			  currencyCode = $currency.val(),
-			  currencyList = JSON.parse( $( this ).attr( 'data-formatting-setting' ) );
+			currencyCode = $currency.val(),
+			currencyList = JSON.parse( $( this ).attr( 'data-formatting-setting' ) );
 
 		let beforeText = afterText = {},
 			formattingSetting = currencyList[ currencyCode ],
@@ -190,9 +190,9 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	let dTemp = Give.fn.getGlobalVar( 'decimal_separator' ), // Temporary variable to store decimal separator.
-	    tTemp = Give.fn.getGlobalVar( 'thousands_separator' ), // Temporary variable to store thousand separator.
-	    symbolRegex = /\(([^)]+)\)/, // Regex to extract currency symbol.
-	    formatterArgs = {
+		tTemp = Give.fn.getGlobalVar( 'thousands_separator' ), // Temporary variable to store thousand separator.
+		symbolRegex = /\(([^)]+)\)/, // Regex to extract currency symbol.
+		formatterArgs = {
 			position: Give.fn.getGlobalVar( 'currency_pos' ),
 			symbol: Give.fn.getGlobalVar( 'currency_sign' ),
 			precision: Give.fn.getGlobalVar( 'number_decimals' ),
@@ -207,10 +207,10 @@ jQuery( document ).ready( function( $ ) {
 	 */
 	$( '#number_decimals, #decimal_separator, #thousands_separator, #currency_position, #currency' ).on( 'input blur change', function( e ) {
 		const preview = $( '#currency_preview' ),
-		    dSeparator = $( '#decimal_separator' ),
-		    tSeparator = $( '#thousands_separator' ),
-		    targetName = e.target.name,
-		    targetValue = e.target.value;
+			dSeparator = $( '#decimal_separator' ),
+			tSeparator = $( '#thousands_separator' ),
+			targetName = e.target.name,
+			targetValue = e.target.value;
 
 		/**
 		 * Sets the precision (number of decimals) for the formatted amount.
@@ -378,9 +378,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 // Handle paypal onboarding.
 document.addEventListener( 'DOMContentLoaded', () => {
 	const onBoardingButton = document.getElementById( 'js-give-paypal-on-boarding-handler' ),
-		  disconnectPayPalAccountButton = document.getElementById( 'js-give-paypal-disconnect-paypal-account' ),
-		  connectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .connection-setting' ),
-		  disConnectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .disconnection-setting' );
+		disconnectPayPalAccountButton = document.getElementById( 'js-give-paypal-disconnect-paypal-account' ),
+		connectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .connection-setting' ),
+		disConnectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .disconnection-setting' );
 
 	if ( onBoardingButton ) {
 		onBoardingButton.addEventListener( 'click', function( evt ) {
@@ -388,7 +388,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 			evt.target.innerText = Give.fn.getGlobalVar( 'loader_translation' ).processing;
 
-			fetch( ajaxurl + '?action=give_paypal_commerce_get_partner_url' )
+			const countryCode = document.getElementById( 'paypal_commerce_account_country' ).value;
+
+			fetch( ajaxurl + `?action=give_paypal_commerce_get_partner_url&countryCode=${ countryCode }` )
 				.then( response => response.json() )
 				.then( function( res ) {
 					// @todo handle error.

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -380,7 +380,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const onBoardingButton = document.getElementById( 'js-give-paypal-on-boarding-handler' ),
 		disconnectPayPalAccountButton = document.getElementById( 'js-give-paypal-disconnect-paypal-account' ),
 		connectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .connection-setting' ),
-		disConnectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .disconnection-setting' );
+		disConnectionSettingContainer = document.querySelector( '#give-paypal-commerce-account-manager-field-wrap .disconnection-setting' ),
+		countryField = document.getElementById( 'paypal_commerce_account_country' ),
+		countryFieldContainer = countryField.parentElement.parentElement;
 
 	if ( onBoardingButton ) {
 		onBoardingButton.addEventListener( 'click', function( evt ) {
@@ -388,7 +390,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 			evt.target.innerText = Give.fn.getGlobalVar( 'loader_translation' ).processing;
 
-			const countryCode = document.getElementById( 'paypal_commerce_account_country' ).value;
+			const countryCode = countryField.value;
 
 			fetch( ajaxurl + `?action=give_paypal_commerce_get_partner_url&countryCode=${ countryCode }` )
 				.then( response => response.json() )
@@ -419,6 +421,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				successConfirm: () => {
 					connectionSettingContainer.classList.remove( 'give-hidden' );
 					disConnectionSettingContainer.classList.add( 'give-hidden' );
+					countryFieldContainer.classList.remove( 'give-hidden' );
 
 					fetch( ajaxurl + '?action=give_paypal_commerce_disconnect_account' );
 				},

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -38,7 +38,7 @@ class AdminSettingFields {
 		/* @var MerchantDetails $merchantRepository */
 		$merchantRepository = give( MerchantDetails::class );
 		?>
-		<tr valign="top" class="<?php echo $merchantRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
+		<tr valign="top" class="js-fields-has-custom-saving-logic<?php echo $merchantRepository->accountIsConnected() ? ' give-hidden' : ''; ?>">
 			<th scope="row" class="titledesc">
 				<label for="give_paypal_commerce_country"><?php esc_html_e( 'Account Country', 'give' ); ?></label>
 			</th>

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -33,54 +33,52 @@ class AdminSettingFields {
 		$recurringAddonInfo     = Give_License::get_plugin_by_slug( 'give-recurring' );
 		$isRecurringAddonActive = isset( $recurringAddonInfo['Status'] ) && 'active' === $recurringAddonInfo['Status'];
 		?>
-		<table class="form-table give-setting-tab-body give-setting-tab-body-gateways">
-			<tbody>
-				<tr valign="top">
-					<th scope="row" class="titledesc">
-						<label for="give_paypal_commerce_country"><?php esc_html_e( 'PayPal Connection', 'give' ); ?></label>
-					</th>
-					<td class="give-forminp give-forminp-select">
-						<div id="give-paypal-commerce-account-manager-field-wrap">
-							<div class="connect-button-wrap">
-								<?php
-								/** @var MerchantDetails $accountRepository */
-								$accountRepository = give( MerchantDetails::class );
-								?>
-								<div
-									class="button-wrap connection-setting <?php echo $accountRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
-									<div>
-										<button class="button button-primary button-large" id="js-give-paypal-on-boarding-handler">
-											<i class="fab fa-paypal"></i>&nbsp;&nbsp;
-											<?php
-											esc_html_e(
-												'Connect with PayPal',
-												'give'
-											);
-											?>
-										</button>
-										<a class="give-hidden" target="_blank"
-										   data-paypal-onboard-complete="givePayPalOnBoardedCallback" href="#"
-										   data-paypal-button="true">
-											<?php esc_html_e( 'Sign up for PayPal', 'give' ); ?>
-										</a>
-										<span class="tooltip">
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="give_paypal_commerce_country"><?php esc_html_e( 'PayPal Connection', 'give' ); ?></label>
+			</th>
+			<td class="give-forminp">
+				<div id="give-paypal-commerce-account-manager-field-wrap">
+					<div class="connect-button-wrap">
+						<?php
+						/** @var MerchantDetails $accountRepository */
+						$accountRepository = give( MerchantDetails::class );
+						?>
+						<div
+							class="button-wrap connection-setting <?php echo $accountRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
+							<div>
+								<button class="button button-primary button-large" id="js-give-paypal-on-boarding-handler">
+									<i class="fab fa-paypal"></i>&nbsp;&nbsp;
+									<?php
+									esc_html_e(
+										'Connect with PayPal',
+										'give'
+									);
+									?>
+								</button>
+								<a class="give-hidden" target="_blank"
+								   data-paypal-onboard-complete="givePayPalOnBoardedCallback" href="#"
+								   data-paypal-button="true">
+									<?php esc_html_e( 'Sign up for PayPal', 'give' ); ?>
+								</a>
+								<span class="tooltip">
 							<span class="left-arrow"></span>
 							<?php esc_html_e( 'Click to get started!', 'give' ); ?>
 						</span>
-									</div>
-									<span class="give-field-description">
+							</div>
+							<span class="give-field-description">
 							<i class="fa fa-exclamation"></i>
 							<?php esc_html_e( 'PayPal is currently NOT connected.', 'give' ); ?>
 						</span>
-								</div>
-								<div
-									class="button-wrap disconnection-setting <?php echo ! $accountRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
-									<div>
-										<button class="button button-large disabled" disabled="disabled">
-											<i class="fab fa-paypal"></i>&nbsp;&nbsp;<?php esc_html_e( 'Connected', 'give' ); ?>
-										</button>
-									</div>
-									<div>
+						</div>
+						<div
+							class="button-wrap disconnection-setting <?php echo ! $accountRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
+							<div>
+								<button class="button button-large disabled" disabled="disabled">
+									<i class="fab fa-paypal"></i>&nbsp;&nbsp;<?php esc_html_e( 'Connected', 'give' ); ?>
+								</button>
+							</div>
+							<div>
 						<span class="give-field-description">
 							<i class="fa fa-check"></i>
 							<?php
@@ -91,25 +89,25 @@ class AdminSettingFields {
 							);
 							?>
 						</span>
-										<span class="actions">
+								<span class="actions">
 							<a href="#"
 							   id="js-give-paypal-disconnect-paypal-account"><?php esc_html_e( 'Disconnect', 'give' ); ?></a>
 						</span>
-									</div>
-									<div class="api-access-feature-list-wrap">
-										<p><?php esc_html_e( 'APIs Connected:', 'give' ); ?></p>
-										<ul>
-											<li><?php esc_html_e( 'Payments', 'give' ); ?></li>
-											<?php if ( $isRecurringAddonActive ) : ?>
-												<li><?php esc_html_e( 'Subscriptions', 'give' ); ?></li>
-											<?php endif; ?>
-											<li><?php esc_html_e( 'Refunds', 'give' ); ?></li>
-										</ul>
-									</div>
+							</div>
+							<div class="api-access-feature-list-wrap">
+								<p><?php esc_html_e( 'APIs Connected:', 'give' ); ?></p>
+								<ul>
+									<li><?php esc_html_e( 'Payments', 'give' ); ?></li>
+									<?php if ( $isRecurringAddonActive ) : ?>
+										<li><?php esc_html_e( 'Subscriptions', 'give' ); ?></li>
+									<?php endif; ?>
+									<li><?php esc_html_e( 'Refunds', 'give' ); ?></li>
+								</ul>
+							</div>
 
-									<?php $accountErrors = give( MerchantDetails::class )->getAccountErrors(); ?>
-									<?php if ( ! empty( $accountErrors ) ) : ?>
-										<div>
+							<?php $accountErrors = give( MerchantDetails::class )->getAccountErrors(); ?>
+							<?php if ( ! empty( $accountErrors ) ) : ?>
+								<div>
 							<span>
 								<p class="error-message"><?php esc_html_e( 'Warning, your account is not ready to accept donations. Please review the following list:', 'give' ); ?></p>
 								<ul class="ul-disc">
@@ -121,17 +119,15 @@ class AdminSettingFields {
 								</ul>
 								<p><a href="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal&paypalStatusCheck' ); ?>"><?php esc_html_e( 'Re-Check Account Status', 'give' ); ?></a></p>
 							</span>
-										</div>
-									<?php endif; ?>
 								</div>
-
-							</div>
-							<?php echo UpsellNotice::recurringAddon(); ?>
+							<?php endif; ?>
 						</div>
-					</td>
-				</tr>
-			</tbody>
-		</table>
+
+					</div>
+					<?php echo UpsellNotice::recurringAddon(); ?>
+				</div>
+			</td>
+		</tr>
 		<?php
 	}
 

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -32,10 +32,13 @@ class AdminSettingFields {
 	 * @since 2.9.0
 	 */
 	public function accountCountryField() {
-		/* @var MerchantDetail $merchantDetails */
-		$merchantDetails = give( MerchantDetail::class );
+		/* @var MerchantDetail $merchantModel */
+		$merchantModel = give( MerchantDetail::class );
+
+		/* @var MerchantDetails $merchantRepository */
+		$merchantRepository = give( MerchantDetails::class );
 		?>
-		<tr valign="top">
+		<tr valign="top" class="<?php echo $merchantRepository->accountIsConnected() ? 'give-hidden' : ''; ?>">
 			<th scope="row" class="titledesc">
 				<label for="give_paypal_commerce_country"><?php esc_html_e( 'Account Country', 'give' ); ?></label>
 			</th>
@@ -55,7 +58,7 @@ class AdminSettingFields {
 						'data'             => [
 							'search-type' => 'no_ajax',
 						],
-						'selected'         => $merchantDetails->accountCountry ?: give_get_country(),
+						'selected'         => $merchantModel->accountCountry ?: give_get_country(),
 					]
 				);
 

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -34,7 +34,6 @@ class AdminSettingFields {
 	public function accountCountryField() {
 		/* @var MerchantDetail $merchantDetails */
 		$merchantDetails = give( MerchantDetail::class );
-
 		?>
 		<tr valign="top">
 			<th scope="row" class="titledesc">

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -38,36 +38,41 @@ class AdminSettingFields {
 
 		/* @var MerchantDetails $merchantRepository */
 		$merchantRepository = give( MerchantDetails::class );
+
+		/* @var Give_HTML_Elements $htmlElements */
+		$htmlElements = give( 'html' );
+
+		/* @var Settings $settingRepository */
+		$settingRepository = give( Settings::class );
+
+		$settingHtml = $htmlElements->select(
+			[
+				'id'               => 'paypal_commerce_account_country',
+				'options'          => give_get_country_list(),
+				'chosen'           => true,
+				'placeholder'      => esc_html__( 'Choose a country', 'give' ),
+				'show_option_all'  => false,
+				'show_option_none' => false,
+				'data'             => [
+					'search-type' => 'no_ajax',
+				],
+				'selected'         => $merchantModel->accountCountry ?: $settingRepository->getAccountCountry(),
+			]
+		);
+
+		$trClass = $merchantRepository->accountIsConnected() ?
+			'js-fields-has-custom-saving-logic hide-with-position' :
+			'js-fields-has-custom-saving-logic';
 		?>
-		<tr valign="top" class="js-fields-has-custom-saving-logic<?php echo $merchantRepository->accountIsConnected() ? ' hide-with-position' : ''; ?>">
+		<tr valign="top" class="<?php echo $trClass; ?>">
 			<th scope="row" class="titledesc">
 				<label for="give_paypal_commerce_country"><?php esc_html_e( 'Account Country', 'give' ); ?></label>
 			</th>
 			<td class="give-forminp">
 				<?php
-				/* @var Give_HTML_Elements $htmlElements */
-				$htmlElements = give( 'html' );
-
-				/* @var Settings $settingRepository */
-				$settingRepository = give( Settings::class );
-
-				echo $htmlElements->select(
-					[
-						'id'               => 'paypal_commerce_account_country',
-						'options'          => give_get_country_list(),
-						'chosen'           => true,
-						'placeholder'      => esc_html__( 'Choose a country', 'give' ),
-						'show_option_all'  => false,
-						'show_option_none' => false,
-						'data'             => [
-							'search-type' => 'no_ajax',
-						],
-						'selected'         => $merchantModel->accountCountry ?: $settingRepository->getAccountCountry(),
-					]
-				);
-
 				printf(
-					'<div class="give-field-description">%1$s</div>',
+					'%1$s<div class="give-field-description">%2$s</div>',
+					$settingHtml,
 					esc_html__( 'The country your site operates from.', 'give' )
 				)
 				?>

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -4,9 +4,7 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
-use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\Views\Admin\UpsellNotice;
-use Give_Admin_Settings;
 use Give_HTML_Elements;
 use Give_License;
 

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -4,7 +4,10 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
+use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\Views\Admin\UpsellNotice;
+use Give_Admin_Settings;
+use Give_HTML_Elements;
 use Give_License;
 
 /**
@@ -21,7 +24,52 @@ class AdminSettingFields {
 	 */
 	public function boot() {
 		add_action( 'give_admin_field_paypal_commerce_account_manger', [ $this, 'payPalCommerceAccountManagerField' ] );
+		add_action( 'give_admin_field_paypal_commerce_account_country', [ $this, 'accountCountryField' ] );
 		add_action( 'give_admin_field_paypal_commerce_introduction', [ $this, 'introductionSection' ] );
+	}
+
+	/**
+	 * Render account country field.
+	 *
+	 * @since 2.9.0
+	 */
+	public function accountCountryField() {
+		/* @var MerchantDetail $merchantDetails */
+		$merchantDetails = give( MerchantDetail::class );
+
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="give_paypal_commerce_country"><?php esc_html_e( 'Account Country', 'give' ); ?></label>
+			</th>
+			<td class="give-forminp">
+				<?php
+				/* @var Give_HTML_Elements $htmlElements */
+				$htmlElements = give( 'html' );
+
+				echo $htmlElements->select(
+					[
+						'id'               => 'paypal_commerce_account_country',
+						'options'          => give_get_country_list(),
+						'chosen'           => true,
+						'placeholder'      => esc_html__( 'Choose a country', 'give' ),
+						'show_option_all'  => false,
+						'show_option_none' => false,
+						'data'             => [
+							'search-type' => 'no_ajax',
+						],
+						'selected'         => $merchantDetails->accountCountry ?: give_get_country(),
+					]
+				);
+
+				printf(
+					'<div class="give-field-description">%1$s</div>',
+					esc_html__( 'The country your site operates from.', 'give' )
+				)
+				?>
+			</td>
+		</tr>
+		<?php
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -4,6 +4,7 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
+use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\Views\Admin\UpsellNotice;
 use Give_HTML_Elements;
 use Give_License;
@@ -47,6 +48,9 @@ class AdminSettingFields {
 				/* @var Give_HTML_Elements $htmlElements */
 				$htmlElements = give( 'html' );
 
+				/* @var Settings $settingRepository */
+				$settingRepository = give( Settings::class );
+
 				echo $htmlElements->select(
 					[
 						'id'               => 'paypal_commerce_account_country',
@@ -58,7 +62,7 @@ class AdminSettingFields {
 						'data'             => [
 							'search-type' => 'no_ajax',
 						],
-						'selected'         => $merchantModel->accountCountry ?: give_get_country(),
+						'selected'         => $merchantModel->accountCountry ?: $settingRepository->getAccountCountry(),
 					]
 				);
 

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -39,7 +39,7 @@ class AdminSettingFields {
 		/* @var MerchantDetails $merchantRepository */
 		$merchantRepository = give( MerchantDetails::class );
 		?>
-		<tr valign="top" class="js-fields-has-custom-saving-logic<?php echo $merchantRepository->accountIsConnected() ? ' give-hidden' : ''; ?>">
+		<tr valign="top" class="js-fields-has-custom-saving-logic<?php echo $merchantRepository->accountIsConnected() ? ' hide-with-position' : ''; ?>">
 			<th scope="row" class="titledesc">
 				<label for="give_paypal_commerce_country"><?php esc_html_e( 'Account Country', 'give' ); ?></label>
 			</th>

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -122,15 +122,20 @@ class AjaxRequestHandler {
 	public function onGetPartnerUrlAjaxRequestHandler() {
 		$this->validateAdminRequest();
 
+		if ( empty( $country = $_GET['countryCode'] ) || ! isset( give_get_country_list()[ $country ] ) ) {
+			wp_send_json_error( 'Must include valid 2-character country code' );
+		}
+
 		$data = $this->payPalAuth->getSellerPartnerLink(
 			admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal&group=paypal-commerce' ),
-			$this->settings->getAccountCountry()
+			$country
 		);
 
 		if ( ! $data ) {
 			wp_send_json_error();
 		}
 
+		$this->settings->updateAccountCountry( $country );
 		$this->settings->updatePartnerLinkDetails( $data );
 
 		wp_send_json_success( $data );
@@ -235,6 +240,7 @@ class AjaxRequestHandler {
 	 * @since 2.9.0
 	 */
 	private function validateAdminRequest() {
+
 		if ( ! current_user_can( 'manage_give_settings' ) ) {
 			wp_die();
 		}

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -4,6 +4,7 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\Helpers\Hooks;
 use Give\PaymentGateways\PaymentGateway;
+use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookChecker;
@@ -43,7 +44,7 @@ class PayPalCommerce implements PaymentGateway {
 	 * @inheritDoc
 	 */
 	public function getOptions() {
-		$options = [
+		return [
 			[
 				'type'       => 'title',
 				'id'         => 'give_gateway_settings_1',
@@ -63,6 +64,11 @@ class PayPalCommerce implements PaymentGateway {
 				'id'   => 'give_gateway_settings_2',
 			],
 			[
+				'name' => esc_html__( 'Account Country', 'give' ),
+				'id'   => 'paypal_commerce_account_country',
+				'type' => 'paypal_commerce_account_country',
+			],
+			[
 				'name' => esc_html__( 'Connect With Paypal', 'give' ),
 				'id'   => 'paypal_commerce_account_manger',
 				'type' => 'paypal_commerce_account_manger',
@@ -72,30 +78,6 @@ class PayPalCommerce implements PaymentGateway {
 				'id'   => 'give_gateway_settings_2',
 			],
 		];
-
-		if ( ! give( MerchantDetails::class )->accountIsConnected() ) {
-			array_splice(
-				$options,
-				4,
-				0,
-				[
-					[
-						'name'       => __( 'Account Country', 'give' ),
-						'desc'       => __( 'The country of your PayPal account.', 'give' ),
-						'id'         => Settings::COUNTRY_KEY,
-						'type'       => 'select',
-						'options'    => give_get_country_list(),
-						'class'      => 'give-select give-select-chosen',
-						'attributes' => [
-							'data-search-type' => 'no_ajax',
-						],
-						'default'    => give_get_country(),
-					],
-				]
-			);
-		}
-
-		return $options;
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -4,9 +4,6 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\Helpers\Hooks;
 use Give\PaymentGateways\PaymentGateway;
-use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
-use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
-use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookChecker;
 
 /**

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -4,6 +4,7 @@ namespace Give\PaymentGateways\PayPalCommerce;
 
 use Give\Helpers\Hooks;
 use Give\PaymentGateways\PaymentGateway;
+use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookChecker;
 
@@ -42,7 +43,7 @@ class PayPalCommerce implements PaymentGateway {
 	 * @inheritDoc
 	 */
 	public function getOptions() {
-		return [
+		$options = [
 			[
 				'type'       => 'title',
 				'id'         => 'give_gateway_settings_1',
@@ -62,18 +63,6 @@ class PayPalCommerce implements PaymentGateway {
 				'id'   => 'give_gateway_settings_2',
 			],
 			[
-				'name'       => __( 'Account Country', 'give' ),
-				'desc'       => __( 'The country of your PayPal account.', 'give' ),
-				'id'         => Settings::COUNTRY_KEY,
-				'type'       => 'select',
-				'options'    => give_get_country_list(),
-				'class'      => 'give-select give-select-chosen',
-				'attributes' => [
-					'data-search-type' => 'no_ajax',
-				],
-				'default'    => give_get_country(),
-			],
-			[
 				'name' => esc_html__( 'Connect With Paypal', 'give' ),
 				'id'   => 'paypal_commerce_account_manger',
 				'type' => 'paypal_commerce_account_manger',
@@ -83,6 +72,30 @@ class PayPalCommerce implements PaymentGateway {
 				'id'   => 'give_gateway_settings_2',
 			],
 		];
+
+		if ( ! give( MerchantDetails::class )->accountIsConnected() ) {
+			array_splice(
+				$options,
+				4,
+				0,
+				[
+					[
+						'name'       => __( 'Account Country', 'give' ),
+						'desc'       => __( 'The country of your PayPal account.', 'give' ),
+						'id'         => Settings::COUNTRY_KEY,
+						'type'       => 'select',
+						'options'    => give_get_country_list(),
+						'class'      => 'give-select give-select-chosen',
+						'attributes' => [
+							'data-search-type' => 'no_ajax',
+						],
+						'default'    => give_get_country(),
+					],
+				]
+			);
+		}
+
+		return $options;
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
@@ -32,7 +32,7 @@ class Settings {
 	 * @return string|null
 	 */
 	public function getAccountCountry() {
-		return give_get_option( self::COUNTRY_KEY, give_get_country() );
+		return get_option( self::COUNTRY_KEY, give_get_country() );
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
@@ -47,6 +47,17 @@ class Settings {
 	}
 
 	/**
+	 * Updates the country account
+	 *
+	 * @param string $country
+	 *
+	 * @return bool
+	 */
+	public function updateAccountCountry( $country ) {
+		return update_option( self::COUNTRY_KEY, $country );
+	}
+
+	/**
 	 * Updates the account access token
 	 *
 	 * @param $token

--- a/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
@@ -117,7 +117,7 @@ class onBoardingRedirectHandler {
 		$payPalAccount['token']                  = $tokenInfo;
 		$payPalAccount['supportsCustomPayments'] = 'PPCP' === $partnerLinkInfo['product'];
 		$payPalAccount['accountIsReady']         = true;
-		$payPalAccount['accountCountry']         = give( Settings::class )->getAccountCountry();
+		$payPalAccount['accountCountry']         = $this->settings->getAccountCountry();
 
 		$merchantDetails = MerchantDetail::fromArray( $payPalAccount );
 		$this->merchantRepository->save( $merchantDetails );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5140 

## Description

The goal of this PR is to simplify the onboarding process such that it is no longer necessary to save the settings for the country code to be applied. Instead, pass the country code via ajax for the partner link.

Ultimately it should perform like the following:

### When the account is not connected
- Display the country field
- Hide all other fields
- When the "Connect with PayPal" button is clicked, pass the country so it's not necessary to "save settings"

### When the account is connected
- Hide the country field
- Show other settings (when there are any)
- Show the connected account details

## Affects

PayPal Commerce onboarding process

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Will fill out once completed