### PR TITLE
Support for the Migration title and Source column is now implemented

### DIFF
--- a/src/API/Endpoints/Migrations/GetMigrations.php
+++ b/src/API/Endpoints/Migrations/GetMigrations.php
@@ -20,7 +20,7 @@ class GetMigrations extends Endpoint {
 	/**
 	 * Enable sorting by these columns
 	 */
-	const SORTABLE_COLUMNS = [ 'id', 'status', 'last_run', 'run_order' ];
+	const SORTABLE_COLUMNS = [ 'id', 'status', 'last_run', 'run_order', 'title', 'source' ];
 
 	/** @var string */
 	protected $endpoint = 'migrations/get-migrations';
@@ -147,12 +147,17 @@ class GetMigrations extends Endpoint {
 				continue;
 			}
 
+			/* @var Migration $migrationClass */
+			$migrationClass = $this->migrationRegister->getMigration( $migration->getId() );
+
 			$data[] = [
 				'id'        => $migration->getId(),
 				'status'    => $migration->getStatus(),
 				'error'     => $migration->getError(),
 				'last_run'  => $migration->getLastRunDate(),
 				'run_order' => $this->migrationHelper->getRunOrderForMigration( $migration->getId() ),
+				'source'    => $migrationClass::source(),
+				'title'     => $migrationClass::title(),
 			];
 		}
 
@@ -165,6 +170,8 @@ class GetMigrations extends Endpoint {
 				'error'     => '',
 				'last_run'  => '',
 				'run_order' => $this->migrationHelper->getRunOrderForMigration( $migration::id() ),
+				'source'    => $migration::source(),
+				'title'     => $migration::title(),
 			];
 		}
 

--- a/src/Framework/Migrations/Contracts/Migration.php
+++ b/src/Framework/Migrations/Contracts/Migration.php
@@ -49,7 +49,7 @@ abstract class Migration {
 	 * @return string
 	 */
 	public static function title() {
-		return self::id();
+		return static::id();
 	}
 
 
@@ -61,6 +61,6 @@ abstract class Migration {
 	 * @return string
 	 */
 	public static function source() {
-		return esc_html__( 'Core', 'give' );
+		return esc_html__( 'GiveWP Core', 'give' );
 	}
 }

--- a/src/Framework/Migrations/Contracts/Migration.php
+++ b/src/Framework/Migrations/Contracts/Migration.php
@@ -42,13 +42,25 @@ abstract class Migration {
 	}
 
 	/**
-	 * Run the migration check
+	 * Return migration title
 	 *
-	 * @since 2.9.7
+	 * @since 2.10.0
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	public function check() {
-		return true;
+	public static function title() {
+		return self::id();
+	}
+
+
+	/**
+	 * Return migration source
+	 *
+	 * @since 2.10.0
+	 *
+	 * @return string
+	 */
+	public static function source() {
+		return esc_html__( 'Core', 'give' );
 	}
 }

--- a/src/Log/Migrations/CreateNewLogTable.php
+++ b/src/Log/Migrations/CreateNewLogTable.php
@@ -24,6 +24,13 @@ class CreateNewLogTable extends Migration {
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function title() {
+		return  esc_html__( 'Create new give_log table' );
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function timestamp() {

--- a/src/Log/Migrations/DeleteOldLogTables.php
+++ b/src/Log/Migrations/DeleteOldLogTables.php
@@ -18,6 +18,13 @@ class DeleteOldLogTables extends Migration {
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function title() {
+		return  esc_html__( 'Delete give_logs and give_logmeta tables' );
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function timestamp() {

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -49,6 +49,13 @@ class MigrateExistingLogs extends Migration {
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function title() {
+		return  esc_html__( 'Migrate existing logs to give_log table' );
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function timestamp() {

--- a/src/MigrationLog/Admin/Migrations/index.js
+++ b/src/MigrationLog/Admin/Migrations/index.js
@@ -212,10 +212,10 @@ const Migrations = () => {
 			},
 		},
 		{
-			key: 'id',
-			label: __( 'Migration ID', 'give' ),
+			key: 'title',
+			label: __( 'Migration Title', 'give' ),
 			sort: true,
-			sortCallback: ( direction ) => setSortDirectionForColumn( 'id', direction ),
+			sortCallback: ( direction ) => setSortDirectionForColumn( 'title', direction ),
 		},
 		{
 			key: 'last_run',
@@ -223,7 +223,16 @@ const Migrations = () => {
 			sort: true,
 			sortCallback: ( direction ) => setSortDirectionForColumn( 'last_run', direction ),
 			styles: {
-				maxWidth: 220,
+				maxWidth: 200,
+			},
+		},
+		{
+			key: 'source',
+			label: __( 'Source', 'give' ),
+			sort: true,
+			sortCallback: ( direction ) => setSortDirectionForColumn( 'source', direction ),
+			styles: {
+				maxWidth: 200,
 			},
 		},
 		{
@@ -240,7 +249,7 @@ const Migrations = () => {
 			label: __( 'Actions', 'give' ),
 			append: true,
 			styles: {
-				maxWidth: 150,
+				maxWidth: 100,
 			},
 		},
 		{

--- a/src/MigrationLog/Migrations/CreateMigrationsTable.php
+++ b/src/MigrationLog/Migrations/CreateMigrationsTable.php
@@ -23,6 +23,13 @@ class CreateMigrationsTable extends Migration {
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function title() {
+		return  esc_html__( 'Create new give_migrations table' );
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function timestamp() {

--- a/src/MigrationLog/Migrations/MigrateCompletedMigrations.php
+++ b/src/MigrationLog/Migrations/MigrateCompletedMigrations.php
@@ -35,6 +35,13 @@ class MigrateCompletedMigrations extends Migration {
 	}
 
 	/**
+	 * @return string
+	 */
+	public static function title() {
+		return  esc_html__( 'Migrate completed migrations to give_migrations table' );
+	}
+
+	/**
 	 * @return int
 	 */
 	public static function timestamp() {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5631

## Description

This PR adds support for the Migration title and source columns. The `Migration` class is extended and 2 static methods, title and source, were added. 

## Affects

Migrations list table.
`Migration` class

## Visuals
![image](https://user-images.githubusercontent.com/4222590/108817135-b751fa00-75b7-11eb-9c45-a9f9b280b00b.png)


<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

Navigate to  `Donations -> Tools -> Data`
