### PR TITLE
Disconnecting a Stripe account no longer revokes GiveWP as an Authorized Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-    Disconnecting a Stripe account no longer revokes GiveWP as an Authorized Application (#5378)
+
 ## 2.9.0-beta.1 - 2020-10-13
 
 ### Fixed

--- a/assets/src/css/admin/stripe-admin.scss
+++ b/assets/src/css/admin/stripe-admin.scss
@@ -345,6 +345,24 @@ a.give-stripe-connect-temp-dismiss:active {
 	}
 }
 
+.give-stripe-disconnect-all {
+	padding: 10px;
+	border: 1px solid #e5e5e5;
+	border-left: 4px solid #ffba00;
+
+	h3 {
+		margin: 0;
+		font-size: 1.1em;
+	}
+
+	.give-stripe-disconnect-all--description {
+		color: #666;
+	}
+}
+.give-stripe-disconnect-all-divider {
+	margin: 40px;
+}
+
 /* Retina support */
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
 	only screen and (min--moz-device-pixel-ratio: 1.5),

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 			add_action( 'give_admin_field_stripe_account_manager', [ $this, 'stripe_account_manager_field' ], 10, 2 );
 			add_action( 'give_admin_field_stripe_webhooks', [ $this, 'stripe_webhook_field' ], 10, 2 );
 			add_action( 'give_admin_field_stripe_styles_field', [ $this, 'stripe_styles_field' ], 10, 2 );
-			add_action( 'give_disconnect_connected_stripe_accout', [ $this, 'disconnect_connected_stripe_accout' ] );
+			add_action( 'give_disconnect_connected_stripe_account', [ $this, 'disconnect_connected_stripe_account' ] );
 		}
 
 		/**
@@ -769,7 +769,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 											'tab'         => 'gateways',
 											'section'     => 'stripe-settings',
 											'give_action' => ( 'connect' === $details['type'] )
-												? 'disconnect_connected_stripe_accout'
+												? 'disconnect_connected_stripe_account'
 												: 'disconnect_manual_stripe_account',
 											'give_stripe_disconnect_slug' => $slug,
 										],
@@ -1077,7 +1077,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 		/**
 		 * @since 2.8.0
 		 */
-		public function disconnect_connected_stripe_accout() {
+		public function disconnect_connected_stripe_account() {
 			$data = give_clean( $_GET );
 			if ( ! isset( $data['give_stripe_disconnect_slug'] ) ) {
 				return;

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -773,7 +773,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 												: 'disconnect_manual_stripe_account',
 											'give_stripe_disconnect_slug' => $slug,
 										],
-										admin_url( 'edit.php' )
+										wp_nonce_url( admin_url( 'edit.php' ), 'give_disconnect_connected_stripe_account_' . $slug )
 									);
 									?>
 									<div id="give-stripe-<?php echo $slug; ?>" class="give-stripe-account-manager-list-item">
@@ -1085,6 +1085,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 			if ( ! isset( $data['give_stripe_disconnect_slug'] ) ) {
 				return;
 			}
+			check_admin_referer( 'give_disconnect_connected_stripe_account_' . $data['give_stripe_disconnect_slug'] );
 			give_stripe_disconnect_account(
 				$data['give_stripe_disconnect_slug']
 			);

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -1078,6 +1078,9 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 		 * @since 2.8.0
 		 */
 		public function disconnect_connected_stripe_account() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
 			$data = give_clean( $_GET );
 			if ( ! isset( $data['give_stripe_disconnect_slug'] ) ) {
 				return;

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -693,6 +693,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 		 *
 		 * @return mixed|void
 		 * @since 2.7.0
+		 * @since 2.9.0 Stripe accounts are now disconnected locally, meaning that GiveWP remains an Authorized Application in the Stripe account.
 		 */
 		public function stripe_account_manager_field( $field, $option_value ) {
 			$stripe_accounts = give_stripe_get_all_accounts();

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -79,6 +79,7 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 			add_action( 'give_admin_field_stripe_account_manager', [ $this, 'stripe_account_manager_field' ], 10, 2 );
 			add_action( 'give_admin_field_stripe_webhooks', [ $this, 'stripe_webhook_field' ], 10, 2 );
 			add_action( 'give_admin_field_stripe_styles_field', [ $this, 'stripe_styles_field' ], 10, 2 );
+			add_action( 'give_disconnect_connected_stripe_accout', [ $this, 'disconnect_connected_stripe_accout' ] );
 		}
 
 		/**
@@ -759,25 +760,20 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 									$account_name       = $details['account_name'];
 									$account_email      = $details['account_email'];
 									$stripe_account_id  = $details['account_id'];
-									$disconnect_message = ( 'connect' === $details['type'] ) ?
-										sprintf(
-											esc_html__( 'Are you sure you want to disconnect GiveWP from Stripe? If disconnected, this website and any others sharing the same Stripe account (%1$s) that are connected to GiveWP will need to reconnect in order to process payments.', 'give' ),
-											$stripe_account_id
-										) :
-										esc_html__( 'Are you sure you want to disconnect GiveWP from Stripe?', 'give' );
-									$disconnect_url     = ( 'connect' === $details['type'] ) ?
-										give_stripe_disconnect_url( $stripe_account_id, $slug ) :
-										add_query_arg(
-											[
-												'post_type' => 'give_forms',
-												'page'    => 'give-settings',
-												'tab'     => 'gateways',
-												'section' => 'stripe-settings',
-												'give_action' => 'disconnect_manual_stripe_account',
-											],
-											admin_url( 'edit.php' )
-										);
-
+									$disconnect_message = esc_html__( 'Are you sure you want to disconnect this Stripe account?', 'give' );
+									$disconnect_url     = add_query_arg(
+										[
+											'post_type'   => 'give_forms',
+											'page'        => 'give-settings',
+											'tab'         => 'gateways',
+											'section'     => 'stripe-settings',
+											'give_action' => ( 'connect' === $details['type'] )
+												? 'disconnect_connected_stripe_accout'
+												: 'disconnect_manual_stripe_account',
+											'give_stripe_disconnect_slug' => $slug,
+										],
+										admin_url( 'edit.php' )
+									);
 									?>
 									<div id="give-stripe-<?php echo $slug; ?>" class="give-stripe-account-manager-list-item">
 										<div class="give-stripe-account-name-wrap">
@@ -1062,6 +1058,19 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 				</td>
 			</tr>
 			<?php
+		}
+
+		/**
+		 * @since 2.8.0
+		 */
+		public function disconnect_connected_stripe_accout() {
+			$data = give_clean( $_GET );
+			if ( ! isset( $data['give_stripe_disconnect_slug'] ) ) {
+				return;
+			}
+			give_stripe_disconnect_account(
+				$data['give_stripe_disconnect_slug']
+			);
 		}
 	}
 }

