### PR TITLE
 GiveWP Database management tools are now backward compatible with MySQL 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix broken link by correctly closing href tag (#5746)
+-   GiveWP Database management tools are now backward compatible with MySQL 5.6 (#5759)
 
 ## 2.10.0 - 2021-03-22
 

--- a/src/MigrationLog/MigrationLogRepository.php
+++ b/src/MigrationLog/MigrationLogRepository.php
@@ -39,8 +39,8 @@ class MigrationLogRepository {
 	 */
 	public function save( MigrationLogModel $model ) {
 		$query = "
-			INSERT INTO {$this->migration_table} (id, status, error ) 
-			VALUES (%s, %s, %s) 
+			INSERT INTO {$this->migration_table} (id, status, error, last_run )
+			VALUES (%s, %s, %s, NOW())
 			ON DUPLICATE KEY UPDATE
 			status = %s,
 			error = %s,

--- a/src/MigrationLog/Migrations/CreateMigrationsTable.php
+++ b/src/MigrationLog/Migrations/CreateMigrationsTable.php
@@ -51,7 +51,7 @@ class CreateMigrationsTable extends Migration {
 			id VARCHAR(180) NOT NULL,
 			status VARCHAR(16) NOT NULL,
 			error text NULL,
-			last_run DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_run TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY  (id)
 		) {$charset}";
 

--- a/src/MigrationLog/Migrations/CreateMigrationsTable.php
+++ b/src/MigrationLog/Migrations/CreateMigrationsTable.php
@@ -51,7 +51,7 @@ class CreateMigrationsTable extends Migration {
 			id VARCHAR(180) NOT NULL,
 			status VARCHAR(16) NOT NULL,
 			error text NULL,
-			last_run TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_run DATETIME NOT NULL,
 			PRIMARY KEY  (id)
 		) {$charset}";
 


### PR DESCRIPTION
Resolves #5758 

## Description
This PR resolves the issue with the migration log table creation process which was failing on older MySQL versions. Table creation was failing because the default value for the `last_run` column was set to `CURRENT_TIMESTAMP` which is not supported for the `DATETIME` column type in MySQL versions <= 5.6. The issue is resolved by changing the column type to `TIMESTAMP`.

## Affects

Create migration table SQL. 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Install Give on a server that has MySQL version <= 5.6

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

