### PR TITLE
Multi-Form Goal end date now reflects time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Load PayPal SDK only on a page that has a donation form (#5376)
 -   Credit Card fields tabbing (#5380)
+-   Multi-Form Goal end date now reflects time zone (#5394)
 
 ## 2.9.0-beta.1 - 2020-10-13
 

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -218,7 +218,7 @@ class Model {
 	protected function getMinutesRemaining() {
 		$enddate = strtotime( $this->getEndDate() );
 		if ( $enddate ) {
-			$now = time();
+			$now = current_time( 'timestamp', false );
 			return $now < $enddate ? ( $enddate - $now ) / 60 : 0;
 		} else {
 			return false;

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -241,7 +241,7 @@ class Model {
 				return round( $minutes / 60 );
 			}
 			case $minutes < 60: {
-				return $minutes;
+				return round( $minutes );
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #5392 

## Description
This PR address a bug which lead to inaccuracy in calculations of time remaining for a Multi-Form Goal.  Previously, the time remaining was calculated against GMT, and ignored WP options to handle any offset. This PR resolves the issue by ensuring that time remaining takes GMT offsets into account. Additionally, the PR addresses a minor error which caused minutes remaining to be rendered to the nearest decimal place, rather than rounded.

## Affects
This PR primarily affects the Progress Bar model, specifically logic involved in determining the minutes remaining toward a goal.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Set the WP option for timezone to reflect your local timezone
2. Add a new page or post
3. Add a Multi-Form Goal block, and set an end date within the next hour
4. Check that the end date is calculated and displayed correctly