### PR TITLE
Fix broken link by correctly closing href tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Fix broken link by correctly closing href tag (#5746)
+
 ## 2.10.0 - 2021-03-22
 
 ### Changed

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -166,7 +166,7 @@ return [
 			[
 				'id'         => 'description',
 				'name'       => __( 'Description', 'give' ),
-				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="http://docs.givewp.com/email-tags target="_blank">any of the available template tags</a> within this message.', 'give' ),
+				'desc'       => __( 'The description is displayed directly below the main headline and should be 1-2 sentences. You may use <a href="http://docs.givewp.com/email-tags" target="_blank">any of the available template tags</a> within this message.', 'give' ),
 				'type'       => 'textarea',
 				'attributes' => [
 					'placeholder' => __( '{name}, your contribution means a lot and will be put to good use making a difference. We’ve sent your donation receipt to {donor_email}. ', 'give' ),


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5746

## Description

I add a double quote around the link in `href` tag to fix ixxue.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This fix does not affect existing functionality.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://user-images.githubusercontent.com/1784821/112435460-c371d880-8d6a-11eb-9ca0-050ecf176b9e.png)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Review description in donation form meta box. You can easily find the field setting by searching text visible in screenshot.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

