### PR TITLE
Onboarding wizard e2e tests are now implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add filter hook to filter PayPal settings (#5502)
 -   Sample onboarding tests are now implemented (#5543)
+-   Onboarding wizard e2e tests are now implemented (#5550)
 
 ### Changed
 

--- a/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/addons/index.js
@@ -55,7 +55,7 @@ const Addons = () => {
 					<strong>{ __( 'Dedicate Donations', 'give' ) }</strong>
 				</Card>
 			</CardInput>
-			<ContinueButton />
+			<ContinueButton testId="addons-continue-button" />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -41,7 +41,7 @@ const DonationForm = () => {
 							{ __( 'Extend with add-ons and more!', 'give' ) }
 						</li>
 					</ul>
-					<ContinueButton />
+					<ContinueButton testId="preview-continue-button" />
 				</div>
 			</div>
 		</div>

--- a/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/features/index.js
@@ -55,7 +55,7 @@ const Features = () => {
 					<strong>{ __( 'Company Donations', 'give' ) }</strong>
 				</Card>
 			</CardInput>
-			<ContinueButton />
+			<ContinueButton testId="features-continue-button" />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
@@ -28,7 +28,7 @@ const Introduction = () => {
 					<p>
 						{ __( 'You\'re minutes away from accepting donations on your website. Use the Onboarding Wizard if this is your first time using GiveWP.', 'give' ) }
 					</p>
-					<ContinueButton clickCallback={ () => onStartSetup() } label={ __( 'Start Setup', 'give' ) } testId="start-setup" />
+					<ContinueButton clickCallback={ () => onStartSetup() } label={ __( 'Start Setup', 'give' ) } testId="intro-continue-button" />
 				</div>
 			</Card>
 			<DismissLink />

--- a/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
@@ -37,7 +37,7 @@ const Location = () => {
 				<SelectInput label={ __( 'State / Province', 'give' ) } value={ state } onChange={ ( value ) => dispatch( setState( value ) ) } options={ statesList } isLoading={ fetchingStatesList } />
 				<SelectInput label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
 			</Card>
-			<ContinueButton />
+			<ContinueButton testId="location-continue-button" />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/location/index.js
@@ -33,9 +33,9 @@ const Location = () => {
 			<BackgroundImage />
 			<h1>{ __( 'Where are you fundraising?', 'give' ) }</h1>
 			<Card>
-				<SelectInput label={ __( 'Country', 'give' ) } value={ country } onChange={ onChangeCountry } options={ countriesList } />
-				<SelectInput label={ __( 'State / Province', 'give' ) } value={ state } onChange={ ( value ) => dispatch( setState( value ) ) } options={ statesList } isLoading={ fetchingStatesList } />
-				<SelectInput label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
+				<SelectInput testId="country-select" label={ __( 'Country', 'give' ) } value={ country } onChange={ onChangeCountry } options={ countriesList } />
+				<SelectInput testId="state-select" label={ __( 'State / Province', 'give' ) } value={ state } onChange={ ( value ) => dispatch( setState( value ) ) } options={ statesList } isLoading={ fetchingStatesList } />
+				<SelectInput testId="currency-select" label={ __( 'Currency', 'give' ) } value={ currency } onChange={ ( value ) => dispatch( setCurrency( value ) ) } options={ currenciesList } />
 			</Card>
 			<ContinueButton testId="location-continue-button" />
 		</div>

--- a/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
@@ -46,7 +46,7 @@ const YourCause = () => {
 			</CardInput>
 			<h2>{ __( 'What is your cause?', 'give' ) }</h2>
 			<span className="screen-reader-text">{ __( 'What is your cause?', 'give' ) }</span>
-			<SelectInput value={ causeType } onChange={ ( value ) => dispatch( setCauseType( value ) ) } options={ getCauseTypes() } />
+			<SelectInput testId="cause-select" value={ causeType } onChange={ ( value ) => dispatch( setCauseType( value ) ) } options={ getCauseTypes() } />
 			<ContinueButton testId="cause-continue-button" />
 		</div>
 	);

--- a/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/your-cause/index.js
@@ -47,7 +47,7 @@ const YourCause = () => {
 			<h2>{ __( 'What is your cause?', 'give' ) }</h2>
 			<span className="screen-reader-text">{ __( 'What is your cause?', 'give' ) }</span>
 			<SelectInput value={ causeType } onChange={ ( value ) => dispatch( setCauseType( value ) ) } options={ getCauseTypes() } />
-			<ContinueButton />
+			<ContinueButton testId="cause-continue-button" />
 		</div>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/components/card-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/card-input/index.js
@@ -24,7 +24,7 @@ const CardInput = ( { checkMultiple, values, onChange, children } ) => {
 		const checked = values.includes( card.props.value );
 		return (
 			<div key={ index }>
-				<input type="checkbox" id={ card.props.value } value={ card.props.value } onChange={ ( evt ) => handleChange( evt.target.value ) } checked={ checked } />
+				<input type="checkbox" id={ card.props.value } value={ card.props.value } onChange={ ( evt ) => handleChange( evt.target.value ) } defaultChecked={ checked } />
 				<div className="give-obw-card-input__option">
 					{ !! checked &&
 						<Selected index={ index } />

--- a/assets/src/js/admin/onboarding-wizard/components/dismiss-link/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/dismiss-link/index.js
@@ -10,7 +10,7 @@ import './style.scss';
 const DismissLink = () => {
 	const setupUrl = getWindowData( 'setupUrl' );
 	return (
-		<a className="give-obw-dismiss-link" href={ setupUrl }>
+		<a className="give-obw-dismiss-link" href={ setupUrl } data-givewp-test="dismiss-wizard-link">
 			{ __( 'Dismiss Setup Wizard', 'give' ) }
 		</a>
 	);

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -64,7 +64,7 @@ const DonationForm = () => {
 	};
 
 	return (
-		<div className="give-obw-donation-form-preview">
+		<div className="give-obw-donation-form-preview" data-givewp-test="preview-form">
 			<div className="give-obw-donation-form-preview__loading-message" style={ messageStyle }>
 				<ConfigurationIcon />
 				<h3>

--- a/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/select-input/index.js
@@ -8,7 +8,7 @@ import { toKebabCase } from '../../utils';
 // Import styles
 import './style.scss';
 
-const SelectInput = ( { label, value, isLoading, onChange, options } ) => {
+const SelectInput = ( { label, value, testId, isLoading, onChange, options } ) => {
 	if ( options && options.length < 2 ) {
 		return null;
 	}
@@ -55,12 +55,13 @@ const SelectInput = ( { label, value, isLoading, onChange, options } ) => {
 	};
 
 	return (
-		<div className="give-obw-select-input">
+		<div className="give-obw-select-input" data-givewp-test={ testId }>
 			{ label && ( <label className="give-obw-select-input__label" htmlFor={ toKebabCase( label ) }>{ label }</label> ) }
 			<Select
 				isLoading={ isLoading }
 				inputId={ label && toKebabCase( label ) }
 				value={ selectedOptionValue }
+				classNamePrefix="givewp-select"
 				onChange={ ( selectedOption ) => onChange( selectedOption.value ) }
 				options={ options }
 				styles={ selectStyles }

--- a/assets/src/js/admin/onboarding-wizard/components/step-link/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/step-link/index.js
@@ -20,7 +20,7 @@ const StepLink = ( { title, stepNumber } ) => {
 	};
 
 	return (
-		<div className="give-obw-step-link">
+		<div className="give-obw-step-link" data-givewp-test="navigation-step">
 			<button className="give-obw-step-button" onClick={ () => dispatch( goToStep( stepNumber ) ) }>
 				<div className={ `give-obw-step-icon${ currentStep >= stepNumber ? ' give-obw-step-icon--green' : '' }` }>
 					{ currentStep <= stepNumber ? stepNumber : <Checkmark index={ stepNumber } /> }

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -113,6 +113,18 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'location-continue-button' ).click();
 		cy.getByTest( 'features-continue-button' ).should( 'exist' );
 
+		// Multiple feature cards can be selected
+		cy.get( 'label[for="donation-comments"]' ).click();
+		cy.get( 'label[for="terms-conditions"]' ).click();
+		cy.get( 'input[value="donation-comments"]' ).should( 'have.attr', 'checked' );
+		cy.get( 'input[value="terms-conditions"]' ).should( 'have.attr', 'checked' );
+
+		// Feature cards can be unselected
+		cy.get( 'label[for="donation-comments"]' ).click();
+		cy.get( 'label[for="terms-conditions"]' ).click();
+		cy.get( 'input[value="donation-comments"]' ).should( 'not.have.attr', 'checked' );
+		cy.get( 'input[value="terms-conditions"]' ).should( 'not.have.attr', 'checked' );
+
 		// Features continue button should lead to preview step
 		cy.getByTest( 'features-continue-button' ).click();
 		cy.getByTest( 'preview-continue-button' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -25,7 +25,7 @@ describe( 'Test onboarding wizard', function() {
 
 		// When not an input or anchor tag, use get by test to target elements by their data-givewp-test attribute
 		cy.getByTest( 'onboarding-wizard-link' ).click();
-		cy.getByTest( 'start-setup' ).should( 'exist' );
+		cy.getByTest( 'intro-continue-button' ).should( 'exist' );
 	} );
 
 	it( 'can dismess onboarding wizard', function() {
@@ -41,7 +41,10 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'intro-continue-button' ).click();
 		cy.getByTest( 'cause-continue-button' ).should( 'exist' );
 
-		//
+		// Only one fundraising type card should be selected at a time
+		cy.get( 'label[for="organization"]' ).click();
+		cy.get( 'input[value="organization"]' ).should( 'have.attr', 'checked' );
+		cy.get( 'input[value="individual"]' ).should( 'not.have.attr', 'checked' );
 
 		// Cause continue button should lead to location step
 		cy.getByTest( 'cause-continue-button' ).click();

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -47,13 +47,67 @@ describe( 'Test onboarding wizard', function() {
 		cy.get( 'input[value="individual"]' ).should( 'not.have.attr', 'checked' );
 
 		// Cause types should be selectable
-		cy.getByTest( 'cause-select' ).get( '.givewp-select__value-container' ).click();
-		cy.getByTest( 'cause-select' ).get( '.givewp-select__menu-list > div' ).eq( 2 ).click();
-		cy.getByTest( 'cause-select' ).get( '.givewp-select__value-container' ).contains( 'Environmental' );
+		cy.getByTest( 'cause-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 2 ).click();
+			cy.get( '.givewp-select__value-container' ).contains( 'Environmental' );
+		} );
 
 		// Cause continue button should lead to location step
 		cy.getByTest( 'cause-continue-button' ).click();
 		cy.getByTest( 'location-continue-button' ).should( 'exist' );
+
+		// Changes to country should update options in state/province and currency inputs
+
+		// Set country to Canada
+		cy.getByTest( 'country-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 1 ).click();
+		} );
+
+		// Check Canadian provinces
+		cy.getByTest( 'state-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 1 ).contains( 'Alberta' );
+			cy.get( '.givewp-select__menu-list > div' ).eq( 2 ).contains( 'British Columbia' );
+		} );
+
+		// Check Candaian currency
+		cy.getByTest( 'currency-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).contains( 'Canadian Dollars ($)' );
+		} );
+
+		// Set country to UK
+		cy.getByTest( 'country-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 2 ).click();
+		} );
+
+		// Check that state select input does not exist
+		cy.getByTest( 'state-select' ).should( 'not.exist' );
+
+		// Check UK currency
+		cy.getByTest( 'currency-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).contains( 'Pounds Sterling (£)' );
+		} );
+
+		// Set country to US
+		cy.getByTest( 'country-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 0 ).click();
+		} );
+
+		// Check US states
+		cy.getByTest( 'state-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).click();
+			cy.get( '.givewp-select__menu-list > div' ).eq( 1 ).contains( 'Alabama' );
+			cy.get( '.givewp-select__menu-list > div' ).eq( 2 ).contains( 'Alaska' );
+		} );
+
+		// Check US currency
+		cy.getByTest( 'currency-select' ).within( () => {
+			cy.get( '.givewp-select__value-container' ).contains( 'US Dollars ($)' );
+		} );
 
 		// Location continue button should lead to features step
 		cy.getByTest( 'location-continue-button' ).click();

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -150,6 +150,20 @@ describe( 'Test onboarding wizard', function() {
 		cy.get( 'input[value="recurring-donations"]' ).should( 'not.have.attr', 'checked' );
 		cy.get( 'input[value="donors-cover-fees"]' ).should( 'not.have.attr', 'checked' );
 
+		// Top navigation should work as expected
+
+		// Check that first step link works as expected
+		cy.getByTest( 'navigation-step' ).eq( 0 ).click();
+		cy.getByTest( 'cause-continue-button' ).should( 'exist' );
+
+		// Check that third step link works as expected
+		cy.getByTest( 'navigation-step' ).eq( 2 ).click();
+		cy.getByTest( 'features-continue-button' ).should( 'exist' );
+
+		// Check that last step link works as expected
+		cy.getByTest( 'navigation-step' ).eq( 4 ).click();
+		cy.getByTest( 'addons-continue-button' ).should( 'exist' );
+
 		// Addons continue button should lead to setup page
 		cy.getByTest( 'addons-continue-button' ).click();
 		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -31,7 +31,7 @@ describe( 'Test onboarding wizard', function() {
 	it( 'can dismess onboarding wizard', function() {
 		cy.visit( baseURL + '/wp-admin/?page=give-onboarding-wizard' );
 		cy.getByTest( 'dismiss-wizard-link' ).click();
-		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );
+		cy.getByTest( 'setup-configuration' ).should( 'exist' );
 	} );
 
 	it( 'can navigate through the Onboarding Wizard', function() {

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -24,7 +24,7 @@ describe( 'Test onboarding wizard', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );
 
 		// When not an input or anchor tag, use get by test to target elements by their data-givewp-test attribute
-		cy.getByTest( 'onboarding-wizard-link' ).click();
+		cy.getByTest( 'setup-configuration' ).click();
 		cy.getByTest( 'intro-continue-button' ).should( 'exist' );
 	} );
 
@@ -166,6 +166,6 @@ describe( 'Test onboarding wizard', function() {
 
 		// Addons continue button should lead to setup page
 		cy.getByTest( 'addons-continue-button' ).click();
-		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );
+		cy.getByTest( 'setup-configuration' ).should( 'exist' );
 	} );
 } );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -41,6 +41,8 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'intro-continue-button' ).click();
 		cy.getByTest( 'cause-continue-button' ).should( 'exist' );
 
+		//
+
 		// Cause continue button should lead to location step
 		cy.getByTest( 'cause-continue-button' ).click();
 		cy.getByTest( 'location-continue-button' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -27,4 +27,38 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'onboarding-wizard-link' ).click();
 		cy.getByTest( 'start-setup' ).should( 'exist' );
 	} );
+
+	it( 'can dismess onboarding wizard', function() {
+		cy.visit( baseURL + '/wp-admin/?page=give-onboarding-wizard' );
+		cy.getByTest( 'dismiss-wizard-link' ).click();
+		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );
+	} );
+
+	it( 'can navigate through the Onboarding Wizard', function() {
+		cy.visit( baseURL + '/wp-admin/?page=give-onboarding-wizard' );
+
+		// Intro continue button should lead to cause step
+		cy.getByTest( 'intro-continue-button' ).click();
+		cy.getByTest( 'cause-continue-button' ).should( 'exist' );
+
+		// Cause continue button should lead to location step
+		cy.getByTest( 'cause-continue-button' ).click();
+		cy.getByTest( 'location-continue-button' ).should( 'exist' );
+
+		// Location continue button should lead to features step
+		cy.getByTest( 'location-continue-button' ).click();
+		cy.getByTest( 'features-continue-button' ).should( 'exist' );
+
+		// Features continue button should lead to preview step
+		cy.getByTest( 'features-continue-button' ).click();
+		cy.getByTest( 'preview-continue-button' ).should( 'exist' );
+
+		// Preview continue button should lead to addons step
+		cy.getByTest( 'preview-continue-button' ).click();
+		cy.getByTest( 'addons-continue-button' ).should( 'exist' );
+
+		// Addons continue button should lead to setup page
+		cy.getByTest( 'addons-continue-button' ).click();
+		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );
+	} );
 } );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -46,6 +46,11 @@ describe( 'Test onboarding wizard', function() {
 		cy.get( 'input[value="organization"]' ).should( 'have.attr', 'checked' );
 		cy.get( 'input[value="individual"]' ).should( 'not.have.attr', 'checked' );
 
+		// Cause types should be selectable
+		cy.getByTest( 'cause-select' ).get( '.givewp-select__value-container' ).click();
+		cy.getByTest( 'cause-select' ).get( '.givewp-select__menu-list > div' ).eq( 2 ).click();
+		cy.getByTest( 'cause-select' ).get( '.givewp-select__value-container' ).contains( 'Environmental' );
+
 		// Cause continue button should lead to location step
 		cy.getByTest( 'cause-continue-button' ).click();
 		cy.getByTest( 'location-continue-button' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -129,6 +129,11 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'features-continue-button' ).click();
 		cy.getByTest( 'preview-continue-button' ).should( 'exist' );
 
+		// Prevew form iframe should load
+		cy.getByTest( 'preview-form' ).within( () => {
+			cy.get( 'iframe' ).its( '0.contentDocument.body' ).should( 'be.visible' );
+		} );
+
 		// Preview continue button should lead to addons step
 		cy.getByTest( 'preview-continue-button' ).click();
 		cy.getByTest( 'addons-continue-button' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
+++ b/tests/e2e/integration/onboarding/onboarding_wizard_spec.js
@@ -138,6 +138,18 @@ describe( 'Test onboarding wizard', function() {
 		cy.getByTest( 'preview-continue-button' ).click();
 		cy.getByTest( 'addons-continue-button' ).should( 'exist' );
 
+		// Multiple addon cards can be selected
+		cy.get( 'label[for="recurring-donations"]' ).click();
+		cy.get( 'label[for="donors-cover-fees"]' ).click();
+		cy.get( 'input[value="recurring-donations"]' ).should( 'have.attr', 'checked' );
+		cy.get( 'input[value="donors-cover-fees"]' ).should( 'have.attr', 'checked' );
+
+		// Addon cards can be unselected
+		cy.get( 'label[for="recurring-donations"]' ).click();
+		cy.get( 'label[for="donors-cover-fees"]' ).click();
+		cy.get( 'input[value="recurring-donations"]' ).should( 'not.have.attr', 'checked' );
+		cy.get( 'input[value="donors-cover-fees"]' ).should( 'not.have.attr', 'checked' );
+
 		// Addons continue button should lead to setup page
 		cy.getByTest( 'addons-continue-button' ).click();
 		cy.getByTest( 'onboarding-wizard-link' ).should( 'exist' );

--- a/tests/e2e/integration/onboarding/setup_page_spec.js
+++ b/tests/e2e/integration/onboarding/setup_page_spec.js
@@ -12,7 +12,7 @@ describe( 'Test setup page', function() {
 	it( 'can manually launch wizard', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );
 		cy.getByTest( 'setup-configuration' ).click();
-		cy.getByTest( 'start-setup' ).should( 'exist' );
+		cy.getByTest( 'intro-continue-button' ).should( 'exist' );
 	} );
 	it( 'can dismiss setup page', function() {
 		cy.visit( baseURL + '/wp-admin/edit.php?post_type=give_forms&page=give-setup' );


### PR DESCRIPTION
Resolves #5546 

## Description

This PR expands upon the existing Onboarding Wizard e2e test spec to cover various additional functionality including dynamic select options, top navigation, preview form loading, and more.

## Affects
This PR affects some frontend logic for the Onboarding Wizard (introducing `data-givewp-test` attributes to a handful of interactive components), but primarily changes the Onboarding Wizard spec, found in the e2e tests directory.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Start the testing environment (`npm run env start`)
2. Open e2e tests (`npm run test:e2e`)
3. Start onboarding wizard tests (`onboarding/onboarding_wizard_spec.js`)