### PR TITLE
Covert donation amount to cent only if currency is non zero type when donation donated with Stripe payment gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Covert donation amount to cent only if currency is not zero-decimal when donation donated with Stripe payment gateway (#5440)
 -   Free add-ons does not trigger GiveWP add-on license errors (#5424)
 -   Stripe Modal renders without any issue across all screens (#5423)
 -   Restore Donate Now button and show donor error after Stripe returns error when create payment method (#5421)

--- a/includes/gateways/stripe/includes/class-give-stripe-gateway.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-gateway.php
@@ -11,6 +11,8 @@
  */
 
 // Exit, if accessed directly.
+use Give\ValueObjects\Money;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -91,7 +93,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 			$this->payment_intent = new Give_Stripe_Payment_Intent();
 			$this->payment_method = new Give_Stripe_Payment_Method();
 
-			add_action( "give_gateway_{$this->id}", array( $this, 'process_payment' ) );
+			add_action( "give_gateway_{$this->id}", [ $this, 'process_payment' ] );
 
 		}
 
@@ -211,7 +213,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 		 *
 		 * @return \Stripe\Token
 		 */
-		public function get_token_details( $id, $args = array() ) {
+		public function get_token_details( $id, $args = [] ) {
 
 			// Set Application Info.
 			give_stripe_set_app_info();
@@ -351,9 +353,9 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 
 					// Attach Source to existing Customer.
 					$card = $stripe_customer->sources->create(
-						array(
+						[
 							'source' => $id,
-						)
+						]
 					);
 
 				} catch ( \Stripe\Error\Base $e ) {
@@ -481,13 +483,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 		 * @return mixed
 		 */
 		public function format_amount( $amount ) {
-
-			// Get the donation amount.
-			if ( give_stripe_is_zero_decimal_currency() ) {
-				return $amount;
-			} else {
-				return $amount * 100;
-			}
+			return Money::of( $amount, give_get_currency() )->getMinorAmount();
 		}
 
 		/**
@@ -622,24 +618,24 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 			$donation_amount = give_donation_amount( $donation_id );
 
 			// Prepare basic source args.
-			$source_args = array(
+			$source_args = [
 				'amount'               => $this->format_amount( $donation_amount ),
 				'currency'             => give_get_currency( $form_id ),
 				'type'                 => 'three_d_secure',
-				'three_d_secure'       => array(
+				'three_d_secure'       => [
 					'card' => $source_id,
-				),
+				],
 				'statement_descriptor' => give_stripe_get_statement_descriptor(),
-				'redirect'             => array(
+				'redirect'             => [
 					'return_url' => add_query_arg(
-						array(
+						[
 							'give-listener' => 'stripe_three_d_secure',
 							'donation_id'   => $donation_id,
-						),
+						],
 						give_get_success_page_uri()
 					),
-				),
-			);
+				],
+			];
 
 			$source = $this->prepare_source( $source_args );
 
@@ -701,7 +697,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 			// Process the charge.
 			$amount = $this->format_amount( $donation_data['price'] );
 
-			$charge_args = array(
+			$charge_args = [
 				'amount'               => $amount,
 				'currency'             => give_get_currency( $form_id ),
 				'customer'             => $stripe_customer_id,
@@ -709,7 +705,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 				'statement_descriptor' => give_stripe_get_statement_descriptor( $donation_data ),
 				'metadata'             => $this->prepare_metadata( $donation_id ),
 				'source'               => $source_id,
-			);
+			];
 
 			// Create charge with general gateway fn.
 			$charge = $this->create_charge( $donation_id, $charge_args );

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -10,9 +10,9 @@
  * @license    https://opensource.org/licenses/gpl-license GNU Public License
  */
 
-// Exit, if accessed directly.
 use Give\ValueObjects\Money;
 
+// Exit, if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1042,7 +1042,7 @@ function give_stripe_cents_to_dollars( $cents ) {
  * @return string
  */
 function give_stripe_dollars_to_cents( $dollars ) {
-	return Money::of( $dollars, give_get_country() )->getMinorAmount();
+	return Money::of( $dollars, give_get_currency() )->getMinorAmount();
 }
 
 /**

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1039,7 +1039,7 @@ function give_stripe_cents_to_dollars( $cents ) {
  * @return string
  */
 function give_stripe_dollars_to_cents( $dollars ) {
-	return round( $dollars, give_currency_decimal_filter() ) * 100;
+	return give_is_zero_based_currency() ? round( $dollars ) : round( $dollars, give_get_price_decimals() ) * 100;
 }
 
 /**

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1035,6 +1035,7 @@ function give_stripe_cents_to_dollars( $cents ) {
  * @param string $dollars Amount in dollars.
  *
  * @since  2.5.0
+ * @since 2.9.2  Return amount in cent only if currency is not zero-decimal currency.
  *
  * @return string
  */

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -11,6 +11,8 @@
  */
 
 // Exit, if accessed directly.
+use Give\ValueObjects\Money;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -1040,7 +1042,7 @@ function give_stripe_cents_to_dollars( $cents ) {
  * @return string
  */
 function give_stripe_dollars_to_cents( $dollars ) {
-	return give_is_zero_based_currency() ? round( $dollars ) : round( $dollars, give_get_price_decimals() ) * 100;
+	return Money::of( $dollars, give_get_country() )->getMinorAmount();
 }
 
 /**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5439

## Description

Stripe asks to send the amount in cents or the smallest unit of supported currency. For zero-based currency, we have sent the amount as is to Stripe. I find out that we send an amount in cents always for all currency. We use `give_stripe_dollars_to_cents` helper function to get the amount in cents, so I updated logic to return the amount based of currency type.

## Additional

- Update `Give_Stripe_Gateway::format_amount` function to use `Money` class to return amount in currcies'smallest unit

## Visuals

![image](https://user-images.githubusercontent.com/1784821/98369473-043caf80-205f-11eb-9921-b34c517428c0.png)


## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Try to reproduce issue with this PR by following the step given in the issue description under the `Steps to reproduce` section
