### PR TITLE
Fix: Multi checkbox options handling

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -184,8 +184,8 @@ class Give_MetaBox_Form_Data {
 								],
 								'options'       => [
 									'display_label' => __( 'Donation Limits: ', 'give' ),
-									'minimum'       => give_format_decimal( ['amount' => '5.00' ] ),
-									'maximum'       => give_format_decimal( ['amount' => '999999.99' ] ),
+									'minimum'       => give_format_decimal( [ 'amount' => '5.00' ] ),
+									'maximum'       => give_format_decimal( [ 'amount' => '999999.99' ] ),
 								],
 							],
 							[
@@ -949,7 +949,7 @@ class Give_MetaBox_Form_Data {
 				// Set default value for checkbox fields.
 				if (
 					! isset( $_POST[ $form_meta_key ] ) &&
-					in_array( $this->get_field_type( $form_meta_key ), [ 'checkbox', 'chosen' ] )
+					in_array( $this->get_field_type( $form_meta_key ), [ 'checkbox', 'chosen', 'multicheck' ] )
 				) {
 					$_POST[ $form_meta_key ] = '';
 				}


### PR DESCRIPTION

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5276 

## Description

This PR solves the issue by adding "multicheck" type to the list of types for handling default properties.

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->


1. Add this piece of code to `functions.php`
```php
add_filter( 'give_metabox_form_data_settings', function( $sections, $formId ) {

	$fields = [
		[
			'id'            => 'give_multicheck_options_admin',
			'name'          => 'Multiple checkbox test',
			'default'       => 1,
			'type'          => 'multicheck',
			'wrapper_class' => 'give_multicheck_options_admin',
			'options'       => [
				'option1' => 'Multi checkbox option 1',
				'option2' => 'Multi checkbox option 2',
				'option3' => 'Multi checkbox option 3',
			],
			'desc' => 'Example of multi checkbox options per setting'
		],
	];

	$sections['form_multicheckbox_test_options'] = [
		'id'     => 'form_test_multicheckbox_options',
		'title'  => esc_html__( 'Test multi checkbox', 'give' ),
		'fields' => $fields,
	];

	return $sections;

}, 10, 2 );

```

2. Go to Edit Donation screen 
3. Check exactly one option and save
4. Now uncheck that option and save

