### PR TITLE
Various Multi-Step form browser styling compatibility issues are now resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Automated unit and integrations tests are now executing (#5489)
 -   Use an absolute path for the autoloader to avoid relative path issues (#5493)
 -   The current state of the Donation Form fields are now preserved when the payment method changes (#5491)
+-   Various Multi-Step form browser styling compatibility issues are now resolved (#5529)
 
 ## 2.9.5 - 2020-12-03
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1332,6 +1332,7 @@ form.give-form .form-row select.multiselect {
 	opacity: 0;
 
 	&.spinning {
+		z-index: 1;
 		opacity: 1;
 		transition: opacity 0.2s ease;
 		animation: load 0.6s linear infinite;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -461,6 +461,7 @@ p {
 		@include before-after-content-none;
 		display: flex;
 		width: fit-content;
+		width: -moz-fit-content;
 		max-width: 80%;
 		position: relative;
 		align-items: center;


### PR DESCRIPTION
Resolves #5497

## Description
This PR introduces minor style improvements for the Multi-Step form as it is presented in Firefox and Safari. Specifically, it ensures that the amount input width is correct, and the spinning loader appears in the donate button.

## Affects
This PR affects frontend styling of the Multi-Step form in Safari and Firefox.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new Multi-Step form
2. View the form in Firefox and Safari
3. Check that the amount input width is correc
4. Check that the spinning loader appears in the donate now button when pressed