### PR TITLE
Public fields api README now has more examples.

### DIFF
--- a/src/Form/LegacyConsumer/README.md
+++ b/src/Form/LegacyConsumer/README.md
@@ -6,6 +6,8 @@ A consumer of the Fields API for GiveWP Donation Forms.
 
 The public Fields API combines the Field Factory and Field Collection methods into a single fluent API.
 
+Note: Currently supports text, textarea, select, and checkbox field types.
+
 ```php
 add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) {
 
@@ -13,10 +15,66 @@ add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) 
     $collection->append(
         give_field( 'text', 'myTextField' )
             ->label( 'My Text Field' )
-            ->required()
+            ->required() // Could instead be marked as readOnly() (optional)
+            ->helpText( __( 'This is my custom text field.' ) )
     );
 });
 ```
+
+```php
+add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) {
+
+    // Show in the Donation Receipt (for the legacy template uses the donation confirmation).
+    $collection->append(
+        give_field( 'text', 'myTextField' )
+            ->label( 'My Text Field' )
+            ->showInReceipt()
+    );
+});
+```
+
+```php
+add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) {
+
+    // Store a field value as Donor Meta (instead of Donation Meta).
+    $collection->append(
+        give_field( 'text', 'myTextField' )
+            ->label( 'My Text Field' )
+            ->storeAsDonorMeta() // Otherwise store as Donation Meta (default)
+            ->showInReceipt() // When stored as Donor meta it uses the Donor section of the receipt.
+    );
+});
+```
+
+```php
+add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) {
+
+    // Add support for an email tag.
+    $collection->append(
+        give_field( 'text', 'myTextField' )
+            ->label( 'My Text Field' )
+            ->emailtag( 'my-text-field' )
+    );
+});
+```
+
+```php
+add_action( 'give_fields_payment_mode_before_gateways', function( $collection ) {
+    $collection->append(
+
+        // Select field with options.
+        give_field( 'select', 'mySelectField' )
+            ->label( 'My Select Field' )
+            ->options([
+                'aye' => __( 'Aye' ),
+                'bee' => __( 'Bee' ),
+            ])
+
+    );
+});
+```
+
+
 
 ## Integrating with the Form
 


### PR DESCRIPTION
Updates the README for the Public Fields API (Legacy Form Consumer) to include additional examples as used in the snippet documentation.