### PR TITLE
Wrap long texts into multiple lines in Donation receipt UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Load PayPal SDK only on a page that has a donation form (#5376)
 -   Credit Card fields tabbing (#5380)
+-   Long text overflowing outside of the container in Donation receipt (#5390)
 
 ## 2.9.0-beta.1 - 2020-10-13
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
@@ -180,7 +180,7 @@
 					flex: 1;
 					text-align: right;
 					color: #555;
-					white-space: nowrap;
+					white-space: pre-wrap;
 
 					@media screen and (max-width: $break-phone) {
 						flex: 0;
@@ -238,7 +238,7 @@
 RTL styles
 -----------------------------------*/
 
-html[dir="rtl"] {
+html[dir='rtl'] {
 	.details-row {
 		> i {
 			padding-right: 0 !important;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves  #5388

## Description

This PR fixes the issue where the long text is overflowed outside container in the Donation receipt. The issue is fixed by changing the `white-space` CSS property value from `nowrap` to `pre-wrap.` 

## Affects

Donation receipt UI. 

## Visuals

|   Before  |  After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/4222590/96569640-af144600-12c9-11eb-9025-a70c1feae06b.png) |  ![image](https://user-images.githubusercontent.com/4222590/96569011-e46c6400-12c8-11eb-985a-b454a2c3a6c9.png) |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

The easiest way to test this is with Funds add-on.

1. Add fund with a very long title
2. Associate that fund with a form
3. View the Donation form on the front-end
4. Make a donation with the selected fund
5. Check the receipt

<!-- Help others test your PR as efficiently as possible. -->
