### PR TITLE
Prevent fatal error when delete donation on WP < 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Prevent fatal error when delete donation on WP < 5.5.0 (#5470)
 -   Stripe single-input credit card field works again (#5469)
 -   Updating a Stripe subscription from the update payment info screen works again (#5467)
 

--- a/src/Revenue/Listeners/DeleteRevenueWhenDonationDeleted.php
+++ b/src/Revenue/Listeners/DeleteRevenueWhenDonationDeleted.php
@@ -25,6 +25,7 @@ class DeleteRevenueWhenDonationDeleted {
 	 * Deletes the revenue associated with a donation when a donation is deleted
 	 *
 	 * @since 2.9.2
+	 * @since 2.9.4 removed $post parameter for < WP 5.5 compatibility
 	 *
 	 * @param  int  $postId
 	 *

--- a/src/Revenue/Listeners/DeleteRevenueWhenDonationDeleted.php
+++ b/src/Revenue/Listeners/DeleteRevenueWhenDonationDeleted.php
@@ -1,10 +1,8 @@
 <?php
-
 namespace Give\Revenue\Listeners;
 
-use Give\Framework\Database\DB;
+use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use Give\Revenue\Repositories\Revenue;
-use WP_Post;
 
 class DeleteRevenueWhenDonationDeleted {
 	/**
@@ -16,6 +14,8 @@ class DeleteRevenueWhenDonationDeleted {
 	 * DeleteRevenueWhenDonationDeleted constructor.
 	 *
 	 * @since 2.9.2
+	 *
+	 * @param  Revenue  $revenueRepository
 	 */
 	public function __construct( Revenue $revenueRepository ) {
 		$this->revenueRepository = $revenueRepository;
@@ -26,11 +26,12 @@ class DeleteRevenueWhenDonationDeleted {
 	 *
 	 * @since 2.9.2
 	 *
-	 * @param int     $postId
-	 * @param WP_Post $post
+	 * @param  int  $postId
+	 *
+	 * @throws DatabaseQueryException
 	 */
-	public function __invoke( $postId, WP_Post $post ) {
-		if ( $post->post_type !== 'give_payment' ) {
+	public function __invoke( $postId ) {
+		if ( 'give_payment' !== get_post_type( $postId ) ) {
 			return;
 		}
 

--- a/src/Revenue/RevenueServiceProvider.php
+++ b/src/Revenue/RevenueServiceProvider.php
@@ -29,7 +29,7 @@ class RevenueServiceProvider implements ServiceProvider {
 	public function boot() {
 		$this->registerMigrations();
 
-		Hooks::addAction( 'delete_post', DeleteRevenueWhenDonationDeleted::class, '__invoke', 10, 2 );
+		Hooks::addAction( 'delete_post', DeleteRevenueWhenDonationDeleted::class, '__invoke', 10, 1 );
 		Hooks::addAction( 'give_insert_payment', DonationHandler::class, 'handle', 999, 1 );
 		Hooks::addAction( 'give_register_updates', AddPastDonationsToRevenueTable::class, 'register', 10, 1 );
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5471 

## Description

I find that the second argument to `delete_post` action hook added in WP 5.5.0 and we are using second argument in our logic, so everyone we face this issue if they are using WP < 5.5.0. I update to logic to use on the first argument of this action hook.

![image](https://user-images.githubusercontent.com/1784821/99793441-b5a70f00-2b4e-11eb-98d4-1ecc92d92adb.png)

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- Use the steps to reproduce the issue as mentioned in the issue description. You should able to delete donations without any issue.
