### PR TITLE
Annual Receipts UI now connects to addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donation History and Dashboard tabs are now dynamically populated (#5455)
 -   Edit Profile UI is now implemented (#5463)
 -   Edit Profile tab now persists data (#5486)
+-   Annual Receipts UI now connects to addon (#5611)
 
 ### Changed
 -   Donor Profile Donation History UI is now polished (#5566)

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -201,7 +201,7 @@ class Donations {
 			'currency' => $payment->currency,
 			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
 			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
-			'method'   => $gateways[ $payment->gateway ]['checkout_label'],
+			'method'   => isset( $gateways[ $payment->gateway ]['checkout_label'] ) ? $gateways[ $payment->gateway ]['checkout_label'] : '',
 			'status'   => $this->getFormattedStatus( $payment->status ),
 			'date'     => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
 			'time'     => date_i18n( 'g:i a', strtotime( $payment->date ) ),

--- a/src/DonorProfiles/resources/js/app/components/annual-receipt-table/annual-receipt-row/index.js
+++ b/src/DonorProfiles/resources/js/app/components/annual-receipt-table/annual-receipt-row/index.js
@@ -1,0 +1,27 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+const { __ } = wp.i18n;
+
+const AnnualReceiptRow = ( { annualReceipt } ) => {
+	const { year, amount, count, statementUrl } = annualReceipt[ 1 ];
+
+	return (
+		<div className="give-donor-profile-table__row">
+			<div className="give-donor-profile-table__column">
+				{ year.label }
+			</div>
+			<div className="give-donor-profile-table__column">
+				{ amount.formatted }
+			</div>
+			<div className="give-donor-profile-table__column">
+				{ count }
+			</div>
+			<div className="give-donor-profile-table__column">
+				<a href={ statementUrl }>
+					{ __( 'View Receipt', 'give' ) } <FontAwesomeIcon icon="arrow-right" />
+				</a>
+			</div>
+		</div>
+	);
+};
+
+export default AnnualReceiptRow;

--- a/src/DonorProfiles/resources/js/app/components/annual-receipt-table/index.js
+++ b/src/DonorProfiles/resources/js/app/components/annual-receipt-table/index.js
@@ -1,0 +1,92 @@
+import { Fragment, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+const { __ } = wp.i18n;
+
+import Table from '../table';
+import AnnualReceiptRow from './annual-receipt-row';
+
+import './style.scss';
+
+const AnnualReceiptTable = ( { annualReceipts, perPage } ) => {
+	const [ page, setPage ] = useState( 1 );
+
+	const getStartIndex = () => {
+		return ( page - 1 ) * perPage;
+	};
+
+	const getEndIndex = () => {
+		return start + perPage <= annualReceiptsArray.length ? start + perPage : annualReceiptsArray.length;
+	};
+
+	const getAnnualReceiptRows = () => {
+		return annualReceiptsArray.reduce( ( rows, annualReceipt, index ) => {
+			if ( index >= start && index < end ) {
+				rows.push( <AnnualReceiptRow key={ index } annualReceipt={ annualReceipt } /> );
+			}
+			return rows;
+		}, [] );
+	};
+
+	let annualReceiptRows = [];
+	let annualReceiptsArray = [];
+	let start = 0;
+	let end = perPage;
+	let lastPage = 1;
+
+	if ( annualReceipts ) {
+		annualReceiptsArray = Object.entries( annualReceipts );
+		start = getStartIndex();
+		end = getEndIndex();
+		lastPage = Math.ceil( annualReceiptsArray.length / perPage );
+		annualReceiptRows = getAnnualReceiptRows();
+	}
+
+	return (
+		<Table
+			header={
+				<Fragment>
+					<div className="give-donor-profile-table__column">
+						{ __( 'Year', 'give' ) }
+					</div>
+					<div className="give-donor-profile-table__column">
+						{ __( 'Amount', 'give' ) }
+					</div>
+					<div className="give-donor-profile-table__column">
+						{ __( 'Count', 'give' ) }
+					</div>
+					<div className="give-donor-profile-table__column">
+						{ __( 'Statement', 'give' ) }
+					</div>
+				</Fragment>
+			}
+
+			rows={
+				<Fragment>
+					{ annualReceiptRows }
+				</Fragment>
+			}
+
+			footer={
+				<Fragment>
+					<div className="give-donor-profile-table__footer-text">
+						{ annualReceipts && `${ __( 'Showing', 'give' ) } ${ start + 1 } - ${ end } ${ __( 'of', 'give' ) } ${ annualReceiptsArray.length } ${ __( 'Donations', 'give' ) }` }
+					</div>
+					<div className="give-donor-profile-table__footer-nav">
+						{ page - 1 >= 1 && (
+							<a onClick={ () => setPage( page - 1 ) }>
+								<FontAwesomeIcon icon="chevron-left" />
+							</a>
+						) }
+						{ page <= lastPage && (
+							<a onClick={ () => setPage( page + 1 ) }>
+								<FontAwesomeIcon icon="chevron-right" />
+							</a>
+						) }
+					</div>
+				</Fragment>
+			}
+		/>
+	);
+};
+
+export default AnnualReceiptTable;

--- a/src/DonorProfiles/resources/js/app/components/annual-receipt-table/style.scss
+++ b/src/DonorProfiles/resources/js/app/components/annual-receipt-table/style.scss
@@ -1,0 +1,60 @@
+.give-donor-profile-table__footer-nav {
+	a {
+		border: none;
+		color: #9fa2b4;
+		cursor: pointer;
+	}
+	svg {
+		margin: 8px;
+	}
+}
+
+.give-donor-profile-table__donation-date,
+.give-donor-profile-table__donation-time {
+	white-space: nowrap;
+}
+
+.give-donor-profile-table__row {
+	line-height: 1.6;
+
+	.give-donor-profile-table__donation-amount {
+		font-size: 18px;
+		color: #424242;
+		font-weight: 500;
+	}
+
+	.give-donor-profile-table__donation-status {
+		display: flex;
+		align-items: center;
+
+		.give-donor-profile-table__donation-status-indicator {
+			width: 12px;
+			height: 12px;
+			border-radius: 50%;
+			overflow: hidden;
+			margin-right: 6px;
+		}
+	}
+
+	.give-donor-profile-table__donation-test-tag {
+		color: #fff;
+		background: #ffba00;
+		padding: 4px 8px;
+		border-radius: 5px;
+		font-weight: 500;
+		font-size: 12px;
+		line-height: 1;
+		margin-top: 4px;
+		display: inline-block;
+	}
+
+	.give-donor-profile-table__donation-id {
+		color: #6b6b6b;
+	}
+
+	.give-donor-profile-table__donation-receipt a {
+		color: #3398db;
+		text-decoration: none;
+		border: none;
+	}
+}

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/content.js
@@ -12,6 +12,8 @@ const Content = () => {
 	const annualReceipts = useSelector( ( state ) => state.annualReceipts );
 	const querying = useSelector( ( state ) => state.querying );
 
+	const annualReceiptsCount = annualReceipts ? Object.entries( annualReceipts ).length : 0;
+
 	useEffect( () => {
 		fetchAnnualReceiptsFromAPI();
 	}, [] );
@@ -26,7 +28,7 @@ const Content = () => {
 	) : (
 		<Fragment>
 			<Heading>
-				{ annualReceipts ? `${ Object.entries( annualReceipts ).length } ${ __( 'Total Annual Receipts', 'give' ) }` : __( '0 Total Annual Receipts', 'give' ) }
+				{ `${ annualReceiptsCount } ${ __( 'Total Annual Receipts', 'give' ) }` }
 			</Heading>
 			<AnnualReceiptTable annualReceipts={ annualReceipts } perPage={ 5 } />
 		</Fragment>

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/content.js
@@ -1,12 +1,34 @@
+import { Fragment, useEffect } from 'react';
+
+const { __ } = wp.i18n;
+
 import Heading from '../../components/heading';
-import { Fragment } from 'react';
+import AnnualReceiptTable from '../../components/annual-receipt-table';
+
+import { useSelector } from './hooks';
+import { fetchAnnualReceiptsFromAPI } from './utils';
 
 const Content = () => {
-	return (
+	const annualReceipts = useSelector( ( state ) => state.annualReceipts );
+	const querying = useSelector( ( state ) => state.querying );
+
+	useEffect( () => {
+		fetchAnnualReceiptsFromAPI();
+	}, [] );
+
+	return querying === true && annualReceipts === null ? (
 		<Fragment>
 			<Heading>
-				Annual Receipts
+				{ __( 'Loading...', 'give' ) }
 			</Heading>
+			<AnnualReceiptTable />
+		</Fragment>
+	) : (
+		<Fragment>
+			<Heading>
+				{ annualReceipts ? `${ Object.entries( annualReceipts ).length } ${ __( 'Total Annual Receipts', 'give' ) }` : __( '0 Total Annual Receipts', 'give' ) }
+			</Heading>
+			<AnnualReceiptTable annualReceipts={ annualReceipts } perPage={ 5 } />
 		</Fragment>
 	);
 };

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/hooks/index.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/hooks/index.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { store } from '../store';
+
+export const useSelector = ( select ) => {
+	const [ selected, setSelected ] = useState( select( store.getState() ) );
+	useEffect( () => {
+		const handleChange = () => {
+			setSelected( select( store.getState() ) );
+		};
+		const unsubscribe = store.subscribe( handleChange );
+		return function cleanup() {
+			unsubscribe();
+		};
+	}, [] );
+	return selected;
+};

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/actions.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/actions.js
@@ -1,0 +1,18 @@
+export const setAnnualReceipts = ( annualReceipts ) => {
+	return {
+		type: 'SET_ANNUAL_RECEIPTS',
+		payload: {
+			annualReceipts,
+		},
+	};
+};
+
+export const setQuerying = ( querying ) => {
+	return {
+		type: 'SET_QUERYING',
+		payload: {
+			querying,
+		},
+	};
+};
+

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/index.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/index.js
@@ -1,0 +1,4 @@
+import { createStore } from 'redux';
+import { reducer } from './reducer';
+
+export const store = createStore( reducer );

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/initialState.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/initialState.js
@@ -1,0 +1,4 @@
+export const initialState = {
+	annualReceipts: null,
+	querying: false,
+};

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/reducer.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/store/reducer.js
@@ -1,0 +1,18 @@
+import { initialState } from './initialState';
+
+export const reducer = ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case 'SET_ANNUAL_RECEIPTS':
+			return {
+				...state,
+				annualReceipts: action.payload.annualReceipts,
+			};
+		case 'SET_QUERYING':
+			return {
+				...state,
+				querying: action.payload.querying,
+			};
+		default:
+			return state;
+	}
+};

--- a/src/DonorProfiles/resources/js/app/tabs/annual-receipts/utils/index.js
+++ b/src/DonorProfiles/resources/js/app/tabs/annual-receipts/utils/index.js
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { store } from '../store';
+import { getAPIRoot, getAPINonce } from '../../../utils';
+import { setAnnualReceipts, setQuerying } from '../store/actions';
+
+export const fetchAnnualReceiptsFromAPI = () => {
+	const { dispatch } = store;
+
+	dispatch( setQuerying( true ) );
+	axios.post( getAPIRoot() + 'give-api/v2/donor-profile/annual-receipts', {},
+		{
+			headers: {
+				'X-WP-Nonce': getAPINonce(),
+			},
+		} )
+		.then( ( response ) => response.data )
+		.then( ( data ) => {
+			const { receipts } = data;
+			dispatch( setAnnualReceipts( receipts ) );
+			dispatch( setQuerying( false ) );
+		} );
+};


### PR DESCRIPTION
**_NOTE: This PR is dependent up work done in this Give Annual Receipts PR: https://github.com/impress-org/give-annual-receipts/pull/89_**

Resolves #5603

## Description

This PR introduces improvements to the Annual Receipts tab UI, so that it can dynamically populate the Annual Receipts table using data fetched from the Annual Receipts addon. 

## Affects

This PR primarily affects frontend rendering of the Donor Profiles application, and specifically the Annual Receipts tab.

## Visuals

<img width="955" alt="Screen Shot 2021-02-17 at 4 42 40 PM" src="https://user-images.githubusercontent.com/5186078/108271843-6e292280-713f-11eb-8308-636453754cab.png">

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions