### PR TITLE
Space now exists between media area and text content in block editor

### DIFF
--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -21,6 +21,10 @@
 		border-radius: 6px !important;
 		overflow: hidden !important;
 	}
+
+	.wp-block-media-text .wp-block-media-text__content {
+		padding: 16px !important;
+	}
 }
 
 .give-multi-form-goal-block__content {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5327 

## Description
This small PR defines the padding for content in the Media-Text block within the context of a Multi-Form Goal to be 16px. This padding is consistent with spacing around the content div represented in the Multi-Form Goal shortcode shortcode. 

## Affects
This PR affects styles for the Multi-Form Goal block.

## Visuals
<img width="808" alt="Screen Shot 2020-10-02 at 11 42 41 AM" src="https://user-images.githubusercontent.com/5186078/94942723-ac7db800-04a4-11eb-9fef-14e6ceb771df.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed