### PR TITLE
Donor Dashboard feature domain no longer has typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donors with no donations now see a "No Donations" notice in Donor Dashboard (#5694)
 -   Donor Dashboard iframe now resizes when the parent window resizes (#5693)
 -   Migration table id column length is now increased (#5698)
+-   Donor Dashboard feature domain no longer has typos (#5704)
 
 ## 2.10.0-beta.3 - 2021-03-09
 

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -59,7 +59,7 @@ class Settings {
 
 		return [
 			'name'       => __( 'Donor Profile Page', 'give' ),
-			'desc'       => sprintf( __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? Let us <a href="%s">generate one for you.</a>', 'give' ), $generateDonorProfilePageUrl ),
+			'desc'       => sprintf( __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? <a href="%s">Generate a new Donor Dashboard page.</a>', 'give' ), $generateDonorProfilePageUrl ),
 			'id'         => 'donor_profile_page',
 			'type'       => 'select',
 			'class'      => 'give-select give-select-chosen',

--- a/src/DonorProfiles/Admin/Settings.php
+++ b/src/DonorProfiles/Admin/Settings.php
@@ -57,9 +57,11 @@ class Settings {
 			admin_url( 'edit.php' )
 		);
 
+		$generateDonorProfilePageDesc = $this->donorProfilePageIsPublished() ? '' : sprintf( __( ' Need helping setting one up? <a href="%s">Generate a new Donor Dashboard page.</a>', 'give' ), $generateDonorProfilePageUrl );
+
 		return [
 			'name'       => __( 'Donor Profile Page', 'give' ),
-			'desc'       => sprintf( __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Profile block or <code>[give_donor_profile]</code> shortcode should be on this page. Need helping setting one up? <a href="%s">Generate a new Donor Dashboard page.</a>', 'give' ), $generateDonorProfilePageUrl ),
+			'desc'       => __( 'This is the page where donors can manage their information, review history and more -- all in one place. The Donor Dashboard block or <code>[give_donor_dashboard]</code> shortcode should be on this page. ', 'give' ) . $generateDonorProfilePageDesc,
 			'id'         => 'donor_profile_page',
 			'type'       => 'select',
 			'class'      => 'give-select give-select-chosen',

--- a/src/DonorProfiles/resources/js/app/components/auth-modal/index.js
+++ b/src/DonorProfiles/resources/js/app/components/auth-modal/index.js
@@ -80,7 +80,7 @@ const AuthModal = () => {
 				<div className="give-donor-profile__auth-modal-content">
 					{ loggedInWithoutDonor && (
 						<div className="give-donor-profile__auth-modal-notice">
-							{ __( 'The account you are currently logged into the site with does not have an associated donor profile. Donate now or contact the site administrator associate this WordPress user with a donor profile.' ) }
+							{ __( 'The account you are currently logged into the site with does not have an associated donor profile. Donate now or contact the site administrator to associate this WordPress user with a donor profile.' ) }
 						</div>
 					) }
 					{ emailAccessEnabled && (


### PR DESCRIPTION
Resolves #5703 

## Description

This PR address a few select typos and tense issues in notices and contextual docs related to the Donor Dashboard feature domain. 

## Affects

This PR affects frontend rendering of the unassociated donor notice (in Donor Dashboard login area), and the context docs for the Donor Dashboard page setting (in General Settings).

## Visuals

<img width="516" alt="Screen Shot 2021-03-11 at 10 18 43 AM" src="https://user-images.githubusercontent.com/5186078/110809733-2df72480-8253-11eb-8639-cab8e3581631.png">

<img width="1309" alt="Screen Shot 2021-03-11 at 10 19 09 AM" src="https://user-images.githubusercontent.com/5186078/110809831-40715e00-8253-11eb-82f6-5664b2e97c88.png">

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

