### PR TITLE
Progress Bar block is no longer available outside of Multi-form Goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Multi-Form Goal wrapper only added for non-block output (#5315)
 -   Multi-Form Goal output has a bottom margin (#5333)
+-   Progress Bar block is no longer available outside of Multi-form Goal (#5338)
 
 
 ### Changed

--- a/src/MultiFormGoals/resources/js/blocks/progress-bar/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/progress-bar/index.js
@@ -31,5 +31,6 @@ export default registerBlockType( 'give/progress-bar', {
 		__( 'progress-bar', 'give' ),
 	],
 	attributes: blockAttributes,
+	parent: [ 'give/multi-form-goal' ],
 	edit: ProgressBar,
 } );


### PR DESCRIPTION
Resolves #5337 

## Description
This PR defines the Multi-Form Goal block as a parent for the Progress Bar block. In doing so, the Progress Bar block is made inaccessible outside the context of a Multi-Form Goal block. This means an admin cannot add a standalone Progress Bar block to a page.

## Affects
This PR affects block editor rendering logic related to the Progress Bar block. Specifically, it clarifies where the block can be added, and limits it to the Multi-Form Goal block.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed