### PR TITLE
Hide state field for South Korea

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -688,6 +688,7 @@ function give_get_country_locale() {
 			'KR' => [
 				'state' => [
 					'required' => false,
+					'hidden'   => true,
 				],
 			],
 			'KW' => [


### PR DESCRIPTION
Resolves #5536

## Description

The status field is not required and not used for Korean addresses. In order to fix this, the "hidden" parameter should be set to "True" when South Korea is selected as country.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Select "South Korea" as country.
2. State field should be hidden.
