### PR TITLE
Reports endpoints no longer throw an error due to missing $schema property

### DIFF
--- a/src/API/Endpoints/Reports/Endpoint.php
+++ b/src/API/Endpoints/Reports/Endpoint.php
@@ -55,6 +55,11 @@ abstract class Endpoint implements RestRoute {
 	protected $currency;
 
 	/**
+	 * @var array
+	 */
+	protected $schema;
+
+	/**
 	 * @inheritDoc
 	 */
 	public function registerRoute() {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4920

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Declare property `$schema` into src/API/Endpoints/Reports/Endpoint.php It prevents PHP notices.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Install WooCommerce: `wp plugin install woocommerce --activate`
Try to run few wp-cli commands.
I've tried `wp cache flush` on few installations and without this PR I see PHP notices.