### PR TITLE
Use easy digital download rest api endpoint to confirm addon is premium or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)
 -   Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
 
+### Changed
+
+-   Use easy digital download rest api endpoint to confirm addon is premium or not (#5426)
+
 ### 2.9.1 - 2020-10-28
 
 ### Fixed

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -277,31 +277,3 @@ function give_get_premium_add_ons() {
 		$list
 	);
 }
-
-/**
- * Get list of premium add-ons urls
- *
- * @return array
- * @since 2.5.0
- */
-function give_get_premium_addons_url() {
-	$list = wp_extract_urls( give_add_ons_feed( 'addons-directory', false ) );
-
-	$urls = array_values(
-		array_filter(
-			$list,
-			static function ( $url ) {
-				return false !== strpos( $url, 'givewp.com/addons' );
-			}
-		)
-	);
-
-	$urls = array_map(
-		static function( $url ) {
-			return untrailingslashit( $url );
-		},
-		$urls
-	);
-
-	return $urls;
-}

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -249,31 +249,3 @@ function give_add_ons_feed( $feed_type = '', $echo = true ) {
 
 	return $cache;
 }
-
-
-/**
- * Get list of premium add-ons
- *
- * @return array
- * @since 2.5.0
- */
-function give_get_premium_add_ons() {
-	$list = wp_extract_urls( give_add_ons_feed( 'addons-directory', false ) );
-	$list = array_values(
-		array_filter(
-			$list,
-			function ( $url ) {
-				return false !== strpos( $url, 'givewp.com/addons' );
-			}
-		)
-	);
-
-	return array_map(
-		function ( $url ) {
-				$path = wp_parse_url( untrailingslashit( $url ) )['path'];
-
-				return str_replace( '/addons/', '', $path );
-		},
-		$list
-	);
-}

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -64,11 +64,11 @@ function give_log_default_views() {
 
 	_give_deprecated_function( __FUNCTION__, '1.8', null, $backtrace );
 
-	$views = array(
+	$views = [
 		'sales'          => __( 'Donations', 'give' ),
 		'gateway_errors' => __( 'Payment Errors', 'give' ),
 		'api_requests'   => __( 'API Requests', 'give' ),
-	);
+	];
 
 	$views = apply_filters( 'give_log_views', $views );
 
@@ -258,7 +258,7 @@ function give_purchase_form_validate_new_user() {
  *
  * @param array $valid_data
  */
-function give_get_purchase_form_user( $valid_data = array() ) {
+function give_get_purchase_form_user( $valid_data = [] ) {
 
 	$backtrace = debug_backtrace();
 
@@ -819,10 +819,10 @@ function give_get_payment_form_title( $meta, $only_level = false, $separator = '
 		$donation = give_get_payment_by( 'key', $meta['key'] );
 	}
 
-	$args = array(
+	$args = [
 		'only_level' => $only_level,
 		'separator'  => $separator,
-	);
+	];
 
 	return give_get_donation_form_title( $donation, $args );
 }
@@ -860,7 +860,7 @@ function give_delete_donor( $args ) {
  *
  * @return array
  */
-function give_get_donor_donation_comments( $donor_id, $comment_args = array(), $search = '' ) {
+function give_get_donor_donation_comments( $donor_id, $comment_args = [], $search = '' ) {
 	_give_deprecated_function(
 		__FUNCTION__,
 		'2.3.0',
@@ -874,7 +874,7 @@ function give_get_donor_donation_comments( $donor_id, $comment_args = array(), $
 		$search
 	);
 
-	return ( ! empty( $comments ) ? $comments : array() );
+	return ( ! empty( $comments ) ? $comments : [] );
 }
 
 /**
@@ -962,23 +962,23 @@ function give_get_donor_latest_comment( $donor_id, $form_id = 0 ) {
 	// Backward compatibility.
 	if ( ! give_has_upgrade_completed( 'v230_move_donor_note' ) ) {
 
-		$comment_args = array(
+		$comment_args = [
 			'post_id'    => 0,
 			'orderby'    => 'comment_ID',
 			'order'      => 'DESC',
 			'number'     => 1,
-			'meta_query' => array(
+			'meta_query' => [
 				'related' => 'AND',
-				array(
+				[
 					'key'   => '_give_donor_id',
 					'value' => $donor_id,
-				),
-				array(
+				],
+				[
 					'key'   => '_give_anonymous_donation',
 					'value' => 0,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		// Get donor donation comment for specific form.
 		if ( $form_id ) {
@@ -990,29 +990,29 @@ function give_get_donor_latest_comment( $donor_id, $form_id = 0 ) {
 		return $comment;
 	}
 
-	$comment_args = array(
+	$comment_args = [
 		'orderby'    => 'comment_ID',
 		'order'      => 'DESC',
 		'number'     => 1,
-		'meta_query' => array(
+		'meta_query' => [
 			'relation' => 'AND',
-			array(
+			[
 				'key'   => '_give_anonymous_donation',
 				'value' => 0,
-			),
-			array(
+			],
+			[
 				'key'   => '_give_donor_id',
 				'value' => $donor_id,
-			),
-		),
-	);
+			],
+		],
+	];
 
 	// Get donor donation comment for specific form.
 	if ( $form_id ) {
-		$comment_args['meta_query'][] = array(
+		$comment_args['meta_query'][] = [
 			'key'   => '_give_form_id',
 			'value' => $form_id,
-		);
+		];
 	}
 
 	$sql = Give()->comment->db->get_sql( $comment_args );
@@ -1139,4 +1139,34 @@ function give_is_host( $host = false ) {
 	}// End if().
 
 	return $return;
+}
+
+/**
+ * Get list of premium add-ons
+ *
+ * @since 2.5.0
+ * @deprecated 2.9.2
+ *
+ * @return array
+ *
+ */
+function give_get_premium_add_ons() {
+	$list = wp_extract_urls( give_add_ons_feed( 'addons-directory', false ) );
+	$list = array_values(
+		array_filter(
+			$list,
+			static function ( $url ) {
+				return false !== strpos( $url, 'givewp.com/addons' );
+			}
+		)
+	);
+
+	return array_map(
+		static function ( $url ) {
+			$path = wp_parse_url( untrailingslashit( $url ) )['path'];
+
+			return str_replace( '/addons/', '', $path );
+		},
+		$list
+	);
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -10,6 +10,8 @@
  */
 
 // Exit if accessed directly.
+use Give\License\PremiumAddonsListManager;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -833,26 +835,22 @@ function give_get_plugins( $args = [] ) {
 	if ( ! empty( $args['only_add_on'] ) ) {
 		$plugins = array_filter(
 			$plugins,
-			function( $plugin ) {
+			static function( $plugin ) {
 				return 'add-on' === $plugin['Type'];
 			}
 		);
 	}
 
 	if ( ! empty( $args['only_premium_add_ons'] ) ) {
-		if ( ! function_exists( 'give_get_premium_add_ons' ) ) {
-			require_once GIVE_PLUGIN_DIR . '/includes/admin/misc-functions.php';
-		}
-
-		$premium_addons_list = give_get_premium_addons_url();
+		/* @var PremiumAddonsListManager $premiumAddonsListManger */
+		$premiumAddonsListManger = give( PremiumAddonsListManager::class );
 
 		foreach ( $plugins as $key => $plugin ) {
 			if ( 'add-on' !== $plugin['Type'] ) {
 				unset( $plugins[ $key ] );
 			}
 
-			$addonUrl = untrailingslashit( $plugin['PluginURI'] );
-			if ( ! in_array( $addonUrl, $premium_addons_list, true ) ) {
+			if ( ! $premiumAddonsListManger->isPremiumAddons( $plugin['PluginURI'] ) ) {
 				unset( $plugins[ $key ] );
 			}
 		}

--- a/src/License/PremiumAddonsListManager.php
+++ b/src/License/PremiumAddonsListManager.php
@@ -1,0 +1,67 @@
+<?php
+namespace Give\License;
+
+/**
+ * Class PremiumAddonManager
+ * @package Give\License
+ *
+ * this class we use to manager premium addons list for licensing.
+ *
+ * @since 2.9.2
+ */
+class PremiumAddonsListManager {
+	/**
+	 * Products list api url.
+	 *
+	 * @since 2.9.2
+	 */
+	const PRODUCTS_LIST_API_URL = 'https://givewp.com/edd-api/products';
+
+
+	/**
+	 * Get premium addons slugs as addons ids.
+	 *
+	 * @since 2.9.2
+	 * @return array
+	 */
+	private function getAddonsIds() {
+		$cachedResult = get_transient( 'give_premium_addons_ids' );
+		if ( $cachedResult ) {
+			return  $cachedResult;
+		}
+
+		$response            = wp_remote_get( self::PRODUCTS_LIST_API_URL . '?number=-1' );
+		$productsInformation = wp_remote_retrieve_body( $response );
+		if ( ! $productsInformation ) {
+			return [];
+		}
+
+		$productsInformation = json_decode( $productsInformation, true );
+		$productsIds         = [];
+		foreach ( $productsInformation['products'] as $product ) {
+			$productsIds[] = $product['info']['slug'];
+		}
+
+		if ( $productsIds ) {
+			set_transient( 'give_premium_addons_ids', $productsIds, DAY_IN_SECONDS );
+		}
+
+		return $productsIds;
+	}
+
+	/**
+	 * Return whether or not addon is premium addon.
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param string $pluginURI
+	 *
+	 * @return bool
+	 */
+	public function isPremiumAddons( $pluginURI ) {
+		$addonId   = basename( $pluginURI );
+		$addonsIds = $this->getAddonsIds();
+
+		return in_array( $addonId, $addonsIds, true );
+	}
+}

--- a/src/License/PremiumAddonsListManager.php
+++ b/src/License/PremiumAddonsListManager.php
@@ -25,7 +25,8 @@ class PremiumAddonsListManager {
 	 * @return array
 	 */
 	private function getAddonsIds() {
-		$cachedResult = get_transient( 'give_premium_addons_ids' );
+		$optionName   = 'give_premium_addons_ids';
+		$cachedResult = get_transient( $optionName );
 		if ( $cachedResult ) {
 			return  $cachedResult;
 		}
@@ -43,7 +44,7 @@ class PremiumAddonsListManager {
 		}
 
 		if ( $productsIds ) {
-			set_transient( 'give_premium_addons_ids', $productsIds, DAY_IN_SECONDS );
+			set_transient( $optionName, $productsIds, DAY_IN_SECONDS );
 		}
 
 		return $productsIds;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4760 

## Description

The issue was already resolved in PR https://github.com/impress-org/givewp/issues/4760. In this PR, I am using [easy digital download plugin rest API endpoint](https://github.com/impress-org/givewp/issues/4760#issuecomment-720907346) to detect if the addon is premium or not. 

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Set `$is_required_days_past` value to `true` to see license warning if not any license activated: https://github.com/impress-org/givewp/blob/56ae547508a0b495e60e4f4b1c0f7a2d6e046015/includes/admin/admin-actions.php#L1415
- Use any type of license key: single key, bundle key, add in one pass license key
- Check whether or not transient with name `give_premium_addons_ids` stored in database options table.
