### PR TITLE
Form Consumer implements Server Side Validation

### DIFF
--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -3,7 +3,6 @@
 namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Framework\FieldsAPI\FieldCollection;
-use Give\Form\LegacyConsumer\FieldView;
 
 /**
  * Setup field validation for custom fields on the required fields hook.

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -5,6 +5,11 @@ namespace Give\Form\LegacyConsumer\Commands;
 use Give\Framework\FieldsAPI\FieldCollection;
 use Give\Form\LegacyConsumer\FieldView;
 
+/**
+ * Setup field validation for custom fields on the required fields hook.
+ *
+ * @unreleased
+ */
 class SetupFieldValidation implements HookCommandInterface {
 	public function __invoke( $hook ) {
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Commands;
+
+use Give\Framework\FieldsAPI\FieldCollection;
+use Give\Form\LegacyConsumer\FieldView;
+
+class SetupFieldValidation implements HookCommandInterface {
+	public function __invoke( $hook ) {
+
+			// Register custom fields during processing to validate required.
+			add_action(
+				'give_donation_form_required_fields',
+				function( $requiredFields, $formID ) use ( $hook ) {
+						$fieldCollection = new FieldCollection( 'root' );
+						do_action( "give_fields_$hook", $fieldCollection, $formID );
+						$fieldCollection->walk(
+							function( $field ) use ( &$requiredFields ) {
+								if ( $field->isRequired() ) {
+										$requiredFields[ $field->getName() ] = $field->getRequiredError();
+								}
+							}
+						);
+						return $requiredFields;
+				},
+				10,
+				2
+			);
+	}
+}
+

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -19,24 +19,5 @@ class SetupNewTemplateHook implements HookCommandInterface {
 				}
 			}
 		);
-
-		// Register custom fields during processing to validate required.
-		add_action(
-			'give_donation_form_required_fields',
-			function( $requiredFields, $formID ) use ( $hook ) {
-				$fieldCollection = new FieldCollection( 'root' );
-				do_action( "give_fields_$hook", $fieldCollection, $formID );
-				$fieldCollection->walk(
-					function( $field ) use ( &$requiredFields ) {
-						if ( $field->isRequired() ) {
-							$requiredFields[ $field->getName() ] = $field->getRequiredError();
-						}
-					}
-				);
-				return $requiredFields;
-			},
-			10,
-			2
-		);
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -6,13 +6,37 @@ use Give\Framework\FieldsAPI\FieldCollection;
 use Give\Form\LegacyConsumer\FieldView;
 
 class SetupNewTemplateHook implements HookCommandInterface {
-    public function __invoke( $hook ) {
-        add_action( "give_$hook", function( $formID ) use ( $hook ) {
-            $fieldCollection = new FieldCollection( 'root' );
-            do_action( "give_fields_$hook", $fieldCollection, $formID );
-            foreach( $fieldCollection->getFields() as $field ) {
-                FieldView::render( $field );
-            }
-        });
-    }
+	public function __invoke( $hook ) {
+
+		// On the old hook, run the new hook and render the fields.
+		add_action(
+			"give_$hook",
+			function( $formID ) use ( $hook ) {
+				$fieldCollection = new FieldCollection( 'root' );
+				do_action( "give_fields_$hook", $fieldCollection, $formID );
+				foreach ( $fieldCollection->getFields() as $field ) {
+					FieldView::render( $field );
+				}
+			}
+		);
+
+		// Register custom fields during processing to validate required.
+		add_action(
+			'give_donation_form_required_fields',
+			function( $requiredFields, $formID ) use ( $hook ) {
+				$fieldCollection = new FieldCollection( 'root' );
+				do_action( "give_fields_$hook", $fieldCollection, $formID );
+				$fieldCollection->walk(
+					function( $field ) use ( &$requiredFields ) {
+						if ( $field->isRequired() ) {
+							$requiredFields[ $field->getName() ] = $field->getRequiredError();
+						}
+					}
+				);
+				return $requiredFields;
+			},
+			10,
+			2
+		);
+	}
 }

