### PR TITLE
show personal information field icons when payment gateway switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Show field icons on personal information input field when payment gateway switch (#5542)
 -   Multiple error redirects does not break donation form view in Multi Step form template view (#5531)
 -   Hover glitches of Fee Recovery checkbox are now fixed (#5508)
 -   PayPal Donations CC fields have border in Firefox browser (#5500)

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -612,6 +612,8 @@
 			} ).done( function() {
 				// Trigger float-labels
 				window.give_fl_trigger();
+
+				setupInputIcons();
 			} );
 		}
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5541

## Description

I find out that the personal information section re-render when donation switch gateway. The icon on the personal information input field adds by javascript which does not run after refreshing the personal information section. I update `refreshPaymentInformationSection` function logic to setup field icons.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

We can merge this pr if input field icons show correctly on the initial donation form and when donor switch gateway.
