### PR TITLE
Free add-ons does not trigger GiveWP add-on license errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-    Free add-ons does not trigger GiveWP add-on license errors (#5424)
+
+### Fixed
+
 -    Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
 -    Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)
 

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -11,7 +11,7 @@
  */
 function give_cmb2_get_post_options( $query_args, $force = false ) {
 
-	$post_options = array( '' => '' ); // Blank option
+	$post_options = [ '' => '' ]; // Blank option
 
 	if ( ( ! isset( $_GET['page'] ) || 'give-settings' != $_GET['page'] ) && ! $force ) {
 		return $post_options;
@@ -19,10 +19,10 @@ function give_cmb2_get_post_options( $query_args, $force = false ) {
 
 	$args = wp_parse_args(
 		$query_args,
-		array(
+		[
 			'post_type'   => 'page',
 			'numberposts' => 10,
-		)
+		]
 	);
 
 	$posts = get_posts( $args );
@@ -53,12 +53,12 @@ function give_cmb2_get_post_options( $query_args, $force = false ) {
 function give_get_featured_image_sizes() {
 	global $_wp_additional_image_sizes;
 
-	$sizes            = array();
+	$sizes            = [];
 	$get_sizes        = get_intermediate_image_sizes();
-	$core_image_sizes = array( 'thumbnail', 'medium', 'medium_large', 'large' );
+	$core_image_sizes = [ 'thumbnail', 'medium', 'medium_large', 'large' ];
 
 	// This will help us to filter special characters from a string
-	$filter_slug_items = array( '_', '-' );
+	$filter_slug_items = [ '_', '-' ];
 
 	foreach ( $get_sizes as $_size ) {
 
@@ -96,7 +96,7 @@ function give_get_featured_image_sizes() {
  *
  * @return string $string
  */
-function give_slug_to_title( $string, $filters = array() ) {
+function give_slug_to_title( $string, $filters = [] ) {
 
 	foreach ( $filters as $filter_item ) {
 		$string = str_replace( $filter_item, ' ', $string );
@@ -223,9 +223,9 @@ function give_add_ons_feed( $feed_type = '', $echo = true ) {
 		}
 
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
-			$feed = vip_safe_wp_remote_get( $feed_url, false, 3, 1, 20, array( 'sslverify' => false ) );
+			$feed = vip_safe_wp_remote_get( $feed_url, false, 3, 1, 20, [ 'sslverify' => false ] );
 		} else {
-			$feed = wp_remote_get( $feed_url, array( 'sslverify' => false ) );
+			$feed = wp_remote_get( $feed_url, [ 'sslverify' => false ] );
 		}
 
 		if ( ! is_wp_error( $feed ) ) {
@@ -276,4 +276,32 @@ function give_get_premium_add_ons() {
 		},
 		$list
 	);
+}
+
+/**
+ * Get list of premium add-ons urls
+ *
+ * @return array
+ * @since 2.5.0
+ */
+function give_get_premium_addons_url() {
+	$list = wp_extract_urls( give_add_ons_feed( 'addons-directory', false ) );
+
+	$urls = array_values(
+		array_filter(
+			$list,
+			static function ( $url ) {
+				return false !== strpos( $url, 'givewp.com/addons' );
+			}
+		)
+	);
+
+	$urls = array_map(
+		static function( $url ) {
+			return untrailingslashit( $url );
+		},
+		$urls
+	);
+
+	return $urls;
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -844,24 +844,15 @@ function give_get_plugins( $args = [] ) {
 			require_once GIVE_PLUGIN_DIR . '/includes/admin/misc-functions.php';
 		}
 
-		$premium_addons_list = give_get_premium_add_ons();
+		$premium_addons_list = give_get_premium_addons_url();
 
 		foreach ( $plugins as $key => $plugin ) {
-			$addon_shortname = str_replace( 'give-', '', $plugin['Dir'] );
-			$tmp             = $premium_addons_list;
-			$is_premium      = count(
-				array_filter(
-					$tmp,
-					function( $plugin ) use ( $addon_shortname ) {
-						return false !== strpos( $plugin, $addon_shortname );
-					}
-				)
-			);
+			if ( 'add-on' !== $plugin['Type'] ) {
+				unset( $plugins[ $key ] );
+			}
 
-			if (
-				'add-on' !== $plugin['Type']
-				|| ( false === strpos( $plugin['PluginURI'], 'givewp.com' ) && ! $is_premium )
-			) {
+			$addonUrl = untrailingslashit( $plugin['PluginURI'] );
+			if ( ! in_array( $addonUrl, $premium_addons_list, true ) ) {
 				unset( $plugins[ $key ] );
 			}
 		}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4760 

## Description

This issue occurs because the list of premium addons that we get from `give_get_plugins` function is not accurate and logic fails in specific scenarios to identify premium addons. After research, I find out that the `Plugin URI` (in plugin header) of every premium addon points to `https://givewp.com/addons/{addonSlug}` which we can compare from premium addon list which we get from `give_get_premium_addons_url` function.

## Visuals
![image](https://user-images.githubusercontent.com/1784821/97737510-1f5d6b80-1b03-11eb-864d-45ebf1aebf4d.png)

As you can see above image `Give - WePay` addon does not consider as a premium addon because it is deprecated but you can see license nag for `Give -Zapier` addon which is a premium addon.


## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in the related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Set `$is_required_days_past` value to `true` to see license warning if not any license activated: https://github.com/impress-org/givewp/blob/56ae547508a0b495e60e4f4b1c0f7a2d6e046015/includes/admin/admin-actions.php#L1415
- Use any type of license key: single key, bundle key, add in one pass license key