### PR TITLE
website onboard to telemetry server when admin grant permission

### DIFF
--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -12,7 +12,7 @@
 	</div>
 	<?php endif; ?>
 
-	<?php echo do_action( 'give_setup_page_before_sectioins' ); ?>
+	<?php do_action( 'give_setup_page_before_sections' ); ?>
 
 	<!-- Configuration -->
 	<?php

--- a/src/Tracking/AdminActionHandler.php
+++ b/src/Tracking/AdminActionHandler.php
@@ -36,7 +36,7 @@ class AdminActionHandler {
 			return;
 		}
 
-		$timestamp = '0';
+		$timestamp = '0'; // permanently.
 		if ( 'hide_opt_in_notice_shortly' === $_GET['give_action'] ) {
 			$timestamp = DAY_IN_SECONDS * 2 + time();
 		}
@@ -58,7 +58,7 @@ class AdminActionHandler {
 		}
 
 		give_update_option( AdminSettings::USAGE_TRACKING_OPTION_NAME, 'enabled' );
-		$this->usageTrackingOnBoarding->disableNotice( 'permanently' );
+		$this->usageTrackingOnBoarding->disableNotice( 0 );
 		$this->storeAccessToken();
 
 		wp_safe_redirect( remove_query_arg( 'give_action' ) );

