### PR TITLE
Show donor error and restore donate now button when Stripe returns error when create payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -    Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
+-    Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)
 
 ### 2.9.1 - 2020-10-28
 

--- a/assets/src/js/frontend/give-stripe-elements.js
+++ b/assets/src/js/frontend/give-stripe-elements.js
@@ -278,25 +278,18 @@ class GiveStripeElements {
 			billing_details: billing_details,
 		} ).then( function( result ) {
 			if ( result.error ) {
-				const donateBtn = formElement.getElementById( 'give-purchase-button' );
+				const jQueryFormElement = jQuery( formElement );
 				const error = `<div class="give_errors"><p class="give_error">${ result.error.message }</p></div>`;
+				const formId = formElement.getAttribute( 'data-id' );
 
-				// re-enable the submit button.
-				donateBtn.setAttribute( 'disabled', false );
+				Give.form.fn.resetDonationButton( jQueryFormElement );
+				formElement.querySelector( `#give-stripe-payment-errors-${ formId }` ).innerHTML = error;
 
-				// Display Error on the form.
-				formElement.getElementById( `give-stripe-payment-errors-${ formId }` ).innerHTML = error;
-
-				// Reset Donate Button.
-				if ( give_global_vars.complete_purchase ) {
-					formElement.value = give_global_vars.complete_purchase;
-				} else {
-					formElement.value = formElement.getAttribute( 'data-before-validation-label' );
-				}
-			} else {
-				formElement.querySelector( 'input[name="give_stripe_payment_method"]' ).value = result.paymentMethod.id;
-				formElement.submit();
+				return;
 			}
+
+			formElement.querySelector( 'input[name="give_stripe_payment_method"]' ).value = result.paymentMethod.id;
+			formElement.submit();
 		} );
 	}
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5420 
## Description
I find out that there were coding-related issues that handle stripe payment method errors on the frontend. I find them to prevent javascript error.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Run npm run dev to compile the JS changes
- Follow the Steps to Reproduce in the Issue
- Be sure to look through the Acceptance Criteria and test each scenario