### PR TITLE
Migrations are retrieved only when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix broken link by correctly closing href tag (#5746)
+-   Retrieve migrations only when necessary (#5760)
 
 ## 2.10.0 - 2021-03-22
 

--- a/src/MigrationLog/Helpers/MigrationHelper.php
+++ b/src/MigrationLog/Helpers/MigrationHelper.php
@@ -42,13 +42,14 @@ class MigrationHelper {
 		MigrationsRegister $migrationRegister,
 		MigrationLogRepository $migrationRepository
 	) {
-		$this->migrationRegister    = $migrationRegister;
-		$this->migrationRepository  = $migrationRepository;
-		$this->migrationsInDatabase = $this->migrationRepository->getMigrations();
+		$this->migrationRegister   = $migrationRegister;
+		$this->migrationRepository = $migrationRepository;
 	}
 
 	/**
 	 * Get migrations sorted by run order
+	 *
+	 * @since 2.10.0
 	 *
 	 * @return array
 	 */
@@ -70,6 +71,8 @@ class MigrationHelper {
 	/**
 	 * Get pending migrations
 	 *
+	 * @since 2.10.0
+	 *
 	 * @return string[]
 	 */
 	public function getPendingMigrations() {
@@ -77,7 +80,7 @@ class MigrationHelper {
 			$this->migrationRegister->getMigrations(),
 			function( $migrationClass ) {
 				/* @var Migration $migrationClass */
-				foreach ( $this->migrationsInDatabase as $migration ) {
+				foreach ( $this->getMigrationsInDatabase() as $migration ) {
 					if ( $migration->getId() === $migrationClass::id() ) {
 						return false;
 					}
@@ -90,11 +93,28 @@ class MigrationHelper {
 	/**
 	 * Get migration run order
 	 *
+	 * @since 2.10.0
+	 *
 	 * @param string $migrationId
 	 *
 	 * @return int
 	 */
 	public function getRunOrderForMigration( $migrationId ) {
 		return array_search( $migrationId, array_values( $this->getMigrationsSorted() ) ) + 1;
+	}
+
+	/**
+	 * Retrieves the migrations from the database, caching the results for future retrieval
+	 *
+	 * @since 2.10.1
+	 *
+	 * @return MigrationLogModel[]
+	 */
+	private function getMigrationsInDatabase() {
+		if ( $this->migrationsInDatabase === null ) {
+			$this->migrationsInDatabase = $this->migrationRepository->getMigrations();
+		}
+
+		return $this->migrationsInDatabase;
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5756 

## Description

This resolves an issue wherein migrations were being queried even when unnecessary, causing a fatal error to be thrown unnecessarily in other contexts. This PR makes sure the migrations are only queried at the proper time, so if there is a problem with migrations it won't show up in other contexts.

## Affects

The migrations API and, hopefully, the page/post edit screen such that they work if the migrations are broken.

## Testing Instructions

1. Delete the `give_migrations` table
2. Try to create a page
3. Creating a page should still work

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

