### PR TITLE
Custom field values now show in Donation Receipt and Donation Confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New
 
 -   Custom field values now display in payment details (#5647)
+-   Custom field values now show in Donation Receipt (#5654)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New
 
 -   Custom field values now display in payment details (#5647)
--   Custom field values now show in Donation Receipt (#5654)
+-   Custom field values now show in Donation Receipt and Donation Confirmation (#5654)
 
 ### Changed
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
@@ -57,6 +57,11 @@ class SetupFieldConfirmation {
 	}
 
 	public function render( FormField $field ) {
+
+		if ( ! $field->shouldShowInReceipt() ) {
+			return;
+		}
+
 		?>
 			<tr>
 				<td scope="row">
@@ -66,12 +71,12 @@ class SetupFieldConfirmation {
 				</td>
 				<td>
 				<?php if ( $field->shouldStoreAsDonorMeta() ) : ?>
-					<?php echo give_get_payment_meta( $this->donationID, $field->getName() ); ?>
-				<?php elseif ( $field->shouldStoreAsDonorMeta() ) : ?>
 					<?php
-						$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
+						$donorID = give_get_payment_meta( $this->donationID, '_give_payment_donor_id' );
 						echo Give()->donor_meta->get_meta( $donorID, $field->getName(), true );
 					?>
+				<?php else : ?>
+					<?php echo give_get_payment_meta( $this->donationID, $field->getName() ); ?>
 				<?php endif; ?>
 				</td>
 			</tr>

--- a/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Commands;
+
+use Give\Framework\FieldsAPI\FormField;
+use Give\Framework\FieldsAPI\FieldCollection;
+
+/**
+ * @unreleased
+ */
+class SetupFieldConfirmation {
+
+	/**
+	 * @unreleased
+	 *
+	 * @param string $hook
+	 */
+	public function __construct( $hook ) {
+		$this->hook = $hook;
+	}
+
+
+	/**
+	 * @unreleased
+	 *
+	 * @return void
+	 */
+	public function __invoke() {
+		add_action(
+			'give_payment_receipt_after',
+			[ $this, 'process' ],
+			10,
+			2
+		);
+	}
+
+	/**
+	 * @unreleased
+	 *
+	 * @param $payment
+	 * @param array $receipt_args
+	 *
+	 * @return void
+	 */
+	public function process( $payment, $receipt_args ) {
+
+		$this->payment     = $payment;
+		$this->receiptArgs = $receipt_args;
+		$this->donationID  = $payment->ID;
+
+		$formID = give_get_payment_meta( $this->donationId, '_give_payment_form_id' );
+
+		$fieldCollection = new FieldCollection( 'root' );
+		do_action( "give_fields_{$this->hook}", $fieldCollection, $formID );
+
+		$fieldCollection->walk( [ $this, 'render' ] );
+	}
+
+	public function render( FormField $field ) {
+		?>
+			<tr>
+				<td scope="row">
+					<strong>
+						<?php echo $field->getLabel(); ?>
+					</strong>
+				</td>
+				<td>
+				<?php if ( $field->shouldStoreAsDonorMeta() ) : ?>
+					<?php echo give_get_payment_meta( $this->donationID, $field->getName() ); ?>
+				<?php elseif ( $field->shouldStoreAsDonorMeta() ) : ?>
+					<?php
+						$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
+						echo Give()->donor_meta->get_meta( $donorID, $field->getName(), true );
+					?>
+				<?php endif; ?>
+				</td>
+			</tr>
+		<?php
+	}
+}

--- a/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
@@ -40,8 +40,10 @@ class SetupFieldReciept {
 		$this->donorSection                 = $receipt->getSections()[ DonationReceipt::DONORSECTIONID ];
 		$this->additionalInformationSection = $receipt->getSections()[ DonationReceipt::ADDITIONALINFORMATIONSECTIONID ];
 
+		$formID = give_get_payment_meta( $this->donationId, '_give_payment_form_id' );
+
 		$fieldCollection = new FieldCollection( 'root' );
-		do_action( "give_fields_{$this->hook}", $fieldCollection, get_the_ID() );
+		do_action( "give_fields_{$this->hook}", $fieldCollection, $formID );
 
 		$fieldCollection->walk( [ $this, 'apply' ] );
 	}

--- a/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
@@ -57,6 +57,10 @@ class SetupFieldReciept {
 	 */
 	public function apply( FormField $field ) {
 
+		if ( ! $field->shouldShowInReceipt() ) {
+			return;
+		}
+
 		if ( $field->shouldStoreAsDonorMeta() ) {
 			$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
 			$this->donorSection->addLineItem(
@@ -66,9 +70,7 @@ class SetupFieldReciept {
 					'value' => Give()->donor_meta->get_meta( $donorID, $field->getName(), true ),
 				]
 			);
-		}
-
-		if ( $field->shouldStoreAsDonationMeta() ) {
+		} else {
 			$this->additionalInformationSection->addLineItem(
 				[
 					'id'    => $field->getName(),

--- a/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldReciept.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Commands;
+
+use Give\Receipt\DonationReceipt;
+use Give\Framework\FieldsAPI\FormField;
+use Give\Framework\FieldsAPI\FieldCollection;
+use Give\Form\LegacyConsumer\FieldView;
+
+/**
+ * @unreleased
+ */
+class SetupFieldReciept {
+
+	/**
+	 * @unreleased
+	 *
+	 * @param string $hook
+	 */
+	public function __construct( $hook ) {
+		$this->hook = $hook;
+	}
+
+
+	/**
+	 * @unreleased
+	 *
+	 * @return void
+	 */
+	public function __invoke() {
+		add_action(
+			'give_new_receipt',
+			[ $this, 'process' ]
+		);
+	}
+
+	public function process( DonationReceipt $receipt ) {
+
+		$this->donationId                   = $receipt->donationId;
+		$this->donorSection                 = $receipt->getSections()[ DonationReceipt::DONORSECTIONID ];
+		$this->additionalInformationSection = $receipt->getSections()[ DonationReceipt::ADDITIONALINFORMATIONSECTIONID ];
+
+		$fieldCollection = new FieldCollection( 'root' );
+		do_action( "give_fields_{$this->hook}", $fieldCollection, get_the_ID() );
+
+		$fieldCollection->walk( [ $this, 'apply' ] );
+	}
+
+	/**
+	 * @unreleased
+	 *
+	 * @param FormField $field
+	 *
+	 * @return void
+	 */
+	public function apply( FormField $field ) {
+
+		if ( $field->shouldStoreAsDonorMeta() ) {
+			$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
+			$this->donorSection->addLineItem(
+				[
+					'id'    => $field->getName(),
+					'label' => $field->getLabel(),
+					'value' => Give()->donor_meta->get_meta( $donorID, $field->getName(), true ),
+				]
+			);
+		}
+
+		if ( $field->shouldStoreAsDonationMeta() ) {
+			$this->additionalInformationSection->addLineItem(
+				[
+					'id'    => $field->getName(),
+					'label' => $field->getLabel(),
+					'value' => give_get_payment_meta( $this->donationId, $field->getName() ),
+				]
+			);
+		}
+
+	}
+}

--- a/src/Form/LegacyConsumer/ServiceProvider.php
+++ b/src/Form/LegacyConsumer/ServiceProvider.php
@@ -31,6 +31,7 @@ class ServiceProvider implements ServiceProviderInterface {
 		give( TemplateHooks::class )->walk( give( Commands\SetupFieldPersistance::class ) );
 		give( TemplateHooks::class )->walk( new Commands\CommandFactory( Commands\SetupPaymentDetailsDisplay::class ) );
 		give( TemplateHooks::class )->walk( new Commands\CommandFactory( Commands\SetupFieldReciept::class ) );
+		give( TemplateHooks::class )->walk( new Commands\CommandFactory( Commands\SetupFieldConfirmation::class ) );
 		if ( ! wp_doing_ajax() ) {
 			give( TemplateHooks::class )->walk( give( Commands\DeprecateOldTemplateHook::class ) );
 		}

--- a/src/Form/LegacyConsumer/ServiceProvider.php
+++ b/src/Form/LegacyConsumer/ServiceProvider.php
@@ -30,6 +30,7 @@ class ServiceProvider implements ServiceProviderInterface {
 		give( TemplateHooks::class )->walk( give( Commands\SetupFieldValidation::class ) );
 		give( TemplateHooks::class )->walk( give( Commands\SetupFieldPersistance::class ) );
 		give( TemplateHooks::class )->walk( new Commands\CommandFactory( Commands\SetupPaymentDetailsDisplay::class ) );
+		give( TemplateHooks::class )->walk( new Commands\CommandFactory( Commands\SetupFieldReciept::class ) );
 		if ( ! wp_doing_ajax() ) {
 			give( TemplateHooks::class )->walk( give( Commands\DeprecateOldTemplateHook::class ) );
 		}

--- a/src/Framework/FieldsAPI/FormField.php
+++ b/src/Framework/FieldsAPI/FormField.php
@@ -14,6 +14,7 @@ class FormField implements Node {
 	use FormField\FieldAttributes;
 	use FormField\FieldDefaultValue;
 	use FormField\FieldStoreAsMeta;
+	use FormField\FieldReceipt;
 
 	/** @var string */
 	protected $type;

--- a/src/Framework/FieldsAPI/FormField/FieldReceipt.php
+++ b/src/Framework/FieldsAPI/FormField/FieldReceipt.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\FormField;
+
+/**
+ * @unreleased
+ */
+trait FieldReceipt {
+
+	/**
+	 * @unreleased
+	 * @var bool
+	 */
+	protected $showInReceipt = false;
+
+	/**
+	 * @unreleased
+	 * @return $this
+	 */
+	public function showInReceipt( $showInReceipt = true ) {
+		$this->showInReceipt = $showInReceipt;
+		return $this;
+	}
+
+	/**
+	 * @unreleased
+	 * @return bool
+	 */
+	public function shouldShowInReceipt() {
+		return $this->showInReceipt;
+	}
+}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5624

Depends on #5652

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Custom field values now show in the Donation Receipt for the Sequoia form template.

NOTE: Custom fields must be stored as donor and/or donation meta in order to be added to the receipt.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Donation Receipt
![Screenshot_2021-02-25 Donation Form – WordPress(1)](https://user-images.githubusercontent.com/10858303/109211517-545d9000-777c-11eb-9584-649d8d7d5af4.png)

Donation Confirmation
![Screenshot_2021-02-25 Donation Confirmation – WordPress](https://user-images.githubusercontent.com/10858303/109214320-b23fa700-777f-11eb-875d-d7ad2d9214a0.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

```php
add_action( 'give_fields_after_donation_levels', function( $fieldCollection, $formID ) {
	$fieldCollection->append(
		give_field( 'text', 'my-custom-field' )
			->label( 'My Custom Field' )
			->required()
			->storeAsDonorMeta()
			->storeAsDonationMeta()
	);
}, 10, 2 );
```
<!-- Help others test your PR as efficiently as possible. -->
