### PR TITLE
The Donor Dashboard are now only be generated in admin-side pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Composer dependencies now reference releases instead of branches (#5763)
 -   Donor search no longer shows undefined index notice (#5752)
 -   Retrieve migrations only when necessary (#5760)
+-   The Donor Dashboard are no only be generated in admin-side pages (#5768)
 
 ## 2.10.0 - 2021-03-22
 

--- a/src/DonorDashboards/RequestHandler.php
+++ b/src/DonorDashboards/RequestHandler.php
@@ -32,7 +32,7 @@ class RequestHandler {
 	 */
 	public function parseRequest( $query ) {
 
-		if ( is_admin() && current_user_can( 'manage_options' ) && array_key_exists( 'give-generate-donor-dashboard-page', $query->query_vars ) ) {
+		if ( is_admin() && current_user_can( 'manage_options' ) && ! wp_doing_ajax() && array_key_exists( 'give-generate-donor-dashboard-page', $query->query_vars ) ) {
 			( new Settings() )->generateDonorDashboardPage();
 			wp_safe_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-settings&give-generated-donor-dashboard-page=1' ) );
 			exit;

--- a/src/DonorDashboards/RequestHandler.php
+++ b/src/DonorDashboards/RequestHandler.php
@@ -32,7 +32,7 @@ class RequestHandler {
 	 */
 	public function parseRequest( $query ) {
 
-		if ( is_admin() && array_key_exists( 'give-generate-donor-dashboard-page', $query->query_vars ) ) {
+		if ( is_admin() && current_user_can( 'manage_options' ) && array_key_exists( 'give-generate-donor-dashboard-page', $query->query_vars ) ) {
 			( new Settings() )->generateDonorDashboardPage();
 			wp_safe_redirect( admin_url( 'edit.php?post_type=give_forms&page=give-settings&give-generated-donor-dashboard-page=1' ) );
 			exit;


### PR DESCRIPTION
Resolves #5767 

## Description

This PR ensures dashboard pages are only generated by users with the correct capabilities.

## Affects

This PR affects the request handler class for Donor Dashboards.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

