### PR TITLE
The spinner should go away when the PDF Receipt is generated on the Donor Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   The spinner should go away when the PDF Receipt is generated on the Donor Dashboard (#5719)
+
 ## 2.10.0-beta.4 - 2021-03-12
 
 ### Changed

--- a/src/DonorProfiles/resources/js/app/components/button/index.js
+++ b/src/DonorProfiles/resources/js/app/components/button/index.js
@@ -9,7 +9,7 @@ const Button = ( { icon, children, onClick, href, type } ) => {
 
 	if ( href ) {
 		return (
-			<a className="give-donor-dashboard-button give-donor-dashboard-button--primary" onClick={ onClick ? ( e ) => handleHrefClick( e ) : null } href={ href }>
+			<a className="give-donor-dashboard-button give-donor-dashboard-button--primary" onClick={ ( e ) => handleHrefClick( e ) } href={ href }>
 				{ children }{ icon && ( <FontAwesomeIcon icon={ icon } /> ) }
 			</a>
 		);


### PR DESCRIPTION
Resolves #5713 

## Description

This PR introduces changes to resolve a big which caused the Donor Dashboard to reload when the Download Receipt button was clicked. Previously, the button relied on an unnecessary ternery operator to check for an "onClick" function, which is not applicable when an href has already been provided.

## Affects

This PR affects frontend rendering logic for the PDF receipts addon.

## Visuals

N/A

## Testing Instructions

1. Go to Donor Dashboard
2. Click on Donation History > View Receipt > Download Receipt
3. Notice that PDF download correctly and the Donor Dashboard app is unaffected

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

