### PR TITLE
Remove outdated Safari workaround

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -223,12 +223,7 @@ jQuery( document ).ready( function( $ ) {
 		if ( typeof give_purchase_form.checkValidity === 'function' && give_purchase_form.checkValidity() === false ) {
 			//Don't leave any hanging loading animations
 			loading_animation.fadeOut();
-
-			//Check for Safari (doesn't support HTML5 required)
-			if ( ( navigator.userAgent.indexOf( 'Safari' ) != -1 && navigator.userAgent.indexOf( 'Chrome' ) == -1 ) === false ) {
-				//Not safari: Support HTML5 "required" so skip the rest of this function
-				return;
-			}
+			return;
 		}
 
 		//prevent form from submitting normally


### PR DESCRIPTION
## Description

Give has a workaround for safari versions which don't support the `required` attribute on HTML5 forms. Safari supports this since late 2016:

https://webkit.org/blog/7093/release-notes-for-safari-technology-preview-19/

AFAICT the first release that included this was 10.1 from March 2017. There is no currently supported version of Safari that does not support `required`, so this workaround is not needed anymore, and it also can interfere with custom event listeners in integrations (which is how we found this)


## Affects

All current Safari versions (which currently can't do proper HTML5 validation)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Try submitting donation forms in Safari with required fields missing