### PR TITLE
Creation of the give_migrations table is not producuing errors anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Personal information section only reloads if condition met (#5727)
 -   Editing the recurring donation amount no longer displays "NaN" (#5735)
+-   Creation of the give_migrations table is not producuing errors anymore (#5737)
 
 ## 2.10.0-rc.1 - 2021-03-16
 

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -2,6 +2,8 @@
 
 namespace Give\Log;
 
+use Exception;
+
 /**
  * Class Log
  *
@@ -20,8 +22,8 @@ namespace Give\Log;
  */
 class Log {
 	/**
-	 * @param  string  $type
-	 * @param  array  $args
+	 * @param string $type
+	 * @param array  $args
 	 */
 	public static function __callStatic( $type, $args ) {
 		list ( $message, $context ) = array_pad( $args, 2, null );
@@ -29,10 +31,11 @@ class Log {
 		if ( is_array( $context ) ) {
 			// Convert context values to string
 			$context = array_map(
-				function( $item ) {
+				function ( $item ) {
 					if ( is_array( $item ) || is_object( $item ) ) {
-						  $item = print_r( $item, true );
+						$item = print_r( $item, true );
 					}
+
 					return $item;
 				},
 				$context
@@ -41,7 +44,7 @@ class Log {
 			// Default fields
 			$data = array_filter(
 				$context,
-				function( $key ) {
+				function ( $key ) {
 					return array_key_exists( $key, LogFactory::getDefaults() );
 				},
 				ARRAY_FILTER_USE_KEY
@@ -62,6 +65,10 @@ class Log {
 		// Set type
 		$data['type'] = $type;
 
-		LogFactory::makeFromArray( $data )->save();
+		try {
+			LogFactory::makeFromArray( $data )->save();
+		} catch ( Exception $exception ) {
+			error_log( $exception->getMessage() );
+		}
 	}
 }

--- a/src/MigrationLog/MigrationLogModel.php
+++ b/src/MigrationLog/MigrationLogModel.php
@@ -34,10 +34,10 @@ class MigrationLogModel {
 	/**
 	 * MigrationModel constructor.
 	 *
-	 * @param  string  $id
-	 * @param  string  $status
-	 * @param  mixed|null  $error
-	 * @param  string|null  $lastRun
+	 * @param string      $id
+	 * @param string      $status
+	 * @param mixed|null  $error
+	 * @param string|null $lastRun
 	 */
 	public function __construct( $id, $status = '', $error = null, $lastRun = null ) {
 		$this->id       = $id;
@@ -49,11 +49,12 @@ class MigrationLogModel {
 	/**
 	 * Set migration status
 	 *
+	 * @see  MigrationLogStatus::STATUS_NAME
+	 *
 	 * @param string $status
-	 * @uses MigrationLogStatus
-	 * @see MigrationLogStatus::STATUS_NAME
 	 *
 	 * @return MigrationLogModel
+	 * @uses MigrationLogStatus
 	 */
 	public function setStatus( $status ) {
 		$this->status = array_key_exists( $status, MigrationLogStatus::getAll() )
@@ -66,7 +67,7 @@ class MigrationLogModel {
 	/**
 	 * Add migration error notice
 	 *
-	 * @param  mixed  $error
+	 * @param mixed $error
 	 *
 	 * @return MigrationLogModel
 	 */
@@ -112,11 +113,6 @@ class MigrationLogModel {
 	 * Save migration
 	 */
 	public function save() {
-		try {
-			give( MigrationLogRepository::class )->save( $this );
-		} catch ( DatabaseQueryException $e ) {
-			error_log( $e->getMessage() );
-			error_log( print_r( $e->getQueryErrors(), true ) );
-		}
+		give( MigrationLogRepository::class )->save( $this );
 	}
 }

--- a/src/MigrationLog/MigrationLogModel.php
+++ b/src/MigrationLog/MigrationLogModel.php
@@ -2,6 +2,8 @@
 
 namespace Give\MigrationLog;
 
+use Give\Framework\Database\Exceptions\DatabaseQueryException;
+
 /**
  * Class MigrationLogModel
  * @package Give\MigrationLog
@@ -110,6 +112,11 @@ class MigrationLogModel {
 	 * Save migration
 	 */
 	public function save() {
-		give( MigrationLogRepository::class )->save( $this );
+		try {
+			give( MigrationLogRepository::class )->save( $this );
+		} catch ( DatabaseQueryException $e ) {
+			error_log( $e->getMessage() );
+			error_log( print_r( $e->getQueryErrors(), true ) );
+		}
 	}
 }

--- a/src/MigrationLog/Migrations/CreateMigrationsTable.php
+++ b/src/MigrationLog/Migrations/CreateMigrationsTable.php
@@ -48,7 +48,7 @@ class CreateMigrationsTable extends Migration {
 		$charset = DB::get_charset_collate();
 
 		$sql = "CREATE TABLE {$table} (
-			id VARCHAR(255) NOT NULL,
+			id VARCHAR(180) NOT NULL,
 			status VARCHAR(16) NOT NULL,
 			error text NULL,
 			last_run DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5736

## Description

This PR resolves the issues with creation of the give_migrations table that was failing on some systems. The problem was in the `id` column key length, which was set to `255`. But on some systems, that key length is causing a fatal error, depending on what MySQL engine and what encoding is being used. The issue is resolved by setting the key length to `180`. 

Additionally, the `MigrationLogRepository::save` method is wrapped up with a try-catch block in order to keep the site functional even if the migration system fails. 

## Affects

Migration system


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

