### PR TITLE
Validate new korean zipcode format

### DIFF
--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1376,7 +1376,7 @@ function give_donation_form_validate_cc_zip( $zip = 0, $country_code = '' ) {
 		'KE' => '\d{5}',
 		'KG' => '\d{6}',
 		'KH' => '\d{5}',
-		'KR' => '\d{3}[\-]\d{3}',
+		'KR' => '\d{5}',
 		'KW' => '\d{5}',
 		'KZ' => '\d{6}',
 		'LA' => '\d{5}',


### PR DESCRIPTION
Resolves #5534

## Description

In 2015, the Korean Government changed their postcodes from 6 digits to 5 digits. Therefore, I updated the regex expression to validate this new format.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Go to a donation form
2. Select "South Korea" as country
3. Fill "06316" in zipcode field.
4. Submit
