### PR TITLE
Custom Fields on the Sequoia template now match alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Form Templates now support custom checkbox fields. (#5643)
 -   Custom fields now support arbitrary attributes (#5641)
 
+### Fixed
+
+-   Custom Fields on the Sequoia template now match alignment (#5669)
+
 ## 2.9.6 - 2021-01-13
 
 ### New

--- a/src/Form/LegacyConsumer/TemplateHooks.php
+++ b/src/Form/LegacyConsumer/TemplateHooks.php
@@ -3,42 +3,41 @@
 namespace Give\Form\LegacyConsumer;
 
 class TemplateHooks {
-    /**
-     * A "full-ish" list of available actions.
-     * @note The `give_` prefix has been removed for interoperability.
-     * @note Update to account for previously deprecated hooks.
-     * @link https://givewp.com/documentation/developers/how-to-create-custom-form-fields/
-     * @link https://givewp.com/add-content-donation-forms/
-     */
-    const TEMPLATE_HOOKS =  [
-        'before_donation_levels',
-        'after_donation_amount',
-        'after_donation_levels',
-        'payment_mode_select',
-        'payment_mode_top',
-        'payment_mode_before_gateways',
-        'payment_mode_after_gateways',
-        'payment_mode_after_gateways_wrap',
-        'payment_mode_bottom',
-        'donation_form',
-        'purchase_form_top',
-        'donation_form_register_login_fields',
-        'donation_form_before_cc_form',
-        'cc_form',
-        'before_cc_fields',
-        'before_cc_expiration',
-        'after_cc_expiration',
-        'after_cc_fields',
-        'donation_form_after_cc_form',
-        'purchase_form_bottom',
-    ];
+	/**
+	 * A "full-ish" list of available actions.
+	 * @note The `give_` prefix has been removed for interoperability.
+	 * @note Update to account for previously deprecated hooks.
+	 * @link https://givewp.com/documentation/developers/how-to-create-custom-form-fields/
+	 * @link https://givewp.com/add-content-donation-forms/
+	 */
+	const TEMPLATE_HOOKS = [
+		'before_donation_levels',
+		'after_donation_amount',
+		'after_donation_levels',
+		'payment_mode_top',
+		'payment_mode_before_gateways',
+		'payment_mode_after_gateways',
+		'payment_mode_after_gateways_wrap',
+		'payment_mode_bottom',
+		'donation_form',
+		'purchase_form_top',
+		'donation_form_register_login_fields',
+		'donation_form_before_cc_form',
+		'cc_form',
+		'before_cc_fields',
+		'before_cc_expiration',
+		'after_cc_expiration',
+		'after_cc_fields',
+		'donation_form_after_cc_form',
+		'purchase_form_bottom',
+	];
 
-    public function walk( callable $callback ) {
-        $hooks = $this->getHooks();
-        array_walk( $hooks, $callback );
-    }
+	public function walk( callable $callback ) {
+		$hooks = $this->getHooks();
+		array_walk( $hooks, $callback );
+	}
 
-    public function getHooks() {
-        return self::TEMPLATE_HOOKS;
-    }
+	public function getHooks() {
+		return self::TEMPLATE_HOOKS;
+	}
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1602,3 +1602,19 @@ html[dir='rtl'] {
 		background-image: url("data:image/svg+xml,%3Csvg width='15' height='11' viewBox='0 0 15 11' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.73047 10.7812C6.00391 11.0547 6.46875 11.0547 6.74219 10.7812L14.7812 2.74219C15.0547 2.46875 15.0547 2.00391 14.7812 1.73047L13.7969 0.746094C13.5234 0.472656 13.0859 0.472656 12.8125 0.746094L6.25 7.30859L3.16016 4.24609C2.88672 3.97266 2.44922 3.97266 2.17578 4.24609L1.19141 5.23047C0.917969 5.50391 0.917969 5.96875 1.19141 6.24219L5.73047 10.7812Z' fill='%234fa651'/%3E%3C/svg%3E%0A") !important;
 	}
 }
+
+/*
+ * Fields API / Form Consumer Styles
+ */
+.give-section.choose-amount > .form-row {
+	padding: 20px 30px 0;
+}
+.give-section.payment > .form-row {
+	padding: 5px 20px 5px;
+}
+#give-payment-mode-wrap > .form-row:not(:first-of-type) {
+	margin-top: 20px;
+}
+div[data-field-type='checkbox'] label {
+	padding: 0 0 0 40px;
+}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5668

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Updates the alignment of custom fields to match the default fields in the Sequoia template.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Adds new CSS to the Sequoia template styles.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Here is a snippet for adding custom fields to each template hook:

```php
add_action( 'init', function() {
	give( \Give\Form\LegacyConsumer\TemplateHooks::class )->walk( function( $hook ) {
		add_action( "give_fields_$hook", function( $fieldCollection, $formID ) use ( $hook ) {
			$fieldCollection->append(
				give_field( 'text', 'my-custom-field-' . uniqid() )
					->label( "$hook" )
			);
			$fieldCollection->append(
				give_field( 'textarea', 'my-custom-field-' . uniqid() )
					->label( "$hook" )
			);
			$fieldCollection->append(
				give_field( 'select', 'my-custom-field-' . uniqid() )
					->label( "$hook" )
					->options([
						'' => "$hook",
					])
			);
			$fieldCollection->append(
				give_field( 'checkbox', 'my-custom-field-' . uniqid() )
					->label( "$hook" )
			);
		}, 10, 2 );
	});
});
```

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Choose Amount | Payment |
| --- | --- |
| ![Screenshot_2021-03-04 Donation Form(2)](https://user-images.githubusercontent.com/10858303/109992329-28409280-7cd9-11eb-928d-1f027f416923.png) | ![Screenshot_2021-03-04 Donation Form(3)](https://user-images.githubusercontent.com/10858303/109992344-2d054680-7cd9-11eb-93fa-2c31cb2df7e8.png) |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

