### PR TITLE
Donation id mentions in exception and log message when insert query for revenue table fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Donation id mentions in exception and log message when insert query for revenue table fails  (#5472)
 -   Prevent fatal error when delete donation on WP < 5.5.0 (#5470)
 -   Stripe single-input credit card field works again (#5469)
 -   Updating a Stripe subscription from the update payment info screen works again (#5467)

--- a/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
+++ b/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
@@ -79,7 +79,7 @@ class AddPastDonationsToRevenueTable extends Migration {
 				];
 
 				$revenueRepository->insert( $revenueData );
-				$this->pauseUpdateOnError( $give_updates );
+				$this->pauseUpdateOnError( $give_updates, $revenueData );
 			}
 
 			wp_reset_postdata();
@@ -107,11 +107,14 @@ class AddPastDonationsToRevenueTable extends Migration {
 	/**
 	 * Pause update process and add log.
 	 *
-	 * @param Give_Updates $give_updates
-	 *
 	 * @since 2.9.2
+	 * @since 2.9.4 add second argument to function.
+	 *
+	 * @param  Give_Updates  $give_updates
+	 *
+	 * @param array $revenueData Donation data to insert into revenue table
 	 */
-	private function pauseUpdateOnError( $give_updates ) {
+	private function pauseUpdateOnError( $give_updates, $revenueData ) {
 		global $wpdb;
 
 		if ( ! $wpdb->last_error ) {
@@ -121,8 +124,9 @@ class AddPastDonationsToRevenueTable extends Migration {
 		give()->logs->add(
 			'Update Error',
 			sprintf(
-				'An error occurred inserting data into the revenue table: ' . "\n" . '%1$s',
-				$wpdb->last_error
+				'An error occurred inserting data into the revenue table: ' . "\n" . '%1$s' . "\n" . '%2$s',
+				$wpdb->last_error,
+				print_r( $revenueData, true )
 			),
 			0,
 			'update'

--- a/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
+++ b/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
@@ -108,7 +108,7 @@ class AddPastDonationsToRevenueTable extends Migration {
 	 * Pause update process and add log.
 	 *
 	 * @since 2.9.2
-	 * @since 2.9.4 add second argument to function.
+	 * @since 2.9.4 Add second argument to function.
 	 *
 	 * @param  Give_Updates  $give_updates
 	 *

--- a/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
+++ b/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
@@ -108,7 +108,7 @@ class AddPastDonationsToRevenueTable extends Migration {
 	 * Pause update process and add log.
 	 *
 	 * @since 2.9.2
-	 * @since 2.9.4 Add second argument to function.
+	 * @since 2.9.4 Add second argument to function and mention donation data in exception message.
 	 *
 	 * @param  Give_Updates  $give_updates
 	 *

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -100,17 +100,6 @@ class Revenue {
 				)
 			);
 		}
-
-		foreach ( $required as $columnName ) {
-			if ( empty( $array[ $columnName ] ) ) {
-				throw new InvalidArgumentException(
-					sprintf(
-						'%1$sEmpty value is not allowed to create revenue.',
-						$errorMessage
-					)
-				);
-			}
-		}
 	}
 
 	/**

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -84,18 +84,29 @@ class Revenue {
 
 		$array = array_filter( $array ); // Remove empty values.
 
+		$errorMessage = '';
+		if ( isset( $array['donation_id'] ) ) {
+			$errorMessage = "An error occurred when processing {$array['donation_id']}. ";
+		}
+
 		if ( array_diff( $required, array_keys( $array ) ) ) {
 			throw new InvalidArgumentException(
 				sprintf(
-					'To insert revenue, please provide valid %1$s.',
-					implode( ', ', $required )
+					'%2$sTo insert revenue, please provide valid %1$s.',
+					implode( ', ', $required ),
+					$errorMessage
 				)
 			);
 		}
 
 		foreach ( $required as $columnName ) {
 			if ( empty( $array[ $columnName ] ) ) {
-				throw new InvalidArgumentException( 'Empty value is not allowed to create revenue.' );
+				throw new InvalidArgumentException(
+					sprintf(
+						'%1$sEmpty value is not allowed to create revenue.',
+						$errorMessage
+					)
+				);
 			}
 		}
 	}

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -88,7 +88,7 @@ class Revenue {
 
 		$errorMessage = '';
 		if ( isset( $array['donation_id'] ) ) {
-			$errorMessage = "An error occurred when processing {$array['donation_id']}. ";
+			$errorMessage = "An error occurred when processing Donation #{$array['donation_id']}. ";
 		}
 
 		if ( array_diff( $required, array_keys( $array ) ) ) {

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -77,6 +77,7 @@ class Revenue {
 	 * Validate new revenue data.
 	 *
 	 * @since 2.9.0
+	 * @since 2.9.4 Mention donation id in exception message.
 	 *
 	 * @param array $array
 	 */

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -50,6 +50,7 @@ class Revenue {
 	 * @param $revenueId
 	 *
 	 * @return false|int
+	 * @throws DatabaseQueryException
 	 */
 	public function deleteByDonationId( $revenueId ) {
 		global $wpdb;

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -84,7 +84,17 @@ class Revenue {
 	protected function validateNewRevenueData( $array ) {
 		$required = [ 'donation_id', 'form_id', 'amount' ];
 
-		$array = array_filter( $array ); // Remove empty values.
+		if ( empty( $array['donation_id'] ) ) {
+			unset( $array['donation_id'] );
+		}
+
+		if ( empty( $array['form_id'] ) ) {
+			unset( $array['form_id'] );
+		}
+
+		if ( ! is_numeric( $array['amount'] ) || (int) $array['amount'] < 0 ) {
+			unset( $array['amount'] );
+		}
 
 		if ( array_diff( $required, array_keys( $array ) ) ) {
 			$errorMessage = '';

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -86,12 +86,12 @@ class Revenue {
 
 		$array = array_filter( $array ); // Remove empty values.
 
-		$errorMessage = '';
-		if ( isset( $array['donation_id'] ) ) {
-			$errorMessage = "An error occurred when processing Donation #{$array['donation_id']}. ";
-		}
-
 		if ( array_diff( $required, array_keys( $array ) ) ) {
+			$errorMessage = '';
+			if ( isset( $array['donation_id'] ) ) {
+				$errorMessage = "An error occurred when processing Donation #{$array['donation_id']}. ";
+			}
+
 			throw new InvalidArgumentException(
 				sprintf(
 					'%2$sTo insert revenue, please provide valid %1$s.',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

## Description

Slack discussion: https://givewp.slack.com/archives/C0FAGC83C/p1605811530057900

After discussion with @JasonTheAdams , we find out that we do not know the actual cause of the `AddPastDonationsToRevenueTable` database upgrade failure. To give an idea to the admin which donation cause upgrade failure, I added donation id in the exception message.

## Visuals

![image](https://user-images.githubusercontent.com/1784821/99834637-7d70f200-2b89-11eb-9135-5830e8daa527.png)


<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Setup to reproduce this issue:
- You must have one donation with zero amount. You can directly edit the donation amount on the donation detail page.
- Clear upgrade from completed upgrade list. Include `give-clear-update=add-past-donation-data-to-revenue-table` query param in admin URL and then visit that URL to remove database upgrade id from list.
- run the update to generate error log

Make sure you will see the donation id in the log message as shown in the screenshot in the `Visuals` seciton.
