### PR TITLE
Add filter hook to filter PayPal settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Add filter hook to filter PayPal settings (#5502)
+
 ### Changed
 
 -   Automated unit and integrations tests are now using GitHub actions, instead of Travis CI (#5489)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   Add filter hook to filter PayPal settings (#5502)
 ### Changed
 
 -   Automated unit and integrations tests are now using GitHub actions, instead of Travis CI (#5489)

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -41,7 +41,7 @@ class PayPalCommerce implements PaymentGateway {
 	 * @inheritDoc
 	 */
 	public function getOptions() {
-		return [
+		$settings = [
 			[
 				'type'       => 'title',
 				'id'         => 'give_gateway_settings_1',
@@ -82,6 +82,13 @@ class PayPalCommerce implements PaymentGateway {
 				'id'   => 'give_gateway_settings_2',
 			],
 		];
+
+		/**
+		 * filter the settings
+		 *
+		 * @since 2.10.0
+		 */
+		return apply_filters( 'give_get_settings_paypal_commerce', $settings );
 	}
 
 	/**

--- a/src/PaymentGateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/PayPalStandard/PayPalStandard.php
@@ -30,7 +30,7 @@ class PayPalStandard implements PaymentGateway {
 	 * @inheritDoc
 	 */
 	public function getOptions() {
-		return [
+		$setting = [
 			// Section 2: PayPal Standard.
 			[
 				'type' => 'title',
@@ -100,6 +100,13 @@ class PayPalStandard implements PaymentGateway {
 				'id'   => 'give_title_gateway_settings_2',
 			],
 		];
+
+		/**
+		 * filter the settings.
+		 *
+		 * @since 2.10.0
+		 */
+		return apply_filters( 'give_get_settings_paypal_standard', $setting );
 	}
 
 	/**

--- a/src/PaymentGateways/PaypalSettingPage.php
+++ b/src/PaymentGateways/PaypalSettingPage.php
@@ -101,15 +101,6 @@ class PaypalSettingPage implements SettingPage {
 
 		if ( $currentSection === $this->getId() ) {
 			$settings = $this->getSettings();
-
-			foreach ( $settings as $subGroupId => $subGroupSetting ) {
-				/**
-				 * Filter sub section settings
-				 *
-				 * @since 1.11.2
-				 */
-				$settings[ $subGroupId ] = apply_filters( "give_get_settings_paypal_{$subGroupId}", $subGroupSetting );
-			}
 		}
 
 		return $settings;

--- a/src/PaymentGateways/PaypalSettingPage.php
+++ b/src/PaymentGateways/PaypalSettingPage.php
@@ -99,9 +99,20 @@ class PaypalSettingPage implements SettingPage {
 	public function registerPaypalSettings( $settings ) {
 		$currentSection = getCurrentSettingSection();
 
-		return $currentSection === $this->getId() ?
-			$this->getSettings() :
-			$settings;
+		if ( $currentSection === $this->getId() ) {
+			$settings = $this->getSettings();
+
+			foreach ( $settings as $subGroupId => $subGroupSetting ) {
+				/**
+				 * Filter sub section settings
+				 *
+				 * @since 1.11.2
+				 */
+				$settings[ $subGroupId ] = apply_filters( "give_get_settings_paypal_{$subGroupId}", $subGroupSetting );
+			}
+		}
+
+		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5503 

## Description

The PayPal settings page is a group of PayPal payment methods. I added logic to filter each group. 
```
give_get_settings_paypal_paypal-commerce -> Setting filter for PayPal Donations
give_get_settings_paypal_paypal -> Setting filter for PayPal Standard
```

## Affects

This change does not affect existing functionality.

## Testing Instructions

- You should able to see all previous PayPal settings in each sub-group.