### PR TITLE
Add currency switcher support to paypal donation payment gateway

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -104,10 +104,18 @@ class AdvancedCardFields extends PaymentMethod {
 			const container = document.createElement( 'div' );
 
 			fieldType = cardFields[ cardFieldsKey ].el.getAttribute( 'name' );
-			container.setAttribute( 'id', `give-${ cardFields[ cardFieldsKey ].el.getAttribute( 'id' ) }` );
-			container.setAttribute( 'class', 'give-paypal-commerce-cc-field' );
+			const fieldId = `give-${ cardFields[ cardFieldsKey ].el.getAttribute( 'id' ) }`;
+			let field;
 
-			this.hostedCardFieldsContainers[ this.getFieldTypeByFieldName( fieldType ) ] = cardFields[ cardFieldsKey ].el.parentElement.appendChild( container );
+			if ( field = this.form.querySelector( `#${ fieldId }` ) ) { // eslint-disable-line
+				// If field container already exist in form then remove paypal field from inside and return same div.
+				field.innerHTML = '';
+				this.hostedCardFieldsContainers[ this.getFieldTypeByFieldName( fieldType ) ] = field;
+			} else {
+				container.setAttribute( 'id', fieldId );
+				container.setAttribute( 'class', 'give-paypal-commerce-cc-field' );
+				this.hostedCardFieldsContainers[ this.getFieldTypeByFieldName( fieldType ) ] = cardFields[ cardFieldsKey ].el.parentElement.appendChild( container );
+			}
 		}
 
 		this.toggleFields();

