### PR TITLE
Edit Profile UI is now implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Front-end donor profiles are scaffolded (#5441)
 -   Donor Profiles UI is implemented (#5444)
 -   Donation History and Dashboard tabs are now dynamically populated (#5455)
+-   Edit Profile UI is now implemented (#5463)
 
 ### Fixed
 

--- a/src/DonorProfiles/resources/js/app/components/avatar-control/index.js
+++ b/src/DonorProfiles/resources/js/app/components/avatar-control/index.js
@@ -1,0 +1,22 @@
+import './style.scss';
+
+const AvatarControl = () => {
+	return (
+		<div className="give-donor-profile-avatar-control">
+			<div className="give-donor-profile-avatar-control__label">
+				Avatar
+			</div>
+			<div className="give-donor-profile-avatar-control__input">
+				<div className="give-donor-profile-avatar-control__preview">
+					<img src="https://cdn.vox-cdn.com/thumbor/ClK0Ing_P9O6kLoQGzbzWleylws=/1400x1050/filters:format(jpeg)/cdn.vox-cdn.com/uploads/chorus_asset/file/19892155/robin_hoo.jpeg" />
+				</div>
+				<div className="give-donor-profile-avatar-control__dropzone">
+					<div className="give-donor-profile-avatar-control__instructions">
+						Drag avatar here to set avatar or <span className="give-donor-profile-avatar-control__select-link">find avatar</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+export default AvatarControl;

--- a/src/DonorProfiles/resources/js/app/components/avatar-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/avatar-control/style.scss
@@ -1,0 +1,47 @@
+.give-donor-profile-avatar-control {
+	display: flex;
+	flex-direction: column;
+	font-weight: 500;
+	color: #555;
+	font-size: 14px;
+
+	.give-donor-profile-avatar-control__label {
+		margin: 16px 0;
+	}
+
+	.give-donor-profile-avatar-control__input {
+		display: flex;
+
+		.give-donor-profile-avatar-control__preview {
+			height: 100px;
+			width: 100px;
+			border-radius: 50%;
+			overflow: hidden;
+			margin-right: 16px;
+
+			img {
+				object-fit: cover;
+				width: 100%;
+				height: 100%;
+			}
+		}
+
+		.give-donor-profile-avatar-control__dropzone {
+			background: #fbfbfb;
+			border: 2px dashed #e2e6ec;
+			flex: 1;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+
+			.give-donor-profile-avatar-control__instructions {
+				text-align: center;
+
+				.give-donor-profile-avatar-control__select-link {
+					text-decoration: underline;
+					cursor: pointer;
+				}
+			}
+		}
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/button/index.js
+++ b/src/DonorProfiles/resources/js/app/components/button/index.js
@@ -3,9 +3,9 @@ import './style.scss';
 
 const Button = ( { icon, children, onClick } ) => {
 	return (
-		<div className="give-donor-profile-button give-donor-profile-button--primary" onClick={ () => onClick() }>
+		<button className="give-donor-profile-button give-donor-profile-button--primary" onClick={ () => onClick() }>
 			{ children }{ icon && ( <FontAwesomeIcon icon={ icon } /> ) }
-		</div>
+		</button>
 	);
 };
 export default Button;

--- a/src/DonorProfiles/resources/js/app/components/button/index.js
+++ b/src/DonorProfiles/resources/js/app/components/button/index.js
@@ -1,0 +1,11 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import './style.scss';
+
+const Button = ( { icon, children, onClick } ) => {
+	return (
+		<div className="give-donor-profile-button give-donor-profile-button--primary" onClick={ () => onClick() }>
+			{ children }{ icon && ( <FontAwesomeIcon icon={ icon } /> ) }
+		</div>
+	);
+};
+export default Button;

--- a/src/DonorProfiles/resources/js/app/components/button/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/button/style.scss
@@ -1,0 +1,18 @@
+.give-donor-profile-button {
+	padding: 12px 20px;
+	font-size: 16px;
+	font-weight: 600;
+	border: 1px solid #68bb6c;
+	border-radius: 3px;
+	display: inline-flex;
+	align-items: center;
+
+	svg {
+		margin-left: 8px;
+	}
+
+	&.give-donor-profile-button--primary {
+		color: #fff;
+		background: #68bb6c;
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/button/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/button/style.scss
@@ -1,4 +1,6 @@
 .give-donor-profile-button {
+	margin: 20px 0;
+	font-family: Montserrat, Arial, Helvetica, sans-serif;
 	padding: 12px 20px;
 	font-size: 16px;
 	font-weight: 600;
@@ -6,9 +8,16 @@
 	border-radius: 3px;
 	display: inline-flex;
 	align-items: center;
+	box-shadow: 0 0 0 0 #7ec980, 0 0 0 0 #4fa651;
+	transition: box-shadow 0.1s ease;
+	cursor: pointer;
 
 	svg {
 		margin-left: 8px;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px #7ec980, 0 0 0 2px #4fa651;
 	}
 
 	&.give-donor-profile-button--primary {

--- a/src/DonorProfiles/resources/js/app/components/desktop-layout/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/desktop-layout/style.scss
@@ -7,7 +7,6 @@
 	background: #fff;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 	border-radius: 8px;
-	overflow: hidden;
 }
 
 .give-donor-profile-desktop-layout__donor-info {
@@ -19,6 +18,7 @@
 	grid-row: 2;
 	background: #fbfbfb;
 	border-right: 1px solid #e2e6ec;
+	border-radius: 0 0 0 8px;
 
 	.give-donor-profile-tab-link {
 		font-size: 15px;

--- a/src/DonorProfiles/resources/js/app/components/divider/index.js
+++ b/src/DonorProfiles/resources/js/app/components/divider/index.js
@@ -1,0 +1,7 @@
+import './style.scss';
+const Divider = () => {
+	return (
+		<div className="give-donor-profile-divider" />
+	);
+};
+export default Divider;

--- a/src/DonorProfiles/resources/js/app/components/divider/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/divider/style.scss
@@ -1,0 +1,6 @@
+.give-donor-profile-divider {
+	margin: 16px 0;
+	height: 1px;
+	width: 100%;
+	background: #e2e6ec;
+}

--- a/src/DonorProfiles/resources/js/app/components/divider/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/divider/style.scss
@@ -1,5 +1,5 @@
 .give-donor-profile-divider {
-	margin: 16px 0;
+	margin: 0;
 	height: 1px;
 	width: 100%;
 	background: #e2e6ec;

--- a/src/DonorProfiles/resources/js/app/components/field-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/field-row/index.js
@@ -1,0 +1,10 @@
+import './style.scss';
+
+const FieldRow = ( { children } ) => {
+	return (
+		<div className="give-donor-profile-field-row">
+			{ children }
+		</div>
+	);
+};
+export default FieldRow;

--- a/src/DonorProfiles/resources/js/app/components/field-row/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/field-row/style.scss
@@ -1,10 +1,11 @@
 .give-donor-profile-field-row {
 	display: flex;
 	align-items: center;
-	margin: 20px 0;
+	margin: 0;
 
 	> * {
 		margin: 0 10px;
+		flex: 1;
 	}
 
 	> *:first-child {

--- a/src/DonorProfiles/resources/js/app/components/field-row/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/field-row/style.scss
@@ -1,0 +1,17 @@
+.give-donor-profile-field-row {
+	display: flex;
+	align-items: center;
+	margin: 20px 0;
+
+	> * {
+		margin: 0 10px;
+	}
+
+	> *:first-child {
+		margin-left: 0;
+	}
+
+	> *:last-child {
+		margin-right: 0;
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/heading/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/heading/style.scss
@@ -1,7 +1,7 @@
 .give-donor-profile-heading {
 	color: #555 !important;
 	font-size: 16px;
-	margin: 16px 0;
+	margin: 20px 0 10px 0;
 	display: flex;
 	align-items: center;
 

--- a/src/DonorProfiles/resources/js/app/components/mobile-layout/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/mobile-layout/style.scss
@@ -5,7 +5,6 @@
 	background: #fff;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 	border-radius: 8px;
-	overflow: hidden;
 }
 
 .give-donor-profile-mobile-layout__tab-menu {

--- a/src/DonorProfiles/resources/js/app/components/mobile-menu/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/mobile-menu/style.scss
@@ -9,6 +9,7 @@
 	padding: 6px 8px 6px 20px;
 	background: #68bb6c;
 	color: #fff;
+	border-radius: 8px 8px 0 0;
 }
 
 .give-donor-profile-mobile-menu__toggle {

--- a/src/DonorProfiles/resources/js/app/components/radio-control/index.js
+++ b/src/DonorProfiles/resources/js/app/components/radio-control/index.js
@@ -1,0 +1,26 @@
+import { toKebabCase } from '../../utils';
+import './style.scss';
+
+const RadioControl = ( { label, description, options, value, onChange } ) => {
+	const optionEls = options.map( ( option, index ) => {
+		const id = toKebabCase( option.value );
+		return (
+			<div className="give-donor-profile-radio-control__option" key={ index }>
+				<input type="radio" name="format" id={ id } value={ option.value } checked={ option.value === value ? true : false } onChange={ ( evt ) => onChange( evt.target.value ) } />
+				<label htmlFor={ id }>{ option.label }</label>
+			</div>
+		);
+	} );
+	return (
+		<fieldset className="give-donor-profile-radio-control">
+			{ label && ( <legend className="give-donor-profile-radio-control__legend">{ label }</legend> ) }
+			{ description && (
+				<div className="give-donor-profile-radio-control__description">
+					{ description }
+				</div>
+			) }
+			{ optionEls }
+		</fieldset>
+	);
+};
+export default RadioControl;

--- a/src/DonorProfiles/resources/js/app/components/radio-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/radio-control/style.scss
@@ -56,7 +56,8 @@
 				border-radius: 50%;
 				background: #fff;
 				border: 1px solid #b4b9be;
-				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+				box-shadow: 0 0 0 0 #4fa651, inset 0 1px 2px rgba(0, 0, 0, 0.25);
+				transition: box-shadow 0.1s ease;
 			}
 
 			&::after {
@@ -79,6 +80,12 @@
 			position: absolute !important;
 
 			&:focus {
+				+ label::before {
+					box-shadow: 0 0 0 1px #4fa651, inset 0 1px 2px rgba(0, 0, 0, 0.25);
+				}
+			}
+
+			&:checked {
 				+ label::after {
 					transform: scale3d(1, 1, 1);
 				}

--- a/src/DonorProfiles/resources/js/app/components/radio-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/radio-control/style.scss
@@ -1,0 +1,88 @@
+.give-donor-profile-radio-control {
+	margin-top: 20px;
+	outline: none;
+	border: none;
+
+	.give-donor-profile-radio-control__legend {
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		font-size: 14px;
+		line-height: 1;
+		color: #555;
+		margin-bottom: 10px;
+	}
+
+	.give-donor-profile-radio-control__description {
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		font-style: italic;
+		font-size: 13px;
+		line-height: 1.4;
+		color: #767676;
+		margin-bottom: 12px;
+	}
+
+	.give-donor-profile-radio-control__option {
+		margin: 10px 0;
+
+		&:first-of-type {
+			margin-top: 20px;
+		}
+
+		&:last-of-type {
+			margin-bottom: 20px;
+		}
+
+		label {
+			font-family: Montserrat, Arial, Helvetica, sans-serif;
+			font-weight: 500;
+			font-size: 14px;
+			line-height: 1.4;
+			color: #555;
+			position: relative;
+
+			padding: 0 0 0 26px;
+			width: 100%;
+			margin-left: 0;
+			display: inline-block;
+
+			&::before {
+				content: ' ';
+				position: absolute;
+				top: calc(50% - 8px);
+				left: 0;
+				width: 16px;
+				height: 16px;
+				border-radius: 50%;
+				background: #fff;
+				border: 1px solid #b4b9be;
+				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+			}
+
+			&::after {
+				transform: scale3d(0, 0, 0);
+				transition: transform 0.2s ease;
+				border-radius: 50%;
+				width: 6px;
+				height: 6px;
+				position: absolute;
+				top: calc(50% - 3px);
+				left: 5px;
+				content: ' ';
+				display: block;
+				background: #68bb6c;
+			}
+		}
+
+		input[type='radio'] {
+			opacity: 0 !important;
+			position: absolute !important;
+
+			&:focus {
+				+ label::after {
+					transform: scale3d(1, 1, 1);
+				}
+			}
+		}
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/select-control/index.js
+++ b/src/DonorProfiles/resources/js/app/components/select-control/index.js
@@ -1,0 +1,104 @@
+// Import vendor dependencies
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+
+// Import utilities
+import { toKebabCase } from '../../utils';
+
+// Import styles
+import './style.scss';
+
+const { __ } = wp.i18n;
+
+const SelectControl = ( { label, value, isLoading, onChange, options, placeholder, width } ) => {
+	if ( options && options.length < 2 ) {
+		return null;
+	}
+
+	const selectedOptionValue = options !== null ? options.filter( option => option.value === value ) : null;
+	const selectStyles = {
+		control: ( provided ) => ( {
+			...provided,
+			fontSize: '14px',
+			fontFamily: 'Montserrat, Arial, Helvetica, sans-serif',
+			fontWeight: '500',
+			color: '#828382',
+			lineHeight: '1.2',
+			width: width,
+			boxSizing: 'border-box',
+			marginTop: '12px',
+			border: '1px solid #b8b8b8',
+			borderRadius: '4px',
+		} ),
+		input: ( provided ) => ( {
+			...provided,
+			fontSize: '14px',
+			fontFamily: 'Montserrat, Arial, Helvetica, sans-serif',
+			fontWeight: '500',
+			color: '#828382',
+			lineHeight: '1.2',
+		} ),
+		valueContainer: ( provided ) => ( {
+			...provided,
+			padding: '7px 12px',
+		} ),
+		option: ( provided, state ) => ( {
+			...provided,
+			fontSize: '14px',
+			fontFamily: 'Montserrat, Arial, Helvetica, sans-serif',
+			fontWeight: '500',
+			color: state.isSelected ? '#fff' : '#333',
+			lineHeight: '1.2',
+		} ),
+		indicatorSeparator: () => ( {
+			display: 'none',
+		} ),
+	};
+
+	return (
+		<div className="give-donor-profile-select-control">
+			{ label && ( <label className="give-donor-profile-select-control__label" htmlFor={ toKebabCase( label ) }>{ label }</label> ) }
+			<Select
+				placeholder={ placeholder }
+				isLoading={ isLoading }
+				inputId={ label && toKebabCase( label ) }
+				value={ selectedOptionValue }
+				onChange={ ( selectedOption ) => onChange( selectedOption.value ) }
+				options={ options }
+				styles={ selectStyles }
+				maxMenuHeight="200px"
+				isDisabled={ isLoading }
+				theme={ ( theme ) => ( {
+					...theme,
+					colors: {
+						...theme.colors,
+						primary: '#4fa651',
+						primary75: '#77b579',
+						primary50: '#c5e0c7',
+						primary25: '#e6f5e7',
+					},
+				} ) }
+			/>
+		</div>
+	);
+};
+
+SelectControl.propTypes = {
+	label: PropTypes.string,
+	value: PropTypes.string.isRequired,
+	onChange: PropTypes.func,
+	options: PropTypes.array.isRequired,
+	placeholder: PropTypes.string,
+	width: PropTypes.string,
+};
+
+SelectControl.defaultProps = {
+	label: null,
+	value: null,
+	onChange: null,
+	options: null,
+	placeholder: __( 'Select...', 'give' ),
+	width: '200px',
+};
+
+export default SelectControl;

--- a/src/DonorProfiles/resources/js/app/components/select-control/index.js
+++ b/src/DonorProfiles/resources/js/app/components/select-control/index.js
@@ -24,9 +24,8 @@ const SelectControl = ( { label, value, isLoading, onChange, options, placeholde
 			fontWeight: '500',
 			color: '#828382',
 			lineHeight: '1.2',
-			width: width,
 			boxSizing: 'border-box',
-			marginTop: '12px',
+			marginTop: '8px',
 			border: '1px solid #b8b8b8',
 			borderRadius: '4px',
 		} ),
@@ -56,7 +55,7 @@ const SelectControl = ( { label, value, isLoading, onChange, options, placeholde
 	};
 
 	return (
-		<div className="give-donor-profile-select-control">
+		<div className="give-donor-profile-select-control" style={ width ? { maxWidth: width } : null }>
 			{ label && ( <label className="give-donor-profile-select-control__label" htmlFor={ toKebabCase( label ) }>{ label }</label> ) }
 			<Select
 				placeholder={ placeholder }
@@ -98,7 +97,7 @@ SelectControl.defaultProps = {
 	onChange: null,
 	options: null,
 	placeholder: __( 'Select...', 'give' ),
-	width: '200px',
+	width: null,
 };
 
 export default SelectControl;

--- a/src/DonorProfiles/resources/js/app/components/select-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/select-control/style.scss
@@ -1,6 +1,8 @@
 /* stylelint-disable  function-url-quotes */
 
 .give-donor-profile-select-control {
+	margin-top: 10px;
+
 	.give-donor-profile-select-control__label {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
 		font-weight: 500;

--- a/src/DonorProfiles/resources/js/app/components/select-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/select-control/style.scss
@@ -1,0 +1,11 @@
+/* stylelint-disable  function-url-quotes */
+
+.give-donor-profile-select-control {
+	.give-donor-profile-select-control__label {
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		font-size: 14px;
+		line-height: 1;
+		color: #555;
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/text-control/index.js
+++ b/src/DonorProfiles/resources/js/app/components/text-control/index.js
@@ -1,0 +1,33 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { toKebabCase } from '../../utils';
+
+import './style.scss';
+
+const TextControl = ( { label, value, onChange, icon, type } ) => {
+	return (
+		<div className="give-donor-profile-text-control">
+			{ label && ( <label className="give-donor-profile-text-control__label" htmlFor={ toKebabCase( label ) }>{ label }</label> ) }
+			<div className="give-donor-profile-text-control__input">
+				{ icon && (
+					<FontAwesomeIcon icon={ icon } />
+				) }
+				<input
+					id={ label && toKebabCase( label ) }
+					type={ type }
+					value={ value }
+					onChange={ ( evt ) => onChange( evt.target.value ) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+TextControl.defaultProps = {
+	label: null,
+	value: '',
+	onChange: null,
+	icon: null,
+	type: 'text',
+};
+
+export default TextControl;

--- a/src/DonorProfiles/resources/js/app/components/text-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/text-control/style.scss
@@ -1,5 +1,5 @@
 .give-donor-profile-text-control {
-	flex: 1;
+	margin-top: 10px;
 
 	.give-donor-profile-text-control__label {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
@@ -24,7 +24,7 @@
 		line-height: 1.2;
 		min-width: 190px;
 		width: 100%;
-		margin-top: 12px;
+		margin-top: 8px;
 		border: 1px solid #b8b8b8;
 		overflow: hidden;
 		padding: 11px 12px;

--- a/src/DonorProfiles/resources/js/app/components/text-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/text-control/style.scss
@@ -1,0 +1,43 @@
+.give-donor-profile-text-control {
+	flex: 1;
+
+	.give-donor-profile-text-control__label {
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		font-size: 14px;
+		line-height: 1;
+		color: #555;
+	}
+
+	.give-donor-profile-text-control__input {
+		align-items: center;
+		background-color: hsl(0, 0%, 100%);
+		border-radius: 4px;
+		cursor: default;
+		display: flex;
+		min-height: 38px;
+		outline: 0 !important;
+		font-size: 14px;
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		color: #828382;
+		line-height: 1.2;
+		min-width: 190px;
+		width: 100%;
+		margin-top: 12px;
+		border: 1px solid #b8b8b8;
+		overflow: hidden;
+		padding: 11px 12px;
+
+		svg {
+			margin-right: 12px;
+		}
+
+		input {
+			outline: none;
+			border: none;
+			padding: 0;
+			width: 100%;
+		}
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/text-control/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/text-control/style.scss
@@ -28,6 +28,12 @@
 		border: 1px solid #b8b8b8;
 		overflow: hidden;
 		padding: 11px 12px;
+		box-shadow: 0 0 0 0 #4fa651;
+		transition: box-shadow 0.1s ease;
+
+		&:focus-within {
+			box-shadow: 0 0 0 1px #4fa651;
+		}
 
 		svg {
 			margin-right: 12px;

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -8,6 +8,8 @@ import TextControl from '../../components/text-control';
 import { Fragment, useState } from 'react';
 const { __ } = wp.i18n;
 
+import './style.scss';
+
 const Content = () => {
 	const [ prefix, setPrefix ] = useState( null );
 	const prefixOptions = [
@@ -28,6 +30,7 @@ const Content = () => {
 	const [ lastName, setLastName ] = useState( '' );
 
 	const [ primaryEmail, setPrimaryEmail ] = useState( '' );
+	const [ additionalEmail, setAdditionalEmail ] = useState( '' );
 
 	const [ country, setCountry ] = useState( '' );
 	const countryOptions = [
@@ -96,6 +99,23 @@ const Content = () => {
 				onChange={ ( value ) => setPrimaryEmail( value ) }
 				icon="envelope"
 			/>
+			<FieldRow>
+				<TextControl
+					label={ __( 'Additional Emails', 'give' ) }
+					value={ additionalEmail }
+					onChange={ ( value ) => setAdditionalEmail( value ) }
+					icon="envelope"
+				/>
+				<div className="give-donor-profile__email-controls">
+					<div className="give-donor-profile__make-primary-email">
+						{ __( 'Make Primary', 'give' ) }
+					</div>
+					|
+					<div className="give-donor-profile__delete-email">
+						{ __( 'Delete', 'give' ) }
+					</div>
+				</div>
+			</FieldRow>
 			<Heading>
 				Address
 			</Heading>

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -5,6 +5,7 @@ import FieldRow from '../../components/field-row';
 import SelectControl from '../../components/select-control';
 import TextControl from '../../components/text-control';
 import RadioControl from '../../components/radio-control';
+import Button from '../../components/button';
 
 import { Fragment, useState } from 'react';
 const { __ } = wp.i18n;
@@ -179,6 +180,9 @@ const Content = () => {
 				onChange={ ( value ) => setAnonymous( value ) }
 				value={ anonymous }
 			/>
+			<Button icon="save">
+				Update Profile
+			</Button>
 		</Fragment>
 	);
 };

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -105,7 +105,7 @@ const Content = () => {
 				value={ country }
 				onChange={ ( value ) => setCountry( value ) }
 				options={ countryOptions }
-				width="580px"
+				width={ null }
 			/>
 			<TextControl
 				label={ __( 'Address 1', 'give' ) }

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -1,12 +1,140 @@
 import Heading from '../../components/heading';
-import { Fragment } from 'react';
+import Divider from '../../components/divider';
+import AvatarControl from '../../components/avatar-control';
+import FieldRow from '../../components/field-row';
+import SelectControl from '../../components/select-control';
+import TextControl from '../../components/text-control';
+
+import { Fragment, useState } from 'react';
+const { __ } = wp.i18n;
 
 const Content = () => {
+	const [ prefix, setPrefix ] = useState( null );
+	const prefixOptions = [
+		{
+			value: 'mr',
+			label: 'Mr.',
+		},
+		{
+			value: 'ms',
+			label: 'Ms.',
+		},		{
+			value: 'mrs',
+			label: 'Mrs.',
+		},
+	];
+
+	const [ firstName, setFirstName ] = useState( '' );
+	const [ lastName, setLastName ] = useState( '' );
+
+	const [ primaryEmail, setPrimaryEmail ] = useState( '' );
+
+	const [ country, setCountry ] = useState( '' );
+	const countryOptions = [
+		{
+			value: 'USA',
+			label: 'United States',
+		},
+		{
+			value: 'UK',
+			label: 'United Kingdom',
+		},		{
+			value: 'CAN',
+			label: 'Canada',
+		},
+	];
+	const [ addressOne, setAddressOne ] = useState( '' );
+	const [ addressTwo, setAddressTwo ] = useState( '' );
+	const [ city, setCity ] = useState( '' );
+	const [ state, setState ] = useState( '' );
+	const stateOptions = [
+		{
+			value: 'NY',
+			label: 'New York',
+		},
+		{
+			value: 'MI',
+			label: 'Michigan',
+		},		{
+			value: 'CA',
+			label: 'California',
+		},
+	];
+	const [ zip, setZip ] = useState( '' );
+
 	return (
 		<Fragment>
 			<Heading>
-				Edit Profile
+				Profile Information
 			</Heading>
+			<Divider />
+			<AvatarControl />
+			<FieldRow>
+				<SelectControl
+					label={ __( 'Prefix', 'give' ) }
+					value={ prefix }
+					onChange={ ( value ) => setPrefix( value ) }
+					options={ prefixOptions }
+					placeholder="--"
+					width="80px"
+				/>
+				<TextControl
+					label={ __( 'First Name', 'give' ) }
+					value={ firstName }
+					onChange={ ( value ) => setFirstName( value ) }
+					icon="user"
+				/>
+				<TextControl
+					label={ __( 'Last Name', 'give' ) }
+					value={ lastName }
+					onChange={ ( value ) => setLastName( value ) }
+				/>
+			</FieldRow>
+			<TextControl
+				label={ __( 'Primary Email', 'give' ) }
+				value={ primaryEmail }
+				onChange={ ( value ) => setPrimaryEmail( value ) }
+				icon="envelope"
+			/>
+			<Heading>
+				Address
+			</Heading>
+			<Divider />
+			<SelectControl
+				label={ __( 'Country', 'give' ) }
+				value={ country }
+				onChange={ ( value ) => setCountry( value ) }
+				options={ countryOptions }
+				width="580px"
+			/>
+			<TextControl
+				label={ __( 'Address 1', 'give' ) }
+				value={ addressOne }
+				onChange={ ( value ) => setAddressOne( value ) }
+			/>
+			<TextControl
+				label={ __( 'Address 2', 'give' ) }
+				value={ addressTwo }
+				onChange={ ( value ) => setAddressTwo( value ) }
+			/>
+			<TextControl
+				label={ __( 'City', 'give' ) }
+				value={ city }
+				onChange={ ( value ) => setCity( value ) }
+			/>
+			<FieldRow>
+				<SelectControl
+					label={ __( 'State', 'give' ) }
+					value={ state }
+					onChange={ ( value ) => setState( value ) }
+					options={ stateOptions }
+				/>
+				<TextControl
+					label={ __( 'Zip', 'give' ) }
+					value={ zip }
+					onChange={ ( value ) => setZip( value ) }
+				/>
+			</FieldRow>
 		</Fragment>
 	);
 };

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -4,6 +4,7 @@ import AvatarControl from '../../components/avatar-control';
 import FieldRow from '../../components/field-row';
 import SelectControl from '../../components/select-control';
 import TextControl from '../../components/text-control';
+import RadioControl from '../../components/radio-control';
 
 import { Fragment, useState } from 'react';
 const { __ } = wp.i18n;
@@ -11,7 +12,7 @@ const { __ } = wp.i18n;
 import './style.scss';
 
 const Content = () => {
-	const [ prefix, setPrefix ] = useState( null );
+	const [ prefix, setPrefix ] = useState( 'mr' );
 	const prefixOptions = [
 		{
 			value: 'mr',
@@ -26,13 +27,13 @@ const Content = () => {
 		},
 	];
 
-	const [ firstName, setFirstName ] = useState( '' );
-	const [ lastName, setLastName ] = useState( '' );
+	const [ firstName, setFirstName ] = useState( 'Robin' );
+	const [ lastName, setLastName ] = useState( 'Hood' );
 
-	const [ primaryEmail, setPrimaryEmail ] = useState( '' );
-	const [ additionalEmail, setAdditionalEmail ] = useState( '' );
+	const [ primaryEmail, setPrimaryEmail ] = useState( 'robin@merrymen.biz' );
+	const [ additionalEmail, setAdditionalEmail ] = useState( 'give2th3p00r@sherwood.net' );
 
-	const [ country, setCountry ] = useState( '' );
+	const [ country, setCountry ] = useState( 'UK' );
 	const countryOptions = [
 		{
 			value: 'USA',
@@ -46,10 +47,10 @@ const Content = () => {
 			label: 'Canada',
 		},
 	];
-	const [ addressOne, setAddressOne ] = useState( '' );
-	const [ addressTwo, setAddressTwo ] = useState( '' );
-	const [ city, setCity ] = useState( '' );
-	const [ state, setState ] = useState( '' );
+	const [ addressOne, setAddressOne ] = useState( '12 King John Way' );
+	const [ addressTwo, setAddressTwo ] = useState( 'Unit B' );
+	const [ city, setCity ] = useState( 'Sherwood Forest' );
+	const [ state, setState ] = useState( 'NY' );
 	const stateOptions = [
 		{
 			value: 'NY',
@@ -63,12 +64,24 @@ const Content = () => {
 			label: 'California',
 		},
 	];
-	const [ zip, setZip ] = useState( '' );
+	const [ zip, setZip ] = useState( '01234' );
+
+	const [ anonymous, setAnonymous ] = useState( 'public' );
+	const anonymousOptions = [
+		{
+			value: 'public',
+			label: __( 'Public - show my donations publicly', 'give' ),
+		},
+		{
+			value: 'private',
+			label: __( 'Private - only organization admins can view my info' ),
+		},
+	];
 
 	return (
 		<Fragment>
 			<Heading>
-				Profile Information
+				{ __( 'Profile Information', 'give' ) }
 			</Heading>
 			<Divider />
 			<AvatarControl />
@@ -117,7 +130,7 @@ const Content = () => {
 				</div>
 			</FieldRow>
 			<Heading>
-				Address
+				{ __( 'Address', 'give' ) }
 			</Heading>
 			<Divider />
 			<SelectControl
@@ -155,6 +168,17 @@ const Content = () => {
 					onChange={ ( value ) => setZip( value ) }
 				/>
 			</FieldRow>
+			<Heading>
+				{ __( 'Additional Info', 'give' ) }
+			</Heading>
+			<Divider />
+			<RadioControl
+				label={ __( 'Anonymous Giving' ) }
+				description={ __( 'This will prevent your avatar, first name, and donation comments and other information from appearing publicly on this orgization’s website.', 'give' ) }
+				options={ anonymousOptions }
+				onChange={ ( value ) => setAnonymous( value ) }
+				value={ anonymous }
+			/>
 		</Fragment>
 	);
 };

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/style.scss
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/style.scss
@@ -1,0 +1,29 @@
+.give-donor-profile__email-controls {
+	display: flex;
+	align-self: stretch;
+	align-items: center;
+	justify-content: center;
+	padding-top: 48px;
+	max-width: fit-content;
+	font-size: 14px;
+
+	.give-donor-profile__make-primary-email {
+		margin-right: 10px;
+		color: #3398db;
+		cursor: pointer;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	.give-donor-profile__delete-email {
+		margin-left: 10px;
+		color: rgb(199, 81, 81);
+		cursor: pointer;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/src/DonorProfiles/resources/js/app/utils/index.js
+++ b/src/DonorProfiles/resources/js/app/utils/index.js
@@ -45,3 +45,17 @@ export const getAPIRoot = () => {
 export const getAPINonce = () => {
 	return getWindowData( 'apiNonce' );
 };
+
+/**
+ * Returns string in Kebab Case (ex: kebab-case)
+ *
+ * @param {string} str String to be returned in Kebab Case
+ * @return {string} String returned in Kebab Case
+ * @since 2.8.0
+ */
+export const toKebabCase = ( str ) => {
+	return str.replace( ' / ', ' ' )
+		.replace( /([a-z])([A-Z])/g, '$1-$2' )
+		.replace( /\s+/g, '-' )
+		.toLowerCase();
+};


### PR DESCRIPTION
Resolves #5456 

## Description
This PR implements React components necessary for rendering to Donor Profile editing UI. Specifically, the PR contains logic to power reuse-able select inputs (<SelectControl/>), text inputs (<TextControl/>), radio inputs (<RadioControl/>) and buttons (<Button/>). While this PR does not go so far as to actually implement functionality that would allow these controls to persist changes to the database, it is meant to lay the groundwork for that next step.

## Affects
This PR affects the Edit Profile tab of the Donor Profiles application, and introduces additional UI components to the Donor Profile app.

## Visuals
![EditProfilePR](https://user-images.githubusercontent.com/5186078/99590330-303f2580-29bb-11eb-804c-3fdec24db58c.png)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new page
2. Add the Donor Profile block
3. Check out the block from the front-end
4. Check the Edit Profile tab, and test interactions with various fields