### PR TITLE
Use absolute path for composer autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Use an absolute path for the autoloader to avoid relative path issues (#5493)
+
 ## 2.9.5 - 2020-12-03
 
 ### New

--- a/give.php
+++ b/give.php
@@ -494,6 +494,6 @@ function Give( $abstract = null ) {
 	return $instance;
 }
 
-require 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 Give()->boot();


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5492 

## Description

This uses an absolute path for loading the composer autoloader file, which should help on some systems that did not like a relative path being used there.

## Affects

Just how the autoloader gets loaded... which is kind of everything. But it should either work completely or break everything, so that's good news.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Just pull the PR and activate GiveWP. If it's working then it's working.