--- a/src/Tracking/AdminActionHandler.php
+++ b/src/Tracking/AdminActionHandler.php
@@ -69,6 +69,8 @@ class AdminActionHandler {
 	/**
 	 * OptIn website to telemetry server when admin grant by changing setting.
 	 *
+	 * @since 2.10.0
+	 *
 	 * @param  array  $oldValue
 	 * @param  array  $newValue
 	 *

--- a/src/Tracking/TrackClient.php
+++ b/src/Tracking/TrackClient.php
@@ -4,6 +4,7 @@ namespace Give\Tracking;
 use Give\Tracking\TrackingData\ServerData;
 use Give\Tracking\TrackingData\WebsiteData;
 use InvalidArgumentException;
+use WP_Error;
 
 /**
  * Class TrackClient
@@ -27,10 +28,10 @@ class TrackClient {
 	 *
 	 * @since 2.10.0
 	 *
-	 * @param string $trackId
-	 * @param array $trackData
+	 * @param  string  $trackId
+	 * @param  array  $trackData
 	 *
-	 * @throws InvalidArgumentException
+	 * @return array|WP_Error
 	 */
 	public function send( $trackId, $trackData ) {
 		if ( ! $trackId || ! $trackData ) {
@@ -50,7 +51,8 @@ class TrackClient {
 			'data_format' => 'body',
 		];
 
-		wp_remote_post( $this->getApiUrl( $trackId ), $tracking_request_args );
+		return wp_remote_post( $this->getApiUrl( $trackId ), $tracking_request_args );
+
 	}
 
 	/**
@@ -62,7 +64,7 @@ class TrackClient {
 	 *
 	 * @return string
 	 */
-	private function getApiUrl( $trackId ) {
+	public function getApiUrl( $trackId ) {
 		return self::SERVER_URL . '/' . $trackId;
 	}
 }

--- a/src/Tracking/TrackClient.php
+++ b/src/Tracking/TrackClient.php
@@ -20,7 +20,7 @@ class TrackClient {
 	 *
 	 * @var string
 	 */
-	const SERVER_URL = 'https://stats.givewp.com';
+	const SERVER_URL = 'http://givetelemetryserver.test/api/v1/track-plugin-usage';
 
 	/**
 	 * Send a track event.

--- a/src/Tracking/TrackClient.php
+++ b/src/Tracking/TrackClient.php
@@ -19,7 +19,7 @@ class TrackClient {
 	 *
 	 * @var string
 	 */
-	const SERVER_URL = 'http://givetelemetryserver.test/api/v1/track-plugin-usage';
+	const SERVER_URL = 'https://givetelemetryserver.test/api/v1/track-plugin-usage';
 
 	/**
 	 * Send a track event.

--- a/src/Tracking/TrackClient.php
+++ b/src/Tracking/TrackClient.php
@@ -37,16 +37,7 @@ class TrackClient {
 			throw new InvalidArgumentException( 'Pass valid track id and tracked data to TrackClient' );
 		}
 
-		$url = add_query_arg(
-			[
-				'en' => $trackId,
-				'ts' => time(),
-			],
-			self::SERVER_URL
-		);
-
-		$trackData['server']  = ( new ServerData() )->get();
-		$trackData['website'] = ( new WebsiteData() )->get();
+		$trackData['request_timestamp'] = time();
 
 		// Set a 'content-type' header of 'application/json'.
 		$tracking_request_args = [
@@ -59,6 +50,19 @@ class TrackClient {
 			'data_format' => 'body',
 		];
 
-		wp_remote_post( $url, $tracking_request_args );
+		wp_remote_post( $this->getApiUrl( $trackId ), $tracking_request_args );
+	}
+
+	/**
+	 * Get api url.
+	 *
+	 * @since 2.10.0
+	 *
+	 * @param $trackId
+	 *
+	 * @return string
+	 */
+	private function getApiUrl( $trackId ) {
+		return self::SERVER_URL . '/' . $trackId;
 	}
 }

--- a/src/Tracking/TrackClient.php
+++ b/src/Tracking/TrackClient.php
@@ -1,8 +1,6 @@
 <?php
 namespace Give\Tracking;
 
-use Give\Tracking\TrackingData\ServerData;
-use Give\Tracking\TrackingData\WebsiteData;
 use InvalidArgumentException;
 use WP_Error;
 
@@ -60,7 +58,7 @@ class TrackClient {
 	 *
 	 * @since 2.10.0
 	 *
-	 * @param $trackId
+	 * @param string $trackId
 	 *
 	 * @return string
 	 */

--- a/src/Tracking/TrackingData/ServerData.php
+++ b/src/Tracking/TrackingData/ServerData.php
@@ -62,9 +62,9 @@ class ServerData implements TrackData {
 
 		$curl = curl_version();
 
-		$ssl_support = true;
+		$ssl_support = 1;
 		if ( ! $curl['features'] && CURL_VERSION_SSL ) {
-			$ssl_support = false;
+			$ssl_support = 0;
 		}
 
 		return [

--- a/src/Tracking/TrackingData/ServerData.php
+++ b/src/Tracking/TrackingData/ServerData.php
@@ -37,13 +37,13 @@ class ServerData implements TrackData {
 		// Validate if the server address is a valid IP-address.
 		$ipaddress = filter_input( INPUT_SERVER, 'SERVER_ADDR', FILTER_VALIDATE_IP );
 		if ( $ipaddress ) {
-			$server_data['ip']       = $ipaddress;
-			$server_data['Hostname'] = gethostbyaddr( $ipaddress );
+			$server_data['server_ip']       = $ipaddress;
+			$server_data['server_hostname'] = gethostbyaddr( $ipaddress );
 		}
 
-		$server_data['os']          = php_uname();
-		$server_data['PhpVersion']  = PHP_VERSION;
-		$server_data['CurlVersion'] = $this->getCurlInfo();
+		$server_data['server_os']   = php_uname();
+		$server_data['php_version'] = PHP_VERSION;
+		$server_data                = array_merge( $server_data, $this->getCurlInfo() );
 
 		return $server_data;
 	}
@@ -68,8 +68,8 @@ class ServerData implements TrackData {
 		}
 
 		return [
-			'version'    => $curl['version'],
-			'sslSupport' => $ssl_support,
+			'curl_version' => $curl['version'],
+			'is_ssl'       => $ssl_support,
 		];
 	}
 }

--- a/src/Tracking/TrackingData/WebsiteData.php
+++ b/src/Tracking/TrackingData/WebsiteData.php
@@ -24,14 +24,13 @@ class WebsiteData implements TrackData {
 		global $wp_version;
 
 		return [
-			'siteTitle'    => get_option( 'blogname' ),
-			'timestamp'    => (int) date( 'Uv' ),
-			'wpVersion'    => $wp_version,
-			'homeURL'      => home_url(),
-			'adminURL'     => admin_url(),
-			'email'        => get_bloginfo( 'admin_email' ),
-			'isMultisite'  => absint( is_multisite() ),
-			'siteLanguage' => get_bloginfo( 'language' ),
+			'site_title'     => get_option( 'blogname' ),
+			'wp_version'     => $wp_version,
+			'givewp_version' => GIVE_VERSION,
+			'home_url'       => home_url(),
+			'admin_url'      => admin_url(),
+			'is_multisite'   => absint( is_multisite() ),
+			'site_language'  => get_bloginfo( 'language' ),
 		];
 	}
 }

--- a/src/Tracking/TrackingServiceProvider.php
+++ b/src/Tracking/TrackingServiceProvider.php
@@ -45,7 +45,7 @@ class TrackingServiceProvider implements ServiceProvider {
 			Hooks::addAction( 'give_hide_opt_in_notice_shortly', AdminActionHandler::class, 'optOutFromUsageTracking' );
 			Hooks::addAction( 'give_hide_opt_in_notice_permanently', AdminActionHandler::class, 'optOutFromUsageTracking' );
 			Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice', 0 );
-			Hooks::addAction( 'give_setup_page_before_sectioins', UsageTrackingOnBoarding::class, 'addNotice', 0 );
+			Hooks::addAction( 'give_setup_page_before_sections', UsageTrackingOnBoarding::class, 'addNotice', 0 );
 
 			// Register track events.
 			Hooks::addAction( 'update_option_give_settings', GivePluginSettingsTracking::class, 'record' );

--- a/src/Tracking/TrackingServiceProvider.php
+++ b/src/Tracking/TrackingServiceProvider.php
@@ -44,7 +44,7 @@ class TrackingServiceProvider implements ServiceProvider {
 			Hooks::addAction( 'give_opt_in_into_tracking', AdminActionHandler::class, 'optInToUsageTracking' );
 			Hooks::addAction( 'give_hide_opt_in_notice_shortly', AdminActionHandler::class, 'optOutFromUsageTracking' );
 			Hooks::addAction( 'give_hide_opt_in_notice_permanently', AdminActionHandler::class, 'optOutFromUsageTracking' );
-			Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice', 0 );
+			Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice' );
 			Hooks::addAction( 'give_setup_page_before_sections', UsageTrackingOnBoarding::class, 'addNotice', 0 );
 
 			// Register track events.

--- a/src/Tracking/TrackingServiceProvider.php
+++ b/src/Tracking/TrackingServiceProvider.php
@@ -44,6 +44,7 @@ class TrackingServiceProvider implements ServiceProvider {
 			Hooks::addAction( 'give_opt_in_into_tracking', AdminActionHandler::class, 'optInToUsageTracking' );
 			Hooks::addAction( 'give_hide_opt_in_notice_shortly', AdminActionHandler::class, 'optOutFromUsageTracking' );
 			Hooks::addAction( 'give_hide_opt_in_notice_permanently', AdminActionHandler::class, 'optOutFromUsageTracking' );
+			Hooks::addAction( 'update_option_give_settings', AdminActionHandler::class, 'optInToUsageTrackingAdminGrantManually', 10, 2 );
 			Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice' );
 			Hooks::addAction( 'give_setup_page_before_sections', UsageTrackingOnBoarding::class, 'addNotice', 0 );
 

--- a/src/Tracking/ValueObjects/EventId.php
+++ b/src/Tracking/ValueObjects/EventId.php
@@ -9,7 +9,6 @@ namespace Give\Tracking\ValueObjects;
  * @since 2.10.0
  */
 class EventId {
-
 	const CREATE_TOKEN            = 'create-token';
 	const PLUGIN_SETTINGS_UPDATED = 'plugin-settings-updated';
 	const THEME_SWITCHED          = 'theme-switched';

--- a/src/Tracking/ValueObjects/EventId.php
+++ b/src/Tracking/ValueObjects/EventId.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Give\Tracking\ValueObjects;
+
+/**
+ * Class EventId
+ * @package Give\Tracking\ValueObjects
+ *
+ * @since 2.10.0
+ */
+class EventId {
+
+	const CREATE_TOKEN            = 'create-token';
+	const PLUGIN_SETTINGS_UPDATED = 'plugin-settings-updated';
+	const THEME_SWITCHED          = 'theme-switched';
+	const THEME_UPDATED           = 'theme-updated';
+	const PLUGIN_LIST_UPDATED     = 'plugin-list-updated';
+	const DONATION_METRICS        = 'donation-metrics';
+	const DONATION_FORM_UPDATED   = 'donation-form-updated';
+}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5589 

## Description

This pull request implements `api/v1/track-plugin-usage/create-token` telemetry API endpoint which generates an access token. The website can use this token to send data to the telemetry server.

## Visuals

**OptIn Notice**
![image](https://user-images.githubusercontent.com/1784821/107514906-4b8f8a80-6bd0-11eb-89e9-976da0606fcc.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

You can onboard to the telemetry server by clicking on `Opt-in` which appears in the admin notice or on the admin onboarding setup page. You can also generate an access token by manually changing the `Settings ->  Advanced  -> Usage Tracking` setting. The access token will store in the `give_telemetry_server_access_token` option.

Note:
1. I set server URL to local site: `https://givetelemetryserver.test/api/v1/track-plugin-usage`. Update it `TrackClient::SERVER_URL` if you have a different URL. Website setup introduction you will find in `Readme.md`:https://github.com/impress-org/give-telemetry-server.
2. After OptedIn notice will be disabled permanently and then admin can generate access token by manually update `Settings ->  Advanced  -> Usage Tracking` the setting to `enabled`. The access token will only generate if it is no already generated.
3. Test this pull request with the `develop` branch of https://github.com/impress-org/give-telemetry-server
