### PR TITLE
Progress Bar block SSR is now improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Totals block now supports custom goal color (#5267)
 -   Migrations framework for database migrations
 -   Multi-Form Goal block and shortcode are now available (#5307)
+-   Progress Bar block now features improved SSR previews (#5316)
 
 ## [2.8.0] - 2020-08-31
 

--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/index.js
@@ -1,13 +1,17 @@
 /**
  * WordPress dependencies
  */
-const ServerSideRender = wp.serverSideRender;
 const { Fragment } = wp.element;
 
 /**
  * Internal dependencies
  */
 import Inspector from './inspector';
+
+/**
+ * Vendor dependencies
+ */
+import ServerSideRender from '../../../components/server-side-render-x';
 
 /**
  * Render Block UI For Editor

--- a/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
+++ b/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import { isEqual, debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+const { Component, RawHTML, Fragment } = wp.element;
+const { __, sprintf } = wp.i18n;
+const apiFetch = wp.apiFetch;
+const { addQueryArgs } = wp.url;
+const { Placeholder } = wp.components;
+
+export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
+	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
+		context: 'edit',
+		...( null !== attributes ? { attributes } : {} ),
+		...urlQueryArgs,
+	} );
+}
+
+export class ServerSideRenderX extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			response: null,
+			prevResponse: null,
+		};
+	}
+
+	componentDidMount() {
+		this.isStillMounted = true;
+		this.fetch( this.props );
+		// Only debounce once the initial fetch occurs to ensure that the first
+		// renders show data as soon as possible.
+		this.fetch = debounce( this.fetch, 500 );
+	}
+
+	componentWillUnmount() {
+		this.isStillMounted = false;
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! isEqual( prevProps, this.props ) ) {
+			this.fetch( this.props );
+		}
+	}
+
+	fetch( props ) {
+		if ( ! this.isStillMounted ) {
+			return;
+		}
+		if ( null !== this.state.response ) {
+			//this.setState({ response: null, prevResponse: this.state.response });
+			this.setState( state => (
+				{
+					response: null,
+					prevResponse: state.response,
+				}
+			) );
+		}
+		const { block, attributes = null, urlQueryArgs = {} } = props;
+
+		const path = rendererPath( block, attributes, urlQueryArgs );
+		// Store the latest fetch request so that when we process it, we can
+		// check if it is the current request, to avoid race conditions on slow networks.
+		const fetchRequest = ( this.currentFetchRequest = apiFetch( { path } )
+			.then( ( response ) => {
+				if (
+					this.isStillMounted &&
+					fetchRequest === this.currentFetchRequest &&
+					response
+				) {
+					this.setState( { response: response.rendered } );
+				}
+			} )
+			.catch( ( error ) => {
+				if (
+					this.isStillMounted &&
+					fetchRequest === this.currentFetchRequest
+				) {
+					this.setState( {
+						response: {
+							error: true,
+							errorMsg: error.message,
+						},
+					} );
+				}
+			} ) );
+		return fetchRequest;
+	}
+
+	render() {
+		const { right, top, unit } = this.props.spinnerLocation;
+		const response = this.state.response;
+		//let response = this.state.response;
+		//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
+		const prevResponse = this.state.prevResponse;
+		let prevResponseHTML = '';
+		if ( prevResponse !== null ) {
+			prevResponseHTML = `<div style="position:relative;"><div style="position:absolute;right:${ right }${ unit };top:${ top }${ unit }"><span class="components-spinner"></span></div>${ prevResponse }</div>`;
+			//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
+		}
+
+		const {
+			className,
+			EmptyResponsePlaceholder,
+			ErrorResponsePlaceholder,
+		} = this.props;
+
+		if ( response === '' ) {
+			return (
+				<EmptyResponsePlaceholder
+					response={ response }
+					{ ...this.props }
+				/>
+			);
+		} else if ( ! response ) {
+			return (
+				<Fragment>
+					<RawHTML key="html" className={ className }>
+						{ prevResponseHTML }
+					</RawHTML>
+				</Fragment>
+			);
+		} else if ( response.error ) {
+			return (
+				<ErrorResponsePlaceholder
+					response={ response }
+					{ ...this.props }
+				/>
+			);
+		}
+
+		return (
+			<RawHTML key="html" className={ className }>
+				{ response }
+			</RawHTML>
+		);
+	}
+}
+
+ServerSideRenderX.defaultProps = {
+	spinnerLocation: { right: 0, top: 10, unit: 'px' },
+	EmptyResponsePlaceholder: ( { className } ) => (
+		<Placeholder className={ className }>
+			{ __( 'Block rendered as empty.' ) }
+		</Placeholder>
+	),
+	ErrorResponsePlaceholder: ( { response, className } ) => {
+		const errorMessage = sprintf(
+			// translators: %s: error message describing the problem
+			__( 'Error loading block: %s' ),
+			response.errorMsg
+		);
+		return (
+			<Placeholder className={ className }>{ errorMessage }</Placeholder>
+		);
+	},
+};
+
+export default ServerSideRenderX;

--- a/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
+++ b/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
@@ -92,14 +92,13 @@ export class ServerSideRenderX extends Component {
 	}
 
 	render() {
-		const { right, top, unit } = this.props.spinnerLocation;
 		const response = this.state.response;
 		//let response = this.state.response;
 		//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
 		const prevResponse = this.state.prevResponse;
 		let prevResponseHTML = '';
 		if ( prevResponse !== null ) {
-			prevResponseHTML = `<div style="position:relative;"><div style="position:absolute;right:${ right }${ unit };top:${ top }${ unit }"><span class="components-spinner"></span></div>${ prevResponse }</div>`;
+			prevResponseHTML = `<div style="position:relative;"><div style="position:absolute;z-index: 1; right:50%;top:calc(50% - 20px)"><span class="components-spinner"></span></div>${ prevResponse }</div>`;
 			//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
 		}
 
@@ -142,7 +141,6 @@ export class ServerSideRenderX extends Component {
 }
 
 ServerSideRenderX.defaultProps = {
-	spinnerLocation: { right: 0, top: 10, unit: 'px' },
 	EmptyResponsePlaceholder: ( { className } ) => (
 		<Placeholder className={ className }>
 			{ __( 'Block rendered as empty.' ) }

--- a/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
+++ b/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
@@ -1,4 +1,15 @@
 /**
+ * NOTE: This is a fork of the original ServerSideRenderX component.
+ * You can find more about that project here: https://github.com/dgwyer/server-side-render-x
+ *
+ * Specifically, for GiveWP we have opted to remove the spinner/loading state that ServerSideRenderX uses entirely.
+ * That change can be found in line 106, where the prevResponseHTML is now only storing the block markup, and
+ * does not include a spinner/loading state.
+ *
+ * Additionally, some minor clean up was done to remove references to variables which were never actually used.
+ */
+
+/**
  * External dependencies
  */
 import { isEqual, debounce } from 'lodash';
@@ -52,7 +63,6 @@ export class ServerSideRenderX extends Component {
 			return;
 		}
 		if ( null !== this.state.response ) {
-			//this.setState({ response: null, prevResponse: this.state.response });
 			this.setState( state => (
 				{
 					response: null,

--- a/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
+++ b/src/MultiFormGoals/resources/js/components/server-side-render-x/index.js
@@ -93,13 +93,10 @@ export class ServerSideRenderX extends Component {
 
 	render() {
 		const response = this.state.response;
-		//let response = this.state.response;
-		//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
 		const prevResponse = this.state.prevResponse;
 		let prevResponseHTML = '';
 		if ( prevResponse !== null ) {
-			prevResponseHTML = `<div style="position:relative;"><div style="position:absolute;z-index: 1; right:50%;top:calc(50% - 20px)"><span class="components-spinner"></span></div>${ prevResponse }</div>`;
-			//response = `<div style="position:relative;"><div style="position:absolute;right:0;top:10px"><span class="components-spinner"></span></div>${response}</div>`;
+			prevResponseHTML = `<div style="position:relative;">${ prevResponse }</div>`;
 		}
 
 		const {


### PR DESCRIPTION
Resolves #5311 

## Description
This PR introduces the ServerSideRenderX component, which improves the Progress Bar editor UI by preserving block appearance until a new preview is loaded via SSR.

## Affects
This PR affects the ProgressBar block, specifically replacing the use of WP core's ServerSideRender block with the community created ServerSideRenderX block.

## Visuals
![SSRX](https://user-images.githubusercontent.com/5186078/94711502-34818780-0316-11eb-9b1a-e5d4d857d657.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed