### PR TITLE
Hover glitches of Fee Recovery checkbox are now fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Hover glitches of Fee Recovery checkbox are now fixed (#5508)
 -   PayPal Donations CC fields have border in Firefox browser (#5500)
 -   Automated unit and integrations tests are now executing (#5489)
 -   Use an absolute path for the autoloader to avoid relative path issues (#5493)

--- a/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/feerecovery.scss
@@ -10,7 +10,6 @@
 	margin: 20px 30px 10px 30px !important;
 	padding: 0 !important;
 	position: relative;
-	transition: border 0.2s ease;
 	width: auto !important;
 
 	@media screen and (max-width: $break-phone) {

--- a/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/recurring.scss
@@ -12,7 +12,6 @@
 	margin: 20px 30px 0 30px !important;
 	padding: 0;
 	position: relative;
-	transition: border 0.2s ease;
 
 	@media screen and (max-width: $break-phone) {
 		margin: 20px 20px 0 20px !important;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5501 

## Description
There is a bug in the Chrome browser with border transitions. The transition effect is applied to the margin of a container as well which creates weird hover glitches. This PR is resolving this issue by removing the transition property completely. 

## Affects

Fee recovery message box border transition effect on hover. 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
|---|---|
|  ![deepin-screen-recorder_Select area_20201214133509](https://user-images.githubusercontent.com/4222590/102082058-8ca63100-3e11-11eb-9cd3-abd13390ebca.gif) | ![deepin-screen-recorder_Select area_20201214133643](https://user-images.githubusercontent.com/4222590/102082075-95970280-3e11-11eb-9ccb-9be9f5c7b5f2.gif)  |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions


1. Create a multi-step Donation Form and enable Fee Recovery add-on
2. Visit Donation Form and try to hover over the Fee Recovery checkbox
