### PR TITLE
Multi-Form Goal Block now defaults to image filling the height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Migrations framework for database migrations
 -   Multi-Form Goal block and shortcode are now available (#5307)
 
+### Changed
+
+-   Multi-Form Goal Block now defaults to image filling the height (#5314)
+
+
 ## [2.8.0] - 2020-08-31
 
 ## [2.8.0-rc.1] - 2020-08-31

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
@@ -20,9 +20,15 @@ import '../../../css/editor.scss';
  * Register Block
  */
 const blockTemplate = [
-	[ 'core/media-text', {}, [
-		[ 'core/heading', { placeholder: __( 'Heading', 'give' ) } ],
-		[ 'core/paragraph', { placeholder: __( 'Summary', 'give' ) } ],
+	[ 'core/media-text', {
+		imageFill: true,
+	}, [
+		[ 'core/heading', {
+			placeholder: __( 'Heading', 'give' ),
+		} ],
+		[ 'core/paragraph', {
+			placeholder: __( 'Summary', 'give' ),
+		} ],
 	] ],
 	[ 'give/progress-bar', {} ],
 ];


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5312

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The Inner Media & Text block is pre-configured to fill the height of the block with the image by default.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Add Multi-Form Block to page/post
- Upload an image to the Inner Media & Text
- Add content to change block height
