### PR TITLE
Donation History UI is now polished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Edit Profile UI is now implemented (#5463)
 -   Edit Profile tab now persists data (#5486)
 
+### Changed
+-   Donor Profile Donation History UI is now polished (#5566)
+
 ## 2.9.6 - 2021-01-13
 
 ### New

--- a/src/DonorProfiles/Factories/DonorFactory.php
+++ b/src/DonorProfiles/Factories/DonorFactory.php
@@ -6,7 +6,7 @@ use \Give_Donor as DonorModel;
 
 class DonorFactory {
 
-	public function make( int $donorId ) {
+	public function make( $donorId ) {
 		return new DonorModel( $donorId );
 	}
 }

--- a/src/DonorProfiles/Pipeline/DonorProfilePipeline.php
+++ b/src/DonorProfiles/Pipeline/DonorProfilePipeline.php
@@ -10,14 +10,14 @@ class DonorProfilePipeline {
 		$this->stages = [];
 	}
 
-	public function pipe( callable $stage ) {
+	public function pipe( $stage ) {
 		$pipeline       = clone $this;
 		$this->stages[] = $stage;
 		return $pipeline;
 	}
 
-	public function process( $payload, callable ...$stages ) {
-		foreach ( $stages as $stage ) {
+	public function process( $payload ) {
+		foreach ( $this->stages as $stage ) {
 			$payload = $stage( $payload );
 		}
 

--- a/src/DonorProfiles/Profile.php
+++ b/src/DonorProfiles/Profile.php
@@ -15,7 +15,7 @@ class Profile {
 	protected $donor;
 	protected $id;
 
-	public function __construct( int $donorId ) {
+	public function __construct( $donorId ) {
 		$donorFactory = new DonorFactory;
 		$this->donor  = $donorFactory->make( $donorId );
 	}

--- a/src/DonorProfiles/Profile.php
+++ b/src/DonorProfiles/Profile.php
@@ -52,9 +52,10 @@ class Profile {
 	/**
 	 * Return array of donor profile data
 	 *
-	 * @return void
 	 * @since 2.11.0
-	 **/
+	 *
+	 * @return array
+	 */
 	public function getProfileData() {
 
 		$titlePrefix = Give()->donor_meta->get_meta( $this->donor->id, '_give_donor_title_prefix', true );

--- a/src/DonorProfiles/Profile.php
+++ b/src/DonorProfiles/Profile.php
@@ -72,7 +72,7 @@ class Profile {
 			'initials'          => $this->donor->get_donor_initals(),
 			'titlePrefix'       => $this->getTitlePrefix(),
 			'addresses'         => $this->donor->address,
-			'isAnonymous'       => $this->donor->get_meta( '_give_anonymous_donor', false )[0] !== '0' ? 'private' : 'public',
+			'isAnonymous'       => $this->donor->get_meta( '_give_anonymous_donor', true ) !== '0' ? 'private' : 'public',
 		];
 	}
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -220,13 +220,13 @@ class Donations {
 		$statusMap = [
 			'publish' => [
 				'color' => '#7AD03A',
-				'label' => __( 'Complete', 'give' ),
+				'label' => esc_html__( 'Complete', 'give' ),
 			],
 		];
 
 		return $statusMap[ $status ] ? $statusMap[ $status ] : [
 			'color' => '#FFBA00',
-			'label' => 'Unknown',
+			'label' => esc_html__( 'Unknown', 'give' ),
 		];
 	}
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -205,6 +205,7 @@ class Donations {
 			'status'   => $this->getFormattedStatus( $payment->status ),
 			'date'     => date( 'F j, Y', strtotime( $payment->date ) ),
 			'time'     => date( 'g:i a', strtotime( $payment->date ) ),
+			'mode'     => $payment->get_meta( '_give_payment_mode' ),
 		];
 	}
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -224,7 +224,7 @@ class Donations {
 			],
 		];
 
-		return $statusMap[ $status ] ? $statusMap[ $status ] : [
+		return isset( $statusMap[ $status ] ) ? $statusMap[ $status ] : [
 			'color' => '#FFBA00',
 			'label' => esc_html__( 'Unknown', 'give' ),
 		];

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -203,8 +203,8 @@ class Donations {
 			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
 			'method'   => $gateways[ $payment->gateway ]['checkout_label'],
 			'status'   => $this->getFormattedStatus( $payment->status ),
-			'date'     => date( 'F j, Y', strtotime( $payment->date ) ),
-			'time'     => date( 'g:i a', strtotime( $payment->date ) ),
+			'date'     => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
+			'time'     => date_i18n( 'g:i a', strtotime( $payment->date ) ),
 			'mode'     => $payment->get_meta( '_give_payment_mode' ),
 		];
 	}

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -199,9 +199,23 @@ class Donations {
 			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
 			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
 			'method'   => $payment->gateway,
-			'status'   => $payment->status,
+			'status'   => $this->getFormattedStatus( $payment->status ),
 			'date'     => date( 'F j, Y', strtotime( $payment->date ) ),
 			'time'     => date( 'g:i a', strtotime( $payment->date ) ),
+		];
+	}
+
+	protected function getFormattedStatus( $status ) {
+		$statusMap = [
+			'publish' => [
+				'color' => '#7AD03A',
+				'label' => __( 'Complete', 'give' ),
+			],
+		];
+
+		return $statusMap[ $status ] ? $statusMap[ $status ] : [
+			'color' => '#FFBA00',
+			'label' => 'Unknown',
 		];
 	}
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -193,12 +193,15 @@ class Donations {
 	 * @return array Payment info
 	 */
 	protected function getPaymentInfo( $payment ) {
+
+		$gateways = give_get_payment_gateways();
+
 		return [
 			'amount'   => $this->getFormattedAmount( $payment->subtotal, $payment ),
 			'currency' => $payment->currency,
 			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
 			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
-			'method'   => $payment->gateway,
+			'method'   => $gateways[ $payment->gateway ]['checkout_label'],
 			'status'   => $this->getFormattedStatus( $payment->status ),
 			'date'     => date( 'F j, Y', strtotime( $payment->date ) ),
 			'time'     => date( 'g:i a', strtotime( $payment->date ) ),

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -209,6 +209,13 @@ class Donations {
 		];
 	}
 
+	/**
+	 * Get formatted status object (used for rendering status correctly in Donor Profile)
+	 *
+	 * @param string $status
+	 * @since 2.10.0
+	 * @return array Formatted status object (with color and label)
+	 */
 	protected function getFormattedStatus( $status ) {
 		$statusMap = [
 			'publish' => [
@@ -223,6 +230,14 @@ class Donations {
 		];
 	}
 
+	/**
+	 * Get formatted payment amount
+	 *
+	 * @param float $amount
+	 * @param Give_Payment $payment
+	 * @since 2.10.0
+	 * @return string Formatted payment amount (with correct decimals and currency symbol)
+	 */
 	protected function getformattedAmount( $amount, $payment ) {
 		return give_currency_filter(
 			give_format_amount(

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -194,14 +194,31 @@ class Donations {
 	 */
 	protected function getPaymentInfo( $payment ) {
 		return [
-			'amount'   => $payment->subtotal,
+			'amount'   => $this->getFormattedAmount( $payment->subtotal, $payment ),
 			'currency' => $payment->currency,
-			'fee'      => ( $payment->total - $payment->subtotal ),
-			'total'    => $payment->total,
+			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
+			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
 			'method'   => $payment->gateway,
 			'status'   => $payment->status,
-			'date'     => $payment->date,
+			'date'     => date( 'F j, Y', strtotime( $payment->date ) ),
+			'time'     => date( 'g:i a', strtotime( $payment->date ) ),
 		];
+	}
+
+	protected function getformattedAmount( $amount, $payment ) {
+		return give_currency_filter(
+			give_format_amount(
+				$amount,
+				[
+					'donation_id' => $payment->ID,
+				]
+			),
+			[
+				'currency_code'   => $payment->currency,
+				'decode_currency' => true,
+				'sanitize'        => false,
+			]
+		);
 	}
 
 	/**

--- a/src/DonorProfiles/Routes/DonationsRoute.php
+++ b/src/DonorProfiles/Routes/DonationsRoute.php
@@ -41,7 +41,7 @@ class DonationsRoute implements RestRoute {
 	 *
 	 * @since 2.10.0
 	 */
-	public function handleRequest( WP_REST_Request $request ) {
+	public function handleRequest( $request ) {
 		return $this->getData();
 	}
 

--- a/src/DonorProfiles/Routes/LocationRoute.php
+++ b/src/DonorProfiles/Routes/LocationRoute.php
@@ -41,7 +41,7 @@ class LocationRoute implements RestRoute {
 	 *
 	 * @since 2.10.0
 	 */
-	public function handleRequest( WP_REST_Request $request ) {
+	public function handleRequest( $request ) {
 		return [
 			'states' => LocationList::getStates(
 				$request->get_param( 'countryCode' )

--- a/src/DonorProfiles/Routes/ProfileRoute.php
+++ b/src/DonorProfiles/Routes/ProfileRoute.php
@@ -83,7 +83,7 @@ class ProfileRoute implements RestRoute {
 	 *
 	 * @since 2.11.0
 	 */
-	public function handleRequest( WP_REST_Request $request ) {
+	public function handleRequest( $request ) {
 		return $this->updateProfile( $request->get_param( 'data' ), $request->get_param( 'id' ) );
 	}
 

--- a/src/DonorProfiles/resources/js/app/components/dashboard-content/index.js
+++ b/src/DonorProfiles/resources/js/app/components/dashboard-content/index.js
@@ -17,10 +17,10 @@ const DashboardContent = () => {
 	}, [ tabs ] );
 
 	const getDashboardContent = ( tabsArray ) => {
-		return tabsArray.reduce( ( content, tab ) => {
+		return tabsArray.reduce( ( content, tab, index ) => {
 			if ( tab[ 1 ].dashboardContent ) {
 				const Content = tab[ 1 ].dashboardContent;
-				content.push( <Content /> );
+				content.push( <Content key={ index } /> );
 			}
 			return content;
 		}, [] );

--- a/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
@@ -44,9 +44,9 @@ const DonationReceipt = ( { donation } ) => {
 							<FontAwesomeIcon icon="globe" /> { __( 'Address:', 'give' ) }
 						</div>
 						<div className="give-donor-profile-donation-receipt__value">
-							{ donor.address.street } <br />
-							{ donor.address.city } { donor.address.state }, { donor.address.zip } <br />
-							{ donor.address.country }
+							{ donor.address.street && ( <div> { donor.address.street } </div> ) }
+							{ donor.address.city && donor.address.state && donor.address.zip && ( <div> { donor.address.city } { donor.address.state }, { donor.address.zip } </div> ) }
+							{ donor.address.country && ( <div> { donor.address.country } </div> ) }
 						</div>
 					</div>
 				) }

--- a/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
@@ -63,7 +63,7 @@ const DonationReceipt = ( { donation } ) => {
 						{ __( 'Payment Status:', 'give' ) }
 					</div>
 					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.status }
+						{ payment.status.label }
 					</div>
 				</div>
 				<div className="give-donor-profile-donation-receipt__row">

--- a/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
@@ -44,7 +44,9 @@ const DonationReceipt = ( { donation } ) => {
 							<FontAwesomeIcon icon="globe" /> { __( 'Address:', 'give' ) }
 						</div>
 						<div className="give-donor-profile-donation-receipt__value">
-							{ donor.address }
+							{ donor.address.street } <br />
+							{ donor.address.city } { donor.address.state }, { donor.address.zip } <br />
+							{ donor.address.country }
 						</div>
 					</div>
 				) }

--- a/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
@@ -14,7 +14,8 @@ const DonationRow = ( { donation } ) => {
 				{ form.title }
 			</div>
 			<div className="give-donor-profile-table__column">
-				{ payment.date }
+				<div className="give-donor-profile-table__donation-date">{ payment.date }</div>
+				<div className="give-donor-profile-table__donation-time">{ payment.time }</div>
 			</div>
 			<div className="give-donor-profile-table__column">
 				<div className="give-donor-profile-table__donation-status">

--- a/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 const { __ } = wp.i18n;
 
 const DonationRow = ( { donation } ) => {
@@ -29,7 +30,7 @@ const DonationRow = ( { donation } ) => {
 				<div className="give-donor-profile-table__donation-id">ID: { id }</div>
 				<div className="give-donor-profile-table__donation-receipt">
 					<Link to={ `/donation-history/${ id }` }>
-						{ __( 'View Receipt', 'give' ) }
+						{ __( 'View Receipt', 'give' ) } <FontAwesomeIcon icon="arrow-right" />
 					</Link>
 				</div>
 			</div>

--- a/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
@@ -25,6 +25,11 @@ const DonationRow = ( { donation } ) => {
 						{ payment.status.label }
 					</div>
 				</div>
+				{ payment.mode !== 'live' && (
+					<div className="give-donor-profile-table__donation-test-tag">
+						{ __( 'Test Donation', 'givewp' ) }
+					</div>
+				) }
 			</div>
 			<div className="give-donor-profile-table__pill">
 				<div className="give-donor-profile-table__donation-id">ID: { id }</div>

--- a/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
@@ -27,7 +27,7 @@ const DonationRow = ( { donation } ) => {
 				</div>
 				{ payment.mode !== 'live' && (
 					<div className="give-donor-profile-table__donation-test-tag">
-						{ __( 'Test Donation', 'givewp' ) }
+						{ __( 'Test Donation', 'give' ) }
 					</div>
 				) }
 			</div>

--- a/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/donation-row/index.js
@@ -19,7 +19,10 @@ const DonationRow = ( { donation } ) => {
 			</div>
 			<div className="give-donor-profile-table__column">
 				<div className="give-donor-profile-table__donation-status">
-					{ payment.status }
+					<div className="give-donor-profile-table__donation-status-indicator" style={ { background: payment.status.color } } />
+					<div className="give-donor-profile-table__donation-status-label">
+						{ payment.status.label }
+					</div>
 				</div>
 			</div>
 			<div className="give-donor-profile-table__pill">

--- a/src/DonorProfiles/resources/js/app/components/donation-table/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/index.js
@@ -49,7 +49,7 @@ const DonationTable = ( { donations, perPage } ) => {
 						{ __( 'Donation', 'give' ) }
 					</div>
 					<div className="give-donor-profile-table__column">
-						{ __( 'Campaign', 'give' ) }
+						{ __( 'Form', 'give' ) }
 					</div>
 					<div className="give-donor-profile-table__column">
 						{ __( 'Date', 'give' ) }

--- a/src/DonorProfiles/resources/js/app/components/donation-table/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/index.js
@@ -21,7 +21,7 @@ const DonationTable = ( { donations, perPage } ) => {
 	const getDonationRows = () => {
 		return donationsArray.reduce( ( rows, donation, index ) => {
 			if ( index >= start && index < end ) {
-				rows.push( <DonationRow donation={ donation } /> );
+				rows.push( <DonationRow key={ index } donation={ donation } /> );
 			}
 			return rows;
 		}, [] );

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -7,3 +7,8 @@
 		margin: 8px;
 	}
 }
+
+.give-donor-profile-table__donation-date,
+.give-donor-profile-table__donation-time {
+	white-space: nowrap;
+}

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -15,17 +15,29 @@
 
 .give-donor-profile-table__row {
 	line-height: 1.6;
-}
 
-.give-donor-profile-table__donation-status {
-	display: flex;
-	align-items: center;
+	.give-donor-profile-table__donation-amount {
+		font-size: 18px;
+		color: #424242;
+		font-weight: 500;
+	}
 
-	.give-donor-profile-table__donation-status-indicator {
-		width: 12px;
-		height: 12px;
-		border-radius: 50%;
-		overflow: hidden;
-		margin-right: 6px;
+	.give-donor-profile-table__donation-status {
+		display: flex;
+		align-items: center;
+
+		.give-donor-profile-table__donation-status-indicator {
+			width: 12px;
+			height: 12px;
+			border-radius: 50%;
+			overflow: hidden;
+			margin-right: 6px;
+		}
+	}
+
+	.give-donor-profile-table__donation-receipt a {
+		color: #3398db;
+		text-decoration: underline;
+		border: none;
 	}
 }

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -35,6 +35,10 @@
 		}
 	}
 
+	.give-donor-profile-table__donation-id {
+		color: #6b6b6b;
+	}
+
 	.give-donor-profile-table__donation-receipt a {
 		color: #3398db;
 		text-decoration: underline;

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -2,6 +2,7 @@
 	a {
 		border: none;
 		color: #9fa2b4;
+		cursor: pointer;
 	}
 	svg {
 		margin: 8px;

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -53,7 +53,7 @@
 
 	.give-donor-profile-table__donation-receipt a {
 		color: #3398db;
-		text-decoration: underline;
+		text-decoration: none;
 		border: none;
 	}
 }

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -35,6 +35,18 @@
 		}
 	}
 
+	.give-donor-profile-table__donation-test-tag {
+		color: #fff;
+		background: #ffba00;
+		padding: 4px 8px;
+		border-radius: 5px;
+		font-weight: 500;
+		font-size: 12px;
+		line-height: 1;
+		margin-top: 4px;
+		display: inline-block;
+	}
+
 	.give-donor-profile-table__donation-id {
 		color: #6b6b6b;
 	}

--- a/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/donation-table/style.scss
@@ -12,3 +12,20 @@
 .give-donor-profile-table__donation-time {
 	white-space: nowrap;
 }
+
+.give-donor-profile-table__row {
+	line-height: 1.6;
+}
+
+.give-donor-profile-table__donation-status {
+	display: flex;
+	align-items: center;
+
+	.give-donor-profile-table__donation-status-indicator {
+		width: 12px;
+		height: 12px;
+		border-radius: 50%;
+		overflow: hidden;
+		margin-right: 6px;
+	}
+}

--- a/src/DonorProfiles/resources/js/app/components/tab-link/index.js
+++ b/src/DonorProfiles/resources/js/app/components/tab-link/index.js
@@ -5,7 +5,7 @@ import './style.scss';
 const TabLink = ( { slug, label, icon } ) => {
 	return (
 		<NavLink to={ `/${ slug }` } className="give-donor-profile-tab-link" activeClassName="give-donor-profile-tab-link--is-active">
-			<FontAwesomeIcon icon={ icon } />
+			<FontAwesomeIcon icon={ icon } fixedWidth={ true } />
 			{ label }
 		</NavLink>
 	);

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
@@ -1,5 +1,6 @@
 import { useLocation, Link } from 'react-router-dom';
 import { Fragment } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const { __ } = wp.i18n;
 
@@ -8,6 +9,8 @@ import DonationReceipt from '../../components/donation-receipt';
 import DonationTable from '../../components/donation-table';
 
 import { useSelector } from './hooks';
+
+import './style.scss';
 
 const Content = () => {
 	const donations = useSelector( ( state ) => state.donations );
@@ -22,9 +25,11 @@ const Content = () => {
 				<Heading>
 					{ __( 'Loading...', 'give' ) }
 				</Heading>
-				<Link to="/donation-history">
-					{ __( 'Back to Donation History', 'give' ) }
-				</Link>
+				<div className="give-donor-profile__donation-history-link">
+					<Link to="/donation-history">
+						<FontAwesomeIcon icon="arrow-left" />  { __( 'Back to Donation History', 'give' ) }
+					</Link>
+				</div>
 			</Fragment>
 		) : (
 			<Fragment>
@@ -32,9 +37,11 @@ const Content = () => {
 					{ __( 'Donation', 'give' ) } #{ id }
 				</Heading>
 				<DonationReceipt donation={ donations[ id ] } />
-				<Link to="/donation-history">
-					{ __( 'Back to Donation History', 'give' ) }
-				</Link>
+				<div className="give-donor-profile__donation-history-link">
+					<Link to="/donation-history">
+						<FontAwesomeIcon icon="arrow-left" /> { __( 'Back to Donation History', 'give' ) }
+					</Link>
+				</div>
 			</Fragment>
 		);
 	}

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/style.scss
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/style.scss
@@ -1,0 +1,16 @@
+.give-donor-profile__donation-history-link {
+	display: inline-block;
+
+	a {
+		color: #3398db;
+		font-size: 14px;
+		text-decoration: none;
+		display: flex;
+		align-items: center;
+		border: none;
+
+		svg {
+			margin-right: 6px;
+		}
+	}
+}


### PR DESCRIPTION
Resolves #5562 

## Description
This PR introduces style improvements to the Donor History UI components (visible in donation tables and donation receipt pages of the Donor Profile).

## Affects
This PR primarily affects frontend styling and some backend logic related to displaying donation history in Donor Profiles.

## Visuals

<img width="653" alt="Screen Shot 2021-01-25 at 5 32 24 PM" src="https://user-images.githubusercontent.com/5186078/105774508-5640f300-5f33-11eb-96e8-e7e147dfe52b.png">

<img width="651" alt="Screen Shot 2021-01-25 at 5 32 09 PM" src="https://user-images.githubusercontent.com/5186078/105774531-593be380-5f33-11eb-92f2-998f3cf634d3.png">

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a Donor Profile block to a new page
2. On the frontend, check that the donation history displayed in Donor Profile matches currently logged in Donor's donaiton history
3. Check that UI components match Figma designs (https://www.figma.com/file/BKr2K0XdDyRRoccJbJKRD7/Epic%3A-Donor-Profile?node-id=397%3A1743)