### PR TITLE
Logs table creation is now backward compatible with MySQL 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Logs table creation is now backward compatible with MySQL 5.6 (#5776) 
+
 ## 2.10.1 - 2021-03-30
 
 ### Fixed

--- a/src/Log/LogFactory.php
+++ b/src/Log/LogFactory.php
@@ -64,7 +64,7 @@ class LogFactory {
 			'source'   => esc_html__( 'Give Core', 'give' ),
 			'context'  => [],
 			'id'       => null,
-			'date'     => null,
+			'date'     => date( 'Y-m-d H:i:s' ),
 		];
 	}
 }

--- a/src/Log/LogModel.php
+++ b/src/Log/LogModel.php
@@ -233,6 +233,7 @@ class LogModel {
 		$repository = give( LogRepository::class );
 
 		if ( $this->getId() ) {
+			$this->date = date( 'Y-m-d H:i:s' );
 			$repository->updateLog( $this );
 		} else {
 			$this->id = $repository->insertLog( $this );

--- a/src/Log/LogModel.php
+++ b/src/Log/LogModel.php
@@ -2,6 +2,7 @@
 
 namespace Give\Log;
 
+use DateTime;
 use Give\Log\ValueObjects\LogType;
 
 /**
@@ -49,7 +50,7 @@ class LogModel {
 	private $id;
 
 	/**
-	 * @var string|null
+	 * @var string
 	 */
 	private $date;
 
@@ -62,16 +63,16 @@ class LogModel {
 	 * @param  string  $source
 	 * @param  array  $context
 	 * @param  int|null  $logId
-	 * @param  string|null $date
+	 * @param  string $date
 	 */
 	public function __construct( $type, $message, $category, $source, $context, $logId, $date ) {
 		$this->setType( $type );
+		$this->setDate( $date );
 		$this->category = $category;
 		$this->source   = $source;
 		$this->context  = $context;
 		$this->message  = $message;
 		$this->id       = $logId;
-		$this->date     = $date;
 	}
 
 	/**
@@ -99,6 +100,17 @@ class LogModel {
 	}
 
 	/**
+	 * Set log date
+	 *
+	 * @param string $date
+	 */
+	private function setDate( $date ) {
+		$this->date = $this->isValidateDate( $date )
+			? $date
+			: date( 'Y-m-d H:i:s' );
+	}
+
+	/**
 	 * Set log source
 	 * If not defined, fallback to default value
 	 *
@@ -108,6 +120,19 @@ class LogModel {
 		$this->source = is_null( $source )
 			? esc_html__( 'Give Core', 'give' )
 			: $source;
+	}
+
+	/**
+	 * Helper method to check if given string is a valid date
+	 *
+	 * @param string $date
+	 * @param string $format
+	 *
+	 * @return bool
+	 */
+	public function isValidateDate( $date, $format = 'Y-m-d H:i:s' ) {
+		$dateTime = DateTime::createFromFormat( $format, $date );
+		return $dateTime && $dateTime->format( $format ) === $date;
 	}
 
 	 /**

--- a/src/Log/LogRepository.php
+++ b/src/Log/LogRepository.php
@@ -47,7 +47,7 @@ class LogRepository {
 				'data'     => $model->getData( $jsonEncode = true ),
 				'category' => $model->getCategory(),
 				'source'   => $model->getSource(),
-				'date'     => date( 'Y-m-d H:i:s' ),
+				'date'     => $model->getDate(),
 			],
 			null
 		);
@@ -70,7 +70,7 @@ class LogRepository {
 				'data'     => $model->getData( $jsonEncode = true ),
 				'category' => $model->getCategory(),
 				'source'   => $model->getSource(),
-				'date'     => date( 'Y-m-d H:i:s' ),
+				'date'     => $model->getDate(),
 			],
 			[
 				'id' => $model->getId(),

--- a/src/Log/LogRepository.php
+++ b/src/Log/LogRepository.php
@@ -47,6 +47,7 @@ class LogRepository {
 				'data'     => $model->getData( $jsonEncode = true ),
 				'category' => $model->getCategory(),
 				'source'   => $model->getSource(),
+				'date'     => date( 'Y-m-d H:i:s' ),
 			],
 			null
 		);

--- a/src/Log/Migrations/CreateNewLogTable.php
+++ b/src/Log/Migrations/CreateNewLogTable.php
@@ -27,7 +27,7 @@ class CreateNewLogTable extends Migration {
 	 * @return string
 	 */
 	public static function title() {
-		return  esc_html__( 'Create new give_log table' );
+		return  esc_html__( 'Create new give_log table', 'give' );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class CreateNewLogTable extends Migration {
 			data text NOT NULL,
 			category VARCHAR(64) NOT NULL,
 			source VARCHAR(64) NOT NULL,
-			date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			date DATETIME NOT NULL,
 			PRIMARY KEY  (id),
 			KEY log_type (log_type),
 			KEY category (category),


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5775

## Description

This PR resolves the issue with the logs table creation process which was failing on older MySQL versions. Table creation was failing because the default value for the `date` column was set to `CURRENT_TIMESTAMP` which is not supported for the `DATETIME` column type in MySQL versions <= 5.6. The issue is resolved by removing the default value and by setting the date with PHP.

## Affects

Create `give_logs` table SQL.


## Testing Instructions

Install GiveWP 2.10.1 on a server that has MySQL version <= 5.6

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

