### PR TITLE
Fix Credit Card fields tabbing inside an iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Load PayPal SDK only on a page that has a donation form (#5376)
+-   Credit Card fields tabbing (#5380)
 
 ## 2.9.0-beta.1 - 2020-10-13
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -83,9 +83,9 @@
 				$( steps[ step ].selector ).show().removeClass( directionClasses ).addClass( `slide-in-${ inDirection }` );
 			}
 			navigator.currentStep = step;
-			setupTabOrder();
 
 			setTimeout( function() {
+				setupTabOrder();
 				// Do not auto-focus form on the page load if the first step is disabled
 				if ( ! navigator.firstFocus && templateOptions.introduction.enabled === 'disabled' ) {
 					return navigator.firstFocus = true;
@@ -400,7 +400,7 @@
 
 		// Move payment information section when gateway updated.
 		$( document ).on( 'give_gateway_loaded', function() {
-			setupTabOrder();
+			setTimeout( setupTabOrder, 200 );
 			moveFieldsUnderPaymentGateway( true );
 			setupSelectInputs();
 			$( '#give_purchase_form_wrap' ).slideDown( 200, function() {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5380

## Description
This PR fixes the issue with tabbing through CC fields inside an iframe. The issue is fixed by wrapping up `setTabOrder` function with `setTimeOut` function to allow time for the loaded elements to appear in the DOM so that setTabOrder can add tabindex attribute to ajax loaded elements. 
## Affects
All input form elements inside the Multi-step Donation form.

## Visuals

![deepin-screen-recorder_Select area_20201016203122](https://user-images.githubusercontent.com/4222590/96295852-9f0d1580-0fee-11eb-86e7-f20c063b9898.gif)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
