### PR TITLE
"Make Primary" address link for multiple addresses now works in Donor Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Multi Form Goal Shortcode class is handleing the empty attributes correctly now (#5716)
 -   The spinner should go away when the PDF Receipt is generated on the Donor Dashboard (#5719)
+-   "Make Primary" address link for multiple addresses now works in Donor Dashboard (#5725)
 
 ## 2.10.0-beta.4 - 2021-03-12
 

--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -1365,7 +1365,7 @@ class Give_Donor {
 		}
 
 		// Bailout: do not save duplicate orders
-		if ( $this->does_address_exist( $address_type, $address ) ) {
+		if ( $this->does_address_exist( $address_type, $address ) && $multi_address_id === null ) {
 			return false;
 		}
 

--- a/src/DonorProfiles/Pipeline/Stages/UpdateDonorAddresses.php
+++ b/src/DonorProfiles/Pipeline/Stages/UpdateDonorAddresses.php
@@ -44,15 +44,6 @@ class UpdateDonorAddresses implements Stage {
 		}
 
 		/**
-		 * Clear out existing additional addresses
-		 */
-
-		$storedAdditionalAddresses = $this->getStoredAdditionalAddresses();
-		foreach ( $storedAdditionalAddresses as $key => $storedAdditionalAddress ) {
-			$this->donor->remove_address( "billing_{$key}" );
-		}
-
-		/**
 		 * If additional addresses are provided, add them to the donor meta table
 		 */
 
@@ -62,26 +53,20 @@ class UpdateDonorAddresses implements Stage {
 				$this->donor->add_address( $addressId, (array) $additionalAddress );
 			}
 		}
-	}
 
-	/**
-	 * Retrieves additional addresses stored in meta database
-	 *
-	 * @return array
-	 *
-	 * @since 2.10.0
-	 */
-	protected function getStoredAdditionalAddresses() {
-		$storedAddresses           = $this->donor->address;
-		$storedAdditionalAddresses = [];
+		/**
+		 * Clear deleted address keys
+		 */
 
-		if ( isset( $storedAddresses['billing'] ) ) {
-			foreach ( $storedAddresses['billing'] as $key => $address ) {
-				if ( $key !== 0 ) {
-					$storedAdditionalAddresses[ $key ] = $address;
-				}
+		$totalStoredAddresses = count( $this->donor->address['billing'] );
+		$totalNewAddresses    = count( $additionalAddresses ) + 1;
+
+		if ( $totalStoredAddresses > $totalNewAddresses ) {
+			$key = $totalNewAddresses;
+			while ( $key < $totalStoredAddresses ) {
+				$this->donor->remove_address( "billing_{$key}" );
+				$key++;
 			}
 		}
-		return $storedAdditionalAddresses;
 	}
 }

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/address-fields/index.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/address-fields/index.js
@@ -10,6 +10,15 @@ import FieldRow from '../../../components/field-row';
 import { fetchStatesWithAPI } from '../utils';
 
 const AddressFields = ( { address, onChange } ) => {
+	useEffect( () => {
+		setCountry( address.country );
+		setLine1( address.line1 );
+		setLine2( address.line2 );
+		setCity( address.city );
+		setState( address.state );
+		setZip( address.zip );
+	}, [ address ] );
+
 	const dispatch = useDispatch();
 	const countryOptions = useSelector( state => state.countries );
 	const stateOptions = useSelector( state => state.states );

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/address-fields/index.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/address-fields/index.js
@@ -31,8 +31,10 @@ const AddressFields = ( { address, onChange } ) => {
 	const [ zip, setZip ] = useState( address.zip );
 
 	const updateStates = async( countryCode ) => {
-		const newStates = await fetchStatesWithAPI( countryCode );
-		dispatch( setStates( newStates ) );
+		if ( countryCode ) {
+			const newStates = await fetchStatesWithAPI( countryCode );
+			dispatch( setStates( newStates ) );
+		}
 	};
 
 	useEffect( () => {

--- a/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorProfiles/resources/js/app/tabs/edit-profile/content.js
@@ -65,12 +65,13 @@ const Content = () => {
 
 	const [ primaryAddress, setPrimaryAddress ] = useState( storedProfile.addresses && storedProfile.addresses.billing ? storedProfile.addresses.billing[ 0 ] : null );
 
-	const reducedAdditionalAddresses = storedProfile.addresses && storedProfile.addresses.billing ? storedProfile.addresses.billing.reduce( ( newArray, address, index ) => {
+	const reducedAdditionalAddresses = storedProfile.addresses && storedProfile.addresses.billing ? Object.values( storedProfile.addresses.billing ).reduce( ( newArray, address, index ) => {
 		if ( index !== 0 ) {
 			newArray.push( address );
 		}
 		return newArray;
 	}, [] ) : [];
+
 	const [ additionalAddresses, setAdditionalAddresses ] = useState( reducedAdditionalAddresses );
 
 	const [ isAnonymous, setIsAnonymous ] = useState( storedProfile.isAnonymous );


### PR DESCRIPTION
Resolves #5715 

## Description

This PR resolves a bug which prevented the "Make Primary Address" button from working correctly in the Donor Dashboard. Previously, when the button was pressed, nothing happened. Now, when you click the button, the Primary Address is set correctly, and when you hit "Update" it is persisted correctly in the database.

## Affects

This PR affects frontend logic for the address controls of the Donor Dashboard, and backend logic used to persist addresses via the Donor Dashboard.

## Visuals

N/A

## Testing Instructions

1. Navigate to Donor Dashboard and add a secondary address and Save.
2. Click on "Make Primary" and see that the primary addresses is swapped with the selected additional address
3. Hit update, and refresh page to ensure that changes persisted correctly
4. Delete additional addresses, and hit update
5. Refresh pade to check that removal of additional addresses was persisted correctly

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

