### PR TITLE
Fix issue with updating subscription card for Stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Updating a Stripe subscription from the update payment info screen works again (#5467)
+
 ## 2.9.3 - 2020-11-17
 
 ### Fixed

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		function mountStripeElements(doUnmount = true) {
 			const { selectedGatewayId, isStripeModalCheckoutGateway } = getFormState();
 
-			if ( 'stripe' === selectedGatewayId || isStripeModalCheckoutGateway ) {
+			if ( isUpdatingPaymentInfo || 'stripe' === selectedGatewayId || isStripeModalCheckoutGateway ) {
 				stripeElements.mountElement( cardElements );
 			} else if( doUnmount ) {
 				stripeElements.unMountElement( cardElements );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5466 

## Description

This PR adds a condition check that was omitted in 2.9.3 which mounts Stripe on the subscription update screen.

## Affects

The subscription payment info update screen.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

See the steps to reproduce in the issue. If you're able to update the card then it's working!