--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -11,8 +11,17 @@ class AdvancedCardFields extends PaymentMethod {
 	 */
 	constructor( customCardFields ) {
 		super( customCardFields.form );
-
 		this.customCardFields = customCardFields;
+
+		this.setFocusStyle();
+	}
+
+	/**
+	 * Setup properties.
+	 *
+	 * @since 2.9.0
+	 */
+	setupProperties() {
 		this.cardFields = {};
 		this.hostedCardFieldsContainers = {};
 		this.hostedFieldContainerStyleProperties = [
@@ -44,8 +53,6 @@ class AdvancedCardFields extends PaymentMethod {
 			'input:focus': {},
 			'input:placeholder': {},
 		};
-
-		this.setFocusStyle();
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -75,6 +75,7 @@ class AdvancedCardFields extends PaymentMethod {
 		this.setupContainerForHostedCardFields();
 		this.applyStyleToContainer();
 
+		const submitEventName = `submit.${ this.form.getAttribute( 'id' ) }`;
 		const createOrder = this.createOrderHandler.bind( this );
 		const styles = await this.getComputedInputFieldForHostedField();
 		const fields = this.getPayPalHostedCardFields();
@@ -82,7 +83,7 @@ class AdvancedCardFields extends PaymentMethod {
 		const onSubmitHandlerForDonationForm = this.onSubmitHandlerForDonationForm.bind( this );
 
 		this.addEventToHostedFields( hostedCardFields );
-		this.jQueryForm.on( 'submit', { hostedCardFields }, onSubmitHandlerForDonationForm );
+		this.jQueryForm.off( submitEventName ).on( submitEventName, { hostedCardFields }, onSubmitHandlerForDonationForm );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/AdvancedCardFields.js
@@ -49,20 +49,6 @@ class AdvancedCardFields extends PaymentMethod {
 	}
 
 	/**
-	 * Add recurring field tracker.
-	 *
-	 * @since 2.9.0
-	 */
-	registerEvents() {
-		if ( this.customCardFields.recurringChoiceHiddenField ) {
-			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceHiddenField, this.toggleFields.bind( this ) );
-			DonationForm.trackRecurringHiddenFieldChange( this.customCardFields.recurringChoiceHiddenField, () => {
-				DonationForm.toggleDonateNowButton( this.form );
-			} );
-		}
-	}
-
-	/**
 	 * Return whether or not render credit card fields.
 	 *
 	 * @since 2.9.0

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -101,16 +101,17 @@ class CustomCardFields extends PaymentMethod {
 	 * Remove custom card fields on gateway load.
 	 *
 	 * @since 2.9.0
+	 * @param {object} evt Event
+	 *
+	 * @return {function} Function
 	 */
-	removeFieldsOnGatewayLoad() {
-		const handler = evt => {
-			if ( this.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
-				this.setupProperties();
-				this.removeFields.bind( this ).call();
+	removeFieldsOnGatewayLoad( evt ) {
+		const self = this;
+		return () => {
+			if ( self.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
+				self.removeFields.bind( self ).call();
 			}
 		};
-
-		document.addEventListener( 'give_gateway_loaded', evt => handler( evt ) );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -27,15 +27,6 @@ class CustomCardFields extends PaymentMethod {
 	/**
 	 * @inheritDoc
 	 */
-	registerEvents() {
-		if ( this.recurringChoiceHiddenField ) {
-			DonationForm.trackRecurringHiddenFieldChange( this.recurringChoiceHiddenField, this.renderPaymentMethodOption.bind( this ) );
-		}
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	onGatewayLoadBoot( evt, self ) {
 		if ( self.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
 			self.setupProperties();

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -98,23 +98,6 @@ class CustomCardFields extends PaymentMethod {
 	}
 
 	/**
-	 * Remove custom card fields on gateway load.
-	 *
-	 * @since 2.9.0
-	 * @param {object} evt Event
-	 *
-	 * @return {function} Function
-	 */
-	removeFieldsOnGatewayLoad( evt ) {
-		const self = this;
-		return () => {
-			if ( self.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
-				self.removeFields.bind( self ).call();
-			}
-		};
-	}
-
-	/**
 	 * Return separator html.
 	 *
 	 * @since 2.9.0

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -5,15 +5,6 @@ import AdvancedCardFields from './AdvancedCardFields';
 
 class CustomCardFields extends PaymentMethod {
 	/**
-	 * @inheritDoc
-	 */
-	constructor( form ) {
-		super( form );
-
-		this.setupProperties();
-	}
-
-	/**
 	 * Setup properties.
 	 *
 	 * @since 2.9.0
@@ -28,17 +19,6 @@ class CustomCardFields extends PaymentMethod {
 				this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() ) :
 				null;
 		}
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	onGatewayLoadBoot( evt, self ) {
-		if ( self.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
-			self.setupProperties();
-		}
-
-		super.onGatewayLoadBoot( evt, self );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -21,7 +21,7 @@ class CustomCardFields extends PaymentMethod {
 	setupProperties() {
 		this.cardFields = this.getCardFields();
 		this.recurringChoiceHiddenField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
-		this.separator = this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() );
+		this.separator = this.cardFields.number.el ? this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() ) : null;
 	}
 
 	/**
@@ -111,10 +111,12 @@ class CustomCardFields extends PaymentMethod {
 	 */
 	removeFields() {
 		for ( const type in this.cardFields ) {
-			this.cardFields[ type ].el.parentElement.remove();
+			this.cardFields[ type ].el && this.cardFields[ type ].el.parentElement.remove(); // eslint-disable-line
 		}
 
-		this.form.querySelector( 'input[name="card_name"]' ).parentElement.remove();
+		const cardNameField = this.form.querySelector( 'input[name="card_name"]' );
+
+		cardNameField && cardNameField.parentElement.remove(); // eslint-disable-line
 		this.separator && this.separator.remove(); // eslint-disable-line
 	}
 

--- a/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
+++ b/assets/src/js/frontend/paypal-commerce/CustomCardFields.js
@@ -19,9 +19,15 @@ class CustomCardFields extends PaymentMethod {
 	 * @since 2.9.0
 	 */
 	setupProperties() {
+		this.ccFieldsContainer = this.form.querySelector( '[id^="give_cc_fields-"]' );
 		this.cardFields = this.getCardFields();
 		this.recurringChoiceHiddenField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
-		this.separator = this.cardFields.number.el ? this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() ) : null;
+
+		if ( ! ( this.separator = this.ccFieldsContainer.querySelector( '.separator-with-text' ) ) ) {
+			this.separator = this.cardFields.number.el ?
+				this.cardFields.number.el.parentElement.insertAdjacentElement( 'beforebegin', this.separatorHtml() ) :
+				null;
+		}
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/DonationForm.js
+++ b/assets/src/js/frontend/paypal-commerce/DonationForm.js
@@ -116,6 +116,35 @@ class DonationForm {
 	}
 
 	/**
+	 * Call function when change field attribute.
+	 *
+	 * @since 2.9.0
+	 *
+	 * @param {object} element Javascript selector
+	 * @param {object} handler Function
+	 */
+	static trackDonationCurrencyChange( element, handler ) {
+		const MutationObserver = new window.MutationObserver( function( mutations ) {
+			// Exit if data attribute does not change does not change.
+			if ( mutations[ 0 ].oldValue === mutations[ 0 ].target.getAttribute( 'data-currency_code' ) ) {
+				return;
+			}
+
+			// Exit if paypal-commerce is not selected.
+			if ( ! DonationForm.isPayPalCommerceSelected( jQuery( mutations[ 0 ].target ) ) ) {
+				return;
+			}
+
+			handler.call();
+		} );
+
+		MutationObserver.observe( element, {
+			attributeFilter: [ 'data-currency_code' ],
+			attributeOldValue: true,
+		} );
+	}
+
+	/**
 	 * Hide donate now button if only PayPal smart buttons payment method available.
 	 *
 	 * @since 2.9.0

--- a/assets/src/js/frontend/paypal-commerce/PaymentMethod.js
+++ b/assets/src/js/frontend/paypal-commerce/PaymentMethod.js
@@ -13,6 +13,8 @@ class PaymentMethod {
 		this.form = form;
 		this.jQueryForm = jQuery( form );
 		this.ajaxurl = Give.fn.getGlobalVar( 'ajaxurl' );
+
+		this.setupProperties();
 	}
 
 	/**
@@ -28,29 +30,7 @@ class PaymentMethod {
 	 * @since 2.9.0
 	 */
 	boot() {
-		const self = this;
-
-		document.addEventListener( 'give_gateway_loaded', evt => {
-			this.onGatewayLoadBoot( evt, self );
-		} );
-
-		if ( DonationForm.isPayPalCommerceSelected( this.jQueryForm ) ) {
-			this.renderPaymentMethodOption();
-		}
-	}
-
-	/**
-	 * Render paypal buttons when reload payment gateways.
-	 *
-	 * @since 2.9.0
-	 *
-	 * @param {object} evt Event object.
-	 * @param {object} self Class object.
-	 */
-	onGatewayLoadBoot( evt, self ) {
-		if ( evt.detail.formIdAttribute === self.form.getAttribute( 'id' ) && DonationForm.isPayPalCommerceSelected( self.jQueryForm ) ) {
-			self.renderPaymentMethodOption();
-		}
+		this.renderPaymentMethodOption();
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/PaymentMethod.js
+++ b/assets/src/js/frontend/paypal-commerce/PaymentMethod.js
@@ -35,7 +35,6 @@ class PaymentMethod {
 		} );
 
 		if ( DonationForm.isPayPalCommerceSelected( this.jQueryForm ) ) {
-			this.registerEvents();
 			this.renderPaymentMethodOption();
 		}
 	}
@@ -60,13 +59,6 @@ class PaymentMethod {
 	 * @since 2.9.0
 	 */
 	renderPaymentMethodOption() {}
-
-	/**
-	 * Register events.
-	 *
-	 * @since 2.9.0
-	 */
-	registerEvents() {}
 
 	/**
 	 * Show error on donation form.

--- a/assets/src/js/frontend/paypal-commerce/SmartButtons.js
+++ b/assets/src/js/frontend/paypal-commerce/SmartButtons.js
@@ -8,12 +8,6 @@ import AdvancedCardFields from './AdvancedCardFields';
  * PayPal Smart Buttons.
  */
 class SmartButtons extends PaymentMethod {
-	constructor( form ) {
-		super( form );
-
-		this.setupProperties();
-	}
-
 	/**
 	 * Setup properties.
 	 *
@@ -23,17 +17,6 @@ class SmartButtons extends PaymentMethod {
 		this.ccFieldsContainer = this.form.querySelector( '[id^="give_cc_fields-"]' );
 		this.recurringChoiceHiddenField = this.form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 		this.smartButton = null;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	onGatewayLoadBoot( evt, self ) {
-		if ( self.isProcessingEventForForm( evt.detail.formIdAttribute ) ) {
-			self.setupProperties();
-		}
-
-		super.onGatewayLoadBoot( evt, self );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/SmartButtons.js
+++ b/assets/src/js/frontend/paypal-commerce/SmartButtons.js
@@ -15,21 +15,6 @@ class SmartButtons extends PaymentMethod {
 	}
 
 	/**
-	 * This function setup a tracker to listen change on recurring hidden field.
-	 *
-	 * When changes occur then smart button will be re render to support onetime or subscription payment.
-	 *
-	 * @since 2.9.0
-	 */
-	registerEvents() {
-		if ( this.recurringChoiceHiddenField ) {
-			DonationForm.trackRecurringHiddenFieldChange( this.recurringChoiceHiddenField, () => {
-				this.onChangeRecurringDonationStatus();
-			} );
-		}
-	}
-
-	/**
 	 * Setup properties.
 	 *
 	 * @since 2.9.0
@@ -114,24 +99,6 @@ class SmartButtons extends PaymentMethod {
 		this.smartButton = paypal.Buttons( options );
 
 		return this.smartButton.render( this.smartButtonContainer );
-	}
-
-	/**
-	 * Render payment method when recurring option changes.
-	 *
-	 * This method locks recurring option till render payment method render.
-	 * Disabled recurring option prevent quick changes to option value which prevent javascript error because smart button take time to setup after changes in recurring option value.
-	 *
-	 * @since 2.9.0
-	 */
-	onChangeRecurringDonationStatus() {
-		const field = this.form.querySelector( 'input[name="give-recurring-period"]' );
-
-		field && ( field.disabled = true ); // eslint-disable-line
-
-		this.renderPaymentMethodOption().then( () => {
-			field && ( field.disabled = false ); // eslint-disable-line
-		} );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -142,7 +142,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function loadPayPalScript( form ) {
 		const options = {};
 		const isRecurring = DonationForm.isRecurringDonation( form );
+
+		// This is the preferred way of setting the intent, but there is a bug with the PayPal SDK.
+		// Setting it to "capture" works for now.
 		// options.intent = isRecurring ? 'subscription' : 'capture';
+
 		options.intent = 'capture';
 		options.vault = !! isRecurring;
 		options.currency = Give.form.fn.getInfo( 'currency_code', jQuery( form ) );

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -65,18 +65,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				return;
 			}
 
-			const smartButtons = new SmartButtons( $form );
-			const customCardFields = new CustomCardFields( $form );
-
-			smartButtons.boot();
-
-			// Boot CustomCardFields class before AdvancedCardFields because of internal dependencies.
-			if ( AdvancedCardFields.canShow() ) {
-				const advancedCardFields = new AdvancedCardFields( customCardFields );
-
-				customCardFields.boot();
-				advancedCardFields.boot();
-			}
+			setupPaymentMethod( $form );
 		} );
 	}
 
@@ -135,7 +124,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		}
 
 		customCardFields.removeFields();
-		document.addEventListener( 'give_gateway_loaded', evt => customCardFields.removeFieldsOnGatewayLoad( evt ) );
 	}
 
 	/**

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -15,9 +15,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function setRecurringFieldTrackerToReloadPaypalSDK( $formWraps ) {
 		$formWraps.forEach( $formWrap => {
 			const $form = $formWrap.querySelector( '.give-form' );
-			DonationForm.trackRecurringHiddenFieldChange( $form.querySelector( 'input[name="_give_is_donation_recurring"]' ), () => {
-				loadPayPalScript( $form );
-			} );
+			const recurringField = $form.querySelector( 'input[name="_give_is_donation_recurring"]' );
+
+			if ( recurringField ) {
+				DonationForm.trackRecurringHiddenFieldChange( $form.querySelector( 'input[name="_give_is_donation_recurring"]' ), () => {
+					loadPayPalScript( $form );
+				} );
+			}
 		} );
 	}
 
@@ -78,7 +82,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		const isRecurring = DonationForm.isRecurringDonation( form );
 		// options.intent = isRecurring ? 'subscription' : 'capture';
 		options.intent = 'capture';
-		options.vault = isRecurring;
+		options.vault = !! isRecurring;
 		options.currency = Give.form.fn.getInfo( 'currency_code', jQuery( form ) );
 
 		loadScript( { ...givePayPalCommerce.payPalSdkQueryParameters, ...options } ).then( () => {

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -47,7 +47,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		const recurringField = $form.querySelector( 'input[name="_give_is_donation_recurring"]' );
 
 		if ( recurringField ) {
-			DonationForm.trackRecurringHiddenFieldChange( $form.querySelector( 'input[name="_give_is_donation_recurring"]' ), () => {
+			DonationForm.trackRecurringHiddenFieldChange( recurringField, () => {
 				loadPayPalScript( $form ).then( () => {
 					setupPaymentMethods();
 				} );
@@ -67,7 +67,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				return;
 			}
 
-			setupPaymentMethod( $form );
+			loadPayPalScript( $form ).then( () => {
+				setupPaymentMethod( $form );
+			} );
 		} );
 	}
 
@@ -140,6 +142,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function loadPayPalScript( form ) {
 		const options = {};
 		const isRecurring = DonationForm.isRecurringDonation( form );
+		console.log( 'isRecurring', isRecurring );
 		// options.intent = isRecurring ? 'subscription' : 'capture';
 		options.intent = 'capture';
 		options.vault = !! isRecurring;

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -8,20 +8,22 @@ import { loadScript } from '@paypal/paypal-js';
 document.addEventListener( 'DOMContentLoaded', () => {
 	const $formWraps = document.querySelectorAll( '.give-form-wrap' );
 
-	if ( $formWraps.length ) {
-		// Setup initial PayPal script on basis of first form on webpage.
-		loadPayPalScript( $formWraps[ 0 ].querySelector( '.give-form' ) )
-			.then( () => {
-				setupPaymentMethods();
-			} );
-
-		$formWraps.forEach( $formWrap => {
-			const $form = $formWrap.querySelector( '.give-form' );
-			setRecurringFieldTrackerToReloadPaypalSDK( $form );
-			setFormCurrencyTrackerToReloadPaypalSDK( $form );
-			setupGatewayLoadEventToRenderPaymentMethods( $form );
-		} );
+	if ( ! $formWraps.length ) {
+		return;
 	}
+
+	// Setup initial PayPal script on basis of first form on webpage.
+	loadPayPalScript( $formWraps[ 0 ].querySelector( '.give-form' ) )
+		.then( () => {
+			setupPaymentMethods();
+		} );
+
+	$formWraps.forEach( $formWrap => {
+		const $form = $formWrap.querySelector( '.give-form' );
+		setRecurringFieldTrackerToReloadPaypalSDK( $form );
+		setFormCurrencyTrackerToReloadPaypalSDK( $form );
+		setupGatewayLoadEventToRenderPaymentMethods( $form );
+	} );
 
 	// On form submit prevent submission for PayPal commerce.
 	// Form submission will be take care internally by smart buttons or advanced card fields.

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -142,7 +142,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function loadPayPalScript( form ) {
 		const options = {};
 		const isRecurring = DonationForm.isRecurringDonation( form );
-		console.log( 'isRecurring', isRecurring );
 		// options.intent = isRecurring ? 'subscription' : 'capture';
 		options.intent = 'capture';
 		options.vault = !! isRecurring;

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -1,4 +1,4 @@
-/* globals jQuery, givePayPalCommerce */
+/* globals Give, jQuery, givePayPalCommerce */
 import DonationForm from './DonationForm';
 import SmartButtons from './SmartButtons';
 import AdvancedCardFields from './AdvancedCardFields';
@@ -16,6 +16,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		$formWraps.forEach( $formWrap => {
 			const $form = $formWrap.querySelector( '.give-form' );
 			DonationForm.trackRecurringHiddenFieldChange( $form.querySelector( 'input[name="_give_is_donation_recurring"]' ), () => {
+				loadPayPalScript( $form );
+			} );
+		} );
+	}
+
+	/**
+	 * Setup form currency tracker to reload paypal sdk.
+	 *
+	 * @since 2.9.0
+	 * @param {object} $formWraps Form container selectors
+	 */
+	function setFormCurrencyTrackerToReloadPaypalSDK( $formWraps ) {
+		$formWraps.forEach( $formWrap => {
+			const $form = $formWrap.querySelector( '.give-form' );
+			DonationForm.trackDonationCurrencyChange( $form, () => {
 				loadPayPalScript( $form );
 			} );
 		} );
@@ -64,6 +79,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		// options.intent = isRecurring ? 'subscription' : 'capture';
 		options.intent = 'capture';
 		options.vault = isRecurring;
+		options.currency = Give.form.fn.getInfo( 'currency_code', jQuery( form ) );
 
 		loadScript( { ...givePayPalCommerce.payPalSdkQueryParameters, ...options } ).then( () => {
 			setupPaymentMethods( $formWraps );
@@ -72,8 +88,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	const $formWraps = document.querySelectorAll( '.give-form-wrap' );
 	if ( $formWraps.length ) {
-		loadPayPalScript( $formWraps[ 0 ] );
+		loadPayPalScript( $formWraps[ 0 ].querySelector( '.give-form' ) );
 		setRecurringFieldTrackerToReloadPaypalSDK( $formWraps );
+		setFormCurrencyTrackerToReloadPaypalSDK( $formWraps );
 	}
 
 	// On form submit prevent submission for PayPal commerce.

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -89,7 +89,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function setFormCurrencyTrackerToReloadPaypalSDK( $form ) {
 		DonationForm.trackDonationCurrencyChange( $form, () => {
 			loadPayPalScript( $form ).then( () => {
-				setupPaymentMethod( $formWraps );
+				setupPaymentMethods();
 			} );
 		} );
 	}
@@ -134,10 +134,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			return;
 		}
 
-		if ( DonationForm.isPayPalCommerceSelected( jQuery( $form ) ) ) {
-			customCardFields.removeFields();
-		}
-
+		customCardFields.removeFields();
 		document.addEventListener( 'give_gateway_loaded', evt => customCardFields.removeFieldsOnGatewayLoad( evt ) );
 	}
 

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -61,7 +61,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	function loadPayPalScript( form ) {
 		const options = {};
 		const isRecurring = DonationForm.isRecurringDonation( form );
-		options.intent = isRecurring ? 'subscription' : 'order';
+		// options.intent = isRecurring ? 'subscription' : 'capture';
+		options.intent = 'capture';
 		options.vault = isRecurring;
 
 		loadScript( { ...givePayPalCommerce.payPalSdkQueryParameters, ...options } ).then( () => {
@@ -71,8 +72,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	const $formWraps = document.querySelectorAll( '.give-form-wrap' );
 	if ( $formWraps.length ) {
-		setRecurringFieldTrackerToReloadPaypalSDK( $formWraps );
 		loadPayPalScript( $formWraps[ 0 ] );
+		setRecurringFieldTrackerToReloadPaypalSDK( $formWraps );
 	}
 
 	// On form submit prevent submission for PayPal commerce.

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -131,7 +131,6 @@ EOT;
 		$payPalSdkQueryParameters = [
 			'client-id'                   => $merchant->clientId,
 			'merchant-id'                 => $merchant->merchantIdInPayPal,
-			'currency'                    => give_get_currency(),
 			'components'                  => 'hosted-fields,buttons',
 			'locale'                      => get_locale(),
 			'disable-funding'             => 'credit',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/5324

## Description
This pr adds a feature to process multiple currencies with donation form without reloading webpage.

**Note: I am still facing issues when passing `inte=subscription` in param SDK URL: https://github.com/paypal/paypal-sdk-client/issues/46#issuecomment-702881717. Currently onetime and subscription payment processing without any issue with `intent=capture`**

## Affects
Javascript which renders PayPal payments refactored completed to the setup payment method on basis of donor choices.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
- Update recurring addon https://github.com/impress-org/give-recurring/tree/epic/paypal-commerce-integration
- update currency switcher https://github.com/impress-org/give-currency-switcher (develop)
- Run `npm i && npm run dev && composer dump` for this pr