--- a/src/Form/LegacyConsumer/ServiceProvider.php
+++ b/src/Form/LegacyConsumer/ServiceProvider.php
@@ -13,10 +13,13 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function register() {
 		include_once plugin_dir_path( __FILE__ ) . '/functions.php';
-		give()->bind( DeprecateOldTemplateHook::class, function() {
-			global $wp_filter;
-			return new DeprecateOldTemplateHook( $wp_filter );
-		} );
+		give()->bind(
+			DeprecateOldTemplateHook::class,
+			function() {
+				global $wp_filter;
+				return new DeprecateOldTemplateHook( $wp_filter );
+			}
+		);
 	}
 
 	/**
@@ -24,7 +27,8 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function boot() {
 		give( TemplateHooks::class )->walk( give( Commands\SetupNewTemplateHook::class ) );
-		if( ! wp_doing_ajax() ) {
+		give( TemplateHooks::class )->walk( give( Commands\SetupFieldValidation::class ) );
+		if ( ! wp_doing_ajax() ) {
 			give( TemplateHooks::class )->walk( give( Commands\DeprecateOldTemplateHook::class ) );
 		}
 	}

--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -1,8 +1,10 @@
 <input
-    type="checkbox"
-    class="give-input required"
-    name="give_<?php echo $field->getName(); ?>"
-    id="give-<?php echo $field->getName(); ?>"
-    required="" aria-required="true"
-    tabindex="1"
-    />
+	type="checkbox"
+	class="give-input required"
+	name="give_<?php echo $field->getName(); ?>"
+	id="give-<?php echo $field->getName(); ?>"
+	<?php if ( $field->isRequired() ) : ?>    
+		required="" aria-required="true"
+	<?php endif; ?>
+	tabindex="1"
+	/>

--- a/src/Form/LegacyConsumer/templates/select.html.php
+++ b/src/Form/LegacyConsumer/templates/select.html.php
@@ -1,12 +1,14 @@
 <select
-    name="give_<?php echo $field->getName(); ?>"
-    id="give-<?php echo $field->getName(); ?>"
-    class="give-input required"
-    placeholder="<?php echo $field->getLabel(); ?>"
-    required="" aria-required="true"
-    tabindex="1"
+	name="give_<?php echo $field->getName(); ?>"
+	id="give-<?php echo $field->getName(); ?>"
+	class="give-input required"
+	placeholder="<?php echo $field->getLabel(); ?>"
+	<?php if ( $field->isRequired() ) : ?>    
+		required="" aria-required="true"
+	<?php endif; ?>
+	tabindex="1"
 >
-    <?php foreach( $field->getOptions() as $key => $value ): ?>
-    <option value="<?php echo $key; ?>"><?php echo $value; ?></option>
-    <?php endforeach; ?>
+	<?php foreach ( $field->getOptions() as $key => $value ) : ?>
+	<option value="<?php echo $key; ?>"><?php echo $value; ?></option>
+	<?php endforeach; ?>
 </select>

--- a/src/Form/LegacyConsumer/templates/text.html.php
+++ b/src/Form/LegacyConsumer/templates/text.html.php
@@ -1,9 +1,11 @@
 <input
-    type="text"
-    class="give-input required"
-    name="give_<?php echo $field->getName(); ?>"
-    id="give-<?php echo $field->getName(); ?>"
-    placeholder="<?php echo $field->getLabel(); ?>"
-    required="" aria-required="true"
-    tabindex="1"
-    />
+	type="text"
+	class="give-input required"
+	name="<?php echo $field->getName(); ?>"
+	id="give-<?php echo $field->getName(); ?>"
+	placeholder="<?php echo $field->getLabel(); ?>"
+	<?php if ( $field->isRequired() ) : ?>    
+		required="" aria-required="true"
+	<?php endif; ?>
+	tabindex="1"
+	/>

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -1,8 +1,10 @@
 <textarea
-    class="give-input required"
-    name="give_<?php echo $field->getName(); ?>"
-    id="give-<?php echo $field->getName(); ?>"
-    placeholder="<?php echo $field->getLabel(); ?>"
-    required="" aria-required="true"
-    tabindex="1"
-    ></textarea>
+	class="give-input required"
+	name="give_<?php echo $field->getName(); ?>"
+	id="give-<?php echo $field->getName(); ?>"
+	placeholder="<?php echo $field->getLabel(); ?>"
+	<?php if ( $field->isRequired() ) : ?>    
+		required="" aria-required="true"
+	<?php endif; ?>
+	tabindex="1"
+	></textarea>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5596

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Adds a hook to register required fields.
- Updates required attributes in templates.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Add a custom field using the new Fields API and set the field as `required`.

The form JS will validate, so you'll need to edit the DOM to manually remove the required attribute so that the form will submit - and then trip server side validation. (You can also inspect the network request and resend the POST without the custom field value).

```php
/**
 * Plugin Name: Give Custom Fields
 */

add_action( 'give_fields_after_donation_levels', function( $fieldCollection, $formID ) {
        $fieldCollection->append(
                give_field( 'text', 'my-custom-field' )
                        ->label( 'My Custom Field' )
                        ->required()
        );
}, 10, 2 );
```
