### PR TITLE
Prevent PHP notices on plugin listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Prevent PHP notices on plugin listing page (#5692)
+
 ## 2.10.0-beta.3 - 2021-03-09
 
 ### Changed

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -624,6 +624,7 @@ add_action( 'after_plugin_row', 'give_show_update_notification_on_multisite', 10
  * @param $plugin
  *
  * @since 2.5.0
+ * @unreleased update condition to verify givewp addons
  */
 function give_show_update_notification_on_single_site( $file, $plugin ) {
 	if ( ! current_user_can( 'update_plugins' ) || is_multisite() ) {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/5692

## Description

We have a helper function `give_get_plugins` which returns plugin data with extra data related to givewp. We show an inline update notice to licensed addon on the plugin listing page. To do that first we verify the add-on license. We are getting PHP notice because some of the plugin data does not return correctly from `Give_License::get_plugin_by_slug( $plugin['slug'] )`. I update the condition to verify empty plugin data too.

## Affects

It does not affect existing functionality.

## Visuals

![image](https://user-images.githubusercontent.com/1784821/110628655-4b7fac00-81c9-11eb-8c3a-830babd6166e.png)

## Testing Instructions

Install `Give - Donation Modules for Divi` plugin. You should not be getting PHP notice on the plugin listing page and licensed givewp addons to update inline notice show correctly (if any).

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in a related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

