### PR TITLE
Importing donations are not affecting form suggestions anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Imported donations now store the correct revenue amount (#5407)
--   Importing donations are not affecting form suggestions anymore (#5410)
+-   Imported donations do not affect form suggestions anymore (#5410)
 
 ## 2.9.0-beta.4 - 2020-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Reports for "All Time" are now inclusive of the first day (#5400)
 -   Fix PayPal Donation webhooks in live mode (#5403)
 -   Imported donations now store the correct revenue amount (#5407)
+-   Importing donations are not affecting form suggestions anymore (#5410)
 
 ## 2.9.0-beta.3 - 2020-10-22
 

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -139,8 +139,6 @@ function give_import_get_form_data_from_csv( $data, $import_setting = array() ) 
 				$price_text[ $new_level ] = strtolower( preg_replace( '/\s+/', '', $data['form_level'] ) );
 
 				if ( ! empty( $prices ) && is_array( $prices ) && ! empty( $prices[0] ) ) {
-					$prices = wp_parse_args( $multi_level_donations, $prices );
-
 					// Sort $prices by amount in ascending order.
 					$prices = wp_list_sort( $prices, '_give_amount', 'ASC' );
 				} else {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5408 

## Description

This PR fixes the issue where imported donations were affecting the form amount suggestions.  The problem was in the code logic, where the check for Donation Level texts was made and if the Level Title column from the imported file is different than already defined form levels, it will add imported donation amount as another donation level. The issue is solved by removing the piece of code which was doing that.

## Affects

Donations import.



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Make a few donations.
2. Export those donations.
3. Delete the donations in GiveWP.
4. Import the donations.
5. View the form on the front end the donations were made in.
