### PR TITLE
 Multi Form Goal Shortcode class is handleing the empty attributes correctly now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+-   Multi Form Goal Shortcode class is handleing the empty attributes correctly now (#5716)
+
 ## 2.10.0-beta.4 - 2021-03-12
 
 ### Changed

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -87,7 +87,7 @@ class Shortcode {
 	 * @return array
 	 */
 	protected function parseAttributeArray( $value ) {
-		if ( ! is_array( $value ) ) {
+		if ( ! is_array( $value ) && ! empty( $value ) ) {
 			$value = explode( ',', $value );
 		}
 		return $value;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5711

## Description

This PR fixes the issue where the empty shortcode attributes were not being passed correctly which lead to displaying the incorrect data for the Multi Form Goal shortcode. The issue is resolved by checking if the value is empty before splitting it by comma. The reason why we need this check is if you split the empty string with the explode function, the returned result will look like this `[ 0 => '' ]` and if you check that later with the `empty` function, which `Give\MultiFormGoals\ProgressBar\Model` does,  the result will be `true` and the returned result will be wrong.

## Affects

 Multi Form Goal Shortcode class

## Testing Instructions

1. Add a new page and for content add this shortcode `[give_multi_form_goal ids="ID"]`
**ID** represents the form that has associated revenue. 
2. Save and View the page. Compare the raised amount on the Multi Form Goal block with the revenue of the selected form.
3. Now edit the shortcode to look like this  `[give_multi_form_goal ids="ID" categories="" tags=""]`
4. Save and View the page. Compare the raised amount on the Multi Form Goal block with the revenue of the selected form.

The `raised` amount should be the same in both cases.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

