### PR TITLE
Stripe Application Fee checks that the connected account country supports application fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix broken link by correctly closing href tag (#5746)
+-   Stripe Application Fee checks that the connected account country supports application fees (#5755)
 
 ## 2.10.0 - 2021-03-22
 

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -33,9 +33,10 @@ class ApplicationFee {
 	public static function canAddFee() {
 		$gate = new static();
 
-		return ! ( $gate->hasLicense()
-			|| $gate->isStripeProAddonActive()
-			|| $gate->isStripeProAddonInstalled( get_plugins() ) );
+		return $gate->doesCountrySupportApplicationFee
+			&& ! $gate->hasLicense()
+			&& ! $gate->isStripeProAddonActive()
+			&& ! $gate->isStripeProAddonInstalled( get_plugins() );
 	}
 
 	/**
@@ -74,5 +75,19 @@ class ApplicationFee {
 	 */
 	public function hasLicense() {
 		return (bool) Give_License::get_license_by_plugin_dirname( static::PluginSlug );
+	}
+
+	/**
+	 * @unreleased
+	 *
+	 * @link https://github.com/impress-org/givewp/issues/5729
+	 *
+	 * @return bool
+	 */
+	public function doesCountrySupportApplicationFee() {
+		$connected     = give_stripe_get_connected_account_options();
+		$accountID     = $connected['stripe_account'];
+		$accountLookup = give_stripe_get_all_accounts();
+		return 'BR' !== $accountLookup[ $accountID ]['account_country'];
 	}
 }

--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -33,7 +33,7 @@ class ApplicationFee {
 	public static function canAddFee() {
 		$gate = new static();
 
-		return $gate->doesCountrySupportApplicationFee
+		return $gate->doesCountrySupportApplicationFee()
 			&& ! $gate->hasLicense()
 			&& ! $gate->isStripeProAddonActive()
 			&& ! $gate->isStripeProAddonInstalled( get_plugins() );

--- a/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
+++ b/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
@@ -111,10 +111,10 @@ final class ApplicationFeeTest extends TestCase {
         give_update_option( '_give_stripe_get_all_accounts', [
             'acct_foo' => [
                 'account_id' => 'acct_foo',
-                'account_country' => 'US'
+                'account_country' => 'BR'
             ]
         ] );
 
-        $this->assertTrue( $this->gate->doesCountrySupportApplicationFee() );
+        $this->assertFalse( $this->gate->doesCountrySupportApplicationFee() );
     }
 }

--- a/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
+++ b/tests/unit/tests/PaymentGateways/Stripe/ApplicationFeeTest.php
@@ -91,4 +91,30 @@ final class ApplicationFeeTest extends TestCase {
             $this->gate->hasLicense( 'give-stripe' )
         );
     }
+
+    public function testConneectedAccontCountrySupportsApplicationFees() {
+
+        give_update_option( '_give_stripe_default_account', 'acct_foo' );
+        give_update_option( '_give_stripe_get_all_accounts', [
+            'acct_foo' => [
+                'account_id' => 'acct_foo',
+                'account_country' => 'US'
+            ]
+        ] );
+
+        $this->assertTrue( $this->gate->doesCountrySupportApplicationFee() );
+    }
+
+    public function testConneectedAccontCountryNotSupportsApplicationFees() {
+
+        give_update_option( '_give_stripe_default_account', 'acct_foo' );
+        give_update_option( '_give_stripe_get_all_accounts', [
+            'acct_foo' => [
+                'account_id' => 'acct_foo',
+                'account_country' => 'US'
+            ]
+        ] );
+
+        $this->assertTrue( $this->gate->doesCountrySupportApplicationFee() );
+    }
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5729

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds a procedural check for the connected account's country, ie not Brazil, supporting application fees

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Follow these [testing instructions](https://github.com/impress-org/givewp/pull/5709). You can also use the Brazilian Stripe test account.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

