### PR TITLE
Legacy log migrations are not failing on fresh install now

### DIFF
--- a/src/Log/Helpers/LegacyLogsTable.php
+++ b/src/Log/Helpers/LegacyLogsTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Give\Log\Helpers;
+
+/**
+ * Class LogsLegacyTable
+ * @package Give\Log\Helpers
+ *
+ * @since @unreleased
+ */
+class LegacyLogsTable {
+	/**
+	 * Check if legacy logs table exists
+	 *
+	 * @return bool
+	 */
+	public function exist() {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare( "SHOW TABLES LIKE '%s'", "{$wpdb->prefix}give_logs" )
+		);
+	}
+}

--- a/src/Log/LogServiceProvider.php
+++ b/src/Log/LogServiceProvider.php
@@ -46,12 +46,7 @@ class LogServiceProvider implements ServiceProvider {
 	 * Register migration
 	 */
 	private function registerMigrations() {
-		give( MigrationsRegister::class )->addMigrations(
-			[
-				CreateNewLogTable::class,
-				MigrateExistingLogs::class,
-			]
-		);
+		give( MigrationsRegister::class )->addMigration( CreateNewLogTable::class );
 
 		// Check if Logs migration batch processing is completed
 		if ( give_has_upgrade_completed( MigrateExistingLogs::id() ) ) {

--- a/src/Log/LogServiceProvider.php
+++ b/src/Log/LogServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Give\Log;
 
 use Give\Helpers\Hooks;
-use Give\Log\Helpers\LegacyLogsTable;
 use Give\ServiceProviders\ServiceProvider;
 use Give\Framework\Migrations\MigrationsRegister;
 use Give\Log\Migrations\CreateNewLogTable;
@@ -47,18 +46,16 @@ class LogServiceProvider implements ServiceProvider {
 	 * Register migration
 	 */
 	private function registerMigrations() {
-		give( MigrationsRegister::class )->addMigration( CreateNewLogTable::class );
+		give( MigrationsRegister::class )->addMigrations(
+			[
+				CreateNewLogTable::class,
+				MigrateExistingLogs::class,
+			]
+		);
 
-		$legacyLogsTable = give( LegacyLogsTable::class );
-
-		// Check if legacy table exist
-		if ( $legacyLogsTable->exist() ) {
-			give( MigrationsRegister::class )->addMigration( MigrateExistingLogs::class );
-
-			// Check if Logs migration batch processing is completed
-			if ( give_has_upgrade_completed( MigrateExistingLogs::id() ) ) {
-				give( MigrationsRegister::class )->addMigration( DeleteOldLogTables::class );
-			}
+		// Check if Logs migration batch processing is completed
+		if ( give_has_upgrade_completed( MigrateExistingLogs::id() ) ) {
+			give( MigrationsRegister::class )->addMigration( DeleteOldLogTables::class );
 		}
 	}
 }

--- a/src/Log/Migrations/DeleteOldLogTables.php
+++ b/src/Log/Migrations/DeleteOldLogTables.php
@@ -21,7 +21,7 @@ class DeleteOldLogTables extends Migration {
 	 * @return string
 	 */
 	public static function title() {
-		return  esc_html__( 'Delete give_logs and give_logmeta tables' );
+		return  esc_html__( 'Delete give_logs and give_logmeta tables', 'give' );
 	}
 
 	/**
@@ -37,6 +37,6 @@ class DeleteOldLogTables extends Migration {
 		$logs_table    = "{$wpdb->prefix}give_logs";
 		$logmeta_table = "{$wpdb->prefix}give_logmeta";
 
-		DB::query( "DROP TABLE {$logs_table}, {$logmeta_table};" );
+		DB::query( "DROP TABLE IF EXISTS {$logs_table}, {$logmeta_table};" );
 	}
 }

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -5,6 +5,7 @@ namespace Give\Log\Migrations;
 use Give\Log\LogFactory;
 use Give\Framework\Database\DB;
 use Give\Log\Helpers\LogTypeHelper;
+use Give\Log\Helpers\LegacyLogsTable;
 use Give\Framework\Migrations\Contracts\Migration;
 use Give_Updates;
 
@@ -14,14 +15,23 @@ class MigrateExistingLogs extends Migration {
 	 * @var LogTypeHelper
 	 */
 	private $logTypeHelper;
+	/**
+	 * @var LegacyLogsTable
+	 */
+	private $legacyLogsTable;
 
 	/**
 	 * MigrateExistingLogs constructor.
 	 *
 	 * @param  LogTypeHelper  $logTypeHelper
+	 * @param  LegacyLogsTable  $legacyLogsTable
 	 */
-	public function __construct( LogTypeHelper $logTypeHelper ) {
-		$this->logTypeHelper = $logTypeHelper;
+	public function __construct(
+		LogTypeHelper $logTypeHelper,
+		LegacyLogsTable $legacyLogsTable
+	) {
+		$this->logTypeHelper   = $logTypeHelper;
+		$this->legacyLogsTable = $legacyLogsTable;
 	}
 	/**
 	 * Register background update.
@@ -69,7 +79,13 @@ class MigrateExistingLogs extends Migration {
 
 		$logs_table    = "{$wpdb->prefix}give_logs";
 		$logmeta_table = "{$wpdb->prefix}give_logmeta";
-		$give_updates  = Give_Updates::get_instance();
+
+		// Check if legacy table exist
+		if ( ! $this->legacyLogsTable->exist() ) {
+			return;
+		}
+
+		$give_updates = Give_Updates::get_instance();
 
 		$perBatch = 500;
 

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -77,13 +77,13 @@ class MigrateExistingLogs extends Migration {
 	public function run() {
 		global $wpdb;
 
-		$logs_table    = "{$wpdb->prefix}give_logs";
-		$logmeta_table = "{$wpdb->prefix}give_logmeta";
-
 		// Check if legacy table exist
 		if ( ! $this->legacyLogsTable->exist() ) {
 			return;
 		}
+
+		$logs_table    = "{$wpdb->prefix}give_logs";
+		$logmeta_table = "{$wpdb->prefix}give_logmeta";
 
 		$give_updates = Give_Updates::get_instance();
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5671

## Description

This PR resolves the issue with Legacy log migrations failing on fresh installs. The issue is resolved by adding a check for the legacy logs table. If the table exists, the migrations for handling legacy logs will be registered. Otherwise, they won't show up in the legacy table.

## Affects

LogServiceProvider

## Testing Instructions
1. Install this branch on fresh WP install
2. Navigate to `Donations -> Tools -> Data`
There shouldn't be any failed migrations responsible for migrating legacy logs

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

