### PR TITLE
Onboarding locales now include Jamaica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### New
+
+-    Onboarding locales now include Jamaica (#5474)
+
 ### Fixed
 
 -   Currency Switcher options are visible in the dropdown on a windows machine (#5453)

--- a/src/Onboarding/LocaleCollection.php
+++ b/src/Onboarding/LocaleCollection.php
@@ -154,6 +154,15 @@ class LocaleCollection {
 			'weight_unit'    => 'kg',
 			'dimension_unit' => 'cm',
 		],
+		'JM' => [
+			'currency_code'  => 'JMD',
+			'currency_pos'   => 'left',
+			'thousand_sep'   => ',',
+			'decimal_sep'    => '.',
+			'num_decimals'   => 2,
+			'weight_unit'    => 'lb',
+			'dimension_unit' => 'in',
+		],
 		'JP' => [
 			'currency_code'  => 'JPY',
 			'currency_pos'   => 'left',


### PR DESCRIPTION
Sync locale collection with WooCommerce locale-info, see https://github.com/woocommerce/woocommerce/commit/b58dc02183a7cc70b121fcb588b3fb5d16fb890c

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I have a file watcher set on the WooCommerce `i18n/locale-info`, with which I manually sync the GiveWP locale collection for onboarding,

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
