### PR TITLE
PDF Receipts are now available from Donation Receipt pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donation History and Dashboard tabs are now dynamically populated (#5455)
 -   Edit Profile UI is now implemented (#5463)
 -   Edit Profile tab now persists data (#5486)
+-   PDF Receipts are now available from Donation Receipt pages (#5613)
 
 ### Changed
 -   Donor Profile Donation History UI is now polished (#5566)

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -196,7 +196,7 @@ class Donations {
 
 		$pdfReceiptUrl = '';
 		if ( class_exists( 'Give_PDF_Receipts' ) ) {
-			$pdfReceiptUrl = esc_url( \Give_PDF_Receipts::get_instance()->engine->get_pdf_receipt_url( $payment->id ) );
+			$pdfReceiptUrl = give_pdf_receipts()->engine->get_pdf_receipt_url( $payment->ID );
 		}
 
 		$gateways = give_get_payment_gateways();

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -196,7 +196,7 @@ class Donations {
 
 		$pdfReceiptUrl = '';
 		if ( class_exists( 'Give_PDF_Receipts' ) ) {
-			$pdfReceiptUrl = give_pdf_receipts()->engine->get_pdf_receipt_url( $payment->ID );
+			$pdfReceiptUrl = html_entity_decode( give_pdf_receipts()->engine->get_pdf_receipt_url( $payment->ID ) );
 		}
 
 		$gateways = give_get_payment_gateways();

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -169,15 +169,15 @@ class Donations {
 		$gateways = give_get_payment_gateways();
 
 		return [
-			'amount'   => $this->getFormattedAmount( $payment->subtotal, $payment ),
-			'currency' => $payment->currency,
-			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
-			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
-			'method'   => isset( $gateways[ $payment->gateway ]['checkout_label'] ) ? $gateways[ $payment->gateway ]['checkout_label'] : '',
-			'status'   => $this->getFormattedStatus( $payment->status ),
-			'date'     => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
-			'time'     => date_i18n( 'g:i a', strtotime( $payment->date ) ),
-			'mode'     => $payment->get_meta( '_give_payment_mode' ),
+			'amount'        => $this->getFormattedAmount( $payment->subtotal, $payment ),
+			'currency'      => $payment->currency,
+			'fee'           => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
+			'total'         => $this->getFormattedAmount( $payment->total, $payment ),
+			'method'        => isset( $gateways[ $payment->gateway ]['checkout_label'] ) ? $gateways[ $payment->gateway ]['checkout_label'] : '',
+			'status'        => $this->getFormattedStatus( $payment->status ),
+			'date'          => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
+			'time'          => date_i18n( 'g:i a', strtotime( $payment->date ) ),
+			'mode'          => $payment->get_meta( '_give_payment_mode' ),
 			'pdfReceiptUrl' => $pdfReceiptUrl,
 		];
 	}

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -194,18 +194,24 @@ class Donations {
 	 */
 	protected function getPaymentInfo( $payment ) {
 
+		$pdfReceiptUrl = '';
+		if ( class_exists( 'Give_PDF_Receipts' ) ) {
+			$pdfReceiptUrl = \Give_PDF_Receipts::get_instance()->engine->get_pdf_receipt_url( $payment->id );
+		}
+
 		$gateways = give_get_payment_gateways();
 
 		return [
-			'amount'   => $this->getFormattedAmount( $payment->subtotal, $payment ),
-			'currency' => $payment->currency,
-			'fee'      => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
-			'total'    => $this->getFormattedAmount( $payment->total, $payment ),
-			'method'   => $gateways[ $payment->gateway ]['checkout_label'],
-			'status'   => $this->getFormattedStatus( $payment->status ),
-			'date'     => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
-			'time'     => date_i18n( 'g:i a', strtotime( $payment->date ) ),
-			'mode'     => $payment->get_meta( '_give_payment_mode' ),
+			'amount'        => $this->getFormattedAmount( $payment->subtotal, $payment ),
+			'currency'      => $payment->currency,
+			'fee'           => $this->getFormattedAmount( ( $payment->total - $payment->subtotal ), $payment ),
+			'total'         => $this->getFormattedAmount( $payment->total, $payment ),
+			'method'        => $gateways[ $payment->gateway ]['checkout_label'],
+			'status'        => $this->getFormattedStatus( $payment->status ),
+			'date'          => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
+			'time'          => date_i18n( 'g:i a', strtotime( $payment->date ) ),
+			'mode'          => $payment->get_meta( '_give_payment_mode' ),
+			'pdfReceiptUrl' => $pdfReceiptUrl,
 		];
 	}
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -196,7 +196,7 @@ class Donations {
 
 		$pdfReceiptUrl = '';
 		if ( class_exists( 'Give_PDF_Receipts' ) ) {
-			$pdfReceiptUrl = \Give_PDF_Receipts::get_instance()->engine->get_pdf_receipt_url( $payment->id );
+			$pdfReceiptUrl = esc_url( \Give_PDF_Receipts::get_instance()->engine->get_pdf_receipt_url( $payment->id ) );
 		}
 
 		$gateways = give_get_payment_gateways();

--- a/src/DonorProfiles/resources/js/app/components/button/index.js
+++ b/src/DonorProfiles/resources/js/app/components/button/index.js
@@ -1,7 +1,19 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import './style.scss';
 
-const Button = ( { icon, children, onClick } ) => {
+const Button = ( { icon, children, onClick, href } ) => {
+	const handleHrefClick = ( e ) => {
+		e.preventDefault();
+		window.parent.location = href;
+	};
+
+	if ( href ) {
+		return (
+			<a className="give-donor-profile-button give-donor-profile-button--primary" onClick={ ( e ) => handleHrefClick( e ) } href={ href }>
+				{ children }{ icon && ( <FontAwesomeIcon icon={ icon } /> ) }
+			</a>
+		);
+	}
 	return (
 		<button className="give-donor-profile-button give-donor-profile-button--primary" onClick={ () => onClick() }>
 			{ children }{ icon && ( <FontAwesomeIcon icon={ icon } /> ) }

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
@@ -51,7 +51,7 @@ const Content = () => {
 						<FontAwesomeIcon icon="arrow-left" /> { __( 'Back to Donation History', 'give' ) }
 					</Link>
 					{ getDonationById( id ).payment.pdfReceiptUrl.length && (
-						<Button icon="file-pdf" onClick={ () => window.location = getDonationById( id ).payment.pdfReceiptUrl }>
+						<Button icon="file-pdf" href={ getDonationById( id ).payment.pdfReceiptUrl }>
 							{ __( 'Download Receipt', 'give' ) }
 						</Button>
 					) }

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 const { __ } = wp.i18n;
 
 import Heading from '../../components/heading';
+import Button from '../../components/button';
 import DonationReceipt from '../../components/donation-receipt';
 import DonationTable from '../../components/donation-table';
 
@@ -37,10 +38,15 @@ const Content = () => {
 					{ __( 'Donation', 'give' ) } #{ id }
 				</Heading>
 				<DonationReceipt donation={ donations[ id ] } />
-				<div className="give-donor-profile__donation-history-link">
+				<div className="give-donor-profile__donation-history-footer">
 					<Link to="/donation-history">
 						<FontAwesomeIcon icon="arrow-left" /> { __( 'Back to Donation History', 'give' ) }
 					</Link>
+					{ donations[ id ].payment.pdfReceiptUrl.length && (
+						<Button icon="file-pdf" onClick={ () => window.location = donations[ id ].payment.pdfReceiptUrl }>
+							{ __( 'Download Receipt', 'give' ) }
+						</Button>
+					) }
 				</div>
 			</Fragment>
 		);

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/style.scss
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/style.scss
@@ -1,5 +1,6 @@
-.give-donor-profile__donation-history-link {
-	display: inline-block;
+.give-donor-profile__donation-history-footer {
+	display: flex;
+	justify-content: space-between;
 
 	a {
 		color: #3398db;


### PR DESCRIPTION
Resolves #5604 

## Description

This PR makes the Donor Profile application aware of PDF receipts, so that a "Download Receipt" button is added to the Donation Receipt page when the PDF Receipt addon is activated.

## Affects

This PR affects frontend rendering logic of the Donor Profile application, and the Donations repository.

## Visuals

<img width="954" alt="Screen Shot 2021-02-17 at 5 28 39 PM" src="https://user-images.githubusercontent.com/5186078/108276562-ff9b9300-7145-11eb-8b95-ea74af21a4fd.png">

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
