### PR TITLE
Editing the recurring donation amount no longer displays "NaN"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Personal information section only reloads if condition met (#5727)
+-   Editing the recurring donation amount no longer displays "NaN" (#5735)
 
 ## 2.10.0-rc.1 - 2021-03-16
 

--- a/src/DonorDashboards/resources/js/app/components/currency-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/currency-control/index.js
@@ -36,7 +36,7 @@ const CurrencyControl = ( { label, onChange, value, placeholder, currency, min, 
 					name={ name }
 					placeholder={ placeholder }
 					value={ value }
-					onValueChange={ ( val ) => onChange( val ) }
+					onValueChange={ ( val ) => isNaN( val ) ? onChange( min ) : onChange( val ) }
 					onBlur={ () => handleBlur() }
 					allowNegativeValue={ false }
 					decimalsLimit={ currency.numberDecimals }

--- a/src/DonorDashboards/resources/js/app/components/currency-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/currency-control/index.js
@@ -41,8 +41,8 @@ const CurrencyControl = ( { label, onChange, value, placeholder, currency, min, 
 					allowNegativeValue={ false }
 					decimalsLimit={ currency.numberDecimals }
 					decimalScale={ currency.numberDecimals }
-					prefix={ currency.currencyPosition === 'before' ? currency.symbol : null }
-					suffix={ currency.currencyPosition === 'after' ? currency.symbol : null }
+					prefix={ currency.currencyPosition === 'before' ? currency.symbol : '' }
+					suffix={ currency.currencyPosition === 'after' ? currency.symbol : '' }
 					decimalSeparator={ currency.decimalSeparator }
 					groupSeparator={ currency.thousandsSeparator }
 				/>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
@@ -7,22 +7,22 @@ const { __ } = wp.i18n;
 import AmountControl from './amount-control';
 import PaymentMethodControl from './payment-method-control';
 
-import { saveSubscriptionWithAPI } from './utils';
+import { updateSubscriptionWithAPI } from './utils';
 
 const SubscriptionManager = ( { id, subscription } ) => {
 	const [ amount, setAmount ] = useState( subscription.payment.amount.raw );
 	const [ paymentMethod, setPaymentMethod ] = useState( null );
-	const [ saving, setSaving ] = useState( false );
+	const [ updating, setUpdating ] = useState( false );
 
-	const handleSave = async() => {
+	const handleUpdate = async() => {
 		// Save with REST API
-		setSaving( true );
-		await saveSubscriptionWithAPI( {
+		setUpdating( true );
+		await updateSubscriptionWithAPI( {
 			id,
 			amount,
 			paymentMethod,
 		} );
-		setSaving( false );
+		setUpdating( false );
 	};
 
 	return (
@@ -39,8 +39,8 @@ const SubscriptionManager = ( { id, subscription } ) => {
 			/>
 			<FieldRow>
 				<div>
-					<Button icon="save" onClick={ () => handleSave() }>
-						{ saving ? __( 'Saving', 'give' ) : __( 'Save', 'give' ) }
+					<Button icon="save" onClick={ () => handleUpdate() }>
+						{ updating ? __( 'Updating', 'give' ) : __( 'Update', 'give' ) }
 					</Button>
 				</div>
 			</FieldRow>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
@@ -1,6 +1,7 @@
 import FieldRow from '../field-row';
 import Button from '../button';
-import { Fragment, useState } from 'react';
+import { Fragment, useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const { __ } = wp.i18n;
 
@@ -12,17 +13,23 @@ import { updateSubscriptionWithAPI } from './utils';
 const SubscriptionManager = ( { id, subscription } ) => {
 	const [ amount, setAmount ] = useState( subscription.payment.amount.raw );
 	const [ paymentMethod, setPaymentMethod ] = useState( null );
-	const [ updating, setUpdating ] = useState( false );
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const [ updated, setUpdated ] = useState( true );
+
+	useEffect( () => {
+		setUpdated( false );
+	}, [ amount, paymentMethod ] );
 
 	const handleUpdate = async() => {
 		// Save with REST API
-		setUpdating( true );
+		setIsUpdating( true );
 		await updateSubscriptionWithAPI( {
 			id,
 			amount,
 			paymentMethod,
 		} );
-		setUpdating( false );
+		setUpdated( true );
+		setIsUpdating( false );
 	};
 
 	return (
@@ -39,8 +46,16 @@ const SubscriptionManager = ( { id, subscription } ) => {
 			/>
 			<FieldRow>
 				<div>
-					<Button icon="save" onClick={ () => handleUpdate() }>
-						{ updating ? __( 'Updating', 'give' ) : __( 'Update', 'give' ) }
+					<Button onClick={ () => handleUpdate() }>
+						{ updated ? (
+							<Fragment>
+								{ __( 'Updated', 'give' ) } <FontAwesomeIcon icon="check" fixedWidth />
+							</Fragment>
+						) : (
+							<Fragment>
+								{ __( 'Update Subscription', 'give' ) } <FontAwesomeIcon className={ isUpdating ? 'give-donor-dashboard__edit-profile-spinner' : '' } icon={ isUpdating ? 'spinner' : 'save' } fixedWidth />
+							</Fragment>
+						) }
 					</Button>
 				</div>
 			</FieldRow>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
@@ -10,6 +10,8 @@ import PaymentMethodControl from './payment-method-control';
 
 import { updateSubscriptionWithAPI } from './utils';
 
+import './style.scss';
+
 const SubscriptionManager = ( { id, subscription } ) => {
 	const [ amount, setAmount ] = useState( subscription.payment.amount.raw );
 	const [ paymentMethod, setPaymentMethod ] = useState( null );
@@ -53,7 +55,7 @@ const SubscriptionManager = ( { id, subscription } ) => {
 							</Fragment>
 						) : (
 							<Fragment>
-								{ __( 'Update Subscription', 'give' ) } <FontAwesomeIcon className={ isUpdating ? 'give-donor-dashboard__edit-profile-spinner' : '' } icon={ isUpdating ? 'spinner' : 'save' } fixedWidth />
+								{ __( 'Update Subscription', 'give' ) } <FontAwesomeIcon className={ isUpdating ? 'give-donor-dashboard__subscription-manager-spinner' : '' } icon={ isUpdating ? 'spinner' : 'save' } fixedWidth />
 							</Fragment>
 						) }
 					</Button>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/card-control/style.scss
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/card-control/style.scss
@@ -1,9 +1,12 @@
 /* stylelint-disable selector-class-pattern */
+.give-donor-dashboard-card-control {
+	margin-top: 10px;
 
-.give-donor-dashboard-card-control__label {
-	font-family: Montserrat, Arial, Helvetica, sans-serif;
-	font-weight: 500;
-	font-size: 14px;
-	line-height: 1;
-	color: #555;
+	.give-donor-dashboard-card-control__label {
+		font-family: Montserrat, Arial, Helvetica, sans-serif;
+		font-weight: 500;
+		font-size: 14px;
+		line-height: 1;
+		color: #555;
+	}
 }

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/stripe-card-control/style.scss
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/stripe-card-control/style.scss
@@ -1,6 +1,8 @@
 /* stylelint-disable selector-class-pattern */
 
 .give-donor-dashboard-stripe-card-control {
+	margin-top: 10px;
+
 	.give-donor-dashboard-stripe-card-control__label {
 		font-family: Montserrat, Arial, Helvetica, sans-serif;
 		font-weight: 500;

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/style.scss
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/style.scss
@@ -1,0 +1,14 @@
+/* stylelint-disable selector-class-pattern */
+
+.give-donor-dashboard__subscription-manager-spinner {
+	animation: spin infinite 1s linear;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { getAPIRoot, getAPINonce } from '../../../utils';
 import { fetchSubscriptionsDataFromAPI } from '../../../tabs/recurring-donations/utils';
 
-export const saveSubscriptionWithAPI = ( { id, amount, paymentMethod } ) => {
+export const updateSubscriptionWithAPI = ( { id, amount, paymentMethod } ) => {
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscription/update', {
 		id: id,
 		amount: amount,


### PR DESCRIPTION
Resolves #5734 

## Description

This PR addresses a minor bug which caused custom amounts to render as "NaN" in the subscription manager when a donor cleared the field. Now, when a donor clears the field, it is set to it's minimum allowed amount. Additionally, this PR includes some minor polish for the recurring donation manager view, aimed at making the "Update Subscription" button UX mirror that of the Edit Profile tab.

## Affects

This PR affects frontend rendering logic for the recurring donations subscription manager in the Donor Dashboard.

## Visuals

N/A

## Testing Instructions

1. Navigate to the donor dashboard and edit a recurring donation
2. Erase the donation amount and check that the minimum amount appears (instead of NaN)

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

