### PR TITLE
Campaigns progress bar uses the theme's editor color palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 -   Campaigns preview heading is differentiated from the post title. (#5285)
 -   Campaigns Progress Block contains Progress Bar and Footer Stats. (#5290)
+-   Campaigns progress bar uses the theme's editor color palette. (#5300)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -45,6 +45,15 @@ class ServiceProvider implements \Give\ServiceProviders\ServiceProvider {
 			$footer = true
 		);
 
+		$editorColorPalette = get_theme_support( 'editor-color-palette' ); // Return value is in a nested array.
+		wp_localize_script(
+			'give-block-campaigns',
+			'giveCampaignsThemeSupport',
+			[
+				'editorColorPalette' => array_shift( $editorColorPalette ),
+			]
+		);
+
 		register_block_type(
 			'give/campaign-preview',
 			[

--- a/src/Campaigns/blocks/CampaignProgress/index.js
+++ b/src/Campaigns/blocks/CampaignProgress/index.js
@@ -1,11 +1,15 @@
 const { __ } = wp.i18n;
-const { useInstanceId } = wp.compose;
 const { registerBlockType } = wp.blocks;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody, BaseControl, ColorPalette } = wp.components;
 
 import ProgressBar from '../components/progress-bar';
 import { Footer, FooterItem } from '../components/footer';
+
+const defaultColor = '#66bb6a';
+
+/* eslint-disable-next-line no-undef */
+const editorColorPalette = giveCampaignsThemeSupport.editorColorPalette;
 
 export default registerBlockType( 'give/campaign-progress', {
 	title: __( 'Progress' ),
@@ -20,57 +24,26 @@ export default registerBlockType( 'give/campaign-progress', {
 	attributes: {
 		color: {
 			type: 'string',
-			default: '#66bb6a',
+			default: defaultColor,
 		},
 	},
 	edit: ( { attributes, setAttributes } ) => {
 		const { color } = attributes;
 
-		const saveSetting = ( name, value ) => {
-			setAttributes( {
-				[ name ]: value,
-			} );
-		};
-
-		const ColorControl = ( { name, label, help, className, value, hideLabelFromVision } ) => {
-			const instanceId = useInstanceId( ColorControl );
-			const id = `give-color-control-${ name }-${ instanceId }`;
-			const colors = [
-				{ name: __( 'Red', 'give' ), color: '#dd3333' },
-				{ name: __( 'Orange', 'give' ), color: '#dd9933' },
-				{ name: __( 'Green', 'give' ), color: '#28C77B' },
-				{ name: __( 'Blue', 'give' ), color: '#1e73be' },
-				{ name: __( 'Purple', 'give' ), color: '#8224e3' },
-				{ name: __( 'Grey', 'give' ), color: '#777777' },
-			];
-			return (
-				<BaseControl
-					label={ label }
-					hideLabelFromVision={ hideLabelFromVision }
-					id={ id }
-					help={ help }
-					className={ className }
-				>
-					<ColorPalette
-						value={ value }
-						colors={ colors }
-						onChange={ ( newValue ) => saveSetting( 'color', newValue ) }
-						clearable={ false }
-					/>
-				</BaseControl>
-			);
-		};
-
 		return (
 			<>
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Settings' ) }>
-						<ColorControl
-							name="color"
+						<BaseControl
 							label={ __( 'Progress Bar Color', 'give' ) }
-							// onChange={ ( value ) => {} }
-							value={ 'red' }
-						/>
+						>
+							<ColorPalette
+								value={ color }
+								colors={ editorColorPalette }
+								onChange={ ( newValue ) => setAttributes( { color: newValue ?? defaultColor } ) }
+								clearable={ true }
+							/>
+						</BaseControl>
 					</PanelBody>
 				</InspectorControls>
 				<div style={ { padding: '20px 10px' } }>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5299

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Localizes `get_theme_support( 'editor-color-palette' )` for use by the Progress Bar settings.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Update the Progress Bar block color using the color palette.
- Clear color to restore default value.