### PR TITLE
Zip Code required field indicator now toggles correctly for the Legacy Form template

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -136,7 +136,7 @@ jQuery( function( $ ) {
 					$form.find( 'input#card_zip' ).toggleClass( 'required', zipRequired )
 						.attr( 'required', zipRequired )
 						.attr( 'aria-required', zipRequired );
-					$form.find( 'label[for="card_zip"] span.give-required-indicator' ).toggleClass( 'give-hidden', zipRequired );
+					$form.find( 'label[for="card_zip"] span.give-required-indicator' ).toggleClass( 'give-hidden', ! zipRequired );
 
 					doc.trigger( 'give_checkout_billing_address_updated', [ response, $form.attr( 'id' ) ] );
 				},


### PR DESCRIPTION
Resolves #5626 

## Description

The state parameter in toggleClass function should be inverted. If the zipcode is required, then it should return "false" instead of "true" so it can properly display or hide the required indicator.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Go to a donation form
2. Select a country where the zipcode is required
3. Scroll down to zipcode field
4. Required indicator is displayed
