### PR TITLE
Donors are now able to log into Donor Dashboard on hosts with page caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Composer dependencies now reference releases instead of branches (#5763)
 -   Donor search no longer shows undefined index notice (#5752)
 -   Retrieve migrations only when necessary (#5760)
+-   Donors are now able to log into Donor Dashboard on hosts with page caching (#5765)
 
 ## 2.10.0 - 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Composer dependencies now reference releases instead of branches (#5763)
 -   Donor search no longer shows undefined index notice (#5752)
 -   Retrieve migrations only when necessary (#5760)
--   Donors are now able to log into Donor Dashboard on hosts with page caching (#5765)
+-   Donors are now able to log into Donor Dashboard on hosts with page caching (#5766)
 
 ## 2.10.0 - 2021-03-22
 

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -36,6 +36,22 @@ class App {
 			$url = $url . '&accent-color=' . urlencode( $attributes['accent_color'] );
 		}
 
+		if ( isset( $_GET['give_nl'] ) ) {
+			$url = $url . '&give_nl=' . urlencode( give_clean( $_GET['give_nl'] ) );
+		}
+
+		if ( isset( $_GET['_give_hash'] ) ) {
+			$url = $url . '&_give_hash=' . urlencode( give_clean( $_GET['_give_hash'] ) );
+		}
+
+		if ( isset( $_GET['action'] ) ) {
+			$url = $url . '&action=' . urlencode( give_clean( $_GET['action'] ) );
+		}
+
+		if ( isset( $_GET['give_nl'] ) ) {
+			$url = $url . '&give_nl=' . urlencode( give_clean( $_GET['give_nl'] ) );
+		}
+
 		$loader = $this->getIframeLoader( $attributes['accent_color'] );
 
 		return sprintf(

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -50,7 +50,7 @@ class App {
 			$queryArgs['action'] = urlencode( give_clean( $_GET['action'] ) );
 		}
 
-		add_query_arg( $queryArgs, $url );
+		$url = add_query_arg( $queryArgs, $url );
 
 		$loader = $this->getIframeLoader( $attributes['accent_color'] );
 

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -48,10 +48,6 @@ class App {
 			$url = $url . '&action=' . urlencode( give_clean( $_GET['action'] ) );
 		}
 
-		if ( isset( $_GET['give_nl'] ) ) {
-			$url = $url . '&give_nl=' . urlencode( give_clean( $_GET['give_nl'] ) );
-		}
-
 		$loader = $this->getIframeLoader( $attributes['accent_color'] );
 
 		return sprintf(

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -32,21 +32,25 @@ class App {
 
 		$url = get_site_url() . '/?give-embed=donor-dashboard';
 
+		$queryArgs = [];
+
 		if ( isset( $attributes['accent_color'] ) ) {
-			$url = $url . '&accent-color=' . urlencode( $attributes['accent_color'] );
+			$queryArgs['accent-color'] = urlencode( $attributes['accent_color'] );
 		}
 
 		if ( isset( $_GET['give_nl'] ) ) {
-			$url = $url . '&give_nl=' . urlencode( give_clean( $_GET['give_nl'] ) );
+			$queryArgs['give_nl'] = urlencode( give_clean( $_GET['give_nl'] ) );
 		}
 
 		if ( isset( $_GET['_give_hash'] ) ) {
-			$url = $url . '&_give_hash=' . urlencode( give_clean( $_GET['_give_hash'] ) );
+			$queryArgs['_give_hash'] = urlencode( give_clean( $_GET['_give_hash'] ) );
 		}
 
 		if ( isset( $_GET['action'] ) ) {
-			$url = $url . '&action=' . urlencode( give_clean( $_GET['action'] ) );
+			$queryArgs['action'] = urlencode( give_clean( $_GET['action'] ) );
 		}
+
+		add_query_arg( $queryArgs, $url );
 
 		$loader = $this->getIframeLoader( $attributes['accent_color'] );
 

--- a/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
@@ -1,15 +1,11 @@
 import axios from 'axios';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 
 export const loginWithAPI = ( { login, password } ) => {
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/login', {
 		login,
 		password,
-	}, 	{
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	}, 	{} )
 		.then( ( response ) => response.data );
 };
 
@@ -17,10 +13,6 @@ export const verifyEmailWithAPI = ( { email, recaptcha } ) => {
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/verify-email', {
 		email,
 		'g-recaptcha-response': recaptcha,
-	}, 	{
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	}, 	{} )
 		.then( ( response ) => response.data );
 };

--- a/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
@@ -1,11 +1,7 @@
 import axios from 'axios';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 
 export const logoutWithAPI = () => {
-	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/logout', {
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/logout', {} )
 		.then( ( response ) => response.data );
 };

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
@@ -1,16 +1,12 @@
 import axios from 'axios';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 import { fetchSubscriptionsDataFromAPI } from '../../../tabs/recurring-donations/utils';
 
 export const cancelSubscriptionWithAPI = ( id ) => {
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscription/cancel', {
 		id: id,
 	},
-	{
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	{} )
 		.then( async( response ) => {
 			await fetchSubscriptionsDataFromAPI();
 			return response;

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 import { fetchSubscriptionsDataFromAPI } from '../../../tabs/recurring-donations/utils';
 
 export const updateSubscriptionWithAPI = ( { id, amount, paymentMethod } ) => {
@@ -8,11 +8,7 @@ export const updateSubscriptionWithAPI = ( { id, amount, paymentMethod } ) => {
 		amount: amount,
 		payment_method: paymentMethod,
 	},
-	{
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	{} )
 		.then( async( response ) => {
 			await fetchSubscriptionsDataFromAPI();
 			return response;

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { store } from '../store';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 import { setAnnualReceipts, setQuerying } from '../store/actions';
 
 export const fetchAnnualReceiptsFromAPI = () => {
@@ -8,11 +8,7 @@ export const fetchAnnualReceiptsFromAPI = () => {
 
 	dispatch( setQuerying( true ) );
 	axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/annual-receipts', {},
-		{
-			headers: {
-				'X-WP-Nonce': getAPINonce(),
-			},
-		} )
+		{} )
 		.then( ( response ) => response.data )
 		.then( ( data ) => {
 			const { receipts } = data;

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
@@ -1,21 +1,25 @@
 import axios from 'axios';
 import { store } from '../store';
-import { getAPIRoot } from '../../../utils';
+import { getAPIRoot, isLoggedIn } from '../../../utils';
 import { setAnnualReceipts, setQuerying } from '../store/actions';
 
 export const fetchAnnualReceiptsFromAPI = () => {
-	const { dispatch } = store;
 
-	dispatch( setQuerying( true ) );
-	axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/annual-receipts', {},
-		{} )
-		.then( ( response ) => response.data )
-		.then( ( data ) => {
-			const { receipts } = data;
-			dispatch( setAnnualReceipts( receipts ) );
-			dispatch( setQuerying( false ) );
-		} )
-		.catch( () => {
-			dispatch( setQuerying( false ) );
-		} );
+	const { dispatch } = store;
+	const loggedIn = isLoggedIn();
+
+	if ( loggedIn ) {
+		dispatch( setQuerying( true ) );
+		axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/annual-receipts', {},
+			{} )
+			.then( ( response ) => response.data )
+			.then( ( data ) => {
+				const { receipts } = data;
+				dispatch( setAnnualReceipts( receipts ) );
+				dispatch( setQuerying( false ) );
+			} )
+			.catch( () => {
+				dispatch( setQuerying( false ) );
+			} );
+	}
 };

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/utils/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { store } from '../store';
-import { getAPIRoot, getAPINonce, isLoggedIn } from '../../../utils';
+import { getAPIRoot, isLoggedIn } from '../../../utils';
 import { setDonations, setQuerying, setError, setCount, setRevenue, setAverage, setCurrency } from '../store/actions';
 
 export const fetchDonationsDataFromAPI = () => {
@@ -10,11 +10,7 @@ export const fetchDonationsDataFromAPI = () => {
 	if ( loggedIn ) {
 		dispatch( setQuerying( true ) );
 		axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/donations', {},
-			{
-				headers: {
-					'X-WP-Nonce': getAPINonce(),
-				},
-			} )
+			{} )
 			.then( ( response ) => response.data )
 			// eslint-disable-next-line camelcase
 			.then( ( { status, body_response } ) => {

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/utils/index.js
@@ -44,11 +44,7 @@ export const updateProfileWithAPI = async( {
 			isAnonymous,
 		} ),
 		id,
-	}, {
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	}, {} )
 		.then( ( response ) => response.data )
 		.then( ( responseData ) => {
 			/**
@@ -78,11 +74,7 @@ export const uploadAvatarWithAPI = ( file ) => {
 export const fetchStatesWithAPI = ( country ) => {
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/location', {
 		countryCode: country,
-	}, {
-		headers: {
-			'X-WP-Nonce': getAPINonce(),
-		},
-	} )
+	}, {} )
 		.then( ( response ) => response.data )
 		.then( ( data ) => {
 			return data.states.map( ( state ) => {

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/index.js
@@ -4,6 +4,8 @@ import Content from './content';
 import { fetchSubscriptionsDataFromAPI } from './utils';
 
 export const registerRecurringDonationsTab = () => {
+
+	
 	fetchSubscriptionsDataFromAPI();
 
 	window.giveDonorDashboard.utils.registerTab( {

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { store } from '../store';
-import { getAPIRoot, getAPINonce } from '../../../utils';
+import { getAPIRoot } from '../../../utils';
 import { setSubscriptions, setQuerying } from '../store/actions';
 
 export const fetchSubscriptionsDataFromAPI = () => {
@@ -8,11 +8,7 @@ export const fetchSubscriptionsDataFromAPI = () => {
 
 	dispatch( setQuerying( true ) );
 	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscriptions', {},
-		{
-			headers: {
-				'X-WP-Nonce': getAPINonce(),
-			},
-		} )
+		{} )
 		.then( ( response ) => response.data )
 		.then( ( data ) => {
 			dispatch( setSubscriptions( data.subscriptions ) );

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
@@ -1,22 +1,25 @@
 import axios from 'axios';
 import { store } from '../store';
-import { getAPIRoot } from '../../../utils';
+import { getAPIRoot, isLoggedIn } from '../../../utils';
 import { setSubscriptions, setQuerying } from '../store/actions';
 
 export const fetchSubscriptionsDataFromAPI = () => {
 	const { dispatch } = store;
+	const loggedIn = isLoggedIn();
 
-	dispatch( setQuerying( true ) );
-	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscriptions', {},
-		{} )
-		.then( ( response ) => response.data )
-		.then( ( data ) => {
-			dispatch( setSubscriptions( data.subscriptions ) );
-			dispatch( setQuerying( false ) );
-			return data;
-		} )
-		.catch( () => {
-			dispatch( setQuerying( false ) );
-			return null;
-		} );
+	if ( loggedIn ) {
+		dispatch( setQuerying( true ) );
+		return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscriptions', {},
+			{} )
+			.then( ( response ) => response.data )
+			.then( ( data ) => {
+				dispatch( setSubscriptions( data.subscriptions ) );
+				dispatch( setQuerying( false ) );
+				return data;
+			} )
+			.catch( () => {
+				dispatch( setQuerying( false ) );
+				return null;
+			} );
+		}
 };


### PR DESCRIPTION
Resolves #5764 

## Description

This PR resolved the issues faced on hosts with aggressive page caching by ensuring that the WP API nonce is not required in order to access the donor dashboard, and ensuring that query params are passed to the iframe which contains the Donor Dashboard application.

## Affects

This PR affects some API query logic for the Donor Dashboard frontend, and some iframe markup output logic in the backend.

## Visuals

N/A

## Testing Instructions

On a WP Engine install:
1. Make a donation with an email not associated with a WP acct
2. Go to Donor Dashboard
3. Request email verification
4. See that the email is sent successfully, and that you can access the Donor Dashboard using the link in the email

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

