### PR TITLE
Multi Form Goal is not producing errors and warnings when used as a Divi module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+-   Multi Form Goal is not producing errors and warnings when used as a Divi module (#5565)
+
 ## 2.9.6 - 2021-01-13
 
 ### New

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -71,7 +71,7 @@ class Shortcode {
 
 		if ( $attributes ) {
 			foreach ( $attributes as $key => &$attribute ) {
-				if ( is_array( $pairs[ $key ] ) ) {
+				if ( isset( $pairs[ $key ] ) && is_array( $pairs[ $key ] ) ) {
 					$attribute = $this->parseAttributeArray( $attribute );
 				}
 			}

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -27,8 +27,6 @@ class Shortcode {
 	 * @since 2.9.0
 	 **/
 	public function renderCallback( $attributes ) {
-		error_log( serialize( $attributes ) );
-
 		$attributes = $this->parseAttributes(
 			[
 				'ids'        => [],


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5564

## Description

This PR resolves the issue where the Multi Form Goal shortcode was producing errors and warnings when used as a Divi module. The issue is fixed by checking if the array key exists before trying to use it. 

## Affects

Multi Form Goal Shortcode.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Download and install the Give Divi add-on
2. Add a new page using Divi editor
3. Insert the Give Multi Form Goal  module
4. Save the page and exit Divi builder
5. Test module on the front-end

