### PR TITLE
Decouple test:e2e command from wp-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 /tmp
 /tests/bin/tmp
 
+# Cypress
+/cypress
+/tests/e2e/videos
+/tests/e2e/screenshots
+
 # Numerous always-ignore extensions
 .diff
 .err

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Onboarding Form Preview template now loads scripts inside of the closing body tag (#5510)
 -   Deprecated e2e tests have been removed, and replaced with Cypress tests (#5533)
 -   New `test:e2e` package script introduced (#5533)
+-   Decouple test:e2e command from wp-env #5545
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
         "lint:scss": "stylelint assets/src/**/*.scss",
         "storybook": "start-storybook -p 6006",
         "storybook:build": "build-storybook -c .storybook -o .storybook-static",
-        "test:e2e": "wp-env start && cypress open",
-        "wp-env": "wp-env",
-        "cypress:open": "cypress open"
+        "test:e2e": "cypress open",
+        "env": "wp-env"
     },
     "repository": {
         "type": "git",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,13 +11,8 @@ A sample `wordpress.sql` is provided within the `/sample-data/` folder that has 
 
 ### Testing
 
-After setting up the local development environment, running tests manually is fairly simple. Navigate to the Give root folder and get things started by running:
-
-```npm run test:e2e```
-
-This will use `wp-env` to spin up a new local version of WordPress with your current changes to GiveWP. Once setup, Cypress is then opened, and ready to run tests against it.
-
-When you're done with testing, simply close the Cypress GUI, and run `npm run wp-env stop` to stop the WP instance that was created.
-
+1. Start local development environment (with docker) by running `npm run env start`.
+1. Run `npm run test:e2e` to open the Cypress UI test runner in the browser.
+1. Stop the local development environment by running `npm run env stop`.
 ### Learn More
 You can find more information about what e2e testing achieves, how e2e tests are implemented in GiveWP, and how to write your own tests via the [GiveWP dev manual](https://app.gitbook.com/@give/s/givewp/testing/types-of-tests/end-to-end-testing). Happy testing!


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Decouples `test:e2e` from `wp-env start`
- Renames `wp-env` command to generic `env`
- Updates documentation to reflect changes

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
