### PR TITLE
prevent WordPress  < 5.1.1 compatibility issue

### DIFF
--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -73,10 +73,10 @@ class DB {
 			$wpdb->show_errors();
 		}
 
-		$errors = self::getQueryErrors( $errorCount );
+		$wpError = self::getQueryErrors( $errorCount );
 
-		if ( $errors->has_errors() ) {
-			throw DatabaseQueryException::create( $errors->get_error_messages() );
+		if ( ! empty( $wpError->errors ) ) {
+			throw DatabaseQueryException::create( $wpError->get_error_messages() );
 		}
 
 		return $output;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://wordpress.org/support/topic/unable-to-install-45/

## Description

I find out that we are using `WP_Error::has_errors` function which introduced in `WP 5.1.1` which means revenue table migration will cause a fatal error on `WP < 5.1.1`. I added custom code to validate WP errors.

## Pre-review Checklist

-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Steps to reproduce
- Install, activate or upgrade plugin lastest GIveWP on WP < 5.1.1
- check errors

## Testing Instructions

- GiveWP plugin should not cause a fatal error on WP < 5.1.1 and WP > 5.1.1
