### PR TITLE
Fix the MigationsRunner warning on fresh WP installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Corrected a warning being thrown by the MigrationRunner (#5457)
+
 ## 2.9.2 - 2020-11-09
 
 ### New

--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -41,7 +41,7 @@ class MigrationsRunner {
 	public function __construct( MigrationsRegister $migrationRegister ) {
 		$this->migrationRegister = $migrationRegister;
 
-		$this->completedMigrations = get_option( self::MIGRATION_OPTION );
+		$this->completedMigrations = get_option( self::MIGRATION_OPTION, [] );
 	}
 
 	/**

--- a/tests/src/Framework/Migrations/MigrationsRunnerTest.php
+++ b/tests/src/Framework/Migrations/MigrationsRunnerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Give\Framework\Migrations\MigrationsRegister;
+use Give\Framework\Migrations\MigrationsRunner;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class MigrationsRunnerTest
+ * @package src\Framework\Migrations
+ * @coversDefaultClass MigrationsRunner
+ */
+class MigrationsRunnerTest extends TestCase {
+	/**
+	 * @see https://github.com/impress-org/givewp/issues/5454
+	 */
+	public function testNoMigrationsDoesNotThrowError() {
+		// Mock get_option to return the default.
+		function get_option( $option, $default = false ) {
+			return $default;
+		}
+
+		$runner = new MigrationsRunner( new MigrationsRegister );
+
+		self::assertFalse(
+			$runner->hasMigrationToRun()
+		);
+	}
+}

--- a/tests/src/bootstrap.php
+++ b/tests/src/bootstrap.php
@@ -4,4 +4,4 @@ ini_set( 'display_errors', 1 );
 ini_set( 'display_startup_errors', 1 );
 error_reporting( E_ALL );
 
-include_once dirname( __FILE__ ) . '/../../vendor/autoload.php';
+include_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5454 

## Description

A bug was introduced in 2.9.2 that throws an error on a fresh WP install or when upgrading from a version of GiveWP prior to the migrations framework. Simply, a default of an empty array was accidentally removed in 2.9.2, which has it default to `false`, which throws a warning. This PR replaces the default.

## Affects

The migrations flow

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Install a fresh version of WP with debugging enabled and visible, then activate GiveWP. If there are no warnings and all the tables (including `give_revenue`) are in place, then it's good to go.
