### PR TITLE
Stripe application fee checks are encapsulated

### DIFF
--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -8,43 +8,65 @@ use Give_License;
  * Class ApplicationFee
  * @package Give\PaymentGateways\Stripe
  *
+ * @see https://github.com/impress-org/givewp/issues/5555#issuecomment-759596226
+ *
  * @unreleased
  */
 class ApplicationFee {
+
 	/**
-	 * @see https://github.com/impress-org/givewp/issues/5555#issuecomment-759596226
+	* @note Plugin slug (which we get from givewp.com) and plugin name are fixed and will never change, so we can hardcode it.
+	*/
+
+	const PluginSlug = 'give-stripe';
+	const PluginName = 'Give - Stripe Gateway';
+
+	/**
+	 *
 	 * @unreleased
 	 *
 	 * @return bool
 	 */
 	public static function canAddFee() {
-		// Plugin slug (which we get from givewp.com) and plugin name are fixed and will never change, so we can hardcode it.
-		$pluginSlug = 'give-stripe';
-		$pluginName = 'Give - Stripe Gateway';
 
-		$isStripeProAddonActive = defined( 'GIVE_STRIPE_VERSION' );
+		$gate = new static();
 
-		if ( $isStripeProAddonActive ) {
-			return false;
-		}
-
-		$isStripeProAddonInstalled = (bool) array_filter(
-			get_plugins(),
-			static function( $pluginsData ) use ( $pluginName ) {
-				return $pluginName === $pluginsData['Name'];
-			}
-		);
-
-		if ( $isStripeProAddonInstalled ) {
-			return false;
-		}
-
-		$hasLicense = (bool) Give_License::get_license_by_plugin_dirname( $pluginSlug );
-
-		if ( $hasLicense ) {
+		if (
+			$gate->hasLicense
+		 || $gate->isStripeProAddonActive
+		 || $gate->isStripeProAddonInstalled( get_plugins() )
+		) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isStripeProAddonActive() {
+		return (bool) defined( 'GIVE_STRIPE_VERSION' );
+	}
+
+	/**
+	 * @param array $plugins Array of arrays of plugin data, keyed by plugin file name. See get_plugin_data().
+	 *
+	 * @return bool
+	 */
+	public function isStripeProAddonInstalled( array $plugins ) {
+		return (bool) array_filter(
+			$plugins,
+			static function( $plugin ) {
+				return static::PluginName === $plugin['Name'];
+			}
+		);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasLicense() {
+		return (bool) Give_License::get_license_by_plugin_dirname( static::PluginSlug );
 	}
 }

--- a/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
+++ b/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Give\PaymentGateways\Stripe\ApplicationFee;
+
+final class ApplicationFeeTest extends TestCase {
+
+    public function setUp() {
+        $this->gate = new ApplicationFee;
+    }
+
+    /**
+     * @note Run this test first, before GIVE_STRIPE_VERSION is defined in the next test.
+     */
+    public function testNotIsStripeProAddonActive() {
+
+        $this->assertFalse(
+            $this->gate->isStripeProAddonActive()
+        );
+    }
+
+    public function testIsStripeProAddonActive() {
+
+        // Mock the Give Stripe Add-on being active.
+        define( 'GIVE_STRIPE_VERSION', '1.2.3' );
+
+        $this->assertTrue(
+            $this->gate->isStripeProAddonActive()
+        );
+    }
+
+    public function testIsStripeProAddonInstalled() {
+
+        // Mock Stripe Add-on installed.
+        $plugins = [
+            [ 'Name' => 'Give - Stripe Gateway' ]
+        ];
+
+        $this->assertTrue(
+            $this->gate->isStripeProAddonInstalled( $plugins )
+        );
+    }
+
+    public function testNotIsStripeProAddonInstalled() {
+
+        // Mock no add-ons installed.
+        $plugins = [];
+
+        $this->assertFalse(
+            $this->gate->isStripeProAddonInstalled( $plugins )
+        );
+    }
+
+    public function testHasLicense() {
+
+        // Mock licensing with Stripe Add-on.
+        update_option( 'give_licenses', [[
+            'is_all_access_pass' => false,
+            'plugin_slug' => 'give-stripe',
+        ]]);
+
+        $this->assertTrue(
+            $this->gate->hasLicense( 'give-stripe' )
+        );
+    }
+
+    public function testNotHasLicense() {
+
+        // Mock licensing without Stripe Add-on.
+        update_option( 'give_licenses', [[
+            'is_all_access_pass' => false,
+            'plugin_slug' => 'not-stripe-addon',
+        ]]);
+
+        $this->assertFalse(
+            $this->gate->hasLicense( 'give-stripe' )
+        );
+    }
+
+    public function testHasLicenseAllAccessPass() {
+
+        // Mock licensing with All Access pass.
+        update_option( 'give_licenses', [[
+            'is_all_access_pass' => true,
+            'download' => [[
+                'plugin_slug' => 'give-stripe',
+            ]],
+        ]]);
+
+        $this->assertTrue(
+            $this->gate->hasLicense( 'give-stripe' )
+        );
+    }
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Related to https://github.com/impress-org/givewp/pull/5709

This refactor encapsulates the individual logical checks involved in deciding whether or not to charge an application fee.

Additionally, this adds unit tests for each of the individual tests.
