### PR TITLE
Block settings are now polished

### DIFF
--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
@@ -35,14 +35,14 @@ const Inspector = ( { attributes, setAttributes } ) => {
 			<PanelBody title={ __( 'Goal', 'give' ) } initialOpen={ true }>
 				<TextControl
 					name="goal"
-					label={ __( 'Goal Amount', 'give' ) }
+					label={ __( 'Goal amount', 'give' ) }
 					type="number"
 					onChange={ ( value ) => saveSetting( 'goal', value ) }
 					value={ goal }
 				/>
 				<TextControl
 					name="enddate"
-					label={ __( 'Goal End Date', 'give' ) }
+					label={ __( 'Goal end date', 'give' ) }
 					type="date"
 					onChange={ ( value ) => saveSetting( 'enddate', value ) }
 					value={ enddate }
@@ -50,7 +50,7 @@ const Inspector = ( { attributes, setAttributes } ) => {
 				<ColorControl
 					colors={ editorColorPalette }
 					name="color"
-					label={ __( 'Progress Bar Color', 'give' ) }
+					label={ __( 'Progress bar color', 'give' ) }
 					onChange={ ( value ) => saveSetting( 'color', value ) }
 					value={ color }
 				/>
@@ -58,19 +58,19 @@ const Inspector = ( { attributes, setAttributes } ) => {
 			<PanelBody title={ __( 'Filters', 'give' ) } initialOpen={ false }>
 				<MultiSelectControl
 					name="ids"
-					label={ __( 'Filter by Forms', 'give' ) }
+					label={ __( 'Filter by forms', 'give' ) }
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="tags"
-					label={ __( 'Filter by Tags', 'give' ) }
+					label={ __( 'Filter by tags', 'give' ) }
 					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
 					options={ tagOptions }
 					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="categories"
-					label={ __( 'Filter by Categories', 'give' ) }
+					label={ __( 'Filter by categories', 'give' ) }
 					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
 					options={ categoryOptions }
 					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />

--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
@@ -60,18 +60,21 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					name="ids"
 					label={ __( 'Filter by forms', 'give' ) }
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
+					placeholder={ __( 'All forms...', 'give' ) }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="categories"
 					label={ __( 'Filter by categories', 'give' ) }
 					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
+					placeholder={ __( 'All categories...', 'give' ) }
 					options={ categoryOptions }
 					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="tags"
 					label={ __( 'Filter by tags', 'give' ) }
 					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
+					placeholder={ __( 'All tags...', 'give' ) }
 					options={ tagOptions }
 					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
 			</PanelBody>

--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
@@ -63,17 +63,17 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
-					name="tags"
-					label={ __( 'Filter by tags', 'give' ) }
-					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
-					options={ tagOptions }
-					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
-				<MultiSelectControl
 					name="categories"
 					label={ __( 'Filter by categories', 'give' ) }
 					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
 					options={ categoryOptions }
 					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />
+				<MultiSelectControl
+					name="tags"
+					label={ __( 'Filter by tags', 'give' ) }
+					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
+					options={ tagOptions }
+					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/edit/inspector.js
@@ -60,21 +60,21 @@ const Inspector = ( { attributes, setAttributes } ) => {
 					name="ids"
 					label={ __( 'Filter by forms', 'give' ) }
 					value={ formOptions.filter( option => ids.includes( option.value ) ) }
-					placeholder={ __( 'All forms...', 'give' ) }
+					placeholder={ `${ __( 'All forms', 'give' ) }...` }
 					options={ formOptions }
 					onChange={ ( value ) => saveSetting( 'ids', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="categories"
 					label={ __( 'Filter by categories', 'give' ) }
 					value={ categoryOptions.filter( option => categories.includes( option.value ) ) }
-					placeholder={ __( 'All categories...', 'give' ) }
+					placeholder={ `${ __( 'All categories', 'give' ) }...` }
 					options={ categoryOptions }
 					onChange={ ( value ) => saveSetting( 'categories', value ? value.map( ( option ) => option.value ) : [] ) } />
 				<MultiSelectControl
 					name="tags"
 					label={ __( 'Filter by tags', 'give' ) }
 					value={ tagOptions.filter( option => tags.includes( option.value ) ) }
-					placeholder={ __( 'All tags...', 'give' ) }
+					placeholder={ `${ __( 'All tags', 'give' ) }...` }
 					options={ tagOptions }
 					onChange={ ( value ) => saveSetting( 'tags', value ? value.map( ( option ) => option.value ) : [] ) } />
 			</PanelBody>

--- a/src/MultiFormGoals/resources/js/components/multi-select-control/index.js
+++ b/src/MultiFormGoals/resources/js/components/multi-select-control/index.js
@@ -74,7 +74,7 @@ MultiSelectControl.defaultProps = {
 	label: null,
 	value: null,
 	onChange: null,
-	placeholder: __( 'Select...', 'give' ),
+	placeholder: `${ __( 'Select', 'give' ) }...`,
 	options: null,
 };
 

--- a/src/MultiFormGoals/resources/js/components/multi-select-control/index.js
+++ b/src/MultiFormGoals/resources/js/components/multi-select-control/index.js
@@ -9,13 +9,14 @@ import Select from 'react-select';
  */
 const { useInstanceId } = wp.compose;
 const { BaseControl } = wp.components;
+const { __ } = wp.i18n;
 
 /**
  * Styles
  */
 import './style.scss';
 
-const MultiSelectControl = ( { name, label, help, className, value, hideLabelFromVision, isLoading, isDisabled, onChange, options } ) => {
+const MultiSelectControl = ( { name, label, help, className, value, placeholder, hideLabelFromVision, isLoading, isDisabled, onChange, options } ) => {
 	const instanceId = useInstanceId( MultiSelectControl );
 	const id = `give-multi-select-control-${ name }-${ instanceId }`;
 
@@ -38,6 +39,7 @@ const MultiSelectControl = ( { name, label, help, className, value, hideLabelFro
 				options={ options }
 				maxMenuHeight="200px"
 				isDisabled={ isDisabled }
+				placeholder={ placeholder }
 				isMulti={ true }
 				theme={ ( theme ) => ( {
 					...theme,
@@ -65,12 +67,14 @@ MultiSelectControl.propTypes = {
 	hideLabelFromVision: PropTypes.bool,
 	isLoading: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	placeholder: PropTypes.string,
 };
 
 MultiSelectControl.defaultProps = {
 	label: null,
 	value: null,
 	onChange: null,
+	placeholder: __( 'Select...', 'give' ),
 	options: null,
 };
 


### PR DESCRIPTION
Resolves #5326 

## Description
This PR makes minor tweaks to presentation of various Progress Bar block settings.

## Affects
This PR affects rendering logic for various Progress Bar block controls and settings.

## Visuals
<img width="281" alt="Screen Shot 2020-10-02 at 1 20 01 PM" src="https://user-images.githubusercontent.com/5186078/94951400-308a6c80-04b2-11eb-9b46-c132bc3001a4.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed