### PR TITLE
Donor Profile receipt content should match receipt displayed during donation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Anonymous donation and company setting choices are now persisted (#5633)
 -   Admin are now shown Donor Profiles upgrade notice (#5660)
 -   Donor Profile page is now generated on new installs (#5600)
+-   Donor Profile receipt content should match receipt displayed during donation (#5666)
 
 ### Changed
 -   Donor Profile Donation History UI is now polished (#5566)

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -185,6 +185,13 @@ class Donations {
 		];
 	}
 
+	/**
+	 * Get array containing dynamic receipt information
+	 *
+	 * @param Give_Payment $payment
+	 * @return array
+	 * @since 2.10.0
+	 */
 	protected function getReceiptInfo( $payment ) {
 
 		$receipt = new DonationReceipt( $payment->ID );

--- a/src/DonorProfiles/resources/js/app/components/auth-modal/index.js
+++ b/src/DonorProfiles/resources/js/app/components/auth-modal/index.js
@@ -56,7 +56,6 @@ const AuthModal = () => {
 		if ( email ) {
 			setVerifyingEmail( true );
 			// eslint-disable-next-line camelcase
-
 			const { status, body_response } = await verifyEmailWithAPI( {
 				email,
 				recaptcha,

--- a/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
+++ b/src/DonorProfiles/resources/js/app/components/donation-receipt/index.js
@@ -1,7 +1,3 @@
-import { Fragment } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-const { __ } = wp.i18n;
-
 import './style.scss';
 
 const DonationReceipt = ( { donation } ) => {
@@ -9,91 +5,26 @@ const DonationReceipt = ( { donation } ) => {
 		return null;
 	}
 
-	const { donor, payment } = donation;
+	const { receipt } = donation;
 
-	return (
-		<Fragment>
-			<div className="give-donor-profile-donation-receipt__table">
-				<div className="give-donor-profile-donation-receipt__row">
+	return receipt.map( ( section, sectionIndex ) => {
+		const lineItems = section.lineItems.map( ( item, itemIndex ) => {
+			return (
+				<div className={ `give-donor-profile-donation-receipt__row${ item.class.includes( 'total' ) ? ' give-donor-profile-donation-receipt__row--footer' : '' }` } key={ itemIndex }>
 					<div className="give-donor-profile-donation-receipt__detail">
-						<FontAwesomeIcon icon="user" /> { __( 'Donor Name:', 'give' ) }
+						{ item.icon && <span dangerouslySetInnerHTML={ { __html: item.icon } } /> } { item.label }
 					</div>
 					<div className="give-donor-profile-donation-receipt__value">
-						{ `${ donor.first_name } ${ donor.last_name }` }
+						{ item.value }
 					</div>
 				</div>
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						<FontAwesomeIcon icon="envelope" /> { __( 'Email Address:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ donor.email }
-					</div>
-				</div>
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						<FontAwesomeIcon icon="calendar" /> { __( 'Donation Date:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.date }
-					</div>
-				</div>
-				{ donor.address && (
-					<div className="give-donor-profile-donation-receipt__row">
-						<div className="give-donor-profile-donation-receipt__detail">
-							<FontAwesomeIcon icon="globe" /> { __( 'Address:', 'give' ) }
-						</div>
-						<div className="give-donor-profile-donation-receipt__value">
-							{ donor.address.street && ( <div> { donor.address.street } </div> ) }
-							{ donor.address.city && donor.address.state && donor.address.zip && ( <div> { donor.address.city } { donor.address.state }, { donor.address.zip } </div> ) }
-							{ donor.address.country && ( <div> { donor.address.country } </div> ) }
-						</div>
-					</div>
-				) }
+			);
+		} );
+		return (
+			<div className="give-donor-profile-donation-receipt__table" key={ sectionIndex }>
+				{ lineItems }
 			</div>
-			<div className="give-donor-profile-donation-receipt__table">
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						{ __( 'Payment Method:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.method }
-					</div>
-				</div>
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						{ __( 'Payment Status:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.status.label }
-					</div>
-				</div>
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						{ __( 'Payment Amount:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.amount }
-					</div>
-				</div>
-				<div className="give-donor-profile-donation-receipt__row">
-					<div className="give-donor-profile-donation-receipt__detail">
-						{ __( 'Processing Fee:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.fee }
-					</div>
-				</div>
-				<div className="give-donor-profile-donation-receipt__row give-donor-profile-donation-receipt__row--footer">
-					<div className="give-donor-profile-donation-receipt__detail">
-						{ __( 'Donation Total:', 'give' ) }
-					</div>
-					<div className="give-donor-profile-donation-receipt__value">
-						{ payment.total }
-					</div>
-				</div>
-			</div>
-		</Fragment>
-	);
+		);
+	} );
 };
 export default DonationReceipt;

--- a/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/donation-history/content.js
@@ -43,7 +43,7 @@ const Content = () => {
 		) : (
 			<Fragment>
 				<Heading>
-					{ __( 'Donation', 'give' ) } { getDonationById( id ).payment.serialCode }
+					{ __( 'Receipt', 'give' ) } { getDonationById( id ).payment.serialCode }
 				</Heading>
 				<DonationReceipt donation={ getDonationById( id ) } />
 				<div className="give-donor-profile__donation-history-footer">


### PR DESCRIPTION
Resolves #5639 

## Description

This PR introduces logic to ensure that the Donation receipt presented inside Donor Profiles matches the donation receipt shown to donors during the donation process. This includes dynamic donation-specific line items like processing fees, subscription information, and custom field information.

## Affects

This PR affects the Donation Receipt view of Donor Profiles, and the Donations repository logic used to retrieve and describe a donor's donation history.

## Visuals

<img width="656" alt="Screen Shot 2021-03-03 at 5 44 54 PM" src="https://user-images.githubusercontent.com/5186078/109883150-f4b62780-7c48-11eb-8e20-096fcf781552.png">

## Testing Instructions

1. Make a donation with dynamic receipt line items (custom fields, subscription, fee recovery, etc).
2. Note the line items shown in your donation receipt during the donation process.
2. From the Donor Profile, view the receipt for that donation.
3. Check that the receipt line items shown inside Donor Profiles match the receipt you were shown during the donation process.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

