### PR TITLE
Load PayPal sdk only on donation form page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Load PayPal SDK only on a page that has a donation form (#5376)
+
 ## 2.9.0-beta.1 - 2020-10-13
 
 ### Fixed

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -6,11 +6,21 @@ import CustomCardFields from './CustomCardFields';
 import { loadScript } from '@paypal/paypal-js';
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const $formWraps = document.querySelectorAll( '.give-form-wrap' );
+	let $formWraps = document.querySelectorAll( '.give-form-wrap' );
+	const $tmpFormWraps = [];
 
-	if ( ! $formWraps.length || ! Give.form.fn.hasDonationForm( $formWraps[ 0 ] ) ) {
+	// Filter container who has donation form.
+	$formWraps.forEach( $formWrap => {
+		if ( Give.form.fn.hasDonationForm( $formWrap ) ) {
+			$tmpFormWraps.push( $formWrap );
+		}
+	} );
+
+	if ( ! $tmpFormWraps.length ) {
 		return;
 	}
+
+	$formWraps = $tmpFormWraps;
 
 	// Setup initial PayPal script on basis of first form on webpage.
 	loadPayPalScript( $formWraps[ 0 ].querySelector( '.give-form' ) )

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -33,7 +33,7 @@ export default {
 		 */
 		hasDonationForm: function( $container ) {
 			const actionHiddenField = $container.querySelector( 'form input[name="give_action"]' );
-			return actionHiddenField && 'give_purchase' === actionHiddenField.value;
+			return actionHiddenField && 'purchase' === actionHiddenField.value;
 		},
 
 		/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5376

## Description
In this PR logic has been updated to load PayPal SDK only on a page that has a donation form.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
- Test this pr on pages with and without donation form and check `paypal.com/sdk` in Google Chrome `network` tab. The number of requests for PayPal SDK will be zero on-page which does not have a donation form and vice versa.

**Zero PayPal SDK request on page without donation form:**
![image](https://user-images.githubusercontent.com/1784821/96025414-bcb57000-0e72-11eb-90a2-bb48a2594da8.png)

**PayPal SDK request loads on page without donation form:**
![image](https://user-images.githubusercontent.com/1784821/96025515-d951a800-0e72-11eb-806a-d7150d579965.png)

