### PR TITLE
Fix Stripe single card input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Stripe single-input credit card field works again (#5469)
+
 ## 2.9.3 - 2020-11-17
 
 ### Fixed

--- a/assets/src/js/frontend/give-stripe-elements.js
+++ b/assets/src/js/frontend/give-stripe-elements.js
@@ -24,6 +24,7 @@ class GiveStripeElements {
 		this.idPrefix = formElement.getAttribute( 'data-id' ) ? formElement.getAttribute( 'data-id' ) : '';
 		this.locale = give_stripe_vars.preferred_locale;
 		this.fieldsFormat = give_stripe_vars.cc_fields_format;
+		this.isSingleInputField = this.fieldsFormat === 'single';
 		this.isMounted = false;
 		this.fontStyles = [];
 
@@ -188,7 +189,7 @@ class GiveStripeElements {
 			cardExpiry: `#give-card-expiration-field-${ this.idPrefix }`,
 		};
 
-		if ( 'single' === this.fieldsFormat ) {
+		if ( this.isSingleInputField ) {
 			elementsToMountOn = {
 				card: `#give-stripe-single-cc-fields-${ this.idPrefix }`,
 			};
@@ -239,7 +240,10 @@ class GiveStripeElements {
 	createPaymentMethod( formElement, stripeElement, cardElements ) {
 		const billing_details = {};
 
-		billing_details.name = formElement.querySelector( 'input[name="card_name"]' ).value;
+		if ( ! this.isSingleInputField ) {
+			billing_details.name = formElement.querySelector( 'input[name="card_name"]' ).value;
+		}
+
 		if ( ! give_stripe_vars.stripe_card_update ) {
 			const firstName = formElement.querySelector( 'input[name="give_first"]' ).value;
 			const lastName = formElement.querySelector( 'input[name="give_last"]' ).value;

--- a/assets/src/js/frontend/give-stripe-elements.js
+++ b/assets/src/js/frontend/give-stripe-elements.js
@@ -235,6 +235,7 @@ class GiveStripeElements {
 	 * @param stripeElement
 	 * @param cardElements
 	 *
+	 * @since 2.9.4 only add card name for multi-input field
 	 * @since 2.8.0
 	 */
 	createPaymentMethod( formElement, stripeElement, cardElements ) {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5468 

## Description

This resolves a bug for the Stripe single input setting. The issue was that when the payment method was being created the JS was looking for a cardholder name field what only exists on the multi-input field setting. The fix is to add a check so the name field is only retrieved on the multi-input setting.

## Affects

Stripe single and multi-input CC fields

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Review the instructions to reproduce the problem in the Issue. Please review the Acceptance Criteria and test each scenario as well.
