### PR TITLE
Currency Switcher options are visible in the dropdown on a windows machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Currency Switcher options are visible in the dropdown on a windows machine (#5453)
+
 ## 2.9.2 - 2020-11-09
 
 ### New

--- a/src/Views/Form/Templates/Sequoia/assets/css/currencyswitcher.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/currencyswitcher.scss
@@ -57,6 +57,11 @@ form[data-currency_position='before'] .give-donation-amount .give-cs-select-curr
 	}
 }
 
+/* @link https://github.com/impress-org/givewp/issues/5452 */
+form .give-donation-amount .give-cs-select-currency.give-cs-mini-dropdown option {
+	color: initial;
+}
+
 .give-currency-switcher-msg {
 	margin: 5px 30px -15px 30px !important;
 	font-weight: 500;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5452

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The Currency Switcher `select` sets a `color` of `transparent` in order to hide the selected input value on the form. On a Windows machine it seems that `color: transparent` is being inherited by the `option` elements, which is not the same as OS X.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Tested via Browser Stack on https://kylej22.sg-host.com/donations/donation-form/

| Windows 10: Edge 86 | OS X Catalina: Safari 13.1 |
| --- | --- |
| ![Screenshot from 2020-11-16 10-34-58](https://user-images.githubusercontent.com/10858303/99274257-1bfefb00-27f8-11eb-8e69-7a3f57f63f47.png) | ![Screenshot from 2020-11-16 10-45-40](https://user-images.githubusercontent.com/10858303/99275105-1950d580-27f9-11eb-9a82-29756808f6d3.png) |

| iPhone 11 Pro: Safari | iPhone 11 Pro: Chrome | Samsung Galaxy S20: Firefox | Samsung Galaxy S20: Chrome |
| --- | --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/10858303/99279246-0391df00-27fe-11eb-92c7-7b0bde4b2db7.png) | ![image](https://user-images.githubusercontent.com/10858303/99279424-3936c800-27fe-11eb-934a-f3a3e06b4334.png) | ![image](https://user-images.githubusercontent.com/10858303/99279630-6d11ed80-27fe-11eb-86b8-8229f0af4605.png) | ![image](https://user-images.githubusercontent.com/10858303/99279694-861a9e80-27fe-11eb-9b9a-de0efdad29be.png) |







## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
