### PR TITLE
Onboarding Form Preview template now loads scripts inside of the closing body tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Automated unit and integrations tests are now using GitHub actions, instead of Travis CI (#5489)
 -   Resolve Avatar size shortcode attribute issue in donor wall shortcode and adds support for avatar size in donor wall block (#5443)
+-   Onboarding Form Preview template now loads scripts inside of the closing body tag (#5510)
 
 ### Fixed
 

--- a/src/Onboarding/Wizard/templates/form-preview.php
+++ b/src/Onboarding/Wizard/templates/form-preview.php
@@ -26,63 +26,63 @@ set_current_screen();
 	</style>
 </head>
 	<body class="<?php echo esc_attr( $wp_version_class ); ?>">
-			<?php
-			echo give_form_shortcode(
-				[
-					'id' => $this->get_preview_form_id(),
-				]
-			);
-			?>
-			<?php wp_print_scripts( [ 'give' ] ); ?>
-	</body>
-	<script>
-		(function checkForBodySizeChange() {
-			var last_body_size = {
-				width: document.body.clientWidth,
-				height: document.body.clientHeight
-			};
+		<?php
+		echo give_form_shortcode(
+			[
+				'id' => $this->get_preview_form_id(),
+			]
+		);
+		?>
+		<?php wp_print_scripts( [ 'give' ] ); ?>
+		<script>
+			(function checkForBodySizeChange() {
+				var last_body_size = {
+					width: document.body.clientWidth,
+					height: document.body.clientHeight
+				};
 
-			function checkBodySizeChange()
-			{
-				var width_changed = last_body_size.width !== document.body.clientWidth,
-					height_changed = last_body_size.height !== document.body.clientHeight;
+				function checkBodySizeChange()
+				{
+					var width_changed = last_body_size.width !== document.body.clientWidth,
+						height_changed = last_body_size.height !== document.body.clientHeight;
 
 
-				if(width_changed || height_changed) {
-					handleBodySizeChange(document.body.clientWidth, document.body.clientHeight);
-					last_body_size = {
-						width: document.body.clientWidth,
-						height: document.body.clientHeight
-					};
+					if(width_changed || height_changed) {
+						handleBodySizeChange(document.body.clientWidth, document.body.clientHeight);
+						last_body_size = {
+							width: document.body.clientWidth,
+							height: document.body.clientHeight
+						};
+					}
+
+					window.requestAnimationFrame(checkBodySizeChange);
+				}
+
+				function handleBodySizeChange(width, height)
+				{
+					window.parent.postMessage({
+						action: 'resize',
+						payload: {
+							height,
+							width
+						}
+					});
 				}
 
 				window.requestAnimationFrame(checkBodySizeChange);
-			}
-
-			function handleBodySizeChange(width, height)
-			{
-				window.parent.postMessage({
-					action: 'resize',
-					payload: {
-						height,
-						width
-					}
-				});
-			}
-
-			window.requestAnimationFrame(checkBodySizeChange);
-		})();
-	</script>
-	<script>
-		(function listenForFormLoaded() {
-			function handleFormLoaded(width, height)
-			{
-				window.parent.postMessage({
-					action: 'loaded',
-					payload: {}
-				});
-			}
-			document.querySelector('iframe').addEventListener('load', handleFormLoaded );
-		})();
-	</script>
+			})();
+		</script>
+		<script>
+			(function listenForFormLoaded() {
+				function handleFormLoaded(width, height)
+				{
+					window.parent.postMessage({
+						action: 'loaded',
+						payload: {}
+					});
+				}
+				document.querySelector('iframe').addEventListener('load', handleFormLoaded );
+			})();
+		</script>
+	</body>
 </html>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5509

## Description
This PR resolves a minor issue where some script tags for the Onboarding Form Preview template were being loaded outside the template's closing `body` tag. With these changes, all script tags are loaded inside either `head` or `body` tags.

## Affects
This PR affects the template file for the Onboarding Wizards Form Preview (what is loaded inside the iframe).

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
Navigate to the Onboarding Wizard (by enabled the "Setup" page and clicking the arrow in the "First Time Configuration" section.

Check that the Form Preview still works as expected (changing various form settings via the "Form Features" tab). 