### PR TITLE
Email access now gives donor access to my donor dashboard

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "test"
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         php: [ 5.6, 7.2 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donors with no donations now see a "No Donations" notice in Donor Dashboard (#5694)
 -   Donor Dashboard iframe now resizes when the parent window resizes (#5693)
 -   Migration table id column length is now increased (#5698)
+-   Email access now gives donor access to my donor dashboard (#5705)
 
 ## 2.10.0-beta.3 - 2021-03-09
 

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -75,31 +75,25 @@ class Donations {
 	 */
 	protected function getDonationIDs( $donorId ) {
 		global $wpdb;
-
 		$result = DB::get_results(
 			DB::prepare(
 				"
-                SELECT 
-                    donation_id as id
-                FROM 
-                    {$wpdb->give_revenue} as revenue
-                INNER JOIN 
-                    {$wpdb->posts} as posts ON revenue.donation_id = posts.ID
-                WHERE 
-                    posts.post_author = %d
-                AND 
-                    posts.post_status IN ( 'publish', 'give_subscription' )
-				",
-				$donorId
+				SELECT revenue.donation_id as id
+				FROM {$wpdb->give_revenue} as revenue
+					INNER JOIN {$wpdb->posts} as posts ON revenue.donation_id = posts.ID
+					INNER JOIN {$wpdb->prefix}give_donationmeta as donationmeta ON revenue.donation_id = donationmeta.donation_id
+				WHERE donationmeta.meta_key = '_give_payment_donor_id'
+					AND donationmeta.meta_value = {$donorId}
+					AND posts.post_status IN ( 'publish', 'give_subscription' )
+			"
 			)
 		);
 
 		$ids = [];
-		if ( $result ) {
+		if ( ! empty( $result ) ) {
 			foreach ( $result as $donation ) {
 				$ids[] = $donation->id;
 			}
-
 			return $ids;
 		}
 


### PR DESCRIPTION
Resolves #5702 

## Description

This PR addresses a bug which prevented donors who accessed the Donor Dashboard via an email access link from seeing their donation history or giving stats. Previously, the Donor Dashboard would load the correct profile, but a "No Donations" message would appear, despite the donor having made a donation by that point in time. 

Ultimately, the bug was determined to be caused by a sql query which checked donor ID against post author id. Because of this, the Donation history functionality (specifically the getDonationIds method) was only functional for donors who's donations were also associated with a WordPress account. To remedy the problem, the getDonationIds method was updated to mirror the sql logic found in the getDonationAggregate method, which checks against the `_give_payment_donor_id` meta property, instead of `post_author`.

## Affects

This PR affects the Donations repository, and specifically the getDonationIds method.

## Visuals

N/A

## Testing Instructions

1. Complete a donation without being logged in
2. Use email verification to retrieve an email verification link
3. Follow the email verification link and see that it loads the correct profile, and retrieves the correct donation history

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

