### PR TITLE
Campaigns UI now differentiates title from preview heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Campaigns UI scaffolded. (#5280)
 -   Campaigns Featured Image block syncs with post featured image. (#5284)
 
+### Changed
+-   Campaigns preview heading is differentiated from the post title. (#5285)
+
 ## [2.8.0] - 2020-08-31
 
 ## [2.8.0-rc.1] - 2020-08-31

--- a/src/Campaigns/config/give_campaigns.cpt.php
+++ b/src/Campaigns/config/give_campaigns.cpt.php
@@ -71,8 +71,7 @@ return [
 				[
 					'core/heading',
 					[
-						'placeholder' => 'Title',
-						'content'     => 'Giving Tuesday',
+						'placeholder' => 'Add a heading',
 					],
 				],
 				[

--- a/src/Campaigns/resources/editor-styles.scss
+++ b/src/Campaigns/resources/editor-styles.scss
@@ -7,11 +7,6 @@
 		display: none;
 	}
 
-	/* Hide the default post title input. */
-	.edit-post-visual-editor__post-title-wrapper {
-		display: none;
-	}
-
 	/* Set custom editor width. */
 	.wp-block {
 		max-width: 1100px;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5282

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Restores the post title UI for the Campaign post type.
- Updates the `<Heading />` Inner Block to differentiate from the post title.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/93926587-b43f9e80-fce5-11ea-9612-706d87247740.png)

![image](https://user-images.githubusercontent.com/10858303/93927226-9292e700-fce6-11ea-8929-254bf9d8cd2e.png)



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Keyboard accessible
-   [ ] Screen reader accessible
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Set a post title
- Set a preview heading, different than the post title

## User Documentation

<!-- Note any user-facing docs that should be added or updated. Delete if not relevant. -->
