### PR TITLE
Exported CSVs now support Chinese/Japanese/Korean characters

### DIFF
--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -46,6 +46,8 @@ class Give_Earnings_Export extends Give_Export {
 		header( 'Content-Disposition: attachment; filename=' . apply_filters( 'give_earnings_export_filename', 'give-export-' . $this->export_type . '-' . date( 'n' ) . '-' . date( 'Y' ) ) . '.csv' );
 		header( 'Expires: 0' );
 
+		// UTF-8 BOM
+		echo "\xEF\xBB\xBF";
 	}
 
 	/**

--- a/includes/admin/tools/export/class-export.php
+++ b/includes/admin/tools/export/class-export.php
@@ -67,6 +67,9 @@ class Give_Export {
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename=' . $file_name . '.csv' );
 		header( 'Expires: 0' );
+
+		// UTF-8 BOM
+		echo "\xEF\xBB\xBF";
 	}
 
 	/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5761 

## Description

The addition of byte order mark (BOM) before the datastream of a CSV file ensures proper display of Chinese characters, Japanese and Korean.

## Affects

Export / Generate CSV function

## Testing Instructions

1. Go to Donations > Tools > Export
2. Click on Generate CSV
3. Open the csv file generated
4. Characters not broken

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

