### PR TITLE
Admin are now shown Donor Profiles upgrade notice and Donor Profile page is generated on new installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donor Profile authentication logic is now implemented (#5569)
 -   Admin can now set Donor Profile accent color (#5615)
 -   Anonymous donation and company setting choices are now persisted (#5633)
+-   Admin are now shown Donor Profiles upgrade notice (#5660)
+-   Donor Profile page is now generated on new installs (#5600)
 
 ### Changed
 -   Donor Profile Donation History UI is now polished (#5566)

--- a/assets/src/css/admin/give-admin.scss
+++ b/assets/src/css/admin/give-admin.scss
@@ -46,3 +46,5 @@
 @import 'tabs';
 @import 'upsells';
 @import '_components.admin-header';
+
+@import '../../../../src/DonorProfiles/resources/styles/upgradenotice.scss';

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -9,6 +9,11 @@
 
 // Typical SCSS for vertical tabs.
 .give-settings-page {
+	.give-disabled-setting {
+		opacity: 50%;
+		pointer-events: none;
+	}
+
 	.give-settings-section-content {
 		display: flex;
 		background-color: #f4f4f4;

--- a/assets/src/js/admin/admin.js
+++ b/assets/src/js/admin/admin.js
@@ -34,6 +34,8 @@ import './stripe-admin';
 // PayPal donations
 import './paypal-commerce';
 
+import '../../../../src/DonorProfiles/resources/js/admin';
+
 GiveAPI.modal = Modals;
 const { init, fn, cache, modal, notice } = GiveAPI;
 window.Give = { init, fn, cache, modal, notice, initializeIframeResize };

--- a/includes/install.php
+++ b/includes/install.php
@@ -271,19 +271,18 @@ function give_after_install() {
 			// Create the donor database.
 			// (this ensures it creates it on multisite instances where it is network activated).
 			@Give()->donors->create_table();
-
-			/**
-			 * Fires after plugin installation.
-			 *
-			 * @since 1.0
-			 *
-			 * @param array $give_options Give plugin options.
-			 */
-			do_action( 'give_after_install', $give_options );
 		}
 
-		update_option( '_give_table_check', ( current_time( 'timestamp' ) + WEEK_IN_SECONDS ), false );
+		/**
+		 * Fires after plugin installation.
+		 *
+		 * @since 1.0
+		 *
+		 * @param array $give_options Give plugin options.
+		 */
+		do_action( 'give_after_install', $give_options );
 
+		update_option( '_give_table_check', ( current_time( 'timestamp' ) + WEEK_IN_SECONDS ), false );
 	}
 
 	// Delete the transient

--- a/includes/install.php
+++ b/includes/install.php
@@ -480,23 +480,6 @@ function give_create_pages() {
 		$options['failure_page'] = $failed;
 	}
 
-	// Checks if the History Page option exists AND that the page exists.
-	if ( ! get_post( give_get_option( 'history_page' ) ) ) {
-		// Donation History Page
-		$history = wp_insert_post(
-			[
-				'post_title'     => esc_html__( 'Donation History', 'give' ),
-				'post_content'   => '[donation_history]',
-				'post_status'    => 'publish',
-				'post_author'    => 1,
-				'post_type'      => 'page',
-				'comment_status' => 'closed',
-			]
-		);
-
-		$options['history_page'] = $history;
-	}
-
 	if ( ! empty( $options ) ) {
 		update_option( 'give_settings', array_merge( give_get_settings(), $options ), false );
 	}

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -21,9 +21,16 @@ class Settings {
 	}
 
 	protected function getDonorProfilePageSetting() {
+
+		$generateDonorProfilePageUrl = add_query_arg(
+			[
+				'give-donor-profile-action' => 'generate-donor-profile-page',
+			]
+		);
+
 		return [
 			'name'       => __( 'Donor Profile Page', 'give' ),
-			'desc'       => __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? Let us <a href="#">generate one for you.</a>', 'give' ),
+			'desc'       => sprintf( __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? Let us <a href="%s">generate one for you.</a>', 'give' ), $generateDonorProfilePageUrl ),
 			'id'         => 'donor_profile_page',
 			'type'       => 'select',
 			'class'      => 'give-select give-select-chosen',
@@ -55,5 +62,35 @@ class Settings {
 		];
 	}
 
+	public function generateDonorProfilePage() {
+
+		error_log( 'generate donor profile page!!!!' );
+
+		$block = [
+			'blockName' => 'give/donor-profile',
+		];
+
+		$markup = render_block( $block );
+
+		error_log( $markup );
+
+		$content = apply_filters( 'the_content', $markup );
+
+		$pageId = wp_insert_post(
+			[
+				'comment_status' => 'close',
+				'ping_status'    => 'close',
+				'post_author'    => 1,
+				'post_title'     => __( 'Donor Profile', 'give' ),
+				'post_status'    => 'publish',
+				'post_content'   => $content,
+				'post_type'      => 'page',
+			]
+		);
+
+		if ( $pageId ) {
+			give_update_option( 'donor_profile_page', $pageId );
+		}
+	}
 
 }

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Give\DonorProfiles\Admin;
+
+class Settings {
+
+	public function register( $settings ) {
+		$donorProfileSettings = [
+			$this->getDonorProfilePageSetting(),
+			$this->getOverrideLegacyDonationManagementPagesSetting(),
+		];
+
+		return give_settings_array_insert(
+			$settings,
+			'base_country',
+			$donorProfileSettings
+		);
+	}
+
+	protected function getDonorProfilePageSetting() {
+		return [
+			'name'       => __( 'Donor Profile Page', 'give' ),
+			'desc'       => __( 'This is the page donors can access to manage their subscriptions. The <code>[give_subscriptions]</code> shortcode should be on this page.', 'give' ),
+			'id'         => 'donor_profile_page',
+			'type'       => 'select',
+			'class'      => 'give-select give-select-chosen',
+			'options'    => give_cmb2_get_post_options(
+				[
+					'post_type'   => 'page',
+					'numberposts' => 30,
+				]
+			),
+			'attributes' => [
+				'data-search-type' => 'pages',
+				'data-placeholder' => esc_html__( 'Choose a page', 'give' ),
+			],
+		];
+	}
+
+	protected function getOverrideLegacyDonationManagementPagesSetting() {
+		return [
+			'name'          => esc_html__( 'Override Legacy Donation Managment Pages', 'give' ),
+			'desc'          => esc_html__( 'Use Donor Profile Page setting to override legacy donation management pages.', 'give' ),
+			'id'            => 'override_legacy_donation_management_pages',
+			'wrapper_class' => 'override-legacy-donation-management-pages',
+			'type'          => 'radio_inline',
+			'default'       => 'enabled',
+			'options'       => [
+				'enabled'  => esc_html__( 'Enabled', 'give' ),
+				'disabled' => esc_html__( 'Disabled', 'give' ),
+			],
+		];
+	}
+
+
+}

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -38,7 +38,7 @@ class Settings {
 	 */
 	protected function donorProfilePageIsPublished() {
 		$donorProfilePageId = ! empty( give_get_option( 'donor_profile_page' ) ) ? give_get_option( 'donor_profile_page' ) : null;
-		return $donorProfilePageId && get_post_status( $donorProfilePageId ) === 'publish' ? true : false;
+		return $donorProfilePageId && get_post_status( $donorProfilePageId ) === 'publish';
 	}
 
 	/**

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -66,13 +66,7 @@ class Settings {
 
 	public function generateDonorProfilePage() {
 
-		$block = [
-			'blockName' => 'give/donor-profile',
-		];
-
-		$markup = render_block( $block );
-
-		$content = apply_filters( 'the_content', $markup );
+		$content = $this->getDonorProfilePageContent( 'block' );
 
 		$pageId = wp_insert_post(
 			[
@@ -89,6 +83,25 @@ class Settings {
 		if ( $pageId ) {
 			give_update_option( 'donor_profile_page', $pageId );
 		}
+	}
+
+	protected function getDonorProfilePageContent( $format ) {
+
+		switch ( $format ) {
+			case 'block': {
+				return get_comment_delimited_block_content(
+					'give/donor-profile',
+					[
+						'align' => 'wide',
+					],
+					null
+				);
+			}
+			default: {
+				return null;
+			}
+		}
+
 	}
 
 	public function overrideLegacyDonationManagementPageSettings( $settings ) {

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -2,13 +2,19 @@
 
 namespace Give\DonorProfiles\Admin;
 
+/**
+ * @since 2.10.0
+ */
 class Settings {
 
-	protected function donorProfilePageIsPublished() {
-		$donorProfilePageId = ! empty( give_get_option( 'donor_profile_page' ) ) ? give_get_option( 'donor_profile_page' ) : null;
-		return $donorProfilePageId && get_post_status( $donorProfilePageId ) === 'publish' ? true : false;
-	}
-
+	/**
+	 * Register settings related to Donor Profiles
+	 *
+	 * @param array $settings
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
 	public function register( $settings ) {
 
 		$donorProfileSettings = [
@@ -23,6 +29,25 @@ class Settings {
 		);
 	}
 
+	/**
+	 * Return true if donor profile page is defined and published, false if not
+	 *
+	 * @return boolean
+	 *
+	 * @since 2.10.0
+	 */
+	protected function donorProfilePageIsPublished() {
+		$donorProfilePageId = ! empty( give_get_option( 'donor_profile_page' ) ) ? give_get_option( 'donor_profile_page' ) : null;
+		return $donorProfilePageId && get_post_status( $donorProfilePageId ) === 'publish' ? true : false;
+	}
+
+	/**
+	 * Return CMB2 compatible array used to render/control donor profile page setting
+	 *
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
 	protected function getDonorProfilePageSetting() {
 
 		$generateDonorProfilePageUrl = add_query_arg(
@@ -51,6 +76,13 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Return CMB2 compatible array used to render/control override legacy donation manamgent pages setting
+	 *
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
 	protected function getOverrideLegacyDonationManagementPagesSetting() {
 		return [
 			'name'          => esc_html__( 'Override Legacy Donation Managment Pages', 'give' ),
@@ -66,6 +98,13 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Generate donor profile page, and update site setting to use it
+	 *
+	 * @return void
+	 *
+	 * @since 2.10.0
+	 */
 	public function generateDonorProfilePage() {
 
 		$content = $this->getDonorProfilePageContent( 'block' );
@@ -102,6 +141,14 @@ class Settings {
 
 	}
 
+	/**
+	 * Get default content for donor profile page, based on format (block vs shortcode)
+	 *
+	 * @param string $format
+	 * @return string
+	 *
+	 * @since 2.10.0
+	 */
 	protected function getDonorProfilePageContent( $format ) {
 
 		switch ( $format ) {
@@ -114,6 +161,9 @@ class Settings {
 					null
 				);
 			}
+			case 'shortcode': {
+				return '[give_donor_profile]';
+			}
 			default: {
 				return null;
 			}
@@ -121,6 +171,14 @@ class Settings {
 
 	}
 
+	/**
+	 * Filter and override legacy donation management page settings
+	 *
+	 * @param array $settings
+	 * @return array
+	 *
+	 * @since 2.10.0
+	 */
 	public function overrideLegacyDonationManagementPageSettings( $settings ) {
 
 		// Only override settings if the the override legacy donation management pages setting is enabled

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -5,14 +5,17 @@ namespace Give\DonorProfiles\Admin;
 class Settings {
 
 	public function register( $settings ) {
+
+		$donorProfilePageIsSet = empty( give_get_option( 'donor_profile_page' ) ) ? false : true;
+
 		$donorProfileSettings = [
 			$this->getDonorProfilePageSetting(),
-			$this->getOverrideLegacyDonationManagementPagesSetting(),
+			$donorProfilePageIsSet ? $this->getOverrideLegacyDonationManagementPagesSetting() : null,
 		];
 
 		return give_settings_array_insert(
 			$settings,
-			'base_country',
+			'history_page',
 			$donorProfileSettings
 		);
 	}
@@ -20,7 +23,7 @@ class Settings {
 	protected function getDonorProfilePageSetting() {
 		return [
 			'name'       => __( 'Donor Profile Page', 'give' ),
-			'desc'       => __( 'This is the page donors can access to manage their subscriptions. The <code>[give_subscriptions]</code> shortcode should be on this page.', 'give' ),
+			'desc'       => __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? Let us <a href="#">generate one for you.</a>', 'give' ),
 			'id'         => 'donor_profile_page',
 			'type'       => 'select',
 			'class'      => 'give-select give-select-chosen',
@@ -40,7 +43,7 @@ class Settings {
 	protected function getOverrideLegacyDonationManagementPagesSetting() {
 		return [
 			'name'          => esc_html__( 'Override Legacy Donation Managment Pages', 'give' ),
-			'desc'          => esc_html__( 'Use Donor Profile Page setting to override legacy donation management pages.', 'give' ),
+			'desc'          => esc_html__( 'Use Donor Profile in favor of legacy donation management pages (Donation History, Edit Proifle, Subscriptions, etc).', 'give' ),
 			'id'            => 'override_legacy_donation_management_pages',
 			'wrapper_class' => 'override-legacy-donation-management-pages',
 			'type'          => 'radio_inline',

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -126,10 +126,18 @@ class Settings {
 		// Only override settings if the the override legacy donation management pages setting is enabled
 		if ( $this->donorProfilePageIsPublished() && give_is_setting_enabled( give_get_option( 'override_legacy_donation_management_pages', 'enabled' ) ) ) {
 
+			$pageId = give_get_option( 'donor_profile_page' );
+
 			$overrideSettingsMap = [
 				'history_page',
 				'subscriptions_page',
 			];
+
+			foreach ( $overrideSettingsMap as $setting ) {
+				if ( give_get_option( $setting ) !== $pageId ) {
+					give_update_option( $setting, $pageId );
+				}
+			}
 
 			// Hide settings that are overriden by Donor Profile setting
 			$key = 0;

--- a/src/DonorProfiles/Admin/SuccessNotice.php
+++ b/src/DonorProfiles/Admin/SuccessNotice.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Give\DonorProfiles\Admin;
+
+class SuccessNotice {
+
+	/**
+	 * Reigster success notice
+	 *
+	 * @return void
+	 *
+	 * @since 2.10.0
+	 */
+	public function register() {
+		error_log( 'register success notice!!' );
+		if ( $this->shouldRenderOutput() ) {
+			$this->renderOutput();
+		}
+	}
+
+	/**
+	 * Return true if notice should be rendered, false if not
+	 *
+	 * @return boolean
+	 *
+	 * @since 2.10.0
+	 */
+	protected function shouldRenderOutput() {
+		return isset( $_GET['give-generated-donor-profile-page'] );
+	}
+
+	/**
+	 * Render notice output
+	 *
+	 * @return void
+	 *
+	 * @since 2.10.0
+	 */
+	protected function renderOutput() {
+		echo $this->getOutput();
+	}
+
+	/**
+	 * Get notice output
+	 *
+	 * @return string
+	 *
+	 * @since 2.10.0
+	 */
+	protected function getOutput() {
+		ob_start();
+		$output = '';
+		require $this->getTemplatePath();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		return $output;
+	}
+
+	/**
+	 * Get template path for notice output
+	 *
+	 * @return string
+	 *
+	 * @since 2.10.0
+	 */
+	protected function getTemplatePath() {
+		return GIVE_PLUGIN_DIR . '/src/DonorProfiles/resources/views/successnotice.php';
+	}
+}

--- a/src/DonorProfiles/Admin/UpgradeNotice.php
+++ b/src/DonorProfiles/Admin/UpgradeNotice.php
@@ -14,8 +14,11 @@ class UpgradeNotice {
 
 		// Give Admin Only.
 		if ( give_is_admin_page() ) {
-			$donorProfilePageIsSet = empty( give_get_option( 'donor_profile_page' ) ) ? false : true;
-			if ( $donorProfilePageIsSet === false ) {
+
+			$donorProfilePageIsSet = empty( give_get_option( 'donor_profile_page' ) ) || get_post_status( give_get_option( 'donor_profile_page' ) ) === false ? false : true;
+			$historyPageIsSet      = empty( give_get_option( 'history_page' ) ) ? false : true;
+
+			if ( $donorProfilePageIsSet === false && $historyPageIsSet === true ) {
 				return true;
 			} else {
 				return false;

--- a/src/DonorProfiles/Admin/UpgradeNotice.php
+++ b/src/DonorProfiles/Admin/UpgradeNotice.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Give\DonorProfiles\Admin;
+
+class UpgradeNotice {
+
+	public function register() {
+		if ( $this->shouldRenderOutput() ) {
+			$this->renderOutput();
+		}
+	}
+
+	protected function shouldRenderOutput() {
+		return true;
+	}
+
+	protected function renderOutput() {
+		echo $this->getOutput();
+	}
+
+	protected function getOutput() {
+		ob_start();
+		$output = '';
+		require $this->getTemplatePath();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		return $output;
+	}
+
+	protected function getTemplatePath() {
+		return GIVE_PLUGIN_DIR . '/src/DonorProfiles/resources/views/upgradenotice.php';
+	}
+}

--- a/src/DonorProfiles/Admin/UpgradeNotice.php
+++ b/src/DonorProfiles/Admin/UpgradeNotice.php
@@ -25,22 +25,13 @@ class UpgradeNotice {
 	 * @since 2.10.0
 	 */
 	protected function shouldRenderOutput() {
-
-		// Give Admin Only.
-		if ( give_is_admin_page() ) {
-
-			$donorProfilePageIsSet = empty( give_get_option( 'donor_profile_page' ) ) || get_post_status( give_get_option( 'donor_profile_page' ) ) === false ? false : true;
-			$historyPageIsSet      = empty( give_get_option( 'history_page' ) ) ? false : true;
-
-			if ( $donorProfilePageIsSet === false && $historyPageIsSet === true ) {
-				return true;
-			} else {
-				return false;
-			}
-			return true;
-		} else {
+		if ( ! give_is_admin_page() ) {
 			return false;
 		}
+
+		$donorProfilePageIsSet = ! empty( give_get_option( 'donor_profile_page' ) ) && get_post_status( give_get_option( 'donor_profile_page' ) );
+		$historyPageIsSet      = ! empty( give_get_option( 'history_page' ) );
+		return ! $donorProfilePageIsSet && $historyPageIsSet;
 	}
 
 	/**

--- a/src/DonorProfiles/Admin/UpgradeNotice.php
+++ b/src/DonorProfiles/Admin/UpgradeNotice.php
@@ -11,7 +11,19 @@ class UpgradeNotice {
 	}
 
 	protected function shouldRenderOutput() {
-		return true;
+
+		// Give Admin Only.
+		if ( give_is_admin_page() ) {
+			$donorProfilePageIsSet = empty( give_get_option( 'donor_profile_page' ) ) ? false : true;
+			if ( $donorProfilePageIsSet === false ) {
+				return true;
+			} else {
+				return false;
+			}
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	protected function renderOutput() {

--- a/src/DonorProfiles/Admin/UpgradeNotice.php
+++ b/src/DonorProfiles/Admin/UpgradeNotice.php
@@ -4,12 +4,26 @@ namespace Give\DonorProfiles\Admin;
 
 class UpgradeNotice {
 
+	/**
+	 * Reigster upgrade notice
+	 *
+	 * @return void
+	 *
+	 * @since 2.10.0
+	 */
 	public function register() {
 		if ( $this->shouldRenderOutput() ) {
 			$this->renderOutput();
 		}
 	}
 
+	/**
+	 * Return true if notice should be rendered, false if not
+	 *
+	 * @return boolean
+	 *
+	 * @since 2.10.0
+	 */
 	protected function shouldRenderOutput() {
 
 		// Give Admin Only.
@@ -29,10 +43,24 @@ class UpgradeNotice {
 		}
 	}
 
+	/**
+	 * Render notice output
+	 *
+	 * @return void
+	 *
+	 * @since 2.10.0
+	 */
 	protected function renderOutput() {
 		echo $this->getOutput();
 	}
 
+	/**
+	 * Get notice output
+	 *
+	 * @return string
+	 *
+	 * @since 2.10.0
+	 */
 	protected function getOutput() {
 		ob_start();
 		$output = '';
@@ -43,6 +71,13 @@ class UpgradeNotice {
 		return $output;
 	}
 
+	/**
+	 * Get template path for notice output
+	 *
+	 * @return string
+	 *
+	 * @since 2.10.0
+	 */
 	protected function getTemplatePath() {
 		return GIVE_PLUGIN_DIR . '/src/DonorProfiles/resources/views/upgradenotice.php';
 	}

--- a/src/DonorProfiles/RequestHandler.php
+++ b/src/DonorProfiles/RequestHandler.php
@@ -19,6 +19,7 @@ class RequestHandler {
 	public function filterQueryVars( $vars ) {
 		$vars[] = 'give-embed';
 		$vars[] = 'give-generate-donor-profile-page';
+		$vars[] = 'give-generated-donor-profile-page';
 		return $vars;
 	}
 
@@ -32,7 +33,7 @@ class RequestHandler {
 
 		if ( is_admin() && array_key_exists( 'give-generate-donor-profile-page', $query->query_vars ) ) {
 			( new Settings() )->generateDonorProfilePage();
-			wp_safe_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-settings' ) );
+			wp_safe_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-settings&give-generated-donor-profile-page=1' ) );
 			exit;
 		}
 

--- a/src/DonorProfiles/RequestHandler.php
+++ b/src/DonorProfiles/RequestHandler.php
@@ -18,7 +18,7 @@ class RequestHandler {
 	 */
 	public function filterQueryVars( $vars ) {
 		$vars[] = 'give-embed';
-		$vars[] = 'give-donor-profile-action';
+		$vars[] = 'give-generate-donor-profile-page';
 		return $vars;
 	}
 
@@ -30,12 +30,10 @@ class RequestHandler {
 	 */
 	public function parseRequest( $query ) {
 
-		error_log( serialize( $query ) );
-
-		if ( array_key_exists( 'give-donor-profile-action', $query->query_vars ) && $query->query_vars['give-donor-profile-action'] === 'generate-donor-profile-page' ) {
-			error_log( 'generate donor profile page!!' );
+		if ( is_admin() && array_key_exists( 'give-generate-donor-profile-page', $query->query_vars ) ) {
 			( new Settings() )->generateDonorProfilePage();
-			return null;
+			wp_safe_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-settings' ) );
+			exit;
 		}
 
 		if ( array_key_exists( 'give-embed', $query->query_vars ) && $query->query_vars['give-embed'] === 'donor-profile' ) {

--- a/src/DonorProfiles/RequestHandler.php
+++ b/src/DonorProfiles/RequestHandler.php
@@ -3,6 +3,7 @@
 namespace Give\DonorProfiles;
 
 use Give\DonorProfiles\App;
+use Give\DonorProfiles\Admin\Settings;
 
 /**
  * @since 2.10.0
@@ -17,6 +18,7 @@ class RequestHandler {
 	 */
 	public function filterQueryVars( $vars ) {
 		$vars[] = 'give-embed';
+		$vars[] = 'give-donor-profile-action';
 		return $vars;
 	}
 
@@ -27,7 +29,12 @@ class RequestHandler {
 	 * @return void
 	 */
 	public function parseRequest( $query ) {
-		if ( is_admin() ) {
+
+		error_log( serialize( $query ) );
+
+		if ( array_key_exists( 'give-donor-profile-action', $query->query_vars ) && $query->query_vars['give-donor-profile-action'] === 'generate-donor-profile-page' ) {
+			error_log( 'generate donor profile page!!' );
+			( new Settings() )->generateDonorProfilePage();
 			return null;
 		}
 

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -20,6 +20,9 @@ use Give\DonorProfiles\Tabs\EditProfileTab\Tab as EditProfileTab;
 
 use Give\DonorProfiles\Tabs\TabsRegister;
 
+use Give\DonorProfiles\Admin\UpgradeNotice;
+use Give\DonorProfiles\Admin\Settings;
+
 /**
  * @since 2.10.0
  */
@@ -39,6 +42,9 @@ class ServiceProvider implements ServiceProviderInterface {
 	 * @inheritDoc
 	 */
 	public function boot() {
+
+		Hooks::addAction( 'admin_notices', UpgradeNotice::class, 'register' );
+		Hooks::addFilter( 'give_settings_general', Settings::class, 'register' );
 
 		Hooks::addAction( 'give_embed_head', App::class, 'loadAssets' );
 

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -43,6 +43,8 @@ class ServiceProvider implements ServiceProviderInterface {
 	 */
 	public function boot() {
 
+		Hooks::addAction( 'give_after_install', Settings::class, 'generateDonorProfilePage' );
+
 		Hooks::addAction( 'admin_notices', UpgradeNotice::class, 'register' );
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'register' );
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'overrideLegacyDonationManagementPageSettings', 999 );

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -45,6 +45,7 @@ class ServiceProvider implements ServiceProviderInterface {
 
 		Hooks::addAction( 'admin_notices', UpgradeNotice::class, 'register' );
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'register' );
+		Hooks::addFilter( 'give_settings_general', Settings::class, 'overrideLegacyDonationManagementPageSettings', 999 );
 
 		Hooks::addAction( 'give_embed_head', App::class, 'loadAssets' );
 

--- a/src/DonorProfiles/ServiceProvider.php
+++ b/src/DonorProfiles/ServiceProvider.php
@@ -21,6 +21,7 @@ use Give\DonorProfiles\Tabs\EditProfileTab\Tab as EditProfileTab;
 use Give\DonorProfiles\Tabs\TabsRegister;
 
 use Give\DonorProfiles\Admin\UpgradeNotice;
+use Give\DonorProfiles\Admin\SuccessNotice;
 use Give\DonorProfiles\Admin\Settings;
 
 /**
@@ -46,6 +47,8 @@ class ServiceProvider implements ServiceProviderInterface {
 		Hooks::addAction( 'give_after_install', Settings::class, 'generateDonorProfilePage' );
 
 		Hooks::addAction( 'admin_notices', UpgradeNotice::class, 'register' );
+		Hooks::addAction( 'admin_notices', SuccessNotice::class, 'register' );
+
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'register' );
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'overrideLegacyDonationManagementPageSettings', 999 );
 

--- a/src/DonorProfiles/resources/js/admin/index.js
+++ b/src/DonorProfiles/resources/js/admin/index.js
@@ -1,14 +1,23 @@
-// Code to handle showing/hiding admin notices based on time since they were dismissed
+// Code to handle showing/hiding admin notices (based on dismissed status in localStorage)
+
 document.addEventListener( 'DOMContentLoaded', () => {
 	// Select dismissable notices
 	const notices = document.querySelectorAll( 'div[data-give-dismissible]' );
 
+	// Apply for every dismissible GiveWP notice
 	notices.forEach( ( notice ) => {
+		// Generate storage id for notice
 		const storageId = `give-dismissed-${ notice.dataset.giveDismissible }`;
+
+		// Retrieve timestamp of notice dismissal, if it has already happened
 		const storedItem = window.localStorage.getItem( storageId );
 
+		// If notice has not yet been dismissed continue
 		if ( ! storedItem ) {
+			// Show the notice, if it has not been dismissed
 			notice.classList.remove( 'hidden' );
+
+			// On dismissal click, add a record to local storage to that it remains hidden in the future
 			notice.addEventListener( 'click', ( e ) => {
 				if ( e.target.classList.contains( 'notice-dismiss' ) ) {
 					window.localStorage.setItem( storageId, Date.now() );

--- a/src/DonorProfiles/resources/js/admin/index.js
+++ b/src/DonorProfiles/resources/js/admin/index.js
@@ -1,0 +1,19 @@
+// Code to handle showing/hiding admin notices based on time since they were dismissed
+document.addEventListener( 'DOMContentLoaded', () => {
+	// Select dismissable notices
+	const notices = document.querySelectorAll( 'div[data-give-dismissible]' );
+
+	notices.forEach( ( notice ) => {
+		const storageId = `give-dismissed-${ notice.dataset.giveDismissible }`;
+		const storedItem = window.localStorage.getItem( storageId );
+
+		if ( ! storedItem ) {
+			notice.classList.remove( 'hidden' );
+			notice.addEventListener( 'click', ( e ) => {
+				if ( e.target.classList.contains( 'notice-dismiss' ) ) {
+					window.localStorage.setItem( storageId, Date.now() );
+				}
+			} );
+		}
+	} );
+} );

--- a/src/DonorProfiles/resources/styles/upgradenotice.scss
+++ b/src/DonorProfiles/resources/styles/upgradenotice.scss
@@ -1,0 +1,71 @@
+.give-donor-profile-upgrade-notice {
+	padding: 20px;
+	display: flex;
+	align-items: center;
+	background: #fff;
+	width: calc(100% - 40px);
+	border: 1px solid #ccd0d4;
+	box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+
+	.give-donor-profile-upgrade-notice__graphic {
+		width: 225px;
+		height: 180px;
+		background: rgb(200, 200, 200);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		margin-right: 20px;
+		border-radius: 8px;
+	}
+
+	.give-donor-profile-upgrade-notice__copy {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		flex: 1;
+
+		.give-donor-profile-upgrade-notice__subtitle {
+			font-size: 16px;
+			margin: 6px 0 12px 0;
+		}
+
+		.give-donor-profile-upgrade-notice__title {
+			font-size: 36px;
+			margin: 6px 0 20px 0;
+		}
+
+		.give-donor-profile-upgrade-notice__body {
+			font-size: 16px;
+			margin: 6px 0 20px 0;
+		}
+
+		a {
+			font-size: 12px;
+			font-style: italic;
+			text-decoration: underline;
+		}
+	}
+
+	.give-donor-profile-upgrade-notice__cta {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		a {
+			font-size: 14px;
+			font-style: italic;
+			text-decoration: underline;
+		}
+
+		a.give-donor-profile-upgrade-notice__button {
+			font-size: 16px;
+			font-style: normal;
+			text-decoration: none;
+			padding: 16px 28px;
+			margin: 16px 0;
+			border-radius: 4px;
+			background: #0073aa;
+			color: #fff;
+		}
+	}
+}

--- a/src/DonorProfiles/resources/styles/upgradenotice.scss
+++ b/src/DonorProfiles/resources/styles/upgradenotice.scss
@@ -1,11 +1,16 @@
 .give-donor-profile-upgrade-notice {
 	padding: 20px;
+	padding-right: 20px !important;
 	display: flex;
 	align-items: center;
 	background: #fff;
 	width: calc(100% - 40px);
 	border: 1px solid #ccd0d4;
 	box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+
+	&.hidden {
+		display: none;
+	}
 
 	.give-donor-profile-upgrade-notice__graphic {
 		width: 225px;

--- a/src/DonorProfiles/resources/views/successnotice.php
+++ b/src/DonorProfiles/resources/views/successnotice.php
@@ -1,0 +1,11 @@
+<?php
+
+$pageId = give_get_option( 'donor_profile_page' );
+
+$pageUrl = get_permalink( $pageId );
+
+?>
+
+<div class="notice notice-success is-dismissible">
+	<p><?php printf( __( 'Success! Donor Profile page was created. You can <a href="%s">take a look at it here.</a>' ), $pageUrl ); ?></p>
+</div>

--- a/src/DonorProfiles/resources/views/upgradenotice.php
+++ b/src/DonorProfiles/resources/views/upgradenotice.php
@@ -1,4 +1,33 @@
+<?php
 
-<div class="notice notice-warning is-dismissible">
-	<p>This notice appears on the settings page.</p>
+$setupUrl = admin_url( 'edit.php?post_type=give_forms&page=give-settings' );
+
+?>
+
+<div class="notice give-donor-profile-upgrade-notice">
+	<div class="give-donor-profile-upgrade-notice__graphic">
+		Donor Profile Graphic
+	</div>
+	<div class="give-donor-profile-upgrade-notice__copy">
+		<div class="give-donor-profile-upgrade-notice__subtitle">
+			New in GiveWP 2.10
+		</div>
+		<div class="give-donor-profile-upgrade-notice__title">
+			Donor Profiles
+		</div>
+		<div class="give-donor-profile-upgrade-notice__body">
+			Let donors update their information, review receipts, and mange subscriptions. All in one place.
+		</div>
+		<a href="#">
+			Learn more on the GiveWP blog
+		</a>
+	</div>
+	<div class="give-donor-profile-upgrade-notice__cta">
+		<a class="give-donor-profile-upgrade-notice__button" href="<?php echo $setupUrl; ?>">
+			Setup Donor Profiles
+		</a>
+		<a>
+			I'll setup Donor Profiles later.
+		</a>
+	</div>
 </div>

--- a/src/DonorProfiles/resources/views/upgradenotice.php
+++ b/src/DonorProfiles/resources/views/upgradenotice.php
@@ -4,7 +4,7 @@ $setupUrl = admin_url( 'edit.php?post_type=give_forms&page=give-settings' );
 
 ?>
 
-<div class="notice give-donor-profile-upgrade-notice">
+<div class="notice give-donor-profile-upgrade-notice is-dismissible hidden" data-give-dismissible="upgrade-donor-profiles-notice-210" >
 	<div class="give-donor-profile-upgrade-notice__graphic">
 		Donor Profile Graphic
 	</div>

--- a/src/DonorProfiles/resources/views/upgradenotice.php
+++ b/src/DonorProfiles/resources/views/upgradenotice.php
@@ -1,0 +1,4 @@
+
+<div class="notice notice-warning is-dismissible">
+	<p>This notice appears on the settings page.</p>
+</div>

--- a/src/DonorProfiles/resources/views/upgradenotice.php
+++ b/src/DonorProfiles/resources/views/upgradenotice.php
@@ -26,8 +26,5 @@ $setupUrl = admin_url( 'edit.php?post_type=give_forms&page=give-settings' );
 		<a class="give-donor-profile-upgrade-notice__button" href="<?php echo $setupUrl; ?>">
 			Setup Donor Profiles
 		</a>
-		<a>
-			I'll setup Donor Profiles later.
-		</a>
 	</div>
 </div>

--- a/src/DonorProfiles/resources/views/upgradenotice.php
+++ b/src/DonorProfiles/resources/views/upgradenotice.php
@@ -1,6 +1,11 @@
 <?php
 
-$setupUrl = admin_url( 'edit.php?post_type=give_forms&page=give-settings' );
+$setupUrl = add_query_arg(
+	[
+		'give-generate-donor-profile-page' => '1',
+	],
+	admin_url( 'edit.php' )
+);
 
 ?>
 


### PR DESCRIPTION
Resolves #5638 
Resolves #5630 

## Description
This PR introduces logic to display an upgrade notice to explain the Donor Profiles feature to admin who have an existing GiveWP install. Additionally, it introduces logic to generate and setup a Donor Profile page when requested.

## Affects
This PR affects the admin interface, specifically pages with GiveWP related controls.

## Visuals
<img width="1610" alt="Screen Shot 2021-03-01 at 5 06 26 PM" src="https://user-images.githubusercontent.com/5186078/109565786-f77e1480-7ab0-11eb-85e9-0383e0fd99a8.png">

<img width="1314" alt="Screen Shot 2021-03-01 at 5 06 47 PM" src="https://user-images.githubusercontent.com/5186078/109565800-fc42c880-7ab0-11eb-967d-98d5f5c60481.png">

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

On an existing GiveWP install:
1) Check that the new Donor Profiles notice appears on GiveWP related admin pages
2) Click "Setup Donor Profiles", check that you are directed to the settings page
3) Find the Donor Profile Page setting. In the description text, click the link that says "Let us generate one for you."
4) The setting page should reload, now with the Donor Profile setting setup (with a page title Donor Profile), and the Override Legacy Donation Management Pages setting enabled. 
5) Check that the Donor Profile upgrade notice is no longer visible.
6) Go to Pages, and edit the new Donor Profile page.
7) Check that the Donor Profile block appears as expected, with accent color controls available.
8) Return to the Pages view, and delete the Donor Profile page (permanently delete the page).
9) Check that the upgrade notice re-appears on GiveWP related admin pages.
10) Click the "x" to dismiss the upgrade notice.
11) Refresh the page to ensure that the Upgrade Notice does not reappear.

On a fresh install:
1) Check that a Donor Profile page was created, and set as the History Page.
2) Check that the Donor Profile page includes a Donor Profile block.
3) In GiveWP settings, check that the Donor Profile page is set, and that the Override Setting is enabled.