### PR TITLE
Multi Form Goal styles are now polished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Multi-Form Goal block and shortcode are now available (#5307)
 -   Progress Bar block now features improved SSR previews (#5316)
 -   Multi-Form Goal block now supports "wide" alignment (#5315)
+-   Multi-Form Goal block and shortcode appearance is now consistent (#5320)
 
 ### Changed
 

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -1,19 +1,47 @@
 // This file used for Total styles common to the frontend and editor
 
+.give-multi-form-goal-block__image img {
+	height: 100%;
+	width: 100%;
+	object-fit: cover;
+}
+
 .give-multi-form-goal-block {
 	background: #fff;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.305862);
 	border-radius: 8px;
 	overflow: hidden;
+
+	.wp-block-media-text {
+		margin: 24px !important;
+	}
+
+	.wp-block-media-text__media,
+	.give-multi-form-goal-block__image {
+		border-radius: 6px !important;
+		overflow: hidden !important;
+	}
 }
 
 .give-multi-form-goal-block__content {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
+	margin: 24px !important;
+	min-height: 250px;
+}
+
+.give-multi-form-goal-block__text {
+	padding: var(--global--spacing-vertical);
+
+	h2 {
+		margin-bottom: var(--global--spacing-vertical);
+	}
 }
 
 .give-progress-bar-block__goal {
 	height: auto;
+	padding: 20px 16px;
+	border-top: 1px solid #ebebeb;
 }
 
 .give-progress-bar-block__progress {
@@ -41,4 +69,32 @@
 .give-progress-bar-block__stats {
 	display: grid;
 	grid-template-columns: repeat(4, 1fr);
+	background: #f5f5f5;
+	height: 96px;
+	border-top: 1px solid #ebebeb;
+}
+
+.give-progress-bar-block__stat {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	border-right: 1px solid #ebebeb;
+	font-weight: 500;
+
+	&:last-of-type {
+		border-right: none;
+	}
+
+	> *:first-child {
+		font-size: 24px;
+		line-height: 28px;
+		color: #4c4c4c;
+	}
+
+	> *:last-child {
+		font-size: 18px;
+		line-height: 1;
+		color: #6f6f6f;
+	}
 }

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -68,19 +68,21 @@
 
 .give-progress-bar-block__stats {
 	display: flex;
+	flex-wrap: wrap;
 	background: #f5f5f5;
-	height: 96px;
+	height: auto;
 	border-top: 1px solid #ebebeb;
 }
 
 .give-progress-bar-block__stat {
 	display: flex;
-	flex: 1;
+	flex: 1 1 110px;
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
 	border-right: 1px solid #ebebeb;
 	font-weight: 500;
+	height: 96px;
 
 	&:last-of-type {
 		border-right: none;

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -67,8 +67,7 @@
 }
 
 .give-progress-bar-block__stats {
-	display: grid;
-	grid-template-columns: repeat(4, 1fr);
+	display: flex;
 	background: #f5f5f5;
 	height: 96px;
 	border-top: 1px solid #ebebeb;
@@ -76,6 +75,7 @@
 
 .give-progress-bar-block__stat {
 	display: flex;
+	flex: 1;
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;

--- a/src/MultiFormGoals/resources/css/editor.scss
+++ b/src/MultiFormGoals/resources/css/editor.scss
@@ -1,1 +1,12 @@
 // This file used for styles specific to the Totals block, as displayed in the block editor
+
+[data-type='give/multi-form-goal'] {
+	[data-type='give/progress-bar'] {
+		margin: 0 !important;
+		max-width: 100% !important;
+	}
+	[data-type='core/media-text'] {
+		margin: 24px !important;
+		max-width: 100% !important;
+	}
+}

--- a/src/MultiFormGoals/resources/views/multiformgoal.php
+++ b/src/MultiFormGoals/resources/views/multiformgoal.php
@@ -18,12 +18,12 @@ if ( ! empty( $this->innerBlocks ) ) {
 				<img src="<?php echo $this->getImageSrc(); ?>" />
 			</div>
 			<div class="give-multi-form-goal-block__text">
-				<div class="give-multi-form-goal-block__heading">
+				<h2>
 					<?php echo $this->getHeading(); ?>
-				</div>
-				<div class="give-multi-form-goal-block__summary">
+				</h2>
+				<p>
 					<?php echo $this->getSummary(); ?>
-				</div>
+				</p>
 			</div>
 		</div>
 		<?php echo $this->getProgressBarOutput(); ?>


### PR DESCRIPTION
Resolves #5317 

## Description
This PR is focused on polishing styles for the Multi Form Goal as it is represented in the block editor, on the frontend, and in the shortcode. Additionally, it handles some specific edge cases with how the align tool can be used to ensure that frontend presentation is consistent with backend appearance.

## Affects
This PR primarily affects common and editor styles for the Multi Form Goal feature.

## Visuals
As seen in the editor:
<img width="637" alt="Screen Shot 2020-09-30 at 4 28 36 PM" src="https://user-images.githubusercontent.com/5186078/94736510-57be2e00-033a-11eb-8961-36e8e1964014.png">

As seen on the front end:
<img width="638" alt="Screen Shot 2020-09-30 at 4 28 53 PM" src="https://user-images.githubusercontent.com/5186078/94736539-6573b380-033a-11eb-9f2f-3bd47bf0df74.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new page or post
2. Add the Multi Form Goal block
3. Add an image, and change some settings
4. Check that appearance on the frontend matches appearance in the editor (and matches Figma designs)
5. Add a shortcode with [give_multi_form_goal]
6. Check how the shortcode is rendered