### PR TITLE
Fix Stripe CC and Checkout Modal donation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Stripe CC donations now work when not the default gateway (#5459)
+-   Stripe modal checkout donations now work when not the default gateway (#5459)
+
 ## 2.9.2 - 2020-11-09
 
 ### New

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -36,6 +36,13 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		const cardElements = stripeElements.createElement( getStripeElements, formElement );
 		const stripeCheckoutTypeHiddenField = Give.form.fn.getInfo( 'stripe-checkout-type', formElement );
 
+		/**
+		 * Returns the state of the
+		 *
+		 * @since 2.9.3
+		 *
+		 * @returns {{selectedGatewayId: string, formGateway: Element, isCheckoutTypeModal: boolean, isStripeModalCheckoutGateway: boolean}}
+		 */
 		function getFormState() {
 			const formGateway = formElement.querySelector( 'input[name="give-gateway"]' );
 			const selectedGatewayId = formGateway ? formGateway.value : '';
@@ -49,6 +56,13 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			}
 		}
 
+		/**
+		 * Mounts and unmounts the Stripe Elements to the form
+		 *
+		 * @since 2.9.3
+		 *
+		 * @param {boolean} doUnmount
+		 */
 		function mountStripeElements(doUnmount = true) {
 			const { selectedGatewayId, isStripeModalCheckoutGateway } = getFormState();
 
@@ -66,6 +80,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		// Do initial mount
 		mountStripeElements(false);
 
+		// Mount & unmount when the users selects a gateway
 		document.addEventListener( 'give_gateway_loaded', mountStripeElements );
 
 		formElement.onsubmit = ( e ) => {

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -28,43 +28,49 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 			return;
 		}
 
-		const formGateway = formElement.querySelector( 'input[name="give-gateway"]' );
 		const isUpdatingPaymentInfo = give_stripe_vars.hasOwnProperty( 'stripe_card_update' ) && parseInt( give_stripe_vars.stripe_card_update );
 		const idPrefixElement = formElement.querySelector( 'input[name="give-form-id-prefix"]' );
 		const stripeElements = new GiveStripeElements( formElement );
 		const setupStripeElement = stripeElements.setupStripeElement();
 		const getStripeElements = stripeElements.getElements( setupStripeElement );
-		const stripeCheckoutTypeHiddenField = Give.form.fn.getInfo( 'stripe-checkout-type' );
-		const selectedGatewayId = formGateway ? formGateway.value : '';
-		const isCheckoutTypeModal = stripeCheckoutTypeHiddenField && 'modal' === stripeCheckoutTypeHiddenField.value;
-		const isStripeModalCheckoutGateway = formGateway && 'stripe_checkout' === selectedGatewayId && isCheckoutTypeModal;
-		let cardElements = stripeElements.createElement( getStripeElements, formElement );
+		const cardElements = stripeElements.createElement( getStripeElements, formElement );
+		const stripeCheckoutTypeHiddenField = Give.form.fn.getInfo( 'stripe-checkout-type', formElement );
 
-		if ( isUpdatingPaymentInfo || 'stripe' === selectedGatewayId || isStripeModalCheckoutGateway ) {
-			stripeElements.mountElement(cardElements);
+		function getFormState() {
+			const formGateway = formElement.querySelector( 'input[name="give-gateway"]' );
+			const selectedGatewayId = formGateway ? formGateway.value : '';
+			const isCheckoutTypeModal = 'modal' === stripeCheckoutTypeHiddenField;
+
+			return {
+				formGateway,
+				selectedGatewayId,
+				isCheckoutTypeModal,
+				isStripeModalCheckoutGateway: formGateway && 'stripe_checkout' === selectedGatewayId && isCheckoutTypeModal
+			}
 		}
 
-		document.addEventListener( 'give_gateway_loaded', ( e ) => {
-			const selectedGateway = e.detail.selectedGateway;
-			const getStripeElements = stripeElements.getElements( setupStripeElement );
-			cardElements = stripeElements.createElement( getStripeElements, formElement );
+		function mountStripeElements(doUnmount = true) {
+			const { selectedGatewayId, isStripeModalCheckoutGateway } = getFormState();
 
-			if ( 'stripe' === selectedGateway || isStripeModalCheckoutGateway ) {
+			if ( 'stripe' === selectedGatewayId || isStripeModalCheckoutGateway ) {
 				stripeElements.mountElement( cardElements );
-			} else {
+			} else if( doUnmount ) {
 				stripeElements.unMountElement( cardElements );
 			}
 
 			if ( isStripeModalCheckoutGateway ) {
 				stripeElements.triggerStripeModal( formElement, stripeElements, setupStripeElement, cardElements );
 			}
-		});
-
-		if ( isStripeModalCheckoutGateway) {
-			stripeElements.triggerStripeModal( formElement, stripeElements, setupStripeElement, cardElements );
 		}
 
+		// Do initial mount
+		mountStripeElements(false);
+
+		document.addEventListener( 'give_gateway_loaded', mountStripeElements );
+
 		formElement.onsubmit = ( e ) => {
+			const { selectedGatewayId, isStripeModalCheckoutGateway } = getFormState();
+
 			// Bailout, if Stripe is not the selected gateway.
 			if ( isUpdatingPaymentInfo || 'stripe' === selectedGatewayId ) {
 				stripeElements.createPaymentMethod( formElement, setupStripeElement, cardElements );

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -100,7 +100,9 @@ export default {
 		 */
 		getInfo: function( str, $form ) {
 			let data = '';
-			$form = 'undefined' !== typeof $form ? $form : {};
+
+			// Check if form is provided and wrap in jQuery in case its a node
+			$form = 'undefined' !== typeof $form ? jQuery( $form ) : {};
 
 			// Bailout.
 			if ( ! str.length || ! $form.length ) {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5458 

## Description

Errors were being thrown by Stripe for both Credit Cards and Checkout modal, both of which had the same root cause which this PR addresses:

A magic and all-powerful feature of JS is closures. A closure is created when a function is called that is defined in another function. The child function inherits the scope of the parent function _at the time the child function was created_. This last bit is super important, as it means that the closure variables in scope when the child function is called are _from the past_. This is a commonly confusing attribute of closures.

The `give-stripe.js` file has been accumulating over time and, frankly, it's just a difficult file to understand. It accounts for things happening a multiple points in time:
1. When the form loads
2. When the gateway changes
3. When the donation is being processed

Everything is defined inside of the first moment — when the form loads. This means that when the donation is being processed, the variables inherited from the closure are _what they were when the form was loaded_. I've noticed that an all too common bug due to this is that a gateway may work if it's the default gateway versus not. The reason for this is because if the closure data is what the gateway needs it to be when the form loads, then all is well when the donation is being processed. However, if it's not the default gateway, then the closure data is invalid.

This PR addresses the greater issue by making a first-class way to retrieve the state of the form with respect to the time the state is retrieved. The file is still rather confusing, but hopefully this will help to clear things up a bit and avoid further confusion and problems in the future.

## Affects

- Stripe CC and Stripe Checkout payment gateways
- A minor change was made to `form.js` which should be safe, but does touch many gateways

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

See the attached issue on how to reproduce the issue
