### PR TITLE
Donor Dashboard page is now only generated if one does not already exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Logs table creation is now backward compatible with MySQL 5.6 (#5776) 
+-   Donor Dashboard page is now only generated if one does not already exist (#5785)
 
 ## 2.10.1 - 2021-03-30
 

--- a/src/DonorDashboards/Admin/Settings.php
+++ b/src/DonorDashboards/Admin/Settings.php
@@ -109,6 +109,12 @@ class Settings {
 	 */
 	public function generateDonorDashboardPage() {
 
+		// Check if a Donor Dashboard page has already been created
+
+		if ( $this->donorDashboardPageIsPublished() === false ) {
+			return;
+		}
+
 		$content = $this->getDonorDashboardPageContent();
 
 		$pageId = wp_insert_post(

--- a/src/DonorDashboards/Admin/Settings.php
+++ b/src/DonorDashboards/Admin/Settings.php
@@ -111,7 +111,7 @@ class Settings {
 
 		// Check if a Donor Dashboard page has already been created
 
-		if ( $this->donorDashboardPageIsPublished() === false ) {
+		if ( ! empty( give_get_option( 'donor_dashboard_page' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Resolves #5783 

## Description

This PR introduces a check to ensure that new Donor Dashboards are only generated if one does not already exist (published or unpublished).

## Affects

This fix affects logic in the generateDonroDashboardPage method, which can be called manually (from the admin settings page), or automatically on new installs.

## Visuals

N/A

## Testing Instructions

On an install of GiveWP with a Donor Dashboard already created and setup:

1. Deactivate GiveWP
2. Remove the plugin
3. Reinstall GiveWP
4. Activate GiveWP
5. Check that a new Donor Dashboard page was not created

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

