### PR TITLE
Added filter for reports to support additional post status

### DIFF
--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -361,10 +361,13 @@ abstract class Endpoint implements RestRoute {
 		$gateway = array_keys( $gatewayObjects );
 
 		$args = [
-			'post_status' => [
-				'publish',
-				'give_subscription',
-			],
+			'post_status' => apply_filters(
+				'give_reports_add_post_status',
+				[
+					'publish',
+					'give_subscription',
+				]
+			),
 			'number'      => $number,
 			'paged'       => 1,
 			'orderby'     => $orderBy,


### PR DESCRIPTION
This PR is a hotfix so it doesn't have any issue related to it. Please find the Slack thread here: https://givewp.slack.com/archives/C0FAGC83C/p1602078781075300

## Description
This PR adds a filter to extend the functionality so that users who wants to customize the post status for donations can add their registered post status support to reports in admin.

## Affects
https://github.com/impress-org/givewp/blob/develop/src/API/Endpoints/Reports/Endpoint.php#L364

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Tests included
-   [ ] Keyboard accessible
-   [ ] Screen reader accessible
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changelog updated
-   [ ] Labels applied if docs are needed
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
