### PR TITLE
MultForm Goal Shortcode now supports comma separated lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Stripe Modal renders without any issue across all screens (#5423)
 -   Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)
 -   Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
+-   MultForm Goal Shortcode now supports comma separated lists (#5432)
 
 ### Changed
 

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -7,12 +7,18 @@ use Give\MultiFormGoals\MultiFormGoal\Model as MultiFormGoal;
 class Shortcode {
 
 	/**
+	 * @since 2.10.0 Extracted from harded-coded value in `addShortcode()`.
+	 * @var string Shortcode tag to be searched in post content.
+	 * */
+	protected $tag = 'give_multi_form_goal';
+
+	/**
 	 * Registers Multi-Form Goal Shortcode
 	 *
 	 * @since 2.9.0
 	 **/
 	public function addShortcode() {
-		add_shortcode( 'give_multi_form_goal', [ $this, 'renderCallback' ] );
+		add_shortcode( $this->tag, [ $this, 'renderCallback' ] );
 	}
 
 	/**
@@ -22,7 +28,8 @@ class Shortcode {
 	 **/
 	public function renderCallback( $attributes ) {
 		error_log( serialize( $attributes ) );
-		$attributes = shortcode_atts(
+
+		$attributes = $this->parseAttributes(
 			[
 				'ids'        => [],
 				'tags'       => [],
@@ -52,5 +59,36 @@ class Shortcode {
 			]
 		);
 		return $multiFormGoal->getOutput();
+	}
+
+	/**
+	 * Parse multiple attributes with defualt values and types (infered from the default values).
+	 * @link https://developer.wordpress.org/reference/functions/shortcode_atts/
+	 * @since 2.10.0
+	 * @param array $pairs Entire list of supported attributes and their defaults.
+	 * @param array $attributes User defined attributes.
+	 * @reutrn array
+	 */
+	protected function parseAttributes( $pairs, $attributes ) {
+		foreach ( $attributes as $key => &$attribute ) {
+			if ( is_array( $pairs[ $key ] ) ) {
+				$attribute = $this->parseAttributeArray( $attribute );
+			}
+		}
+
+		return shortcode_atts( $pairs, $attributes, $this->tag );
+	}
+
+	/**
+	 * Parses an individual attributes as an array (or from a comma-separated string).
+	 * @since 2.10.0
+	 * @param string|array $value
+	 * @return array
+	 */
+	protected function parseAttributeArray( $value ) {
+		if ( ! is_array( $value ) ) {
+			$value = explode( ',', $value );
+		}
+		return $value;
 	}
 }

--- a/tests/src/MultiFormGoals/MultiFormGoal/ShortcodeTest.php
+++ b/tests/src/MultiFormGoals/MultiFormGoal/ShortcodeTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+final class ShortcodeTest extends TestCase {
+
+	public function setUp(): void {
+		function shortcode_atts( $pairs, $attributes, $tag ) {
+			return $attributes;
+		}
+	}
+
+	public function testParsedAttributes(): void {
+		$shortcodeClass = new \Give\MultiFormGoals\MultiFormGoal\Shortcode();
+
+        $class = new \ReflectionClass( $shortcodeClass );
+        $method = $class->getMethod( 'parseAttributes' ) ;
+        $method->setAccessible(true);
+
+		$pairs = [
+			'string' => 'default',
+			'array' => [],
+		];
+
+		$attributes = [
+			'string' => 'this is a string.',
+			'array' => '1,2,3', // Should be parsed into an array.
+		];
+
+		$attributes = $method->invokeArgs( $shortcodeClass, [ $pairs, $attributes ] );
+		$this->assertTrue( is_string( $attributes[ 'string' ] ) );
+		$this->assertTrue( is_array( $attributes[ 'array' ] ) );
+	}
+}

--- a/tests/src/MultiFormGoals/MultiFormGoal/ShortcodeTest.php
+++ b/tests/src/MultiFormGoals/MultiFormGoal/ShortcodeTest.php
@@ -19,15 +19,21 @@ final class ShortcodeTest extends TestCase {
 		$pairs = [
 			'string' => 'default',
 			'array' => [],
+			'listSingle' => [],
+			'listMultiple' => [],
 		];
 
 		$attributes = [
 			'string' => 'this is a string.',
-			'array' => '1,2,3', // Should be parsed into an array.
+			'array' => [],
+			'listSingle' => '1', //Should be parsed into an array.
+			'listMultiple' => '1,2,3', // Should be parsed into an array.
 		];
 
 		$attributes = $method->invokeArgs( $shortcodeClass, [ $pairs, $attributes ] );
 		$this->assertTrue( is_string( $attributes[ 'string' ] ) );
 		$this->assertTrue( is_array( $attributes[ 'array' ] ) );
+		$this->assertTrue( is_array( $attributes[ 'listSingle' ] ) );
+		$this->assertTrue( is_array( $attributes[ 'listMultiple' ] ) );
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5431

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Wraps the call to `shortcode_atts` to first parse attributes by type. Attributes provided an array as a default value will be parsed to convert a comma separated list into an array. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1.Add the [give_multi_form_goal ids="513,509"] shortcode to a page.
1. The Multi-Form Goal includes all listed forms.
1. Repeat for `tags` and `categories` attributes.