### PR TITLE
GiveWP 2.9.0 is now compatible with WP 4.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Prevent Onboarding wizard and setup from displaying for WP < 5.x (#5416)
+-   Retain WP 4.9 compatibility by preventing block registration (#5416)
+
 ## 2.9.0-rc.1 - 2020-10-27
 
 ### Added

--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -133,9 +133,9 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 							],
 						],
 						[
-							'name'    => __( 'Setup Page', 'give' ),
+							'name'          => __( 'Setup Page', 'give' ),
 							/* translators: %s: about page URL */
-							'desc'    => sprintf(
+							'desc'          => sprintf(
 								wp_kses(
 									__( 'Disable this option if you would like to disable the <a href="%s" target="_blank">GiveWP Setup page</a> that displays when GiveWP is first installed.', 'give' ),
 									[
@@ -147,17 +147,18 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 								),
 								esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-setup' ) )
 							),
-							'id'      => 'setup_page_enabled',
-							'type'    => 'radio_inline',
-							'default' => give_is_setting_enabled(
+							'id'            => 'setup_page_enabled',
+							'type'          => 'radio_inline',
+							'default'       => give_is_setting_enabled(
 								SetupPage::getSetupPageEnabledOrDisabled()
 							)
 								? SetupPage::ENABLED
 								: SetupPage::DISABLED,
-							'options' => [
+							'options'       => [
 								SetupPage::ENABLED  => __( 'Enabled', 'give' ),
 								SetupPage::DISABLED => __( 'Disabled', 'give' ),
 							],
+							'wrapper_class' => version_compare( get_bloginfo( 'version' ), '5.0', '<=' ) ? 'give-hidden' : null,
 						],
 						[
 							'name'    => __( 'Form Page URL Prefix', 'give' ),

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: givewp, dlocc, webdevmattcrom, ravinderk, mehul0810, kevinwhoffman, jason_the_adams, henryholtgeerts, kbjohnson90, alaca
 Donate link: https://givewp.com/
 Tags: donation, fundraising, crowdfunding, givewp, give
-Requires at least: 4.8
+Requires at least: 4.9
 Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 2.9.0

--- a/src/MultiFormGoals/ServiceProvider.php
+++ b/src/MultiFormGoals/ServiceProvider.php
@@ -15,8 +15,11 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function register() {
 		give()->singleton( MultiFormGoalShortcode::class );
-		give()->singleton( MultiFormGoalBlock::class );
-		give()->singleton( ProgressBarBlock::class );
+
+		if ( function_exists( 'register_block_type' ) ) {
+			give()->singleton( MultiFormGoalBlock::class );
+			give()->singleton( ProgressBarBlock::class );
+		}
 	}
 
 	/**
@@ -24,8 +27,11 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function boot() {
 		Hooks::addAction( 'init', MultiFormGoalShortcode::class, 'addShortcode' );
-		Hooks::addAction( 'init', MultiFormGoalBlock::class, 'addBlock' );
-		Hooks::addAction( 'init', ProgressBarBlock::class, 'addBlock' );
-		Hooks::addAction( 'enqueue_block_editor_assets', ProgressBarBlock::class, 'localizeAssets' );
+
+		if ( function_exists( 'register_block_type' ) ) {
+			Hooks::addAction( 'init', MultiFormGoalBlock::class, 'addBlock' );
+			Hooks::addAction( 'init', ProgressBarBlock::class, 'addBlock' );
+			Hooks::addAction( 'enqueue_block_editor_assets', ProgressBarBlock::class, 'localizeAssets' );
+		}
 	}
 }

--- a/src/ServiceProviders/Onboarding.php
+++ b/src/ServiceProviders/Onboarding.php
@@ -27,6 +27,12 @@ class Onboarding implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function register() {
+
+		// Onboarding Wizard and Setup page require WP v5.0.x or greater
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<=' ) ) {
+			return;
+		}
+
 		give()->singleton( SetupPage::class );
 		give()->singleton( WizardPage::class );
 		give()->singleton( FormPreview::class );
@@ -47,6 +53,11 @@ class Onboarding implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function boot() {
+
+		// Onboarding Wizard and Setup page require WP v5.0.x or greater
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<=' ) ) {
+			return;
+		}
 
 		// Load Wizard Page
 		Hooks::addAction( 'admin_menu', WizardPage::class, 'add_page' );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5415 

## Description
This PR prevents a fatal error related to GiveWP 2.9 which appeared on installs running WP 4.9.x. To resolve the error, the MultiForm Block ServiceProvider now checks for existance of the `register_block_type` function before attempting to add blocks.

## Affects
This PR affects the Multi-Form Goal ServiceProvider, allowing it conditionally add hooks related to blocks only if the `register_block_type` function exists.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Setup a fresh install of WP 4.9.x
2. Install this branch of GiveWP
3. Check that you are redirected to the Onboarding Wizard
4. Check that the "Setup" page does not appear in the menu
5. Check that there is no setting to enable the setup page in Settings > Advanced
6. Check that you can navigate the site and admin area without issue
7. Check that Multi-Form Goal shortcodes still work as expected