### PR TITLE
While in the same session, donors are now able to see their donor dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Donor Dashboard iframe now resizes when the parent window resizes (#5693)
 -   Migration table id column length is now increased (#5698)
 -   Email access now gives donor access to my donor dashboard (#5705)
+-   While in the same session, donors are now able to see their donor dashboard (#5707)
     
 ### New
 -   Donor Dashboard errors are now logged (#5706)

--- a/src/DonorProfiles/Helpers.php
+++ b/src/DonorProfiles/Helpers.php
@@ -13,6 +13,13 @@ class Helpers {
 	 */
 	public static function getCurrentDonorId() {
 
+		if ( get_current_user_id() ) {
+			$donor = give()->donors->get_donor_by( 'user_id', get_current_user_id() );
+			if ( $donor ) {
+				return $donor->id;
+			}
+		}
+
 		if ( give()->email_access ) {
 			give()->email_access->init();
 			$useToken = give()->email_access->check_for_token();
@@ -23,8 +30,12 @@ class Helpers {
 			}
 		}
 
-		if ( get_current_user_id() ) {
-			$donor = give()->donors->get_donor_by( 'user_id', get_current_user_id() );
+		if (
+			false !== give()->session->get_session_expiration() ||
+			true === give_get_history_session()
+		) {
+			$email = give()->session->get( 'give_email' );
+			$donor = give()->donors->get_donor_by( 'email', $email );
 			if ( $donor ) {
 				return $donor->id;
 			}


### PR DESCRIPTION
Resolves #5700 

## Description

This PR resolves an issue which prevented donors without a WP account from viewing their donation dashboard. Now, donors are able to see their donor dashboard while they are in the same session (clicking link in email receipt, or navigating to the Donor Dashboard page directly from the donation form).

## Affects

This PR affects logic in the Helpers::getCurrentDonorId method. This impacts how the current donor ID is determined, and not ensures that the existing history session logic is taken into account.

## Visuals

N/A

## Testing Instructions

1. Make a donation (without an account)
2. Navigate to the donor dashboard
3. See that the Donor Dashboard loads correctly

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

