### PR TITLE
Multiple error redirects does not break donation form view in Multi Step form template view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Multiple error redirects does not break donation form view in Multi Step form template view (#5531)
 -   Hover glitches of Fee Recovery checkbox are now fixed (#5508)
 -   PayPal Donations CC fields have border in Firefox browser (#5500)
 -   Send form title to PayPal (#5495)

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -260,7 +260,10 @@ class Form {
 	 */
 	public function handlePrePaymentProcessingErrorRedirect( $redirect ) {
 		$redirect = add_query_arg(
-			[ 'showDonationProcessingError' => 1 ],
+			[
+				'showDonationProcessingError' => 1,
+				'giveDonationFormInIframe'    => 1,
+			],
 			$redirect
 		);
 

--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -253,10 +253,12 @@ class Form {
 	 *
 	 * These redirects mainly happen when donation form data is not valid.
 	 *
+	 * @since 2.7.0
+	 * @since 2.9.6 Adds giveDonationFormInIframe query param to url
+	 *
 	 * @param string $redirect
 	 *
 	 * @return string
-	 * @since 2.7.0
 	 */
 	public function handlePrePaymentProcessingErrorRedirect( $redirect ) {
 		$redirect = add_query_arg(


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5530 

## Description

In the Multi-Step form template view, we render the donation form in an iframe. To render the correct donation form view we depends upon the referrer and query parameter. On the first redirect, the donor sees the donation form in an iframe because we detect it by referer but not in the second redirect. To detect whether we are viewing the donation forms in an iframe or not, we use the `giveDonationFormInIframe` query param. I added the same parameter in error redirect to redirect the donation form on error redirect.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

- This consider being good to merge if `Acceptance Criteria` fulfilled and you will not able to replicate this issue with the step mentioned in the issue description.
