### PR TITLE
Multi-Form Goal Progress Bar only shows "time to go" if the end date has not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
 -   Reports page main menu is now extendable ( #5339 )
+-   Multi-Form Goal Progress Bar only shows "time to go" if the end date has not passed (#5350)
 
 ## [2.9.0-alpha.1] - 2020-10-06
 

--- a/src/MultiFormGoals/resources/views/progressbar.php
+++ b/src/MultiFormGoals/resources/views/progressbar.php
@@ -26,7 +26,7 @@
 			<div><?php echo $this->getFormattedGoal(); ?></div>
 			<div><?php echo __( 'goal', 'give' ); ?></div>
 		</div>
-		<?php if ( ! empty( $this->getEndDate() ) ) : ?>
+		<?php if ( ! empty( $this->getEndDate() ) && $this->getMinutesRemaining() ) : ?>
 			<div class="give-progress-bar-block__stat">
 				<div><?php echo $this->getTimeToGo(); ?></div>
 				<div><?php echo $this->getTimeToGoLabel(); ?></div>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Closes #5349

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Checks the return value of `getMinutesRemaining()` to conditionally render the output.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/95363323-4ecede80-089d-11eb-91b8-f9a5eb94e683.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Delete tasks that are not relevant. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Add a Multi-Form Goal block
- Set an End Date in the future and see the "time to go" stat displayed
- Change an End Date in the past and see the "time to go" stat is **not** displayed
