### PR TITLE
Checkbox click handler does not double trigger for touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Automated unit and integrations tests are now executing (#5489)
 -   Use an absolute path for the autoloader to avoid relative path issues (#5493)
 -   The current state of the Donation Form fields are now preserved when the payment method changes (#5491)
+-   Checkbox click handler does not double trigger for touch devices (#5526)
 
 ## 2.9.5 - 2020-12-03
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -701,7 +701,7 @@
 		}
 
 		// Persist checkbox input border when selected
-		$( document ).on( 'click touchend', label, function( evt ) {
+		$( document ).on( 'click', label, function( evt ) {
 			if ( container === label ) {
 				evt.stopPropagation();
 				evt.preventDefault();


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5525

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

On touch devices, the click and touchend events are triggering the event handler twice for a given interaction. AS far as I can tell the handling of the touchend event is not specifcally needed, or it is no longer necessary.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The Sequoia Template checkbox click handler

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. With touch enabled (physical device or simulated)
2. Enable Recurring Donations (Donor's choice, admin specifies period)
3. "Touch" the "Make this donation monthly" element.
4. The active class is applied and not automatically removed.
