### PR TITLE
Apply Stripe fee when applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changes
+
+-   Apply Stripe fee when applicable (#5555)
+
 ## 2.10.0-beta.4 - 2021-03-12
 
 ### Changed

--- a/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
@@ -41,7 +41,7 @@ class Give_Stripe_Checkout_Session {
 			$args = apply_filters( 'give_stripe_create_checkout_session_args', $args );
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() && isset( $args['payment_intent_data'] ) ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() && isset( $args['payment_intent_data'] ) ) {
 				$args['payment_intent_data']['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['line_items'][0]['amount'] );
 			}
 

--- a/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
@@ -41,7 +41,7 @@ class Give_Stripe_Checkout_Session {
 			$args = apply_filters( 'give_stripe_create_checkout_session_args', $args );
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() && isset( $args['payment_intent_data'] ) ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::canAddfee() && isset( $args['payment_intent_data'] ) ) {
 				$args['payment_intent_data']['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['line_items'][0]['amount'] );
 			}
 

--- a/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-checkout-session.php
@@ -41,7 +41,7 @@ class Give_Stripe_Checkout_Session {
 			$args = apply_filters( 'give_stripe_create_checkout_session_args', $args );
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( ! defined( 'GIVE_STRIPE_VERSION' ) && isset( $args['payment_intent_data'] ) ) {
+			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() && isset( $args['payment_intent_data'] ) ) {
 				$args['payment_intent_data']['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['line_items'][0]['amount'] );
 			}
 

--- a/includes/gateways/stripe/includes/class-give-stripe-gateway.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-gateway.php
@@ -565,7 +565,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 				$charge_args = apply_filters( "give_{$this->id}_create_charge_args", $charge_args );
 
 				// Charge application fee, only if the Stripe premium add-on is not active.
-				if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
+				if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
 					// Set Application Fee Amount.
 					$charge_args['application_fee_amount'] = give_stripe_get_application_fee_amount( $charge_args['amount'] );
 				}

--- a/includes/gateways/stripe/includes/class-give-stripe-gateway.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-gateway.php
@@ -565,7 +565,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 				$charge_args = apply_filters( "give_{$this->id}_create_charge_args", $charge_args );
 
 				// Charge application fee, only if the Stripe premium add-on is not active.
-				if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
+				if ( \Give\PaymentGateways\Stripe\ApplicationFee::canAddfee() ) {
 					// Set Application Fee Amount.
 					$charge_args['application_fee_amount'] = give_stripe_get_application_fee_amount( $charge_args['amount'] );
 				}

--- a/includes/gateways/stripe/includes/class-give-stripe-gateway.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-gateway.php
@@ -565,7 +565,7 @@ if ( ! class_exists( 'Give_Stripe_Gateway' ) ) {
 				$charge_args = apply_filters( "give_{$this->id}_create_charge_args", $charge_args );
 
 				// Charge application fee, only if the Stripe premium add-on is not active.
-				if ( ! defined( 'GIVE_STRIPE_VERSION' ) ) {
+				if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
 					// Set Application Fee Amount.
 					$charge_args['application_fee_amount'] = give_stripe_get_application_fee_amount( $charge_args['amount'] );
 				}

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function create( $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['amount'] );
 			}
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function update( $client_secret, $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_format_amount( give_stripe_get_application_fee_amount( $args['amount'] ) );
 			}
 

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function create( $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['amount'] );
 			}
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function update( $client_secret, $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( \Give\PaymentGateways\Stripe\ApplicationFee::class::canAddfee() ) {
+			if ( \Give\PaymentGateways\Stripe\ApplicationFee::canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_format_amount( give_stripe_get_application_fee_amount( $args['amount'] ) );
 			}
 

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function create( $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( ! defined( 'GIVE_STRIPE_VERSION' ) ) {
+			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_get_application_fee_amount( $args['amount'] );
 			}
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		public function update( $client_secret, $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.
-			if ( ! defined( GIVE_STRIPE_VERSION ) ) {
+			if ( give( \Give\PaymentGateways\Stripe\ApplicationFee::class )->canAddfee() ) {
 				$args['application_fee_amount'] = give_stripe_format_amount( give_stripe_get_application_fee_amount( $args['amount'] ) );
 			}
 

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -18,7 +18,7 @@ class ApplicationFee {
 	 * @return bool
 	 */
 	public static function canAddFee() {
-		// Plugin slugs (which we get from givewp.com) are fixed and will never change, so we can hardcode it.
+		// Plugin slug (which we get from givewp.com) and plugin name are fixed and will never change, so we can hardcode it.
 		$pluginSlug = 'give-stripe';
 		$pluginName = 'Give - Stripe Gateway';
 

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -2,6 +2,8 @@
 
 namespace Give\PaymentGateways\Stripe;
 
+use Give_License;
+
 /**
  * Class ApplicationFee
  * @package Give\PaymentGateways\Stripe
@@ -14,15 +16,25 @@ class ApplicationFee {
 	 *
 	 * @return bool
 	 */
-	public function canAddFee() {
-		return ! $this->isStripeProAddonActive();
+	public static function canAddFee() {
+		return ! self::isStripeProAddonActive() || ! self::hasLicense();
 	}
 
 	/**
 	 * @unreleased
 	 * @return bool
 	 */
-	public function isStripeProAddonActive() {
+	private static function isStripeProAddonActive() {
 		return defined( 'GIVE_STRIPE_VERSION' );
+	}
+
+	/**
+	 * @unreleased
+	 * @return bool
+	 */
+	private static function hasLicense() {
+		// Plugin slugs (which we get from givewp.com) are fixed and will never change, so we can hardcode it.
+		$pluginSlug = 'give-stripe';
+		return (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -17,24 +17,12 @@ class ApplicationFee {
 	 * @return bool
 	 */
 	public static function canAddFee() {
-		return ! self::isStripeProAddonActive() || ! self::hasLicense();
-	}
+		$isStripeProAddonActive = defined( 'GIVE_STRIPE_VERSION' );
 
-	/**
-	 * @unreleased
-	 * @return bool
-	 */
-	private static function isStripeProAddonActive() {
-		return defined( 'GIVE_STRIPE_VERSION' );
-	}
-
-	/**
-	 * @unreleased
-	 * @return bool
-	 */
-	private static function hasLicense() {
 		// Plugin slugs (which we get from givewp.com) are fixed and will never change, so we can hardcode it.
 		$pluginSlug = 'give-stripe';
-		return (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
+		$hasLicense = (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
+
+		return ! $isStripeProAddonActive || ! $hasLicense;
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Give\PaymentGateways\Stripe;
+
+/**
+ * Class ApplicationFee
+ * @package Give\PaymentGateways\Stripe
+ *
+ * @unreleased
+ */
+class ApplicationFee {
+	/**
+	 * Return whether or not apple Stripe application fee.
+	 *
+	 * @unreleased
+	 *
+	 * @return bool
+	 */
+	public function canApply() {
+		return true;
+	}
+}

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -10,13 +10,19 @@ namespace Give\PaymentGateways\Stripe;
  */
 class ApplicationFee {
 	/**
-	 * Return whether or not apple Stripe application fee.
-	 *
 	 * @unreleased
 	 *
 	 * @return bool
 	 */
-	public function canApply() {
-		return true;
+	public function canAddFee() {
+		return ! $this->isStripeProAddonActive();
+	}
+
+	/**
+	 * @unreleased
+	 * @return bool
+	 */
+	public function isStripeProAddonActive() {
+		return defined( 'GIVE_STRIPE_VERSION' );
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -25,7 +25,7 @@ class ApplicationFee {
 		$isStripeProAddonActive = defined( 'GIVE_STRIPE_VERSION' );
 
 		if ( $isStripeProAddonActive ) {
-			return true;
+			return false;
 		}
 
 		$isStripeProAddonInstalled = (bool) array_filter(
@@ -36,15 +36,15 @@ class ApplicationFee {
 		);
 
 		if ( $isStripeProAddonInstalled ) {
-			return true;
+			return false;
 		}
 
 		$hasLicense = (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
 
 		if ( $hasLicense ) {
-			return true;
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -28,25 +28,18 @@ class ApplicationFee {
 	 * @return bool
 	 */
 	public static function canAddFee() {
-
 		$gate = new static();
 
-		if (
-			$gate->hasLicense
-		 || $gate->isStripeProAddonActive
-		 || $gate->isStripeProAddonInstalled( get_plugins() )
-		) {
-			return false;
-		}
-
-		return true;
+		return ! ( $gate->hasLicense()
+			|| $gate->isStripeProAddonActive()
+			|| $gate->isStripeProAddonInstalled( get_plugins() ) );
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function isStripeProAddonActive() {
-		return (bool) defined( 'GIVE_STRIPE_VERSION' );
+		return defined( 'GIVE_STRIPE_VERSION' );
 	}
 
 	/**
@@ -57,7 +50,7 @@ class ApplicationFee {
 	public function isStripeProAddonInstalled( array $plugins ) {
 		return (bool) array_filter(
 			$plugins,
-			static function( $plugin ) {
+			static function ( $plugin ) {
 				return static::PluginName === $plugin['Name'];
 			}
 		);

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -12,17 +12,39 @@ use Give_License;
  */
 class ApplicationFee {
 	/**
+	 * @see https://github.com/impress-org/givewp/issues/5555#issuecomment-759596226
 	 * @unreleased
 	 *
 	 * @return bool
 	 */
 	public static function canAddFee() {
-		$isStripeProAddonActive = defined( 'GIVE_STRIPE_VERSION' );
-
 		// Plugin slugs (which we get from givewp.com) are fixed and will never change, so we can hardcode it.
 		$pluginSlug = 'give-stripe';
+		$pluginName = 'Give - Stripe Gateway';
+
+		$isStripeProAddonActive = defined( 'GIVE_STRIPE_VERSION' );
+
+		if ( $isStripeProAddonActive ) {
+			return true;
+		}
+
+		$isStripeProAddonInstalled = (bool) array_filter(
+			get_plugins(),
+			static function( $pluginsData ) use ( $pluginName ) {
+				return $pluginName === $pluginsData['Name'];
+			}
+		);
+
+		if ( $isStripeProAddonInstalled ) {
+			return true;
+		}
+
 		$hasLicense = (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
 
-		return ! ( $isStripeProAddonActive || $hasLicense );
+		if ( $hasLicense ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -13,15 +13,18 @@ use Give_License;
  * @unreleased
  */
 class ApplicationFee {
+	/**
+	 * Slug of the Stripe add-on on GiveWP.com
+	 */
+	const PluginSlug = 'give-stripe';
 
 	/**
-	* @note Plugin slug (which we get from givewp.com) and plugin name are fixed and will never change, so we can hardcode it.
-	*/
-
-	const PluginSlug = 'give-stripe';
+	 * Name of the Stripe add-on on GiveWP.com
+	 */
 	const PluginName = 'Give - Stripe Gateway';
 
 	/**
+	 * Returns true or false based on whether the Stripe fee should be applied or not
 	 *
 	 * @unreleased
 	 *
@@ -36,6 +39,10 @@ class ApplicationFee {
 	}
 
 	/**
+	 * Returns true or false based on whether the Stripe Pro add-on is activated
+	 *
+	 * @unreleased
+	 *
 	 * @return bool
 	 */
 	public function isStripeProAddonActive() {
@@ -43,6 +50,8 @@ class ApplicationFee {
 	}
 
 	/**
+	 * Returns true or false based on whether the plugin is installed (but not necessarily active)
+	 *
 	 * @param array $plugins Array of arrays of plugin data, keyed by plugin file name. See get_plugin_data().
 	 *
 	 * @return bool
@@ -57,6 +66,10 @@ class ApplicationFee {
 	}
 
 	/**
+	 * Returns true or false based on whether a license has been provided for the Stripe add-on
+	 *
+	 * @unreleased
+	 *
 	 * @return bool
 	 */
 	public function hasLicense() {

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -23,6 +23,6 @@ class ApplicationFee {
 		$pluginSlug = 'give-stripe';
 		$hasLicense = (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
 
-		return ! $isStripeProAddonActive || ! $hasLicense;
+		return ! ( $isStripeProAddonActive || $hasLicense );
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5555

## Description

Added logic to add Stripe application fee when applicable. I applied the rule written in [this comment](https://github.com/impress-org/givewp/issues/5555#issuecomment-759596226).

## Testing Instructions

Stripe application fee should not apply to one time donations when
- Stripe pro addon active.
- Stripe pro addon install.
- Stripe single license active.
- All access pass license active (includes Stripe addons)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

