### PR TITLE
Migrations and Logs UI is now polished

### DIFF
--- a/src/MigrationLog/Admin/Migrations/index.js
+++ b/src/MigrationLog/Admin/Migrations/index.js
@@ -219,6 +219,11 @@ const Migrations = () => {
 			label: __( 'Migration Title', 'give' ),
 			sort: true,
 			sortCallback: ( direction ) => setSortDirectionForColumn( 'title', direction ),
+			styles: {
+				overflowWrap: 'break-word',
+				wordWrap: 'break-word',
+				wordBreak: 'break-all',
+			},
 		},
 		{
 			key: 'last_run',

--- a/src/MigrationLog/Admin/Migrations/index.js
+++ b/src/MigrationLog/Admin/Migrations/index.js
@@ -278,7 +278,7 @@ const Migrations = () => {
 				<button
 					className="button"
 					onClick={ () => openMigrationRunModal( migration.id ) }>
-					{ __( 'Run Update', 'give' ) }
+					{ __( 'Re-run Update', 'give' ) }
 				</button>
 			);
 		},

--- a/src/Views/Components/PeriodSelector/style.module.scss
+++ b/src/Views/Components/PeriodSelector/style.module.scss
@@ -1,8 +1,7 @@
 .periodSelector {
 	display: inline-flex;
 	align-items: center;
-	max-width: 330px;
-	width: 100%;
+	min-width: 330px;
 }
 
 .datepicker {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5659

## Description

This PR adds minor tweaks to CSS styles to fix the issue with elements that are not displaying correctly on smaller screens.
And the text of the migration run button has been updated. 

Elements that were not displaying correctly:

- Period selector
- Migration title



## Affects

Migrations list table.

## Visuals

| Migrations list table | Logs list table |
|---|---|
| ![image](https://user-images.githubusercontent.com/4222590/109619397-090aff00-7b39-11eb-9395-58d686c50ed6.png) | ![image](https://user-images.githubusercontent.com/4222590/109619898-91899f80-7b39-11eb-87db-18fce51accbe.png) |




## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
**Migrations list table**
1. Navigate to `Donations -> Tools -> Data` page. 
2. Resize your browser window to a smaller size ( migration title text should break onto the next line )

**Logs list table**
1. Navigate to `Donations -> Tools -> Logs` page. 
2. Resize your browser window to a smaller size ( the period selector should not break )