--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -891,6 +891,19 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 							?>
 						</div>
 					</div>
+					<!-- DESTRUCTIVE: Disconnect all Stripe accounts. -->
+					<hr class="give-stripe-disconnect-all-divider" />
+					<div class="give-stripe-disconnect-all">
+						<h3><?php esc_html_e( 'Remove GiveWP as an Authorized Application for my Stripe account.', 'give' ); ?></h3> 
+						<p class="give-stripe-disconnect-all--description">
+							<?php esc_html_e( 'Removing GiveWP as an Authorized Application for your Stripe account will remove the connection between the website you are disconnecting as well as any other sites that you have connected to GiveWP using the same Stripe account and connect method. Proceed with caution when disconnecting if you have multiple sites connected.', 'give' ); ?>
+						</p>
+						<p>
+							<a target="_blank" href="https://dashboard.stripe.com/account/applications">
+								<?php esc_html_e( 'View authorized applications in Stripe', 'give' ); ?>
+							</a>
+						</p>
+					</div>
 				</td>
 			</tr>
 			<?php


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5198

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This change allows for Stripe accounts to be disconnected form a site while preserving GiveWP as an Authorized Application to prevent other connected sites from breaking.

Additionally, this change offers instructions for revoking GiveWP as an Authorized Application in an explicit manner.

**Note**: This does NOT change the behaviour of which Stripe accounts are listed with a Disconnect action. The behaviour is the same as `develop`.

- Disconnects a Stripe account using `give_stripe_disconnect_account`, which does not revoke GiveWP as an Authorized Application in Stripe.
- Adds a new `give_disconnect_connected_stripe_account` action with corresponding method callback.
- Adds a notice below the Stripe account list with instructions on revoking GiveWP as an Authorized Application.

Note: This is a fork of #5201. The big difference is that there is no longer an option to "Remove All" which originally was intended to Revoke access but only worked for the default connected account. Instead, the notice now serves as discover-able, inline documentation for users that want to revoke GiveWP as an Authorized Application.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Disconnecting a site no longer revokes GiveWP as an Authorized Application.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Stripe Settings |
| --- |
| **Multiple connected Stripe accounts** ![Screenshot_2020-10-14 GiveWP Settings ‹ WordPress — WordPress(2)](https://user-images.githubusercontent.com/10858303/96040901-008b8380-0e39-11eb-9f5e-6f445798935e.png) |
| **A single connected Stripe account** ![Screenshot_2020-10-14 GiveWP Settings ‹ WordPress — WordPress(1)](https://user-images.githubusercontent.com/10858303/96040902-01241a00-0e39-11eb-9c60-aa1215fe898d.png) |
| **No connected Stripe accounts** ![Screenshot_2020-10-14 GiveWP Settings ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/96040903-01bcb080-0e39-11eb-88f6-ba65d64aa4ec.png) |


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Go to Settings -> Payment Gateways -> Stripe -> Manage Accounts.
1. Click "Connect with Stripe" and complete the connect process.
1. Go to Settings -> [Authorized Applications](https://dashboard.stripe.com/account/applications) in the Stripe dashboard of the connected account.
1. View GiveWP as an Authorized Application.
1. Go to Settings -> Payment Gateways -> Stripe -> Manage Accounts.
1. Click "Disconnect" to remove a connected account.
1. Go to Settings -> [Authorized Applications](https://dashboard.stripe.com/account/applications) in the Stripe dashboard of the connected account.
1. View GiveWP is still an Authorized Application.