### PR TITLE
Schedule tracking job only if admin accessing website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+-   Usage tracking job scheduler should not reduce performance (#5678)
+
 ## 2.10.0-beta.2 - 2021-03-05
 
 ### New

--- a/src/Tracking/TrackingServiceProvider.php
+++ b/src/Tracking/TrackingServiceProvider.php
@@ -31,19 +31,22 @@ class TrackingServiceProvider implements ServiceProvider {
 	 */
 	public function boot() {
 		if ( Track::isTrackingEnabled() ) {
-			$this->registerTrackEvents();
-			Hooks::addAction( 'shutdown', TrackJobScheduler::class, 'schedule', 999 );
 			Hooks::addAction( TrackJobScheduler::CRON_JOB_HOOK_NAME, TrackJob::class, 'send' );
 		}
 
-		if ( is_admin() && Track::checkEnvironment() ) {
-			Hooks::addFilter( 'give_get_settings_advanced', AdminSettings::class, 'addSettings' );
-			Hooks::addAction( 'give_opt_in_into_tracking', AdminActionHandler::class, 'optInToUsageTracking' );
-			Hooks::addAction( 'give_hide_opt_in_notice_shortly', AdminActionHandler::class, 'optOutFromUsageTracking' );
-			Hooks::addAction( 'give_hide_opt_in_notice_permanently', AdminActionHandler::class, 'optOutFromUsageTracking' );
-			Hooks::addAction( 'update_option_give_settings', AdminActionHandler::class, 'optInToUsageTrackingAdminGrantManually', 10, 2 );
-			Hooks::addAction( 'give_setup_page_before_sections', UsageTrackingOnBoarding::class, 'addNotice', 0 );
-			Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice' );
+		if ( is_admin() ) {
+			$this->registerTrackEvents();
+			Hooks::addAction( 'shutdown', TrackJobScheduler::class, 'schedule', 999 );
+
+			if ( Track::checkEnvironment() ) {
+				Hooks::addFilter( 'give_get_settings_advanced', AdminSettings::class, 'addSettings' );
+				Hooks::addAction( 'give_opt_in_into_tracking', AdminActionHandler::class, 'optInToUsageTracking' );
+				Hooks::addAction( 'give_hide_opt_in_notice_shortly', AdminActionHandler::class, 'optOutFromUsageTracking' );
+				Hooks::addAction( 'give_hide_opt_in_notice_permanently', AdminActionHandler::class, 'optOutFromUsageTracking' );
+				Hooks::addAction( 'update_option_give_settings', AdminActionHandler::class, 'optInToUsageTrackingAdminGrantManually', 10, 2 );
+				Hooks::addAction( 'give_setup_page_before_sections', UsageTrackingOnBoarding::class, 'addNotice', 0 );
+				Hooks::addAction( 'admin_notices', UsageTrackingOnBoarding::class, 'addNotice' );
+			}
 		}
 	}
 

--- a/src/Tracking/TrackingServiceProvider.php
+++ b/src/Tracking/TrackingServiceProvider.php
@@ -30,13 +30,17 @@ class TrackingServiceProvider implements ServiceProvider {
 	 * @inheritdoc
 	 */
 	public function boot() {
-		if ( Track::isTrackingEnabled() ) {
+		$isTrackingEnabled = Track::isTrackingEnabled();
+
+		if ( $isTrackingEnabled ) {
 			Hooks::addAction( TrackJobScheduler::CRON_JOB_HOOK_NAME, TrackJob::class, 'send' );
 		}
 
 		if ( is_admin() ) {
-			$this->registerTrackEvents();
-			Hooks::addAction( 'shutdown', TrackJobScheduler::class, 'schedule', 999 );
+			if ( $isTrackingEnabled ) {
+				$this->registerTrackEvents();
+				Hooks::addAction( 'shutdown', TrackJobScheduler::class, 'schedule', 999 );
+			}
 
 			if ( Track::checkEnvironment() ) {
 				Hooks::addFilter( 'give_get_settings_advanced', AdminSettings::class, 'addSettings' );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/5678

## Description

Usage tracking job scheduler will run only in WP Backend.

## Testing Instructions

This considers as working if you should able to optin to usage tracking on the live website.
**Usage tracking optin only appears on live sites in WP Backed. Once you accept optin then let me know I will review the data on the telemetry server.**

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

