### PR TITLE
Add migration to remove revenue foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Various Multi-Step form browser styling compatibility issues are now resolved (#5529)
 -   Checkbox click handler does not double trigger for touch devices (#5526)
 -   Multi-Form Goals added via shortcode now stack image and text when needed (#5528)
+-   Added migration to remove any leftover foreign keys on the revenue table (#5540)
 
 ## 2.9.5 - 2020-12-03
 

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -5,6 +5,22 @@ namespace Give\Framework\Database;
 use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use WP_Error;
 
+/**
+ * Class DB
+ *
+ * A static decorator for the $wpdb class and decorator function which does SQL error checking when performing queries.
+ * If a SQL error occurs a DatabaseQueryException is thrown.
+ *
+ * @method static int|bool query( string $query )
+ * @method static int|false insert( string $table, array $data, array|string $format )
+ * @method static int|false delete( string $table, array $where, array|string $where_format )
+ * @method static int|false update( string $table, array $where, array|string $where_format )
+ * @method static int|false replace( string $table, array $data, array|string $format )
+ * @method static null|string get_var( string $query = null, int $x = 0, int $y = 0 )
+ * @method static array|object|null|void get_row( string $query = null, string $output = OBJECT, int $y = 0 )
+ * @method static array get_col( string $query = null, int $x = 0 )
+ * @method static array|object|null get_results( string $query = null, string $output = OBJECT )
+ */
 class DB {
 	/**
 	 * Runs the dbDelta function and returns a WP_Error with any errors that occurred during the process
@@ -27,25 +43,40 @@ class DB {
 	}
 
 	/**
-	 * Runs the $wpdb::delete method with SQL error checking
+	 * A convenience method for the $wpdb->prepare method
 	 *
-	 * @see wpdb::delete() for parameter and return details
+	 * @see WPDB::prepare() for usage details
 	 *
-	 * @since 2.9.2
+	 * @since 2.9.6
 	 *
-	 * @param string $tableName
-	 * @param array  $data
-	 * @param array  $formats
+	 * @param string $query
+	 * @param mixed  ...$args
 	 *
-	 * @return int|false
+	 * @return false|mixed
+	 */
+	public static function prepare( $query, ...$args ) {
+		global $wpdb;
+
+		return $wpdb->prepare( $query, ...$args );
+	}
+
+	/**
+	 * Magic method which calls the static method on the $wpdb while performing error checking
+	 *
+	 * @since 2.9.6
+	 *
+	 * @param $name
+	 * @param $arguments
+	 *
+	 * @return mixed
 	 * @throws DatabaseQueryException
 	 */
-	public static function delete( $tableName, $data, $formats ) {
+	public static function __callStatic( $name, $arguments ) {
 		return self::runQueryWithErrorChecking(
-			function () use ( $tableName, $data, $formats ) {
+			function () use ( $name, $arguments ) {
 				global $wpdb;
 
-				return $wpdb->delete( $tableName, $data, $formats = null );
+				return call_user_func_array( [ $wpdb, $name ], $arguments );
 			}
 		);
 	}

--- a/src/Framework/Migrations/Contracts/Migration.php
+++ b/src/Framework/Migrations/Contracts/Migration.php
@@ -31,7 +31,7 @@ abstract class Migration {
 	/**
 	 * Return a Unix Timestamp for when the migration was created
 	 *
-	 * Example: strtotime( '2020-09-16 ')
+	 * Example: strtotime( '2020-09-16 12:30:00')
 	 *
 	 * @since 2.9.0
 	 *

--- a/src/Revenue/Migrations/RemoveRevenueForeignKeys.php
+++ b/src/Revenue/Migrations/RemoveRevenueForeignKeys.php
@@ -5,6 +5,12 @@ namespace Give\Revenue\Migrations;
 use Give\Framework\Database\DB;
 use Give\Framework\Migrations\Contracts\Migration;
 
+/**
+ * Class RemoveRevenueForeignKeys
+ *
+ * @since 2.9.6
+ * @package Give\Revenue\Migrations
+ */
 class RemoveRevenueForeignKeys extends Migration {
 	/**
 	 * @inheritDoc

--- a/src/Revenue/Migrations/RemoveRevenueForeignKeys.php
+++ b/src/Revenue/Migrations/RemoveRevenueForeignKeys.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Give\Revenue\Migrations;
+
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+
+class RemoveRevenueForeignKeys extends Migration {
+	/**
+	 * @inheritDoc
+	 */
+	public static function id() {
+		return 'remove_revenue_foreign_keys';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function run() {
+		global $wpdb;
+
+		$this->dropColumnForeignKeyConstraint( $wpdb->give_revenue, 'form_id' );
+		$this->dropColumnForeignKeyConstraint( $wpdb->give_revenue, 'donation_id' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function timestamp() {
+		return strtotime( '01-05-2020 12:45:00' );
+	}
+
+	/**
+	 * Drops the foreign key constraint for a given table and column
+	 *
+	 * @since 2.9.6
+	 *
+	 * @param string $table
+	 * @param string $column
+	 */
+	private function dropColumnForeignKeyConstraint( $table, $column ) {
+		$constraintName = DB::get_var(
+			DB::prepare(
+				"
+					SELECT constraints.CONSTRAINT_NAME
+					FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS as constraints
+					JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE as column_usage
+						ON constraints.CONSTRAINT_NAME = column_usage.CONSTRAINT_NAME
+					WHERE constraints.CONSTRAINT_TYPE = 'FOREIGN KEY'
+						AND constraints.TABLE_NAME = %s
+						AND column_usage.COLUMN_NAME = %s
+				",
+				$table,
+				$column
+			)
+		);
+
+		if ( ! empty( $constraintName ) ) {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			DB::query( "ALTER TABLE {$table} DROP FOREIGN KEY {$constraintName}" );
+		}
+	}
+}

--- a/src/Revenue/RevenueServiceProvider.php
+++ b/src/Revenue/RevenueServiceProvider.php
@@ -7,6 +7,7 @@ use Give\Helpers\Hooks;
 use Give\Revenue\Listeners\DeleteRevenueWhenDonationDeleted;
 use Give\Revenue\Migrations\AddPastDonationsToRevenueTable;
 use Give\Revenue\Migrations\CreateRevenueTable;
+use Give\Revenue\Migrations\RemoveRevenueForeignKeys;
 use Give\ServiceProviders\ServiceProvider;
 
 class RevenueServiceProvider implements ServiceProvider {
@@ -41,6 +42,11 @@ class RevenueServiceProvider implements ServiceProvider {
 		/** @var MigrationsRegister $register */
 		$register = give( MigrationsRegister::class );
 
-		$register->addMigration( CreateRevenueTable::class );
+		$register->addMigrations(
+			[
+				CreateRevenueTable::class,
+				RemoveRevenueForeignKeys::class,
+			]
+		);
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5539

## Description

Since foreign keys should no longer be used, this adds a migration to remove any foreign keys which may be left over from a previous migration.

It also extends the `DB` static facade to completely wrap the `WPDB` class so the query methods may be called with SQL error checking in place.

## Affects

The wp_give_revenue table in the database

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Try adding a foreign key to the revenue `form_id` and `donation_id` columns, then run the migration. The foreign keys should now be removed. Try running the migration again to make sure it doesn't cause any problems if there are no foreign keys — it should do nothing and cause no errors.