### PR TITLE
Donor Dashboard history now includes pending donations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Donor Dashboard history now includes pending donations (#5721)
+
 ## 2.10.0-beta.4 - 2021-03-12
 
 ### Changed

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -297,9 +297,12 @@ class Donations {
 		$statusMap = [];
 
 		$colorMap = [
-			'publish'           => '#7AD03A',
-			'give_subscription' => '#3398DB',
-			'refunded'          => '#D75A4B',
+			'publish'           => '#7ad03a',
+			'give_subscription' => '#5bc0de',
+			'refunded'          => '#777',
+			'failed'            => '#a00',
+			'abandoned'         => '#333',
+			'revoked'           => '#d9534f',
 		];
 
 		foreach ( give_get_payment_statuses() as $key => $value ) {
@@ -308,7 +311,7 @@ class Donations {
 				continue;
 			}
 
-			$color = '#FFBA00';
+			$color = '#888';
 			if ( in_array( $key, array_keys( $colorMap ) ) ) {
 				$color = $colorMap[ $key ];
 			}

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -334,7 +334,7 @@ class Donations {
 			]
 		);
 
-		return $formatted;
+		return $formatted ? $formatted : (string) $amount;
 	}
 
 	/**

--- a/src/DonorProfiles/Repositories/Donations.php
+++ b/src/DonorProfiles/Repositories/Donations.php
@@ -303,6 +303,7 @@ class Donations {
 			'failed'            => '#a00',
 			'abandoned'         => '#333',
 			'revoked'           => '#d9534f',
+			'pending'           => '#ffba00',
 		];
 
 		foreach ( give_get_payment_statuses() as $key => $value ) {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5714 

## Description

This PR introduces logic to ensure that all donation statuses are included in querying for the Donation History tab of Donor Dashboard. Along the way, another bug was resolved which sometimes lead to formatting issues in the Giving Stats section when no completed donations where found.

## Affects

This PR affects backend logic for the Donation History tab and dashboard content of the Donor Dashboard.

## Visuals

<img width="665" alt="Screen Shot 2021-03-15 at 6 00 09 PM" src="https://user-images.githubusercontent.com/5186078/111227013-4e5b1200-85b8-11eb-9e12-51dd03c9d22c.png">

## Testing Instructions

1. Go to Donor Dashboard
2. Select Donation History tab
3. Notice that donations of all donation statuses appear
4. 
## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

