### PR TITLE
Fields API throws an exception when inserting relative to a node that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+-   Fields API throws an exception when inserting relative to a node that does not exist (#5640)
+
 ## 2.9.6 - 2021-01-13
 
 ### New

--- a/src/Framework/FieldsAPI/FieldCollection/Exception/ReferenceNodeNotFoundException.php
+++ b/src/Framework/FieldsAPI/FieldCollection/Exception/ReferenceNodeNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\FieldCollection\Exception;
+
+/**
+ * @unreleased
+ */
+class ReferenceNodeNotFoundException extends \Exception {
+	public function __construct( $name, $code = 0, Exception $previous = null ) {
+		$message = "Reference node with the name \"$name\" not found - cannot insert new node.";
+		parent::__construct( $message, $code, $previous );
+	}
+}

--- a/src/Framework/FieldsAPI/FieldCollection/InsertNode.php
+++ b/src/Framework/FieldsAPI/FieldCollection/InsertNode.php
@@ -13,27 +13,40 @@ trait InsertNode {
 
 	/**
 	 * @unreleased
+	 *
+	 * @param string $siblingName
+	 * @param Node $node
+	 *
+	 * @return $this
 	 */
 	public function insertAfter( $siblingName, Node $node ) {
 		$this->checkNameCollisionDeep( $node );
-		$this->_insertAfter( $siblingName, $node );
+		$this->insertAfterRecursive( $siblingName, $node );
 		return $this;
 	}
 
 	/**
 	 * @unreleased
+	 *
+	 * @param string $siblingName
+	 * @param Node $node
+	 *
+	 * @throws ReferenceNodeNotFoundException
+	 *
+	 * @return void
 	 */
-	protected function _insertAfter( $siblingName, Node $node ) {
+	protected function insertAfterRecursive( $siblingName, Node $node ) {
 		$siblingIndex = $this->getNodeIndexByName( $siblingName );
 		if ( false !== $siblingIndex ) {
-			return $this->insertAtIndex(
+			$this->insertAtIndex(
 				$siblingIndex + 1,
 				$node
 			);
+			return;
 		} elseif ( $this->nodes ) {
 			foreach ( $this->nodes as $childNode ) {
 				if ( $childNode instanceof GroupNode ) {
-					$childNode->_insertAfter( $siblingName, $node );
+					$childNode->insertAfterRecursive( $siblingName, $node );
 				}
 			}
 			return;
@@ -43,27 +56,40 @@ trait InsertNode {
 
 	/**
 	 * @unreleased
+	 *
+	 * @param string $siblingName
+	 * @param Node $node
+	 *
+	 * @return $this
 	 */
 	public function insertBefore( $siblingName, Node $node ) {
 		$this->checkNameCollisionDeep( $node );
-		$this->_insertBefore( $siblingName, $node );
+		$this->insertBeforeRecursive( $siblingName, $node );
 		return $this;
 	}
 
 	/**
 	 * @unreleased
+	 *
+	 * @param string $siblingName
+	 * @param Node $node
+	 *
+	 * @throws ReferenceNodeNotFoundException
+	 *
+	 * @return void
 	 */
-	protected function _insertBefore( $siblingName, Node $node ) {
+	protected function insertBeforeRecursive( $siblingName, Node $node ) {
 		$siblingIndex = $this->getNodeIndexByName( $siblingName );
 		if ( false !== $siblingIndex ) {
-			return $this->insertAtIndex(
+			$this->insertAtIndex(
 				$siblingIndex - 1,
 				$node
 			);
+			return;
 		} elseif ( $this->nodes ) {
 			foreach ( $this->nodes as $childNode ) {
 				if ( $childNode instanceof GroupNode ) {
-					$childNode->_insertBefore( $siblingName, $node );
+					$childNode->insertBeforeRecursive( $siblingName, $node );
 				}
 			}
 			return;

--- a/src/Framework/FieldsAPI/FieldCollection/InsertNode.php
+++ b/src/Framework/FieldsAPI/FieldCollection/InsertNode.php
@@ -11,13 +11,18 @@ use Give\Framework\FieldsAPI\FieldCollection\Exception\ReferenceNodeNotFoundExce
  */
 trait InsertNode {
 
+	/**
+	 * @unreleased
+	 */
 	public function insertAfter( $siblingName, Node $node ) {
-		// Check that reference node exists.
 		$this->checkNameCollisionDeep( $node );
 		$this->_insertAfter( $siblingName, $node );
 		return $this;
 	}
 
+	/**
+	 * @unreleased
+	 */
 	protected function _insertAfter( $siblingName, Node $node ) {
 		$siblingIndex = $this->getNodeIndexByName( $siblingName );
 		if ( false !== $siblingIndex ) {
@@ -36,13 +41,18 @@ trait InsertNode {
 		throw new ReferenceNodeNotFoundException( $siblingName );
 	}
 
+	/**
+	 * @unreleased
+	 */
 	public function insertBefore( $siblingName, Node $node ) {
-		// Check that reference node exists.
 		$this->checkNameCollisionDeep( $node );
 		$this->_insertBefore( $siblingName, $node );
 		return $this;
 	}
 
+	/**
+	 * @unreleased
+	 */
 	protected function _insertBefore( $siblingName, Node $node ) {
 		$siblingIndex = $this->getNodeIndexByName( $siblingName );
 		if ( false !== $siblingIndex ) {
@@ -61,6 +71,9 @@ trait InsertNode {
 		throw new ReferenceNodeNotFoundException( $siblingName );
 	}
 
+	/**
+	 * @unreleased
+	 */
 	protected function insertAtIndex( $index, $node ) {
 		array_splice( $this->nodes, $index, 0, [ $node ] );
 	}

--- a/tests/unit/tests/Framework/FieldsAPI/FieldCollection/InsertNodeTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/FieldCollection/InsertNodeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Give\Framework\FieldsAPI\FormField;
+use Give\Framework\FieldsAPI\FieldCollection;
+use Give\Framework\FieldsAPI\FieldCollection\Exception\ReferenceNodeNotFoundException;
+
+final class InsertNodeTest extends TestCase {
+
+    public function testInsertAfter() {
+        $collection = new FieldCollection( 'root', [
+            new FormField( 'text', 'my-text-field' ),
+        ]);
+        $collection->insertAfter( 'my-text-field', new FormField( 'text', 'my-second-text-field' ) );
+        $this->assertEquals( 1, $collection->getNodeIndexByName( 'my-second-text-field' ) );
+    }
+
+    public function testInsertAfterReferenceNotFound() {
+        $collection = new FieldCollection( 'root' );
+        $this->expectException( ReferenceNodeNotFoundException::class );
+        $collection->insertAfter( 'my-non-existant-text-field', new FormField( 'text', 'my-text-field' ) );
+    }
+
+    public function testNestedInsertAfter() {
+        $collection = new FieldCollection( 'root', [
+            new FormField( 'text', 'my-text-field' ),
+            new FieldCollection( 'nested', [
+                new FormField( 'text', 'my-second-text-field' )
+            ]),
+        ]);
+        $collection->insertAfter( 'my-second-text-field',  new FormField( 'text', 'my-third-text-field' ) );
+
+        $nodes = $collection->getFields();
+        $nestedCollection = $nodes[ $collection->getNodeIndexByName( 'nested' ) ];
+        $this->assertEquals( 1, $nestedCollection->getNodeIndexByName( 'my-third-text-field' ) );
+    }
+
+    public function testInsertBefore() {
+        $collection = new FieldCollection( 'root', [
+            new FormField( 'text', 'my-text-field' ),
+        ]);
+        $collection->insertBefore( 'my-text-field', new FormField( 'text', 'my-second-text-field' ) );
+        $this->assertEquals( 0, $collection->getNodeIndexByName( 'my-second-text-field' ) );
+    }
+
+    public function testInsertBeforeReferenceNotFound() {
+        $collection = new FieldCollection( 'root' );
+        $this->expectException( ReferenceNodeNotFoundException::class );
+        $collection->insertBefore( 'my-non-existant-text-field', new FormField( 'text', 'my-text-field' ) );
+    }
+
+    public function testNestedInsertBefore() {
+        $collection = new FieldCollection( 'root', [
+            new FormField( 'text', 'my-text-field' ),
+            new FieldCollection( 'nested', [
+                new FormField( 'text', 'my-second-text-field' )
+            ]),
+        ]);
+        $collection->insertBefore( 'my-second-text-field',  new FormField( 'text', 'my-third-text-field' ) );
+
+        $nodes = $collection->getFields();
+        $nestedCollection = $nodes[ $collection->getNodeIndexByName( 'nested' ) ];
+        $this->assertEquals( 0, $nestedCollection->getNodeIndexByName( 'my-third-text-field' ) );
+    }
+}

--- a/tests/unit/tests/Framework/FieldsAPI/FieldCollectionTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/FieldCollectionTest.php
@@ -13,50 +13,6 @@ final class FieldCollectionTest extends TestCase {
         $this->assertEquals( 'root', $collection->getName() );
     }
 
-    public function testInsertAfter() {
-        $collection = new FieldCollection( 'root', [
-            new FormField( 'text', 'my-text-field' ),
-        ]);
-        $collection->insertAfter( 'my-text-field', new FormField( 'text', 'my-second-text-field' ) );
-        $this->assertEquals( 1, $collection->getNodeIndexByName( 'my-second-text-field' ) );
-    }
-
-    public function testNestedInsertAfter() {
-        $collection = new FieldCollection( 'root', [
-            new FormField( 'text', 'my-text-field' ),
-            new FieldCollection( 'nested', [
-                new FormField( 'text', 'my-second-text-field' )
-            ]),
-        ]);
-        $collection->insertAfter( 'my-second-text-field',  new FormField( 'text', 'my-third-text-field' ) );
-
-        $nodes = $collection->getFields();
-        $nestedCollection = $nodes[ $collection->getNodeIndexByName( 'nested' ) ];
-        $this->assertEquals( 1, $nestedCollection->getNodeIndexByName( 'my-third-text-field' ) );
-    }
-
-    public function testInsertBefore() {
-        $collection = new FieldCollection( 'root', [
-            new FormField( 'text', 'my-text-field' ),
-        ]);
-        $collection->insertBefore( 'my-text-field', new FormField( 'text', 'my-second-text-field' ) );
-        $this->assertEquals( 0, $collection->getNodeIndexByName( 'my-second-text-field' ) );
-    }
-
-    public function testNestedInsertBefore() {
-        $collection = new FieldCollection( 'root', [
-            new FormField( 'text', 'my-text-field' ),
-            new FieldCollection( 'nested', [
-                new FormField( 'text', 'my-second-text-field' )
-            ]),
-        ]);
-        $collection->insertBefore( 'my-second-text-field',  new FormField( 'text', 'my-third-text-field' ) );
-
-        $nodes = $collection->getFields();
-        $nestedCollection = $nodes[ $collection->getNodeIndexByName( 'nested' ) ];
-        $this->assertEquals( 0, $nestedCollection->getNodeIndexByName( 'my-third-text-field' ) );
-    }
-
     public function testGetNodeByName() {
         $collection = new FieldCollection( 'root', [
             new FormField( 'text', 'my-text-field' ),


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5635

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Adds the `ReferenceNodeNotFoundException` exception, which is thrown when inserting before or after a node that does not exist.
- Optimizes `InsertNode` methods `insertBefore` and `insertAfter` by avoiding unecessary name collision checks on each nesting level, since the collision check is already recursive.
- Moves `InsertNode` trait tests to a separate `InsertNodeTest` test file.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Testing instructions are outlined in `tests/unit/tests/Framework/FieldsAPI/FieldCollection/InsertNodeTest.php`.
