### PR TITLE
Give Aid add-on description popup is now working when using multi-step form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Checkbox click handler does not double trigger for touch devices (#5526)
 -   Multi-Form Goals added via shortcode now stack image and text when needed (#5528)
 -   Added migration to remove any leftover foreign keys on the revenue table (#5540)
+-   Give Aid add-on description popup is now working when using multi-step form (#5549)
 
 ## 2.9.5 - 2020-12-03
 

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1406,7 +1406,9 @@ form.give-form .form-row select.multiselect {
 /* Hide everything which is not output by Give core or addon */
 // exclude PayPal payment contingency handler.
 // This is popup used by PayPal to verify 3ds card.
-body > *:not([class^='give']):not([id^='give']):not([class*='payments-sdk-contingency-handler']) {
+// Exclude Give Aid add-on popup too by adding give-modal to the selector
+body
+	> *:not([class^='give']):not([id^='give']):not([class*='payments-sdk-contingency-handler']):not([class*='give-modal']) {
 	display: none;
 }
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5548

## Description

This PR resolves the issue where the Gift Aid popup was not showing up when using the multi-step form. The issue is solved by updating the CSS selector which was hiding all the elements that don't belong to the GiveWP. The Gift Aid popup was not displaying correctly because it was affected by this [rule-set](https://github.com/impress-org/givewp/blob/da50ffe5de7276bd5734f329beb372a200501cc3/src/Views/Form/Templates/Sequoia/assets/css/form.scss#L1409) from the core plugin. 

## Affects

Gift Aid popup.

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Create a donation form with the multi-step template.
2. Add custom Gift aid settings for that form
3. Navigate to the donation form
4. Click on the "Tell me more" link (the popup window should appear)

