### PR TITLE
Fix loader color when using shortcode or block #5435

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Stripe Modal renders without any issue across all screens (#5423)
 -   Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)
 -   Stripe Checkout payment method does not cause of javascript error on donation form page (#5419)
+-   Multi-step form loader color is incorrectly the default green color when embedded. (#5436)
 
 ### Changed
 

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -87,7 +87,7 @@ abstract class Template {
 	 * Returns starting height for iframe (in pixels), this is used to predict iframe height before the iframe loads
 	 * Implemented in includes/shortcodes.php:
 	 *
-	 * @param  int  $formId  Form ID
+	 * @param int $formId Form ID
 	 *
 	 * @return int
 	 **/
@@ -111,20 +111,31 @@ abstract class Template {
 	/**
 	 * Get loading view filepath
 	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @return string
 	 */
 	public function getLoadingView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultLoadingView.php';
 	}
 
 	/**
+	 * Renders the loading view
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param int $formId
+	 */
+	public function renderLoadingView( $formId = null ) {
+		include $this->getLoadingView();
+	}
+
+	/**
 	 * Get form view filepath
 	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @return string
 	 */
 	public function getFormView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultFormTemplate.php';
@@ -133,9 +144,9 @@ abstract class Template {
 	/**
 	 * Get receipt view filepath
 	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @return string
 	 */
 	public function getReceiptView() {
 		return GIVE_PLUGIN_DIR . 'src/Views/Form/defaultFormReceiptTemplate.php';
@@ -144,32 +155,32 @@ abstract class Template {
 	/**
 	 * return form template ID.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	abstract public function getID();
 
 	/**
 	 * Get form template name.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	abstract public function getName();
 
 	/**
 	 * Get form template image.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	abstract public function getImage();
 
 	/**
 	 * Get options config
 	 *
-	 * @return array
 	 * @since 2.7.0
+	 * @return array
 	 */
 	abstract public function getOptionsConfig();
 
@@ -185,8 +196,8 @@ abstract class Template {
 	/**
 	 * Get failed/cancelled donation message.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	public function getFailedDonationMessage() {
 		return esc_html__(
@@ -199,10 +210,11 @@ abstract class Template {
 	/**
 	 * Get failed donation page URL.
 	 *
-	 * @param  int  $formId
+	 * @since 2.7.0
+	 *
+	 * @param int $formId
 	 *
 	 * @return mixed
-	 * @since 2.7.0
 	 */
 	public function getFailedPageURL( $formId ) {
 		return FormUtils::createFailedPageURL( Give()->routeForm->getURL( get_post_field( 'post_name', $formId ) ) );
@@ -211,8 +223,8 @@ abstract class Template {
 	/**
 	 * Get donate now button label text.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	public function getDonateNowButtonLabel() {
 		return __( 'Donate Now', 'give' );
@@ -221,8 +233,8 @@ abstract class Template {
 	/**
 	 * Get continue to donation form button label text.
 	 *
-	 * @return string
 	 * @since 2.7.0
+	 * @return string
 	 */
 	public function getContinueToDonationFormLabel() {
 		return __( 'Donate Now', 'give' );
@@ -231,8 +243,8 @@ abstract class Template {
 	/**
 	 * Get donation introduction text.
 	 *
-	 * @return string|null
 	 * @since 2.7.0
+	 * @return string|null
 	 */
 	public function getDonationIntroductionContent() {
 		return null;
@@ -244,8 +256,8 @@ abstract class Template {
 	 * Note: Even you are free to add introduction content at any place on donation form
 	 *       But still this depends upon form template style and configuration on which places you are allowed to show display introduction content.
 	 *
-	 * @return string|null
 	 * @since 2.7.0
+	 * @return string|null
 	 */
 	public function getDonationIntroductionContentPosition() {
 		return null;
@@ -254,10 +266,11 @@ abstract class Template {
 	/**
 	 * Get receipt details.
 	 *
-	 * @param  int  $donationId
+	 * @since 2.7.0
+	 *
+	 * @param int $donationId
 	 *
 	 * @return DonationReceipt
-	 * @since 2.7.0
 	 */
 	public function getReceiptDetails( $donationId ) {
 		$receipt = new DonationReceipt( $donationId );
@@ -275,11 +288,11 @@ abstract class Template {
 	/**
 	 * Get form heading
 	 *
-	 * @param  int  $formId
-	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @param int $formId
+	 *
+	 * @return string
 	 */
 	public function getFormHeading( $formId ) {
 		return get_the_title( $formId );
@@ -288,11 +301,11 @@ abstract class Template {
 	/**
 	 * Get form image
 	 *
-	 * @param  int  $formId
-	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @param int $formId
+	 *
+	 * @return string
 	 */
 	public function getFormFeaturedImage( $formId ) {
 		return get_the_post_thumbnail_url( $formId, 'full' );
@@ -301,11 +314,11 @@ abstract class Template {
 	/**
 	 * Get form excerpt
 	 *
-	 * @param  int|null  $formId
-	 *
-	 * @return string
 	 * @since 2.7.0
 	 *
+	 * @param int|null $formId
+	 *
+	 * @return string
 	 */
 	public function getFormExcerpt( $formId ) {
 		return get_the_excerpt( $formId );

--- a/src/Views/Form/Templates/Sequoia/views/loading.php
+++ b/src/Views/Form/Templates/Sequoia/views/loading.php
@@ -2,9 +2,12 @@
 use Give\Helpers\Form\Template as FormTemplateUtils;
 
 /**
+ * The following variables should be in scope when including this view
+ *
  * @var int $formId
  */
-$templateOptions = FormTemplateUtils::getOptions($formId);
+
+$templateOptions = FormTemplateUtils::getOptions( $formId );
 $primaryColor    = ! empty( $templateOptions['introduction']['primary_color'] ) ? $templateOptions['introduction']['primary_color'] : '#28C77B';
 $primaryColor    = trim( $primaryColor, '#' );
 

--- a/src/Views/Form/Templates/Sequoia/views/loading.php
+++ b/src/Views/Form/Templates/Sequoia/views/loading.php
@@ -1,7 +1,10 @@
 <?php
 use Give\Helpers\Form\Template as FormTemplateUtils;
 
-$templateOptions = FormTemplateUtils::getOptions();
+/**
+ * @var int $formId
+ */
+$templateOptions = FormTemplateUtils::getOptions($formId);
 $primaryColor    = ! empty( $templateOptions['introduction']['primary_color'] ) ? $templateOptions['introduction']['primary_color'] : '#28C77B';
 $primaryColor    = trim( $primaryColor, '#' );
 

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -200,8 +200,8 @@ class IframeView {
 	 */
 	private function getIframeHTML() {
 		ob_start();
-		$formId = $this->formId;
-		include $this->template->getLoadingView();
+
+		$this->template->renderLoadingView( $this->formId );
 
 		$loader = sprintf(
 			'<div class="iframe-loader">%1$s</div>',

--- a/src/Views/IframeView.php
+++ b/src/Views/IframeView.php
@@ -200,6 +200,7 @@ class IframeView {
 	 */
 	private function getIframeHTML() {
 		ob_start();
+		$formId = $this->formId;
 		include $this->template->getLoadingView();
 
 		$loader = sprintf(


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5435

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

IFrameView passes the `$formId` now so the loader can properly pull the color from template options.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Shortcodes / Embeds

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
