### PR TITLE
Add bottom margin to Multi-Form Goal block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Multi-Form Goal wrapper only added for non-block output (#5315)
+-   Multi-Form Goal output has a bottom margin (#5333)
 
 
 ### Changed

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -13,6 +13,7 @@
 	background: #fff;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.305862);
 	border-radius: 8px;
+	margin-bottom: 20px;
 
 	.wp-block-media-text {
 		margin: 24px !important;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5328

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds a `20px` bottom margin to the wrapper element.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Block Output

![Screenshot_2020-10-02 WordPress(1)](https://user-images.githubusercontent.com/10858303/94949009-3e3df300-04ae-11eb-87c6-202bf2b81d63.png)

### Shortcode Output

![Screenshot_2020-10-02 WordPress](https://user-images.githubusercontent.com/10858303/94949018-40a04d00-04ae-11eb-9fcc-f97858b78e16.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
