### PR TITLE
Legacy Form Consumer now uses closures to nest callbacks

### DIFF
--- a/src/Form/LegacyConsumer/Commands/Helper/AttributeBag.php
+++ b/src/Form/LegacyConsumer/Commands/Helper/AttributeBag.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Commands\Helper;
+
+class AttributeBag {
+	public function __construct( $attributes = [] ) {
+		foreach ( $attributes as $key => $value ) {
+			$this->$key = $value;
+		}
+	}
+}

--- a/src/Form/LegacyConsumer/Commands/Helper/ClosureProxy.php
+++ b/src/Form/LegacyConsumer/Commands/Helper/ClosureProxy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Commands\Helper;
+
+class ClosureProxy {
+
+	/**
+	 * @param callable $callback
+	 * @param HookCommandInterface $command
+	 */
+	public function __construct( callable $callback, $command ) {
+		$this->callback = $callback;
+		$this->command  = $command;
+	}
+
+	public function with( $attributes = [] ) {
+
+		// Merge command closure properties with attributes.
+		$reflection = new \ReflectionClass( $this->command );
+		foreach ( $reflection->getProperties() as $property ) {
+			if ( is_a( $this->command->{$property->name}, ClosureProxy::class ) ) {
+				$attributes[ $property->name ] = $this->command->{$property->name};
+			}
+		}
+
+		// Return closure bound with attributes.
+		return \Closure::bind( $this->callback, new AttributeBag( $attributes ), AttributeBag::class );
+	}
+}

--- a/src/Form/LegacyConsumer/Commands/README.md
+++ b/src/Form/LegacyConsumer/Commands/README.md
@@ -1,0 +1,74 @@
+# Making sense of the nested interations
+
+Why is this so complicated?
+
+For the purpose of backwards compatibility, we need to setup a Field Collection for each of the deprecated template hooks. This allows developers to use the Fields API to manage fields within the context of a template location. Additionally, a form ID is needed for conditionally adding fields to a specific form.
+
+Note: It is important to note that we are re-using the template hooks list outside of the context of the form for the purpose of persisting and displaying stored data, which do not have context of the form template rendering - so we are elevating the new hooks to a higher context so that they can be use for display, persistance, and recall without repeating field registration in each of these separate contexts.
+
+Because the field collection needs context of both the template location and the relevent donation form ID, which are available at different points of time, we are using a series of closures to "wire-up" the field collections with the necessary context as it becomes available.
+
+Additionally, closures are used to avoid convoluted, nested anonymous functions with indentation easily reaching 6 or more levels deep.
+
+## Processing Flow
+
+The general flow is that the Service provider walks the template hooks list and executes a command on each of the hooks. The command then queues up the specific action hook to intialize the field collection at the approproiate time. The action hook callback then walks the fields in the new collection executing a closure to handle each field.
+
+### Service Provider
+
+The service provider executes a command for each template hook.
+
+```php
+give( TemplateHooks::class )
+    ->walk( give( Commands\Setup::class ) );
+```
+
+### Command
+
+The command then queues an action hook to run at a later time.
+
+```php
+add_action(
+    'give_view_donation_details_billing_after',
+    $this->process->with([
+        'hook' => $hook,
+    ])
+);
+```
+
+### Action Hook Callback
+
+The action hook callback then executes another callback for each field in the collection.
+
+```php
+$fieldCollection = new FieldCollection( 'root' );
+do_action( "give_fields_$this->hook", $fieldCollection, $formID );
+
+$fieldCollection->walk(
+    $this->output->with([ 'donationID' => $donationID ])
+);
+```
+
+## Helpers
+
+## The Closure Proxy
+
+The closure proxy is used to bind context to a callback.
+
+A callback that is proxied can pass with itself additional attributes. This is similar to the `use` method in an anonymous function - providing context to the closure.
+
+Additionally, any public properties of the proxied class will be passed as attributes which can be passed further down the line.
+
+The `with()` method provides a fluent API for passing the additional context.
+
+```php
+
+$callback = new ClosureProxy( $callback, $classInstance );
+add_action( 'action_hook',
+    $callback->with([ 'foo' => 'bar'])
+);
+```
+
+## The Attribute Bag
+
+The attribute bag is used by the closure proxy to store the attributes passed as context.

--- a/src/Form/LegacyConsumer/Commands/README.md
+++ b/src/Form/LegacyConsumer/Commands/README.md
@@ -1,4 +1,4 @@
-# Making sense of the nested interations
+# Making sense of the nested callbacks
 
 Why is this so complicated?
 

