### PR TITLE
Multi-Form Goals added via shortcode now stack image and text when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Automated unit and integrations tests are now executing (#5489)
 -   Use an absolute path for the autoloader to avoid relative path issues (#5493)
 -   The current state of the Donation Form fields are now preserved when the payment method changes (#5491)
+-   Multi-Form Goals added via shortcode now stack image and text when needed (#5528)
 
 ## 2.9.5 - 2020-12-03
 

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -70,9 +70,12 @@ class Shortcode {
 	 * @reutrn array
 	 */
 	protected function parseAttributes( $pairs, $attributes ) {
-		foreach ( $attributes as $key => &$attribute ) {
-			if ( is_array( $pairs[ $key ] ) ) {
-				$attribute = $this->parseAttributeArray( $attribute );
+
+		if ( $attributes ) {
+			foreach ( $attributes as $key => &$attribute ) {
+				if ( is_array( $pairs[ $key ] ) ) {
+					$attribute = $this->parseAttributeArray( $attribute );
+				}
 			}
 		}
 

--- a/src/MultiFormGoals/resources/css/common.scss
+++ b/src/MultiFormGoals/resources/css/common.scss
@@ -1,11 +1,5 @@
 // This file used for Total styles common to the frontend and editor
 
-.give-multi-form-goal-block__image img {
-	height: 100%;
-	width: 100%;
-	object-fit: cover;
-}
-
 .give-multi-form-goal-block {
 	display: flex;
 	flex-direction: column;
@@ -32,19 +26,27 @@
 
 .give-multi-form-goal-block__content {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+	grid-gap: 16px;
 	margin: 24px !important;
 	min-height: 250px;
-}
 
-.give-multi-form-goal-block__text {
-	padding-left: 16px;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
+	.give-multi-form-goal-block__text {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 
-	h2 {
-		margin-bottom: var(--global--spacing-vertical);
+		h2 {
+			margin-bottom: var(--global--spacing-vertical);
+		}
+	}
+
+	.give-multi-form-goal-block__image {
+		img {
+			height: 100%;
+			width: 100%;
+			object-fit: cover;
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves #5527 

## Description
This PR introduces styling improvements to ensure that image and text areas are stacked when needed inside Multi-Form Goal blocks that are added via shortcodes. Using CSS grid minmax and auto-fill, the image and text areas stack if there is less than enough space for each to be 200px wide.

## Affects
The PR affects frontend styling of the Multi-Form Goal shortcode.

## Visuals
![screencapture-give-test-2020-12-21-09_08_39](https://user-images.githubusercontent.com/5186078/102805987-e9a16a00-4370-11eb-95f8-de8f40505eeb.png)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new Multi-Form Goal via shortcode
2. Place the Multi-Form Goal inside a narrow column layout
3. View it on the frontend
4. Check that image and text stack as expected
