### PR TITLE
Progress bar inner block no longer crops focus outline

### DIFF
--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -7,10 +7,12 @@
 }
 
 .give-multi-form-goal-block {
+	display: flex;
+	flex-direction: column;
+
 	background: #fff;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.305862);
 	border-radius: 8px;
-	overflow: hidden;
 
 	.wp-block-media-text {
 		margin: 24px !important;
@@ -75,6 +77,7 @@
 	background: #f5f5f5;
 	height: auto;
 	border-top: 1px solid #ebebeb;
+	border-radius: 0 0 8px 8px;
 }
 
 .give-progress-bar-block__stat {


### PR DESCRIPTION
Resolves #5325 

## Description
This PR makes minor changes to block styling so ensure that the Progress Bar focus outline is not cropped when selected in the block editor. 

## Affects
Changes in the PR affect frontend and editor styles for the Multi-Form Goal block and Progress Bar block.

## Visuals
<img width="636" alt="Screen Shot 2020-10-02 at 11 50 15 AM" src="https://user-images.githubusercontent.com/5186078/94944528-5f4f1580-04a7-11eb-8cfd-754c52d32698.png">

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed