### PR TITLE
PayPal Standard functionality is now restored after breakage in 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-    Set PayPal Standard payment gateway id to original (#5414)
+
 ## 2.9.0-rc.1 - 2020-10-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--    Set PayPal Standard payment gateway id to original (#5414)
+-    Restore PayPal Standard functionality that was affected by a name change in GiveWP 2.9.0 (#5414)
 
 ## 2.9.0-rc.1 - 2020-10-27
 

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -160,6 +160,10 @@ function give_do_automatic_upgrades() {
 		case version_compare( $give_version, '2.9.0', '<' ):
 			give_v290_remove_old_export_files();
 			$did_upgrade = true;
+
+		case version_compare( $give_version, '2.9.1', '<' ):
+			give_v290_upgrades();
+			$did_upgrade = true;
 	}
 
 	if ( $did_upgrade || version_compare( $give_version, GIVE_VERSION, '<' ) ) {
@@ -3828,4 +3832,22 @@ function give_v270_store_stripe_account_for_donation_callback() {
 function give_v290_remove_old_export_files() {
 	@unlink( WP_CONTENT_DIR . '/uploads/give-payments.csv' );
 	@unlink( WP_CONTENT_DIR . '/uploads/give-donors.csv' );
+}
+
+/**
+ * Upgrade for Give 2.9.1
+ *
+ * @since 2.9.1
+ */
+function give_v290_upgrades() {
+	$gateways = give_get_option( 'gateways' );
+
+	if ( ! array_key_exists( 'paypal-standard', $gateways, true ) ) {
+		)
+		return;
+	}
+
+	$paypalStandardId              = 'paypal';
+	$gateways[ $paypalStandardId ] = '1';
+	give_update_option( 'gateways', $gateways );
 }

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -162,7 +162,7 @@ function give_do_automatic_upgrades() {
 			$did_upgrade = true;
 
 		case version_compare( $give_version, '2.9.1', '<' ):
-			give_v290_upgrades();
+			give_v291_upgrades();
 			$did_upgrade = true;
 	}
 
@@ -3839,7 +3839,7 @@ function give_v290_remove_old_export_files() {
  *
  * @since 2.9.1
  */
-function give_v290_upgrades() {
+function give_v291_upgrades() {
 	$gateways = give_get_option( 'gateways' );
 
 	if ( ! array_key_exists( 'paypal-standard', $gateways, true ) ) {

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -160,10 +160,6 @@ function give_do_automatic_upgrades() {
 		case version_compare( $give_version, '2.9.0', '<' ):
 			give_v290_remove_old_export_files();
 			$did_upgrade = true;
-
-		case version_compare( $give_version, '2.9.1', '<' ):
-			give_v291_upgrades();
-			$did_upgrade = true;
 	}
 
 	if ( $did_upgrade || version_compare( $give_version, GIVE_VERSION, '<' ) ) {
@@ -3832,22 +3828,4 @@ function give_v270_store_stripe_account_for_donation_callback() {
 function give_v290_remove_old_export_files() {
 	@unlink( WP_CONTENT_DIR . '/uploads/give-payments.csv' );
 	@unlink( WP_CONTENT_DIR . '/uploads/give-donors.csv' );
-}
-
-/**
- * Upgrade for Give 2.9.1
- *
- * @since 2.9.1
- */
-function give_v291_upgrades() {
-	$gateways = give_get_option( 'gateways' );
-
-	if ( ! array_key_exists( 'paypal-standard', $gateways, true ) ) {
-		)
-		return;
-	}
-
-	$paypalStandardId              = 'paypal';
-	$gateways[ $paypalStandardId ] = '1';
-	give_update_option( 'gateways', $gateways );
 }

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -16,7 +16,8 @@ class SetPayPalStandardGatewayId extends Migration {
 	 */
 	public function run() {
 		// Reset paypal gateway id to paypal.
-		$gateways = give_get_option( 'gateways' );
+		$give_settings = give_get_settings();
+		$gateways      = $give_settings['gateways'];
 		if ( array_key_exists( 'paypal-standard', $gateways ) ) {
 			unset( $gateways['paypal-standard'] );
 			$gateways['paypal'] = '1';

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -24,7 +24,6 @@ class SetPayPalStandardGatewayId extends Migration {
 
 		$gateways_label = give_get_option( 'gateways_label' );
 		if ( array_key_exists( 'paypal-standard', $gateways_label ) ) {
-			)
 			$gateways['paypal'] = $gateways['paypal-standard'];
 			unset( $gateways['paypal-standard'] );
 			give_update_option( 'gateways_label', $gateways );

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -33,22 +33,14 @@ class SetPayPalStandardGatewayId extends Migration {
 	}
 
 	/**
-	 * Return a unique identifier for the migration
-	 *
-	 * @return string
+	 * @inheritdoc
 	 */
 	public static function id() {
 		return 'set-paypal-standard-id-to-paypal-from-paypal-standard';
 	}
 
 	/**
-	 * Return a Unix Timestamp for when the migration was created
-	 *
-	 * Example: strtotime( '2020-09-16 ')
-	 *
-	 * @since 2.9.0
-	 *
-	 * @return int Unix timestamp for when the migration was created
+	 * @inheritdoc
 	 */
 	public static function timestamp() {
 		return strtotime( '2020-10-28' );

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -15,6 +15,7 @@ class SetPayPalStandardGatewayId extends Migration {
 	 * @inheritdoc
 	 */
 	public function run() {
+		// Reset paypal gateway id to paypal.
 		$gateways = give_get_option( 'gateways' );
 		if ( array_key_exists( 'paypal-standard', $gateways ) ) {
 			unset( $gateways['paypal-standard'] );
@@ -22,6 +23,7 @@ class SetPayPalStandardGatewayId extends Migration {
 			give_update_option( 'gateways', $gateways );
 		}
 
+		// Reset paypal gateway custom label.
 		$gateways_label = give_get_option( 'gateways_label' );
 		if ( array_key_exists( 'paypal-standard', $gateways_label ) ) {
 			$gateways['paypal'] = $gateways['paypal-standard'];

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -37,6 +37,12 @@ class SetPayPalStandardGatewayId extends Migration {
 			$updateSettings                  = true;
 		}
 
+		// Set paypal standard as default payment gateway.
+		if ( 'paypal-standard' === $give_settings['default_gateway'] ) {
+			$give_settings['default_gateway'] = 'paypal';
+			$updateSettings                   = true;
+		}
+
 		if ( $updateSettings ) {
 			update_option( 'give_settings', $give_settings );
 		}

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -36,7 +36,7 @@ class SetPayPalStandardGatewayId extends Migration {
 	 * @inheritdoc
 	 */
 	public static function id() {
-		return 'set-paypal-standard-id-to-paypal-from-paypal-standard';
+		return 'set_paypal_standard_id_to_paypal_from_paypal_standard';
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -16,20 +16,29 @@ class SetPayPalStandardGatewayId extends Migration {
 	 */
 	public function run() {
 		// Reset paypal gateway id to paypal.
-		$give_settings = give_get_settings();
-		$gateways      = $give_settings['gateways'];
+		$give_settings  = give_get_settings();
+		$gateways       = $give_settings['gateways'];
+		$updateSettings = false;
+
 		if ( array_key_exists( 'paypal-standard', $gateways ) ) {
 			unset( $gateways['paypal-standard'] );
-			$gateways['paypal'] = '1';
-			give_update_option( 'gateways', $gateways );
+			$gateways['paypal']        = '1';
+			$give_settings['gateways'] = $gateways;
+
+			$updateSettings = true;
 		}
 
 		// Reset paypal gateway custom label.
-		$gateways_label = give_get_option( 'gateways_label' );
+		$gateways_label = $give_settings['gateways_label'];
 		if ( array_key_exists( 'paypal-standard', $gateways_label ) ) {
 			$gateways_label['paypal'] = $gateways_label['paypal-standard'];
 			unset( $gateways_label['paypal-standard'] );
-			give_update_option( 'gateways_label', $gateways_label );
+			$give_settings['gateways_label'] = $gateways_label;
+			$updateSettings                  = true;
+		}
+
+		if ( $updateSettings ) {
+			update_option( 'give_settings', $give_settings );
 		}
 	}
 

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -1,0 +1,55 @@
+<?php
+namespace Give\PaymentGateways\PayPalStandard\Migrations;
+
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * Class SetPayPalStandardGatewayId
+ * @package Give\PaymentGateways\PayPalStandard\Migrations
+ *
+ * @since 2.9.1
+ */
+class SetPayPalStandardGatewayId extends Migration {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function run() {
+		$gateways = give_get_option( 'gateways' );
+		if ( array_key_exists( 'paypal-standard', $gateways ) ) {
+			unset( $gateways['paypal-standard'] );
+			$gateways['paypal'] = '1';
+			give_update_option( 'gateways', $gateways );
+		}
+
+		$gateways_label = give_get_option( 'gateways_label' );
+		if ( array_key_exists( 'paypal-standard', $gateways_label ) ) {
+			)
+			$gateways['paypal'] = $gateways['paypal-standard'];
+			unset( $gateways['paypal-standard'] );
+			give_update_option( 'gateways_label', $gateways );
+		}
+	}
+
+	/**
+	 * Return a unique identifier for the migration
+	 *
+	 * @return string
+	 */
+	public static function id() {
+		return 'set-paypal-standard-id-tp-paypal-from-paypal-standard';
+	}
+
+	/**
+	 * Return a Unix Timestamp for when the migration was created
+	 *
+	 * Example: strtotime( '2020-09-16 ')
+	 *
+	 * @since 2.9.0
+	 *
+	 * @return int Unix timestamp for when the migration was created
+	 */
+	public static function timestamp() {
+		return strtotime( '2020-10-28' );
+	}
+}

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -26,9 +26,9 @@ class SetPayPalStandardGatewayId extends Migration {
 		// Reset paypal gateway custom label.
 		$gateways_label = give_get_option( 'gateways_label' );
 		if ( array_key_exists( 'paypal-standard', $gateways_label ) ) {
-			$gateways['paypal'] = $gateways['paypal-standard'];
-			unset( $gateways['paypal-standard'] );
-			give_update_option( 'gateways_label', $gateways );
+			$gateways_label['paypal'] = $gateways_label['paypal-standard'];
+			unset( $gateways_label['paypal-standard'] );
+			give_update_option( 'gateways_label', $gateways_label );
 		}
 	}
 

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Give\PaymentGateways\PayPalStandard\Migrations;
 
 use Give\Framework\Migrations\Contracts\Migration;
@@ -6,6 +7,10 @@ use Give\Framework\Migrations\Contracts\Migration;
 /**
  * Class SetPayPalStandardGatewayId
  * @package Give\PaymentGateways\PayPalStandard\Migrations
+ *
+ * This migration fixes a bug that was introduced in 2.9.0 wherein the PayPal Standard gateway ID was changed from
+ * paypal to paypal-standard. This caused problems on existing sites using PayPal Standard. The purpose of this
+ * migration is to help those that are on 2.9.0 to recover to using the paypal ID for the gateway.
  *
  * @since 2.9.1
  */

--- a/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -37,7 +37,7 @@ class SetPayPalStandardGatewayId extends Migration {
 	 * @return string
 	 */
 	public static function id() {
-		return 'set-paypal-standard-id-tp-paypal-from-paypal-standard';
+		return 'set-paypal-standard-id-to-paypal-from-paypal-standard';
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/PayPalStandard/PayPalStandard.php
@@ -9,7 +9,7 @@ class PayPalStandard implements PaymentGateway {
 	 * @inheritDoc
 	 */
 	public function getId() {
-		return 'paypal-standard';
+		return 'paypal';
 	}
 
 	/**

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -53,8 +53,6 @@ class PaymentGateways implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function register() {
-		$this->registerMigrations();
-
 		give()->bind(
 			'PAYPAL_COMMERCE_ATTRIBUTION_ID',
 			static function() {
@@ -74,6 +72,8 @@ class PaymentGateways implements ServiceProvider {
 		add_filter( 'give_register_gateway', [ $this, 'bootGateways' ] );
 		add_action( 'admin_init', [ $this, 'handleSellerOnBoardingRedirect' ] );
 		add_action( 'give-settings_start', [ $this, 'registerPayPalSettingPage' ] );
+
+		$this->registerMigrations();
 	}
 
 	/**

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -69,6 +69,8 @@ class PaymentGateways implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function boot() {
+		$this->registerMigrations();
+
 		add_filter( 'give_register_gateway', [ $this, 'bootGateways' ] );
 		add_action( 'admin_init', [ $this, 'handleSellerOnBoardingRedirect' ] );
 		add_action( 'give-settings_start', [ $this, 'registerPayPalSettingPage' ] );

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -69,8 +69,6 @@ class PaymentGateways implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function boot() {
-		$this->registerMigrations();
-
 		add_filter( 'give_register_gateway', [ $this, 'bootGateways' ] );
 		add_action( 'admin_init', [ $this, 'handleSellerOnBoardingRedirect' ] );
 		add_action( 'give-settings_start', [ $this, 'registerPayPalSettingPage' ] );

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -3,6 +3,7 @@
 namespace Give\ServiceProviders;
 
 use Give\Controller\PayPalWebhooks;
+use Give\Framework\Migrations\MigrationsRegister;
 use Give\PaymentGateways\PaymentGateway;
 use Give\PaymentGateways\PayPalCommerce\AdvancedCardFields;
 use Give\PaymentGateways\PayPalCommerce\AjaxRequestHandler;
@@ -17,6 +18,7 @@ use Give\PaymentGateways\PayPalCommerce\PayPalClient;
 use Give\PaymentGateways\PayPalCommerce\PayPalCommerce;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookRegister;
+use Give\PaymentGateways\PayPalStandard\Migrations\SetPayPalStandardGatewayId;
 use Give\PaymentGateways\PayPalStandard\PayPalStandard;
 use Give\PaymentGateways\PaypalSettingPage;
 
@@ -51,6 +53,8 @@ class PaymentGateways implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function register() {
+		$this->registerMigrations();
+
 		give()->bind(
 			'PAYPAL_COMMERCE_ATTRIBUTION_ID',
 			static function() {
@@ -157,5 +161,17 @@ class PaymentGateways implements ServiceProvider {
 				$repository->setMode( give_is_test_mode() ? 'sandbox' : 'live' );
 			}
 		);
+	}
+
+	/**
+	 * Register migrations
+	 *
+	 * @since 2.9.1
+	 */
+	private function registerMigrations() {
+		/* @var MigrationsRegister $migrationRegisterer */
+		$migrationRegisterer = give( MigrationsRegister::class );
+
+		$migrationRegisterer->addMigration( SetPayPalStandardGatewayId::class );
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://feedback.givewp.com/bug-reports/p/paypal-standard-should-not-break-on-290

## Description
I find out that I renamed PayPal Standard payment gateway id to `paypal-standard` from `paypal` which cause of most of the issues with PayPal Standard payment gateway. To resolve the issue, I update the payment gateway id `paypal`.

## Affects
We can not detect if PayPal Standard was enabled when GiveWP update to `2.9.0` that why we can not reenable it. IF admin catch this issue on their site then they have to reenable it to fix the issue on the site after that everything will work as before.

## Pre-review Checklist
-   [x] Relevant @since tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing instruction

Check the following user cases
- [x] Does `PayPal Standard` has the same custom label as it was in `Give 2.9.0`
- [x] Does `PayPal Standard` set as default payment gateway as it was in `Give 2.9.0`
- [x] Does `PayPal Standard` set as activate payment gateway as it was in `Give 2.9.0`