### PR TITLE
Sample onboarding tests are now implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Add filter hook to filter PayPal settings (#5502)
+-   Sample onboarding tests are now implemented (#5543)
 
 ### Changed
 

--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
@@ -28,7 +28,7 @@ const Introduction = () => {
 					<p>
 						{ __( 'You\'re minutes away from accepting donations on your website. Use the Onboarding Wizard if this is your first time using GiveWP.', 'give' ) }
 					</p>
-					<ContinueButton clickCallback={ () => onStartSetup() } label={ __( 'Start Setup', 'give' ) } />
+					<ContinueButton clickCallback={ () => onStartSetup() } label={ __( 'Start Setup', 'give' ) } testId="start-setup" />
 				</div>
 			</Card>
 			<DismissLink />

--- a/assets/src/js/admin/onboarding-wizard/components/button/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/button/index.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 // Import styles
 import './style.scss';
 
-const Button = ( { onClick, children } ) => {
+const Button = ( { onClick, testId, children } ) => {
 	return (
-		<button className="give-obw-button" onClick={ onClick }>
+		<button className="give-obw-button" data-givewp-test={ testId } onClick={ onClick }>
 			{ children }
 		</button>
 	);
@@ -14,11 +14,13 @@ const Button = ( { onClick, children } ) => {
 
 Button.propTypes = {
 	onClick: PropTypes.func,
+	testId: PropTypes.string,
 	children: PropTypes.node,
 };
 
 Button.defaultProps = {
 	onClick: null,
+	testId: null,
 	children: null,
 };
 

--- a/assets/src/js/admin/onboarding-wizard/components/continue-button/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/continue-button/index.js
@@ -16,11 +16,11 @@ import Chevron from '../icons/chevron';
 // Import styles
 import './style.scss';
 
-const ContinueButton = ( { label, clickCallback } ) => {
+const ContinueButton = ( { label, testId, clickCallback } ) => {
 	const [ { currentStep, lastStep }, dispatch ] = useStoreValue();
 
 	return (
-		<Button onClick={ () => {
+		<Button testId={ testId } onClick={ () => {
 			clickCallback();
 			if ( currentStep + 1 <= lastStep ) {
 				dispatch( goToStep( currentStep + 1 ) );
@@ -38,11 +38,13 @@ const ContinueButton = ( { label, clickCallback } ) => {
 
 ContinueButton.propTypes = {
 	label: PropTypes.string,
+	testId: PropTypes.string,
 	clickCallback: PropTypes.IsCallable,
 };
 
 ContinueButton.defaultProps = {
 	label: __( 'Continue', 'give' ),
+	testId: null,
 	clickCallback: () => {},
 };
 

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -22,6 +22,7 @@
 				'contents' => $this->render_template(
 					'row-item',
 					[
+						'testId'      => 'onboarding-wizard-link',
 						'class'       => ( $this->isFormConfigured() ) ? 'setup-item-configuration setup-item-completed' : 'setup-item-configuration',
 						'icon'        => ( $this->isFormConfigured() )
 											? $this->image( 'check-circle.min.png' )

--- a/src/Onboarding/Setup/templates/row-item.html
+++ b/src/Onboarding/Setup/templates/row-item.html
@@ -1,4 +1,4 @@
-<article id="{{ id }}" class="setup-item {{ class }}">
+<article id="{{ id }}" class="setup-item {{ class }}" data-givewp-test="{{ testId }}">
     <img class="icon" src="{{ icon }}" alt="{{ icon_alt }}">
     <div class="content">
         <h3 class="header">

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -1,0 +1,17 @@
+const cy = window.cy;
+const baseURL = window.baseURL;
+
+describe( 'Test onboarding wizard', function() {
+	it( 'can enable setup page', function() {
+		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=advanced' );
+		cy.get( 'input[name="setup_page_enabled"][value="enabled"]' ).click();
+		cy.get( 'input[name="save"]' ).click();
+		cy.visit( baseURL + '/wp-admin' );
+		cy.get( 'a[href="edit.php?post_type=give_forms&page=give-setup"]' ).should( 'exist' );
+	} );
+	it( 'can open the onboarding wizard', function() {
+		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );
+		cy.get( 'article[data-givewp-test="onboarding-wizard-link"]' ).click();
+		cy.get( 'button[data-givewp-test="start-setup"]' ).should( 'exist' );
+	} );
+} );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -11,7 +11,7 @@ describe( 'Test onboarding wizard', function() {
 	} );
 	it( 'can open the onboarding wizard', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );
-		cy.get( 'article[data-givewp-test="onboarding-wizard-link"]' ).click();
-		cy.get( 'button[data-givewp-test="start-setup"]' ).should( 'exist' );
+		cy.getByTest( 'onboarding-wizard-link' ).click();
+		cy.getByTest( 'start-setup' ).should( 'exist' );
 	} );
 } );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -1,16 +1,29 @@
 const cy = window.cy;
 const baseURL = window.baseURL;
 
+/**
+ * Test interactions and functionality required to utilize the Onboarding Wizard
+ */
+
+// First, describe this spec, and what you are testing
 describe( 'Test onboarding wizard', function() {
+	// For reach test, describe what it aims to check
 	it( 'can enable setup page', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=advanced' );
+
+		// Target inputs by their name attribute
 		cy.get( 'input[name="setup_page_enabled"][value="enabled"]' ).click();
 		cy.get( 'input[name="save"]' ).click();
 		cy.visit( baseURL + '/wp-admin' );
+
+		// Be sure to include some assertion (here, that a link to the Setup Page should now exist)
 		cy.get( 'a[href="edit.php?post_type=give_forms&page=give-setup"]' ).should( 'exist' );
 	} );
+
 	it( 'can open the onboarding wizard', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );
+
+		// When not an input or anchor tag, use get by test to target elements by their data-givewp-test attribute
 		cy.getByTest( 'onboarding-wizard-link' ).click();
 		cy.getByTest( 'start-setup' ).should( 'exist' );
 	} );

--- a/tests/e2e/integration/onboarding/setup_page_options_spec.js
+++ b/tests/e2e/integration/onboarding/setup_page_options_spec.js
@@ -1,0 +1,19 @@
+const cy = window.cy;
+const baseURL = window.baseURL;
+
+describe( 'Test setup page options', function() {
+	it( 'can enable setup page', function() {
+		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=advanced' );
+		cy.get( 'input[name="setup_page_enabled"][value="enabled"]' ).click();
+		cy.get( 'input[name="save"]' ).click();
+		cy.visit( baseURL + '/wp-admin' );
+		cy.get( 'a[href="edit.php?post_type=give_forms&page=give-setup"]' ).should( 'exist' );
+	} );
+	it( 'can disable setup page', function() {
+		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=advanced' );
+		cy.get( 'input[name="setup_page_enabled"][value="disabled"]' ).click();
+		cy.get( 'input[name="save"]' ).click();
+		cy.visit( baseURL + '/wp-admin' );
+		cy.get( 'a[href="edit.php?post_type=give_forms&page=give-setup"]' ).should( 'not.exist' );
+	} );
+} );

--- a/tests/e2e/integration/onboarding/setup_page_spec.js
+++ b/tests/e2e/integration/onboarding/setup_page_spec.js
@@ -1,7 +1,7 @@
 const cy = window.cy;
 const baseURL = window.baseURL;
 
-describe( 'Test setup page options', function() {
+describe( 'Test setup page', function() {
 	it( 'can enable setup page', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=advanced' );
 		cy.get( 'input[name="setup_page_enabled"][value="enabled"]' ).click();

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -30,6 +30,8 @@ const Cypress = window.Cypress;
 window.baseURL = Cypress.env( 'site' ).url;
 const baseURL = window.baseURL;
 
+Cypress.Commands.add( 'getByTest', name => cy.get( `[data-givewp-test="${ name }"]` ) );
+
 beforeEach( function() {
 	cy.visit( baseURL + '/wp-login.php' );
 	cy.wait( 1000 );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves # N/A

## Description
This PR introduces some onboarding e2e tests (and additional supporting test functions), to demonstrate e2e testing implementation. Notably, it adds specs for testing the setup page and onboarding wizard, as well as support for a `data-givewp-test` attribute used to target specific elements for testing. To query those targets, tests can make use of the `cy.getTest( "id" )` command. 

## Affects
This PR affects some frontend rendering logic for the setup page and onboarding wizard, and introducing new testing specs to the tests/e2e/onboarding directory.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Install and setup all necessary e2e testing dependencies
2. Use `npm run env start` to start the wp-env for testing
3. Use `npm run test:e2e` to open Cypress tests
4. Select any spec under onboarding, check that it passes
5. Close Cypress and use `npm run env stop` to stop the wp-env when finished testing