### PR TITLE
Multi-Form Goal Blocks now auto-focus the Progress Bar on insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Set composer platform PHP version to 5.6 to ensure package compatibility (#5266)
 
+### Changed
+
+-   Multi-Form Goal Blocks now auto-focus the Progress Bar on insert (#5364)
+
 ## [2.9.0-alpha.2] - 2020-10-09
 
 ### Added

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/edit/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/edit/index.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { InnerBlocks } = wp.blockEditor;
+const { useEffect } = wp.element;
+const { select, dispatch } = wp.data;
+
+const edit = ( { isSelected, clientId } ) => {
+	// When adding a new Multi-Form Goal block, select the inner Progress Bar block by default
+	useEffect( () => {
+		if ( isSelected ) {
+			selectProgressBar();
+		}
+	}, [] );
+
+	const selectProgressBar = () => {
+		const parentBlock = select( 'core/editor' ).getBlocksByClientId( clientId )[ 0 ];
+		const progressBarBlock = parentBlock.innerBlocks[ parentBlock.innerBlocks.length - 1 ];
+		dispatch( 'core/block-editor' ).selectBlock( progressBarBlock.clientId );
+	};
+
+	const blockTemplate = [
+		[ 'core/media-text', {
+			imageFill: true,
+		}, [
+			[ 'core/heading', {
+				placeholder: __( 'Heading', 'give' ),
+			} ],
+			[ 'core/paragraph', {
+				placeholder: __( 'Summary', 'give' ),
+			} ],
+		] ],
+		[ 'give/progress-bar', {} ],
+	];
+
+	return (
+		<div className="give-multi-form-goal-block">
+			<InnerBlocks
+				template={ blockTemplate }
+				templateLock="all"
+			/>
+		</div>
+	);
+};
+export default edit;

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
@@ -3,14 +3,13 @@
  */
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
-const { InnerBlocks } = wp.blockEditor;
-const { useEffect } = wp.element;
-const { select, dispatch } = wp.data;
 
 /**
  * Internal dependencies
  */
 import GiveLogo from '../../components/logo';
+import edit from './edit';
+import save from './save';
 
 /**
  * Required styles (both common and editor styles)
@@ -21,19 +20,6 @@ import '../../../css/editor.scss';
 /**
  * Register Block
  */
-const blockTemplate = [
-	[ 'core/media-text', {
-		imageFill: true,
-	}, [
-		[ 'core/heading', {
-			placeholder: __( 'Heading', 'give' ),
-		} ],
-		[ 'core/paragraph', {
-			placeholder: __( 'Summary', 'give' ),
-		} ],
-	] ],
-	[ 'give/progress-bar', {} ],
-];
 
 export default registerBlockType( 'give/multi-form-goal', {
 	title: __( 'Multi-Form Goal', 'give' ),
@@ -49,34 +35,6 @@ export default registerBlockType( 'give/multi-form-goal', {
 			'wide',
 		],
 	},
-	edit: ( { isSelected, clientId } ) => {
-		// When adding a new Multi-Form Goal block, select the inner Progress Bar block by default
-		useEffect( () => {
-			if ( isSelected ) {
-				selectProgressBar();
-			}
-		}, [] );
-
-		const selectProgressBar = () => {
-			const parentBlock = select( 'core/editor' ).getBlocksByClientId( clientId )[ 0 ];
-			const progressBarBlock = parentBlock.innerBlocks[ parentBlock.innerBlocks.length - 1 ];
-			dispatch( 'core/block-editor' ).selectBlock( progressBarBlock.clientId );
-		};
-
-		return (
-			<div className="give-multi-form-goal-block">
-				<InnerBlocks
-					template={ blockTemplate }
-					templateLock="all"
-				/>
-			</div>
-		);
-	},
-	save: () => {
-		return (
-			<div className="give-multi-form-goal-block">
-				<InnerBlocks.Content />
-			</div>
-		);
-	},
+	edit: edit,
+	save: save,
 } );

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/index.js
@@ -4,6 +4,8 @@
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 const { InnerBlocks } = wp.blockEditor;
+const { useEffect } = wp.element;
+const { select, dispatch } = wp.data;
 
 /**
  * Internal dependencies
@@ -47,7 +49,20 @@ export default registerBlockType( 'give/multi-form-goal', {
 			'wide',
 		],
 	},
-	edit: () => {
+	edit: ( { isSelected, clientId } ) => {
+		// When adding a new Multi-Form Goal block, select the inner Progress Bar block by default
+		useEffect( () => {
+			if ( isSelected ) {
+				selectProgressBar();
+			}
+		}, [] );
+
+		const selectProgressBar = () => {
+			const parentBlock = select( 'core/editor' ).getBlocksByClientId( clientId )[ 0 ];
+			const progressBarBlock = parentBlock.innerBlocks[ parentBlock.innerBlocks.length - 1 ];
+			dispatch( 'core/block-editor' ).selectBlock( progressBarBlock.clientId );
+		};
+
 		return (
 			<div className="give-multi-form-goal-block">
 				<InnerBlocks

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/save/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/save/index.js
@@ -1,0 +1,10 @@
+const { InnerBlocks } = wp.blockEditor;
+
+const save = () => {
+	return (
+		<div className="give-multi-form-goal-block">
+			<InnerBlocks.Content />
+		</div>
+	);
+};
+export default save;


### PR DESCRIPTION
Resolves #5362 

## Description
This PR introduces logic to ensure that when a Multi-Form Goal block is inserted, the inner Progress Bar block is selected by default.
 
## Affects
This PR solely affects rendering logic for the Multi-Form Goal block, as it appears in the block editor.

## Visuals
![DefaultSelectProgressBar](https://user-images.githubusercontent.com/5186078/95760659-4bf73380-0c79-11eb-812c-d3645194f7a2.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add new page or post
2. Add Multi-Form Goal block
3. Check that the inner Progress Bar block is selected by default