--- a/src/Form/LegacyConsumer/Commands/SetupPaymentDetailsDisplay.php
+++ b/src/Form/LegacyConsumer/Commands/SetupPaymentDetailsDisplay.php
@@ -6,32 +6,53 @@ use Give\Framework\FieldsAPI\FieldCollection;
 use Give\Form\LegacyConsumer\FieldView;
 
 class SetupPaymentDetailsDisplay implements HookCommandInterface {
+
+	// Public properties of type ClosureProxy will be available to callbacks.
+
+	public $process;
+	public $output;
+
+	public function __construct() {
+		$this->process = new Helper\ClosureProxy( $this->process(), $this );
+		$this->output  = new Helper\ClosureProxy( $this->output(), $this );
+	}
+
 	public function __invoke( $hook ) {
 		add_action(
 			'give_view_donation_details_billing_after',
-			function( $donationID ) use ( $hook ) {
-
-				$fieldCollection = new FieldCollection( 'root' );
-				do_action( "give_fields_$hook", $fieldCollection, get_the_ID() );
-
-				$fieldCollection->walk(
-					function( $field ) use ( $donationID ) {
-						?>
-					<div class="referral-data postbox" style="padding-bottom: 15px;">
-						<h3 class="hndle">
-								<?php echo $field->getLabel(); ?>
-						</h3>
-						<div class="inside">    
-							<p>   
-									<?php echo give_get_meta( $donationID, $field->getName(), true ); ?>
-							</p>
-						</div>
-					</div>
-						<?php
-					}
-				);
-			}
+			$this->process->with(
+				[
+					'hook' => $hook,
+				]
+			)
 		);
 	}
-}
 
+	public function process() {
+		return function( $donationID ) {
+			$fieldCollection = new FieldCollection( 'root' );
+			do_action( "give_fields_$this->hook", $fieldCollection, get_the_ID() );
+
+			$fieldCollection->walk(
+				$this->output->with( [ 'donationID' => $donationID ] )
+			);
+		};
+	}
+
+	public function output() {
+		return function( $field ) {
+			?>
+			<div class="referral-data postbox" style="padding-bottom: 15px;">
+				<h3 class="hndle">
+						<?php echo $field->getLabel(); ?>
+				</h3>
+				<div class="inside">    
+					<p>   
+							<?php echo give_get_meta( $this->donationID, $field->getName(), true ); ?>
+					</p>
+				</div>
+			</div>
+			<?php
+		};
+	}
+}


### PR DESCRIPTION
Copied from https://github.com/impress-org/givewp/pull/5644/files#diff-502c7cd3455b48626d368dfe129f29402ccd4132d5402f49c8259ad6461f148a

Note: The purpose of all of this is to make the end code more maintainable through architecture and less like spaghetti code.

# Making sense of the nested callbacks

Why is this so complicated?

For the purpose of backwards compatibility, we need to setup a Field Collection for each of the deprecated template hooks. This allows developers to use the Fields API to manage fields within the context of a template location. Additionally, a form ID is needed for conditionally adding fields to a specific form.

Note: It is important to note that we are re-using the template hooks list outside of the context of the form for the purpose of persisting and displaying stored data, which do not have context of the form template rendering - so we are elevating the new hooks to a higher context so that they can be use for display, persistance, and recall without repeating field registration in each of these separate contexts.

Because the field collection needs context of both the template location and the relevent donation form ID, which are available at different points of time, we are using a series of closures to "wire-up" the field collections with the necessary context as it becomes available.

Additionally, closures are used to avoid convoluted, nested anonymous functions with indentation easily reaching 6 or more levels deep.

## Processing Flow

The general flow is that the Service provider walks the template hooks list and executes a command on each of the hooks. The command then queues up the specific action hook to intialize the field collection at the approproiate time. The action hook callback then walks the fields in the new collection executing a closure to handle each field.

### Service Provider

The service provider executes a command for each template hook.

```php
give( TemplateHooks::class )
    ->walk( give( Commands\Setup::class ) );
```

### Command

The command then queues an action hook to run at a later time.

```php
add_action(
    'give_view_donation_details_billing_after',
    $this->process->with([
        'hook' => $hook,
    ])
);
```

### Action Hook Callback

The action hook callback then executes another callback for each field in the collection.

```php
$fieldCollection = new FieldCollection( 'root' );
do_action( "give_fields_$this->hook", $fieldCollection, $formID );

$fieldCollection->walk(
    $this->output->with([ 'donationID' => $donationID ])
);
```

## Helpers

## The Closure Proxy

The closure proxy is used to bind context to a callback.

A callback that is proxied can pass with itself additional attributes. This is similar to the `use` method in an anonymous function - providing context to the closure.

Additionally, any public properties of the proxied class will be passed as attributes which can be passed further down the line.

The `with()` method provides a fluent API for passing the additional context.

```php

$callback = new ClosureProxy( $callback, $classInstance );
add_action( 'action_hook',
    $callback->with([ 'foo' => 'bar'])
);
```

## The Attribute Bag

The attribute bag is used by the closure proxy to store the attributes passed as context.