### PR TITLE
Add since-unreleased script for updating @unreleased docblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### New
+
+-   Add since-unreleased script for updating @unreleased docblocks. (#5602)
+
 ## 2.9.7 - 2021-02-09
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "issues": "https://github.com/impress-org/givewp/issues"
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "unreleased": "./vendor/bin/since-unreleased.sh"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "phpcompatibility/phpcompatibility-wp": "*",
         "wp-coding-standards/wpcs": "*",
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "^5",
+        "kjohnson/since-unreleased": "dev-master"
     },
     "keywords": [
         "wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc0dcf10ca939b11c001c3e575820f20",
+    "content-hash": "9c085cc23e5c3cfd17ef0e256f7ea77b",
     "packages": [
         {
             "name": "composer/installers",
@@ -530,6 +530,30 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "kjohnson/since-unreleased",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kjohnson/since-unreleased.git",
+                "reference": "009ed47f2660cded1f2d24f789a70f4fef90f86f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kjohnson/since-unreleased/zipball/009ed47f2660cded1f2d24f789a70f4fef90f86f",
+                "reference": "009ed47f2660cded1f2d24f789a70f4fef90f86f",
+                "shasum": ""
+            },
+            "bin": [
+                "bin/since-unreleased.sh"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "time": "2021-02-12T21:24:47+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2056,12 +2080,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
+                "url": "https://github.com/webmozart/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -2149,7 +2173,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "kjohnson/since-unreleased": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds the `kjohnson/since-unreleased` package to update `@unreleased` tags with version numbers.

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Run `composer install`
- Add `@unreleased` tag to a dockblock (php and/or js)
- Run `composer run unreleased 3.0.0`
- Tag(s) should be updated from `@unreleased` to `@since 3.0.0`
