### PR TITLE
Setup Page gateway links now render styles correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 -   Multi Form Goal is not producing errors and warnings when used as a Divi module (#5565)
-
+-   Setup Page gateway links now render styles correctly (#5576)
 ## 2.9.6 - 2021-01-13
 
 ### New

--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -64,7 +64,7 @@ class PageView {
 		}
 
 		// Stripe unmerged tags.
-		$output = preg_replace( '/{{\s*.*\s*}}/', '', $output );
+		$output = preg_replace( '/{{\s*\w*\s*}}/', '', $output );
 
 		return $output;
 	}

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -53,6 +53,7 @@
 					! $this->isStripeSetup() ? $this->render_template(
 						'row-item',
 						[
+							'testId'      => 'paypal',
 							'class'       => ( $this->isPayPalSetup() ) ? 'paypal setup-item-completed' : 'paypal',
 							'icon'        => ( $this->isPayPalSetup() )
 												? $this->image( 'check-circle.min.png' )
@@ -79,6 +80,7 @@
 					! $this->isPayPalSetup() ? $this->render_template(
 						'row-item',
 						[
+							'testId'      => 'stripe',
 							'class'       => ( $this->isStripeSetup() ) ? 'stripe setup-item-completed' : 'stripe',
 							'icon'        => ( $this->isStripeSetup() )
 											 ? $this->image( 'check-circle.min.png' )

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -12,7 +12,7 @@ This folder contains instructions and test code for Give PHPUnit testing.
 
 2) Install WordPress and the WP Unit Test library using the `install.sh` script located in `give/tests/bin/` directory. Change to the plugin root directory and type:
 
-    `$ tests/wordpress/bin/install.sh <db-name> <db-user> <db-password> [db-host]`
+    `$ tests/unit/bin/install.sh <db-name> <db-user> <db-password> [db-host]`
 
 Sample usage: `$ tests/bin/install.sh give_tests root root`
 

--- a/tests/unit/tests/Onboarding/Setup/PageViewTest.php
+++ b/tests/unit/tests/Onboarding/Setup/PageViewTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Give\Onboarding\FormRepository;
+use Give\Onboarding\Setup\PageView;
+
+final class PageViewTest extends TestCase {
+
+    /**
+     * @link https://github.com/impress-org/givewp/issues/5575
+     * @link https://github.com/impress-org/givewp/issues/5575#issuecomment-770950149
+     */
+    public function testContentSurroundedByUnmergedTagIsNotScrubbed() {
+        $pageView = new PageView(
+            $this->createMock( FormRepository::class )
+        );
+
+        $this->assertContains(
+            '<article id="" class="setup-item foo" data-givewp-test="">',
+            $pageView->render_template( 'row-item', [ 'class' => 'foo' ] )
+        );
+    }
+}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5575

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adding the `testId` tag created a situation where two unmerged were being scrubbed as one large unmerged tag.

Example:
```
id="{{ id }}" class="setup-item" testId="{{ testId }}" 
```

was being interpreted as a a single tag:

id="`{{ id }}" class="setup-item" testId="{{ testId }}`"

which, when scrubbed, results in:
```
id=""
```

See: https://github.com/impress-org/givewp/issues/5575#issuecomment-770950149

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Updates the un-merged tag regex to be more accurate.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/106344490-1605ab80-6278-11eb-801b-049d0d368f5a.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

