### PR TITLE
Prevent javascript error on donation form if stripe checkout payment method active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-    Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
+
 ### 2.9.1 - 2020-10-28
 
 ### Fixed

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -27,9 +27,12 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		const stripeElements = new GiveStripeElements( formElement );
 		const setupStripeElement = stripeElements.setupStripeElement();
 		const getStripeElements = stripeElements.getElements( setupStripeElement );
+		const stripeCheckoutTypeHiddenField = formElement.querySelector( 'input[name="stripe-checkout-type"]' );
+		const isCheckoutTypeModal = stripeCheckoutTypeHiddenField && 'modal' === stripeCheckoutTypeHiddenField.value;
+		const isStripeModalCheckoutGateway = 'stripe_checkout' === formGateway.value && isCheckoutTypeModal;
 		let cardElements = stripeElements.createElement( getStripeElements, formElement );
 
-		if ( 'stripe' === formGateway.value || 'stripe_checkout' === formGateway.value ) {
+		if ( 'stripe' === formGateway.value || isStripeModalCheckoutGateway ) {
 			stripeElements.mountElement(cardElements);
 		}
 
@@ -38,18 +41,18 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			const getStripeElements = stripeElements.getElements( setupStripeElement );
 			cardElements = stripeElements.createElement( getStripeElements, formElement );
 
-			if ( 'stripe' === selectedGateway || 'stripe_checkout' === selectedGateway ) {
+			if ( 'stripe' === selectedGateway || isStripeModalCheckoutGateway ) {
 				stripeElements.mountElement( cardElements );
 			} else {
 				stripeElements.unMountElement( cardElements );
 			}
 
-			if ( 'stripe_checkout' === selectedGateway ) {
+			if ( isStripeModalCheckoutGateway ) {
 				stripeElements.triggerStripeModal( formElement, stripeElements, setupStripeElement, cardElements );
 			}
 		});
 
-		if ( 'stripe_checkout' === formGateway.value ) {
+		if ( isStripeModalCheckoutGateway) {
 			stripeElements.triggerStripeModal( formElement, stripeElements, setupStripeElement, cardElements );
 		}
 
@@ -60,7 +63,9 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			if ( 'stripe' === selectedGateway ) {
 				stripeElements.createPaymentMethod( formElement, setupStripeElement, cardElements );
 				e.preventDefault();
-			} else if ( 'stripe_checkout' === selectedGateway ) {
+			}
+
+			if ( isStripeModalCheckoutGateway ) {
 				const stripeModal = formElement.querySelector( '.give-stripe-checkout-modal' );
 				const modalAmountElement = stripeModal.querySelector( '.give-stripe-checkout-donation-amount' );
 				const modalEmailElement = stripeModal.querySelector( '.give-stripe-checkout-donor-email' );

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -86,7 +86,9 @@ class Form {
 					 * Fire the action hook.
 					 *
 					 * If developer wants to verify payment before showing receipt then use `give_handle_donation_confirm` action hook to verify donation.
-					 * You can use src/Helpers/Session/DonationConfirmation/Frontend.php::getPostedData function to get response from payment gateway (if any).
+					 * Developer can access query parameters return by payment gateway. for example
+					 * $session = new DonationAccessor();
+					 * $session->getByKey( "postDataFor{$paymentGatewayId}" )
 					 *
 					 * @since 2.7.0
 					 * @param int $donationId

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -93,10 +93,10 @@ class Form {
 					 */
 					do_action( 'give_handle_donation_confirmation', $donationId );
 
+					ConfirmDonation::removePostedDataFromDonationSession();
+
 					// Load payment processing view only if donation is in pending status.
 					if ( 'pending' === get_post_status( $donationId ) ) {
-						ConfirmDonation::removePostedDataFromDonationSession();
-
 						include GIVE_PLUGIN_DIR . 'src/Views/Form/defaultFormDonationProcessing.php';
 						exit();
 					}

--- a/src/Helpers/Frontend/ConfirmDonation.php
+++ b/src/Helpers/Frontend/ConfirmDonation.php
@@ -23,16 +23,16 @@ class ConfirmDonation {
 	public static function storePostedDataInDonationSession() {
 		$isShowingDonationReceipt = ! empty( $_REQUEST['giveDonationAction'] ) && 'showReceipt' === give_clean( $_REQUEST['giveDonationAction'] );
 
-		if ( $isShowingDonationReceipt ) {
-			$paymentGatewayId = ucfirst( give_clean( $_GET['payment-confirmation'] ) );
-
-			$session = new DonationAccessor();
-			$session->store( "postDataFor{$paymentGatewayId}", array_map( 'give_clean', $_POST ) );
-
-			return true;
+		if ( ! $isShowingDonationReceipt || ! isset( $_GET['payment-confirmation'] ) ) {
+			return false;
 		}
 
-		return false;
+		$paymentGatewayId = ucfirst( give_clean( $_GET['payment-confirmation'] ) );
+
+		$session = new DonationAccessor();
+		$session->store( "postDataFor{$paymentGatewayId}", array_map( 'give_clean', $_POST ) );
+
+		return true;
 	}
 
 	/**
@@ -43,6 +43,10 @@ class ConfirmDonation {
 	 * @since 2.7.0
 	 */
 	public static function removePostedDataFromDonationSession() {
+		if ( ! isset( $_GET['payment-confirmation'] ) ) {
+			return;
+		}
+
 		$paymentGatewayId = ucfirst( give_clean( $_GET['payment-confirmation'] ) );
 
 		$session = new DonationAccessor();

--- a/src/Helpers/Frontend/ConfirmDonation.php
+++ b/src/Helpers/Frontend/ConfirmDonation.php
@@ -43,10 +43,6 @@ class ConfirmDonation {
 	 * @since 2.7.0
 	 */
 	public static function removePostedDataFromDonationSession() {
-		if ( ! isset( $_GET['payment-confirmation'] ) ) {
-			return;
-		}
-
 		$paymentGatewayId = ucfirst( give_clean( $_GET['payment-confirmation'] ) );
 
 		$session = new DonationAccessor();

--- a/src/PaymentGateways/Stripe/DonationFormElements.php
+++ b/src/PaymentGateways/Stripe/DonationFormElements.php
@@ -1,0 +1,26 @@
+<?php
+namespace Give\PaymentGateways\Stripe;
+
+/**
+ * Class DonationFormElements
+ * @package Give\PaymentGateways\Stripe
+ *
+ * We use this class to output HTML fields on donation form.
+ *
+ * @since 2.9.2
+ */
+class DonationFormElements {
+	/**
+	 * Add hidden fields to donation forms.
+	 *
+	 * @since 2.9.2
+	 */
+	public function addHiddenFields() {
+		if ( give_is_gateway_active( 'stripe_checkout' ) ) {
+			printf(
+				'<input type="hidden" name="stripe-checkout-type" value="%1$s">',
+				give_stripe_get_checkout_type()
+			);
+		}
+	}
+}

--- a/src/ServiceProviders/PaymentGateways.php
+++ b/src/ServiceProviders/PaymentGateways.php
@@ -4,6 +4,7 @@ namespace Give\ServiceProviders;
 
 use Give\Controller\PayPalWebhooks;
 use Give\Framework\Migrations\MigrationsRegister;
+use Give\Helpers\Hooks;
 use Give\PaymentGateways\PaymentGateway;
 use Give\PaymentGateways\PayPalCommerce\AdvancedCardFields;
 use Give\PaymentGateways\PayPalCommerce\AjaxRequestHandler;
@@ -21,6 +22,7 @@ use Give\PaymentGateways\PayPalCommerce\Webhooks\WebhookRegister;
 use Give\PaymentGateways\PayPalStandard\Migrations\SetPayPalStandardGatewayId;
 use Give\PaymentGateways\PayPalStandard\PayPalStandard;
 use Give\PaymentGateways\PaypalSettingPage;
+use Give\PaymentGateways\Stripe\DonationFormElements;
 
 /**
  * Class PaymentGateways
@@ -62,6 +64,7 @@ class PaymentGateways implements ServiceProvider {
 
 		give()->singleton( PayPalWebhooks::class );
 		give()->singleton( Webhooks::class );
+		give()->singleton( DonationFormElements::class );
 		$this->registerPayPalCommerceClasses();
 	}
 
@@ -72,6 +75,7 @@ class PaymentGateways implements ServiceProvider {
 		add_filter( 'give_register_gateway', [ $this, 'bootGateways' ] );
 		add_action( 'admin_init', [ $this, 'handleSellerOnBoardingRedirect' ] );
 		add_action( 'give-settings_start', [ $this, 'registerPayPalSettingPage' ] );
+		Hooks::addAction( 'give_donation_form_top', DonationFormElements::class, 'addHiddenFields', 99 );
 
 		$this->registerMigrations();
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5418 

## Description
The stripe checkout method allows us to process payment `onpage` and` offpage`. Admin has a setting to configure the payment method checkout type either `Modal` or `Redirect`. When checkout type set to `Modal` then javascript code run to setup stripe card fields which donor can use to process the payment `onpage`. This logic should not run when the checkout type set to `Redirect`. I update the code to fix this issue.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Run npm run dev to compile the JS changes
- Follow the Steps to Reproduce in the Issue
- Be sure to look through the Acceptance Criteria and test each scenario
