### PR TITLE
  Donor Dashboard iframe now resize when the parent window resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+-   Donor Dashboard iframe now resize when the parent window resizes (#5693)
+
 ## 2.10.0-beta.3 - 2021-03-09
 
 ### Changed

--- a/assets/src/js/plugins/form-template/utils.js
+++ b/assets/src/js/plugins/form-template/utils.js
@@ -50,6 +50,10 @@ export const initializeIframeResize = function( iframe ) {
 			},
 			onInit: function() {
 				const parent = iframe.parentElement;
+				// Set iframe width to parent window inner width
+				window.top.addEventListener( 'resize', function() {
+					iframe.style.width = window.top.innerWidth + 'px';
+				} );
 
 				let parentUnload = false;
 				window.addEventListener( 'beforeunload', function() {

--- a/src/DonorProfiles/resources/js/app/hooks/index.js
+++ b/src/DonorProfiles/resources/js/app/hooks/index.js
@@ -20,19 +20,19 @@ export const useWindowSize = () => {
 		function handleResize() {
 			// Set window width/height to state
 			setWindowSize( {
-				width: window.innerWidth,
-				height: window.innerHeight,
+				width: window.top.innerWidth,
+				height: window.top.innerHeight,
 			} );
 		}
 
 		// Add event listener
-		window.addEventListener( 'resize', handleResize );
+		window.top.addEventListener( 'resize', handleResize );
 
 		// Call handler right away so state gets updated with initial window size
 		handleResize();
 
 		// Remove event listener on cleanup
-		return () => window.removeEventListener( 'resize', handleResize );
+		return () => window.top.removeEventListener( 'resize', handleResize );
 	}, [] ); // Empty array ensures that effect is only run on mount
 
 	return windowSize;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5688

## Description

This PR fixes the issue where the Donor Dashboard didn't resize when the parent window resizes. The issue is fixed by attaching a `resize` event to the topmost window instance and on the iframe itself. 

The `resize` event for the iframe was already set with `iframe-resizer` library, but for some reason that didn't work for Donor Dashboard. The easiest solution was to attach another resize event to the iframe itself and handle iframe width directly as "fixing" the `iframe-resizer` library is not an option.

## Affects

Donor Dashboard iframe
Donation Form iframe

## Visuals

![deepin-screen-recorder_Select area_20210310100735](https://user-images.githubusercontent.com/4222590/110604562-84e3f780-8188-11eb-9f53-96bbd19227b0.gif)


## Testing Instructions

Go to the Donor Dashboard page and resize your browser window. The DOnor Dashboard iframe should resize when the browser window resizes. 
Make sure you check the Donation form as well because these changes affect the multi-step template too.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

