### PR TITLE
Improve PayPal Donations WP backend UX

### DIFF
--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -9,7 +9,7 @@
  * @license:     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 
-/* globals Give, jQuery, givePayPalCommerce */
+/* globals Give, jQuery, givePayPalCommerce, ajaxurl */
 
 import { GiveConfirmModal } from './../plugins/modal';
 
@@ -386,23 +386,37 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	if ( onBoardingButton ) {
 		onBoardingButton.addEventListener( 'click', function( evt ) {
 			evt.preventDefault();
+			const buttonState = {
+				enable: () => {
+					onBoardingButton.disabled = false;
+					evt.target.innerText = onBoardingButton.getAttribute( 'data-initial-label' );
+				},
+				disable: () => {
+					// Preserve initial label.
+					if ( ! onBoardingButton.hasAttribute( 'data-initial-label' ) ) {
+						onBoardingButton.setAttribute( 'data-initial-label', onBoardingButton.innerText );
+					}
 
-			onBoardingButton.disabled = true;
+					onBoardingButton.disabled = true;
+					evt.target.innerText = Give.fn.getGlobalVar( 'loader_translation' ).processing;
+				},
+			};
 
-			evt.target.innerText = Give.fn.getGlobalVar( 'loader_translation' ).processing;
+			buttonState.disable();
 
 			const countryCode = countryField.value;
 
 			fetch( ajaxurl + `?action=give_paypal_commerce_get_partner_url&countryCode=${ countryCode }` )
 				.then( response => response.json() )
 				.then( function( res ) {
-					// @todo handle error.
 					if ( true === res.success ) {
 						const payPalLink = document.querySelector( '[data-paypal-button]' );
 
 						payPalLink.href = `${ res.data.partnerLink }&displayMode=minibrowser`;
 						payPalLink.click();
 					}
+
+					buttonState.enable();
 				}
 				);
 

--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -10,7 +10,9 @@ namespace Give\Onboarding\Setup;
 
 defined( 'ABSPATH' ) || exit;
 
+use Give\Helpers\Gateways\Stripe;
 use Give\Onboarding\FormRepository;
+use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 
 /**
  * @since 2.8.0
@@ -80,16 +82,18 @@ class PageView {
 	 * @since 2.8.0
 	 */
 	public function isStripeSetup() {
-		return \Give\Helpers\Gateways\Stripe::isAccountConfigured();
+		return Stripe::isAccountConfigured();
 	}
 
 	/**
+	 * Return whether ot not PayPal account connected.
+	 *
 	 * @return bool
 	 *
 	 * @since 2.8.0
 	 */
 	public function isPayPalSetup() {
-		return false;
+		return (bool) give( MerchantDetails::class )->getDetails();
 	}
 
 	/**

--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -93,7 +93,7 @@ class PageView {
 	 * @since 2.8.0
 	 */
 	public function isPayPalSetup() {
-		return (bool) give( MerchantDetails::class )->getDetails();
+		return (bool) give( MerchantDetails::class )->accountIsConnected();
 	}
 
 	/**

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -60,7 +60,7 @@
 							'title'       => esc_html__( 'Connect to PayPal', 'give' ),
 							'description' => esc_html__( 'PayPal is synonymous with nonprofits and online charitable gifts. It\'s been the go-to payment merchant for many of the world\'s top NGOs. Accept PayPal, credit and debit cards without any added platform fees.', 'give' ),
 							'action'      => sprintf(
-								'<a href="%s"><i class="fab fa-paypal"></i>&nbsp;&nbsp;Connect to PayPal</a>',
+								'<a href="%1$s"><i class="fab fa-paypal"></i>&nbsp;&nbsp;%2$s</a>',
 								add_query_arg(
 									[
 										'post_type' => 'give_forms',
@@ -70,7 +70,8 @@
 										'group'     => 'paypal-commerce',
 									],
 									esc_url_raw( admin_url( 'edit.php' ) )
-								)
+								),
+								! $this->isPayPalSetup() ? esc_html__( 'Connect to PayPal', 'give' ) : esc_html__( 'PayPal Settings', 'give' )
 							),
 						]
 					) : '',

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
@@ -40,7 +40,7 @@ class Settings {
 	 *
 	 * @since 2.9.0
 	 *
-	 * @return string|null
+	 * @return array|null
 	 */
 	public function getAccessToken() {
 		return get_option( self::ACCESS_TOKEN_KEY, null );

--- a/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
@@ -364,12 +364,21 @@ class onBoardingRedirectHandler {
 	 */
 	private function registerPayPalSSLNotice() {
 		if ( is_ssl() && empty( $this->webhooksRepository->getWebhookConfig() ) ) {
+			$logLink = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				admin_url( '/edit.php?post_type=give_forms&page=give-tools&tab=logs' ),
+				esc_html__( 'check logs', 'give' )
+			);
+
 			Give_Admin_Settings::add_error(
 				'paypal-webhook-error',
-				esc_html__(
-					'There was a problem creating a webhook for your account. Please try disconnecting and then
-					reconnect. If the problem persists, please contact support',
-					'give'
+				sprintf(
+					esc_html__(
+						'There was a problem creating a webhook for your account. Please try disconnecting and then
+					reconnect. If the problem persists, %1$s and please contact support',
+						'give'
+					),
+					$logLink
 				)
 			);
 		}

--- a/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php
@@ -367,15 +367,14 @@ class onBoardingRedirectHandler {
 			$logLink = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				admin_url( '/edit.php?post_type=give_forms&page=give-tools&tab=logs' ),
-				esc_html__( 'check logs', 'give' )
+				esc_html__( 'logs data', 'give' )
 			);
 
 			Give_Admin_Settings::add_error(
 				'paypal-webhook-error',
 				sprintf(
 					esc_html__(
-						'There was a problem creating a webhook for your account. Please try disconnecting and then
-					reconnect. If the problem persists, %1$s and please contact support',
+						'There was a problem setting up the webhooks for your PayPal account. Please try disconnecting and reconnecting your PayPal account. If the problem persists, please contact support and provide them with the latest %1$s',
 						'give'
 					),
 					$logLink


### PR DESCRIPTION

Resolves #5391

## Description
This PR resolve issue by
- Reverting back button initial state after the PayPal model open
- Add log link in webhook setup failure notice
- Conditionally update PayPal gateway information on the tab on GiveWP Setup page

## Visuals
![image](https://user-images.githubusercontent.com/1784821/96568465-9c0f6f00-12e5-11eb-96d5-a9384808e033.png)
![image](https://user-images.githubusercontent.com/1784821/96572380-615c0580-12ea-11eb-9664-59b7c2771d73.png)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
- Run`npm i && npm run dev` before testing this pr
- If you unable to reproduce the webhook setup issue then comment the `if` condition in this function and then connect PayPal account: https://github.com/impress-org/givewp/blob/163a038f4925218f345e7181d3d85515528b6dcc/src/PaymentGateways/PayPalCommerce/onBoardingRedirectHandler.php#L366