### PR TITLE
Front-end donor profiles are scaffolded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   Front-end donor profiles are scaffolded (#5441)
+
 ### Fixed
 
 -   Free add-ons does not trigger GiveWP add-on license errors (#5424)

--- a/give.php
+++ b/give.php
@@ -50,6 +50,7 @@ use Give\ServiceProviders\LegacyServiceProvider;
 use Give\ServiceProviders\RestAPI;
 use Give\ServiceProviders\Onboarding;
 use Give\MultiFormGoals\ServiceProvider as MultiFormGoalsServiceProvider;
+use Give\DonorProfiles\ServiceProvider as DonorProfilesServiceProvider;
 use Give\ServiceProviders\ServiceProvider;
 
 // Exit if accessed directly.
@@ -142,6 +143,7 @@ final class Give {
 		MigrationsServiceProvider::class,
 		RevenueServiceProvider::class,
 		MultiFormGoalsServiceProvider::class,
+		DonorProfilesServiceProvider::class,
 	];
 
 	/**

--- a/src/DonorProfiles/Block.php
+++ b/src/DonorProfiles/Block.php
@@ -15,7 +15,7 @@ class Block {
 	/**
 	 * Registers Donor Profile block
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function addBlock() {
 		register_block_type(
@@ -35,7 +35,7 @@ class Block {
 	/**
 	 * Returns Donor Profile block markup
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function renderCallback( $attributes ) {
 		return $this->donorProfile->getOutput( $attributes );
@@ -44,7 +44,7 @@ class Block {
 	/**
 	 * Load Donor Profile frontend assets
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function loadFrontendAssets() {
 		if ( has_block( 'give/donor-profile' ) ) {
@@ -55,7 +55,7 @@ class Block {
 	/**
 	 * Load Donor Profile block editor assets
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function loadEditorAssets() {
 		wp_enqueue_script(

--- a/src/DonorProfiles/Block.php
+++ b/src/DonorProfiles/Block.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Give\DonorProfiles;
+
+use Give\DonorProfiles\Model as DonorProfile;
+
+class Block {
+
+	protected $donorProfile;
+
+	public function __construct() {
+		$this->donorProfile = give( DonorProfile::class );
+	}
+
+	/**
+	 * Registers Donor Profile block
+	 *
+	 * @since 2.9.0
+	 **/
+	public function addBlock() {
+		register_block_type(
+			'give/donor-profile',
+			[
+				'render_callback' => [ $this, 'renderCallback' ],
+				'attributes'      => [
+					'enabled' => [
+						'type'    => 'array',
+						'default' => [],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Returns Donor Profile block markup
+	 *
+	 * @since 2.9.0
+	 **/
+	public function renderCallback( $attributes ) {
+		return $this->donorProfile->getOutput( $attributes );
+	}
+
+	/**
+	 * Load Donor Profile frontend assets
+	 *
+	 * @since 2.9.0
+	 **/
+	public function loadFrontendAssets() {
+		if ( has_block( 'give/donor-profile' ) ) {
+			return $this->donorProfile->loadAssets();
+		}
+	}
+
+	/**
+	 * Load Donor Profile block editor assets
+	 *
+	 * @since 2.9.0
+	 **/
+	public function loadEditorAssets() {
+		wp_enqueue_script(
+			'give-donor-profiles-block',
+			GIVE_PLUGIN_URL . 'assets/dist/js/donor-profiles-block.js',
+			[],
+			GIVE_VERSION,
+			true
+		);
+	}
+}

--- a/src/DonorProfiles/Model.php
+++ b/src/DonorProfiles/Model.php
@@ -14,7 +14,7 @@ class Model {
 	 * Constructs and sets up setting variables for a new Donor Profile model
 	 *
 	 * @param array $args Arguments for new Donor Profile, including 'enabled'
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function __construct() {
 		$this->enabled = [];
@@ -25,7 +25,7 @@ class Model {
 	 * Get output markup for Multi-Form Goal
 	 *
 	 * @return string
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function getOutput() {
 		ob_start();
@@ -40,7 +40,7 @@ class Model {
 	 * Get enabled tabs for Donor Profile
 	 *
 	 * @return string
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function getEnabled() {
 		return $this->enabled;
@@ -58,7 +58,7 @@ class Model {
 	 * Enqueue assets for front-end donor profiles
 	 *
 	 * @return void
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function loadAssets() {
 		wp_enqueue_script(

--- a/src/DonorProfiles/Model.php
+++ b/src/DonorProfiles/Model.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Give\DonorProfiles;
+
+class Model {
+
+	// Settings
+	protected $enabled;
+
+	// Internal variables
+	protected $tabs;
+
+	/**
+	 * Constructs and sets up setting variables for a new Donor Profile model
+	 *
+	 * @param array $args Arguments for new Donor Profile, including 'enabled'
+	 * @since 2.9.0
+	 **/
+	public function __construct() {
+		$this->enabled = [];
+		$this->tabs    = [];
+	}
+
+	/**
+	 * Get output markup for Multi-Form Goal
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	public function getOutput() {
+		ob_start();
+		$output = '';
+		require $this->getTemplatePath();
+		$output = ob_get_contents();
+		ob_end_clean();
+		return $output;
+	}
+
+	/**
+	 * Get enabled tabs for Donor Profile
+	 *
+	 * @return string
+	 * @since 2.9.0
+	 **/
+	public function getEnabled() {
+		return $this->enabled;
+	}
+
+	/**
+	 * Get template path for Donor Profile component template
+	 * @since 2.9.0
+	 **/
+	public function getTemplatePath() {
+		return GIVE_PLUGIN_DIR . '/src/DonorProfiles/resources/views/donorprofile.php';
+	}
+
+	/**
+	 * Enqueue assets for front-end donor profiles
+	 *
+	 * @return void
+	 * @since 2.9.0
+	 **/
+	public function loadAssets() {
+		wp_enqueue_script(
+			'give-donor-profiles-app',
+			GIVE_PLUGIN_URL . 'assets/dist/js/donor-profiles-app.js',
+			[ 'wp-element' ],
+			GIVE_VERSION,
+			true
+		);
+	}
+}

--- a/src/DonorProfiles/Routes/DonationHistoryRoute.php
+++ b/src/DonorProfiles/Routes/DonationHistoryRoute.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Give\DonorProfiles\Routes;
+
+use WP_REST_Request;
+use Give\API\RestRoute;
+use Give\Onboarding\FormRepository;
+
+/**
+ * @since 2.10.0
+ */
+class DonationHistoryRoute implements RestRoute {
+
+	/** @var string */
+	protected $endpoint = 'donor-profile/donation-history';
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => function() {
+						return is_user_logged_in();
+					},
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+    }
+    
+    /**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		return [
+			'data' => [
+				'donations' => [
+                    '2' => [
+                        'form' => [
+                            'title' => 'Save the Trees',
+                            'id' => '3',
+                        ],
+                        'payment' => [
+                            'amount' => '33.00',
+                            'currency' => 'USD',
+                            'fee' => '5.00',
+                            'total' => '38.00',
+                            'method' => 'paypal',
+                            'status' => 'pending',
+                            'date' => '04-01-2020 12:00:00'
+                        ],
+                        'donor' => [
+                            'name' => 'Ben Smith',
+                            'email' => 'bensmith@gmail.com',
+                            'address' => [
+                                'street' => '875 26th St',
+                                'city' => 'San Diego',
+                                'state' => 'CA',
+                                'zipcode' => '92081',
+                                'country' => 'USA',
+                            ]
+                        ]
+                    ],
+                    '7' => [
+                        'form' => [
+                            'title' => 'Save the Whales',
+                            'id' => '5',
+                        ],
+                        'payment' => [
+                            'amount' => '30.00',
+                            'currency' => 'USD',
+                            'fee' => '5.00',
+                            'total' => '35.00',
+                            'method' => 'paypal',
+                            'status' => 'pending',
+                            'date' => '04-04-2020 12:00:00'
+                        ],
+                        'donor' => [
+                            'name' => 'Ben Smith',
+                            'email' => 'bensmith@gmail.com',
+                            'address' => [
+                                'street' => '875 26th St',
+                                'city' => 'San Diego',
+                                'state' => 'CA',
+                                'zipcode' => '92081',
+                                'country' => 'USA',
+                            ]
+                        ]
+                    ],
+                ],
+			],
+		];
+	}
+
+	/**
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
+	public function getSchema() {
+		return [
+			// This tells the spec of JSON Schema we are using which is draft 4.
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			// The title property marks the identity of the resource.
+			'title'      => 'donor-profile',
+			'type'       => 'object',
+			// In JSON Schema you can specify object properties in the properties attribute.
+			'properties' => [
+				// ...
+			],
+		];
+	}
+}

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -7,6 +7,7 @@ use Give\Helpers\Hooks;
 use Give\DonorProfiles\Shortcode as DonorProfileShortcode;
 use Give\DonorProfiles\Block as DonorProfileBlock;
 use Give\DonorProfiles\Model as DonorProfile;
+use Give\DonorProfiles\Routes\DonationHistoryRoute;
 
 class ServiceProvider implements ServiceProviderInterface {
 
@@ -15,7 +16,10 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function register() {
 		give()->singleton( DonorProfile::class );
+
 		give()->singleton( DonorProfileShortcode::class );
+
+		give()->bind( DonationHistoryRoute::class );
 
 		if ( function_exists( 'register_block_type' ) ) {
 			give()->singleton( DonorProfileBlock::class );
@@ -28,6 +32,7 @@ class ServiceProvider implements ServiceProviderInterface {
 	public function boot() {
 		Hooks::addAction( 'init', DonorProfileShortcode::class, 'addShortcode' );
 		Hooks::addAction( 'wp_enqueue_scripts', DonorProfileShortcode::class, 'loadFrontendAssets' );
+		Hooks::addAction( 'rest_api_init', DonationHistoryRoute::class, 'registerRoute' );
 
 		if ( function_exists( 'register_block_type' ) ) {
 			Hooks::addAction( 'init', DonorProfileBlock::class, 'addBlock' );

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -14,8 +14,8 @@ class ServiceProvider implements ServiceProviderInterface {
 	 * @inheritDoc
 	 */
 	public function register() {
-		give()->singleton( DonorProfileShortcode::class );
 		give()->singleton( DonorProfile::class );
+		give()->singleton( DonorProfileShortcode::class );
 
 		if ( function_exists( 'register_block_type' ) ) {
 			give()->singleton( DonorProfileBlock::class );

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Give\DonorProfiles;
+
+use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give\Helpers\Hooks;
+use Give\DonorProfiles\Shortcode as DonorProfileShortcode;
+use Give\DonorProfiles\Block as DonorProfileBlock;
+use Give\DonorProfiles\Model as DonorProfile;
+
+class ServiceProvider implements ServiceProviderInterface {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		give()->singleton( DonorProfileShortcode::class );
+		give()->singleton( DonorProfile::class );
+
+		if ( function_exists( 'register_block_type' ) ) {
+			give()->singleton( DonorProfileBlock::class );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function boot() {
+		Hooks::addAction( 'init', DonorProfileShortcode::class, 'addShortcode' );
+		Hooks::addAction( 'wp_enqueue_scripts', DonorProfileShortcode::class, 'loadFrontendAssets' );
+
+		if ( function_exists( 'register_block_type' ) ) {
+			Hooks::addAction( 'init', DonorProfileBlock::class, 'addBlock' );
+			Hooks::addAction( 'wp_enqueue_scripts', DonorProfileBlock::class, 'loadFrontendAssets' );
+			Hooks::addAction( 'enqueue_block_editor_assets', DonorProfileBlock::class, 'loadEditorAssets' );
+		}
+	}
+}

--- a/src/DonorProfiles/Shortcode.php
+++ b/src/DonorProfiles/Shortcode.php
@@ -15,7 +15,7 @@ class Shortcode {
 	/**
 	 * Registers Donor Profile Shortcode
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function addShortcode() {
 		add_shortcode( 'give_donor_profile', [ $this, 'renderCallback' ] );
@@ -36,7 +36,7 @@ class Shortcode {
 	/**
 	 * Returns Shortcode markup
 	 *
-	 * @since 2.9.0
+	 * @since 2.10.0
 	 **/
 	public function renderCallback( $attributes ) {
 		$attributes = shortcode_atts(

--- a/src/DonorProfiles/Shortcode.php
+++ b/src/DonorProfiles/Shortcode.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Give\DonorProfiles;
+
+use Give\DonorProfiles\Model as DonorProfile;
+
+class Shortcode {
+
+	protected $donorProfile;
+
+	public function __construct() {
+		$this->donorProfile = give( DonorProfile::class );
+	}
+
+	/**
+	 * Registers Donor Profile Shortcode
+	 *
+	 * @since 2.9.0
+	 **/
+	public function addShortcode() {
+		add_shortcode( 'give_donor_profile', [ $this, 'renderCallback' ] );
+	}
+
+	/**
+	 * Load Donor Profile frontend assets
+	 *
+	 * @since 2.9.0
+	 **/
+	public function loadFrontendAssets() {
+		global $post;
+		if ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'give_donor_profile' ) ) {
+			return $this->donorProfile->loadAssets();
+		}
+	}
+
+	/**
+	 * Returns Shortcode markup
+	 *
+	 * @since 2.9.0
+	 **/
+	public function renderCallback( $attributes ) {
+		$attributes = shortcode_atts(
+			[
+				'enabled' => [],
+			],
+			$attributes,
+			'give_donor_profile'
+		);
+		return $this->donorProfile->getOutput( $attributes );
+	}
+}

--- a/src/DonorProfiles/resources/js/app/index.js
+++ b/src/DonorProfiles/resources/js/app/index.js
@@ -1,0 +1,15 @@
+// Entry point for Donor Profile app
+
+// Vendor dependencies
+import { HashRouter as Router } from 'react-router-dom';
+import ReactDOM from 'react-dom';
+
+// Reports app
+import App from '../components/app';
+
+ReactDOM.render(
+	<Router>
+		<App />
+	</Router>,
+	document.getElementById( 'give-donor-profile' )
+);

--- a/src/DonorProfiles/resources/js/block/data/attributes.js
+++ b/src/DonorProfiles/resources/js/block/data/attributes.js
@@ -1,0 +1,12 @@
+/**
+ * Block Attributes
+*/
+
+const blockAttributes = {
+	enabled: {
+		type: 'array',
+		default: [],
+	},
+};
+
+export default blockAttributes;

--- a/src/DonorProfiles/resources/js/block/edit/index.js
+++ b/src/DonorProfiles/resources/js/block/edit/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { Fragment } = wp.element;
+
+/**
+ * Internal dependencies
+ */
+import Inspector from './inspector';
+
+const edit = ( { attributes, setAttributes } ) => {
+	return (
+		<Fragment>
+			<Inspector { ... { attributes, setAttributes } } />
+			<div className="give-donor-profile">
+				<h2>{ __( 'Donor Profile!', 'give' ) }</h2>
+			</div>
+		</Fragment>
+	);
+};
+export default edit;

--- a/src/DonorProfiles/resources/js/block/edit/inspector.js
+++ b/src/DonorProfiles/resources/js/block/edit/inspector.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { InspectorControls } = wp.blockEditor;
+const { PanelBody, ToggleControl } = wp.components;
+
+/**
+ * Render Inspector Controls
+*/
+
+const Inspector = ( { attributes, setAttributes } ) => {
+	const { enabled } = attributes;
+	const saveSetting = ( name, value ) => {
+		setAttributes( {
+			[ name ]: value,
+		} );
+	};
+	return (
+		<InspectorControls key="inspector">
+			<PanelBody title={ __( 'Tabs', 'give' ) } initialOpen={ true }>
+				<h2>{ __( 'This is a test', 'give' ) }</h2>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;

--- a/src/DonorProfiles/resources/js/block/index.js
+++ b/src/DonorProfiles/resources/js/block/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+const { __ } = wp.i18n;
+const { registerBlockType } = wp.blocks;
+
+/**
+ * Internal dependencies
+ */
+import blockAttributes from './data/attributes';
+import GiveLogo from './logo';
+import edit from './edit';
+
+/**
+ * Register Block
+ */
+
+export default registerBlockType( 'give/donor-profile', {
+	title: __( 'Donor Profile', 'give' ),
+	description: __( 'The Donor Profile block allows donors to modify and review their donor information from the front-end.', 'give' ),
+	category: 'give',
+	icon: <GiveLogo color="grey" />,
+	keywords: [
+		__( 'donor', 'give' ),
+		__( 'profile', 'give' ),
+	],
+	attributes: blockAttributes,
+	supports: {
+		align: [
+			'wide',
+		],
+	},
+	edit: edit,
+} );

--- a/src/DonorProfiles/resources/js/block/logo/index.js
+++ b/src/DonorProfiles/resources/js/block/logo/index.js
@@ -1,0 +1,41 @@
+/**
+ * Give Logo
+ * @param {*} props Logo properties
+ * @returns {Element} SVG Icon
+ */
+function GiveLogo( { size = '24px', color, className } ) {
+	let colorCode;
+
+	switch ( color ) {
+		case 'white':
+			colorCode = '#FFFFFF';
+			break;
+
+		case 'grey':
+			colorCode = '#555d66';
+			break;
+
+		default:
+			colorCode = '#66BB6A';
+			break;
+	}
+
+	return (
+		<svg id="Layer_1" width={ size } height={ size } className={ className } xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink"
+			viewBox="100 0 404 400" >
+			<g id="Layer_2">
+				<circle fill={ colorCode } cx="300" cy="200" r="200" />
+				<defs>
+					<circle id="SVGID_1_" cx="300" cy="200" r="200" />
+				</defs>
+				<clippath id="SVGID_2_">
+					<use xlinkHref="#SVGID_1_" overflow="visible" />
+				</clippath>
+				<path clipPath="url(#SVGID_2_)" fill="#FFF" d="M328.5,214.2c0.8,1.8,2.5,3.3,2.5,3.3c35.4,4.3,85.5-0.5,123.7-5.6 c-21.9,47.1-61.1,78.4-96.9,78.4c-67.4,0-119.3-81.7-119.3-81.7c20.9-18.3,55.2-78.4,104.8-78.4s71.2,27.2,71.2,27.2l5.6-8.9 c0,0-23.2-81.2-88.8-81.2S195.9,175.1,155.2,199.7c0,0,56,132.8,178.6,132.8c102.8,0,128.8-98.2,133.6-122.6 c13.7-2,25.2-4.1,32.6-5.3c2.5-5.6,5.3-15.5,3.3-28.8c-41,15.8-103.1,33.6-175.8,33.6C327.2,209.4,327.5,212,328.5,214.2z"
+				/>
+			</g>
+		</svg>
+	);
+}
+
+export default GiveLogo;

--- a/src/DonorProfiles/resources/js/components/app/index.js
+++ b/src/DonorProfiles/resources/js/components/app/index.js
@@ -1,0 +1,8 @@
+const App = () => {
+	return (
+		<div>
+			<h1>Donor Profile App!</h1>
+		</div>
+	);
+};
+export default App;

--- a/src/DonorProfiles/resources/views/donorprofile.php
+++ b/src/DonorProfiles/resources/views/donorprofile.php
@@ -1,0 +1,4 @@
+
+<div id="give-donor-profile">
+	<h2>Donor Profile</h2>
+</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,8 @@ const config = {
 		'admin-paypal-commerce': [ './assets/src/css/admin/paypal-commerce.scss' ],
 		'admin-onboarding-wizard': [ './assets/src/js/admin/onboarding-wizard/index.js' ],
 		'multi-form-goal-block': [ './src/MultiFormGoals/resources/css/common.scss' ],
+		'donor-profiles-app': [ './src/DonorProfiles/resources/js/app/index.js' ],
+		'donor-profiles-block': [ './src/DonorProfiles/resources/js/block/index.js' ],
 	},
 	output: {
 		path: path.join( __dirname, './assets/dist/' ),


### PR DESCRIPTION
Resolves #5428 

## Description
This PR introduces logic to scaffold front-end donor profiles, including the block, shortcode and API routes necessary to support them. The newly created `DonorProfiles` domain in `src` contains all the new changes, including the resources necessary to load a simple frontend app where donor profiles are meant to go.

## Affects
This PR makes a Donor Profile block available in the editor, and also introduces the new `give_donor_profile` shortcode. It registers an API endpoint, which currently returns dummy donation history data.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Create a new page
2. Add a "Donor Profile" block
3. Check that the app renders on the front end (should say "Donor Profile App!")