### PR TITLE
Form Consumer now persists custom field value as donor and/or donation meta.

### DIFF
--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
@@ -21,7 +21,6 @@ class SetupFieldPersistance implements HookCommandInterface {
 					function( $field ) use ( $donationID ) {
 						if ( isset( $_POST[ $field->getName() ] ) ) {
 							$value = wp_strip_all_tags( $_POST[ $field->getName() ], true );
-<<<<<<< HEAD
 
 							if ( $field->shouldStoreAsDonationMeta() ) {
 								give_update_payment_meta( $donationID, $field->getName(), $value );
@@ -31,9 +30,6 @@ class SetupFieldPersistance implements HookCommandInterface {
 								$donorID = give_get_payment_meta( $donationID, '_give_payment_donor_id' );
 								Give()->donor_meta->update_meta( $donorID, $field->getName(), $value );
 							}
-=======
-							give_update_payment_meta( $donationID, $field->getName(), $value );
->>>>>>> epic/fields-api
 						}
 					}
 				);

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
@@ -22,13 +22,12 @@ class SetupFieldPersistance implements HookCommandInterface {
 						if ( isset( $_POST[ $field->getName() ] ) ) {
 							$value = wp_strip_all_tags( $_POST[ $field->getName() ], true );
 
-							if ( $field->shouldStoreAsDonationMeta() ) {
-								give_update_payment_meta( $donationID, $field->getName(), $value );
-							}
-
 							if ( $field->shouldStoreAsDonorMeta() ) {
 								$donorID = give_get_payment_meta( $donationID, '_give_payment_donor_id' );
 								Give()->donor_meta->update_meta( $donorID, $field->getName(), $value );
+							} else {
+								// Store as Donation Meta - default behavior.
+								give_update_payment_meta( $donationID, $field->getName(), $value );
 							}
 						}
 					}

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistance.php
@@ -19,9 +19,17 @@ class SetupFieldPersistance implements HookCommandInterface {
 				do_action( "give_fields_$hook", $fieldCollection, $donationData['give_form_id'] );
 				$fieldCollection->walk(
 					function( $field ) use ( $donationID ) {
-						if ( isset( $_POST[ 'give_' . $field->getName() ] ) ) {
-							$value = wp_strip_all_tags( $_POST[ 'give_' . $field->getName() ], true );
-							give_update_payment_meta( $donationID, $field->getName(), $value );
+						if ( isset( $_POST[ $field->getName() ] ) ) {
+							$value = wp_strip_all_tags( $_POST[ $field->getName() ], true );
+
+							if ( $field->shouldStoreAsDonationMeta() ) {
+								give_update_payment_meta( $donationID, $field->getName(), $value );
+							}
+
+							if ( $field->shouldStoreAsDonorMeta() ) {
+								$donorID = give_get_payment_meta( $donationID, '_give_payment_donor_id' );
+								Give()->donor_meta->update_meta( $donorID, $field->getName(), $value );
+							}
 						}
 					}
 				);

--- a/src/Framework/FieldsAPI/FormField.php
+++ b/src/Framework/FieldsAPI/FormField.php
@@ -13,6 +13,7 @@ class FormField implements Node {
 	use FormField\FieldHelpText;
 	use FormField\FieldAttributes;
 	use FormField\FieldDefaultValue;
+	use FormField\FieldStoreAsMeta;
 
 	/** @var string */
 	protected $type;

--- a/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
+++ b/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\FormField;
+
+/**
+ * @unreleased
+ */
+trait FieldStoreAsMeta {
+
+	/**
+	 * @unreleased
+	 * @var bool
+	 */
+	public $storeAsDonorMeta = false;
+
+	/**
+	 * @unreleased
+	 * @var bool
+	 */
+	public $storeAsDonationMeta = false;
+
+	/**
+	 * @unreleased
+	 * @param bool $storeAsDonorMeta
+	 * @return $this
+	 */
+	public function storeAsDonorMeta( $storeAsDonorMeta = true ) {
+		$this->storeAsDonorMeta = $storeAsDonorMeta;
+		return $this;
+	}
+
+	/**
+	 * @unreleased
+	 * @return bool
+	 */
+	public function shouldStoreAsDonorMeta() {
+		return $this->storeAsDonorMeta;
+	}
+
+	/**
+	 * @unreleased
+	 * @param bool $storeAsDonationMeta
+	 * @return $this
+	 */
+	public function storeAsDonationMeta( $storeAsDonationMeta = true ) {
+		$this->storeAsDonationMeta = $storeAsDonationMeta;
+		return $this;
+	}
+
+	/**
+	 * @unreleased
+	 * @return bool
+	 */
+	public function shouldStoreAsDonationMeta() {
+		return $this->storeAsDonationMeta;
+	}
+}

--- a/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
+++ b/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
@@ -15,17 +15,10 @@ trait FieldStoreAsMeta {
 
 	/**
 	 * @unreleased
-	 * @var bool
-	 */
-	public $storeAsDonationMeta = false;
-
-	/**
-	 * @unreleased
-	 * @param bool $storeAsDonorMeta
 	 * @return $this
 	 */
-	public function storeAsDonorMeta( $storeAsDonorMeta = true ) {
-		$this->storeAsDonorMeta = $storeAsDonorMeta;
+	public function storeAsDonorMeta() {
+		$this->storeAsDonorMeta = true;
 		return $this;
 	}
 
@@ -35,23 +28,5 @@ trait FieldStoreAsMeta {
 	 */
 	public function shouldStoreAsDonorMeta() {
 		return $this->storeAsDonorMeta;
-	}
-
-	/**
-	 * @unreleased
-	 * @param bool $storeAsDonationMeta
-	 * @return $this
-	 */
-	public function storeAsDonationMeta( $storeAsDonationMeta = true ) {
-		$this->storeAsDonationMeta = $storeAsDonationMeta;
-		return $this;
-	}
-
-	/**
-	 * @unreleased
-	 * @return bool
-	 */
-	public function shouldStoreAsDonationMeta() {
-		return $this->storeAsDonationMeta;
 	}
 }

--- a/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
+++ b/src/Framework/FieldsAPI/FormField/FieldStoreAsMeta.php
@@ -11,7 +11,7 @@ trait FieldStoreAsMeta {
 	 * @unreleased
 	 * @var bool
 	 */
-	public $storeAsDonorMeta = false;
+	protected $storeAsDonorMeta = false;
 
 	/**
 	 * @unreleased

--- a/tests/unit/tests/Framework/FieldsAPI/FormField/FieldStoreAsMetaTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/FormField/FieldStoreAsMetaTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Give\Framework\FieldsAPI\FormField;
+
+final class FieldStoreAsMetaTest extends TestCase {
+
+    public function testStoreAsDonorMeta() {
+        $field = new FormField( 'text', 'my-text-field' );
+        $field->storeAsDonorMeta();
+        $this->assertTrue( $field->shouldStoreAsDonorMeta() );
+    }
+
+    public function testNotStoreAsDonorMeta() {
+        $field = new FormField( 'text', 'my-text-field' );
+
+        // False by default.
+        $this->assertFalse( $field->shouldStoreAsDonorMeta() );
+
+        $field->storeAsDonorMeta(); // Toggle on.
+        $field->storeAsDonorMeta( false ); // Toggle off.
+        $this->assertFalse( $field->shouldStoreAsDonorMeta() );
+    }
+
+    public function testStoreAsDonationMeta() {
+        $field = new FormField( 'text', 'my-text-field' );
+        $field->storeAsDonationMeta();
+        $this->assertTrue( $field->shouldStoreAsDonationMeta() );
+    }
+
+    public function testNotStoreAsDonationMeta() {
+        $field = new FormField( 'text', 'my-text-field' );
+
+        // False by default.
+        $this->assertFalse( $field->shouldStoreAsDonationMeta() );
+
+        $field->storeAsDonationMeta(); // Toggle on.
+        $field->storeAsDonationMeta( false ); // Toggle off.
+        $this->assertFalse( $field->shouldStoreAsDonationMeta() );
+    }
+}

--- a/tests/unit/tests/Framework/FieldsAPI/FormField/FieldStoreAsMetaTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/FormField/FieldStoreAsMetaTest.php
@@ -21,21 +21,4 @@ final class FieldStoreAsMetaTest extends TestCase {
         $field->storeAsDonorMeta( false ); // Toggle off.
         $this->assertFalse( $field->shouldStoreAsDonorMeta() );
     }
-
-    public function testStoreAsDonationMeta() {
-        $field = new FormField( 'text', 'my-text-field' );
-        $field->storeAsDonationMeta();
-        $this->assertTrue( $field->shouldStoreAsDonationMeta() );
-    }
-
-    public function testNotStoreAsDonationMeta() {
-        $field = new FormField( 'text', 'my-text-field' );
-
-        // False by default.
-        $this->assertFalse( $field->shouldStoreAsDonationMeta() );
-
-        $field->storeAsDonationMeta(); // Toggle on.
-        $field->storeAsDonationMeta( false ); // Toggle off.
-        $this->assertFalse( $field->shouldStoreAsDonationMeta() );
-    }
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5625

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Custom fields can be stored as donor meta with the fluent API method `storeAsDonorMeta()`.
- Custom fields can be stored as donation meta with the fluent API method `storeAsDonationMeta()`.

```php
add_action( 'give_fields_after_donation_levels', function( $fieldCollection, $formID ) {
	$fieldCollection->append(
		give_field( 'text', 'my-custom-field' )
			->label( 'My Custom Field' )
			->required()
			->storeAsDonorMeta()
	);
}, 10, 2 );
```

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/109199777-d8f4e200-776d-11eb-8240-2a87cc6d21be.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
