### PR TITLE
Buttons are now allowed in the content area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Multi-Form Goal wrapper only added for non-block output (#5315)
 -   Multi-Form Goal output has a bottom margin (#5333)
 -   Progress Bar block is no longer available outside of Multi-form Goal (#5338)
+-   Multi-Form Goal block now supports Buttons, through the Multi-Form Goal Content block (#5341)
 
 
 ### Changed

--- a/blocks/load.js
+++ b/blocks/load.js
@@ -8,5 +8,8 @@ import '../src/Totals/resources/js/index';
 // Import multi-form goal block from Multi-Form Goals src
 import '../src/MultiFormGoals/resources/js/blocks/multi-form-goal/index';
 
+// Import multi-form goal content block from Multi-Form Goals src
+import '../src/MultiFormGoals/resources/js/blocks/multi-form-goal-content/index';
+
 // Import progress bar block from Multi-Form Goals src
 import '../src/MultiFormGoals/resources/js/blocks/progress-bar/index';

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -6,6 +6,12 @@
 	object-fit: cover;
 }
 
+.give-multi-form-goal-content-block {
+	> * {
+		margin: revert;
+	}
+}
+
 .give-multi-form-goal-block {
 	display: flex;
 	flex-direction: column;

--- a/src/MultiFormGoals/resources/css/editor.scss
+++ b/src/MultiFormGoals/resources/css/editor.scss
@@ -10,3 +10,9 @@
 		max-width: 100% !important;
 	}
 }
+
+[data-type='give/multi-form-goal-content'] {
+	.block-editor-inner-blocks {
+		padding: 0 !important;
+	}
+}

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal-content/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal-content/index.js
@@ -20,41 +20,43 @@ import '../../../css/editor.scss';
  * Register Block
  */
 const blockTemplate = [
-	[ 'core/media-text', {
-		imageFill: true,
-	}, [
-		[ 'give/multi-form-goal-content', {} ],
-	] ],
-	[ 'give/progress-bar', {} ],
+	[ 'core/heading', {
+		placeholder: __( 'Heading', 'give' ),
+	} ],
+	[ 'core/paragraph', {
+		placeholder: __( 'Summary', 'give' ),
+	} ],
 ];
 
-export default registerBlockType( 'give/multi-form-goal', {
-	title: __( 'Multi-Form Goal', 'give' ),
+const allowedBlocks = [
+	'core/paragraph',
+	'core/buttons',
+];
+
+export default registerBlockType( 'give/multi-form-goal-content', {
+	title: __( 'Multi-Form Goal Content', 'give' ),
 	description: __( 'The Multi-Form Goals block displays progress made across donation forms towards a common goal.', 'give' ),
 	category: 'give',
 	icon: <GiveLogo color="grey" />,
+	parent: [ 'give/multi-form-goal' ],
 	keywords: [
 		__( 'donation', 'give' ),
 		__( 'multi form goals', 'give' ),
 	],
-	supports: {
-		align: [
-			'wide',
-		],
-	},
 	edit: () => {
 		return (
-			<div className="give-multi-form-goal-block">
+			<div className="give-multi-form-goal-content-block">
 				<InnerBlocks
 					template={ blockTemplate }
-					templateLock="all"
+					allowedBlocks={ allowedBlocks }
+					templateLock={ false }
 				/>
 			</div>
 		);
 	},
 	save: () => {
 		return (
-			<div className="give-multi-form-goal-block">
+			<div className="give-multi-form-goal-content-block">
 				<InnerBlocks.Content />
 			</div>
 		);


### PR DESCRIPTION
Resolves #5340 

## Description
This PR introduces the ability for admin to add Buttons to the Multi-Form Goal block. It does so through a new child block called Multi-Form Goal Content, which has uses the same block template that Multi-Form Goals previously did, but also includes an "allowed blocks" attribute which allows users to add core paragraph and buttons blocks.

## Affects
This PR affects the editor interface for Multi-Form Goal blocks.

## Visuals
<img width="798" alt="Screen Shot 2020-10-05 at 12 01 02 PM" src="https://user-images.githubusercontent.com/5186078/95104182-8c97ff80-0703-11eb-8d64-ee000e14a541.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add new page or post
2. Add Multi-Form goal block
3. Add buttons to Multi-Form Goal block
4. Check how editor appearance compares with frontend appearance