### PR TITLE
Donors can no longer see other donors donations (on certain hosts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Logs table creation is now backward compatible with MySQL 5.6 (#5776) 
+-   Donors can no longer see other donors donations (on certain hosts) (#5787)
 
 ## 2.10.1 - 2021-03-30
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -55,7 +55,7 @@ class Donations {
 	 * @param string $rawAggregate raw SELECT to determine what to aggregate over
 	 * @param int $donorId
 	 *
-	 * @return array
+	 * @return object
 	 */
 	private function getDonationAggregate( $rawAggregate, $donorId ) {
 		global $wpdb;
@@ -114,10 +114,6 @@ class Donations {
 	 * @return array Donations
 	 */
 	public function getDonations( $donorId ) {
-
-		if ( Give()->donors->get_donor_by( 'id', $donorId ) !== false ) {
-			return null;
-		}
 
 		$ids = $this->getDonationIds( $donorId );
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -115,6 +115,10 @@ class Donations {
 	 */
 	public function getDonations( $donorId ) {
 
+		if ( Give()->donors->get_donor_by( 'id', $donorId ) !== false ) {
+			return null;
+		}
+
 		$ids = $this->getDonationIds( $donorId );
 
 		if ( $ids === null ) {

--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -69,13 +69,17 @@ abstract class Route implements RestRoute {
 	public function handleRequestWithDonorIdCheck( WP_REST_Request $request ) {
 
 		// Check that the provided donor ID is valid
-		if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
+		//if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
 			Log::error(
 				esc_html__( 'An error occurred while validating donor ID on request.', 'give' ),
 				[
 					'source'   => 'Donor Dashboard',
 					'Donor ID' => give()->donorDashboard->getId(),
-					'Error'    => __( 'An invalid Donor ID was provided.', 'give' ),
+					'Current User ID' => get_current_user_id(),
+					'Email Access Token' => give()->email_access->token_email,
+					'Session Email' => give()->session->get( 'give_email' ),
+					'Session Expiration' => give()->session->get_session_expiration(),
+					'Error'    => __( 'Donor ID coud not be validated for request.', 'give' ),
 				]
 			);
 
@@ -88,7 +92,7 @@ abstract class Route implements RestRoute {
 					],
 				]
 			);
-		}
+		//}
 
 		return $this->handleRequest( $request );
 

--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -69,17 +69,17 @@ abstract class Route implements RestRoute {
 	public function handleRequestWithDonorIdCheck( WP_REST_Request $request ) {
 
 		// Check that the provided donor ID is valid
-		//if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
+		if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
 			Log::error(
 				esc_html__( 'An error occurred while validating donor ID on request.', 'give' ),
 				[
-					'source'   => 'Donor Dashboard',
-					'Donor ID' => give()->donorDashboard->getId(),
-					'Current User ID' => get_current_user_id(),
+					'source'             => 'Donor Dashboard',
+					'Donor ID'           => give()->donorDashboard->getId(),
+					'Current User ID'    => get_current_user_id(),
 					'Email Access Token' => give()->email_access->token_email,
-					'Session Email' => give()->session->get( 'give_email' ),
+					'Session Email'      => give()->session->get( 'give_email' ),
 					'Session Expiration' => give()->session->get_session_expiration(),
-					'Error'    => __( 'Donor ID coud not be validated for request.', 'give' ),
+					'Error'              => __( 'Donor ID coud not be validated for request.', 'give' ),
 				]
 			);
 
@@ -92,7 +92,7 @@ abstract class Route implements RestRoute {
 					],
 				]
 			);
-		//}
+		}
 
 		return $this->handleRequest( $request );
 

--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -69,7 +69,7 @@ abstract class Route implements RestRoute {
 	public function handleRequestWithDonorIdCheck( WP_REST_Request $request ) {
 
 		// Check that the provided donor ID is valid
-		if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
+		if ( ! Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) ) {
 			Log::error(
 				esc_html__( 'An error occurred while validating donor ID on request.', 'give' ),
 				[

--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -69,9 +69,9 @@ abstract class Route implements RestRoute {
 	public function handleRequestWithDonorIdCheck( WP_REST_Request $request ) {
 
 		// Check that the provided donor ID is valid
-		if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) !== false ) {
+		if ( Give()->donors->get_donor_by( 'id', give()->donorDashboard->getId() ) === false ) {
 			Log::error(
-				esc_html__( 'An error occurred while retrieving donation records', 'give' ),
+				esc_html__( 'An error occurred while validating donor ID on request.', 'give' ),
 				[
 					'source'   => 'Donor Dashboard',
 					'Donor ID' => give()->donorDashboard->getId(),
@@ -82,7 +82,7 @@ abstract class Route implements RestRoute {
 			return new WP_REST_Response(
 				[
 					'status'        => 400,
-					'response'      => 'database_error',
+					'response'      => 'invalid_donor_id',
 					'body_response' => [
 						'message' => esc_html__( 'An error occurred while retrieving your donation records. Contact a site administrator and have them search the logs at Donations > Tools > Logs for a more specific cause of the problem.', 'give' ),
 					],

--- a/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
+++ b/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
@@ -53,28 +53,6 @@ class DonationsRoute extends RouteAbstract {
 	 */
 	protected function getData( DonationsRepository $repository, $donorId ) {
 
-		// Check that the provided donor ID is valid
-		if ( Give()->donors->get_donor_by( 'id', $donorId ) !== false ) {
-			Log::error(
-				esc_html__( 'An error occurred while retrieving donation records', 'give' ),
-				[
-					'source'   => 'Donor Dashboard',
-					'Donor ID' => $donorId,
-					'Error'    => __( 'An invalid Donor ID was provided.', 'give' ),
-				]
-			);
-
-			return new WP_REST_Response(
-				[
-					'status'        => 400,
-					'response'      => 'database_error',
-					'body_response' => [
-						'message' => esc_html__( 'An error occurred while retrieving your donation records. Contact the site administrator for assistance.', 'give' ),
-					],
-				]
-			);
-		}
-
 		// If the provided donor ID is valid, attempt to query data
 		try {
 			$donations = $repository->getDonations( $donorId );

--- a/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
+++ b/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
@@ -52,6 +52,30 @@ class DonationsRoute extends RouteAbstract {
 	 * @return WP_REST_Response
 	 */
 	protected function getData( DonationsRepository $repository, $donorId ) {
+
+		// Check that the provided donor ID is valid
+		if ( Give()->donors->get_donor_by( 'id', $donorId ) !== false ) {
+			Log::error(
+				esc_html__( 'An error occurred while retrieving donation records', 'give' ),
+				[
+					'source'   => 'Donor Dashboard',
+					'Donor ID' => $donorId,
+					'Error'    => __( 'An invalid Donor ID was provided.', 'give' ),
+				]
+			);
+
+			return new WP_REST_Response(
+				[
+					'status'        => 400,
+					'response'      => 'database_error',
+					'body_response' => [
+						'message' => esc_html__( 'An error occurred while retrieving your donation records.', 'give' ),
+					],
+				]
+			);
+		}
+
+		// If the provided donor ID is valid, attempt to query data
 		try {
 			$donations = $repository->getDonations( $donorId );
 			$count     = $repository->getDonationCount( $donorId );

--- a/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
+++ b/src/DonorDashboards/Tabs/DonationHistoryTab/DonationsRoute.php
@@ -69,7 +69,7 @@ class DonationsRoute extends RouteAbstract {
 					'status'        => 400,
 					'response'      => 'database_error',
 					'body_response' => [
-						'message' => esc_html__( 'An error occurred while retrieving your donation records.', 'give' ),
+						'message' => esc_html__( 'An error occurred while retrieving your donation records. Contact the site administrator for assistance.', 'give' ),
 					],
 				]
 			);
@@ -116,7 +116,7 @@ class DonationsRoute extends RouteAbstract {
 					'status'        => 400,
 					'response'      => 'database_error',
 					'body_response' => [
-						'message' => esc_html__( 'An error occurred while retrieving your donation records.', 'give' ),
+						'message' => esc_html__( 'An error occurred while retrieving your donation records. Contact the site administrator for assistance.', 'give' ),
 					],
 				]
 			);

--- a/src/DonorDashboards/resources/js/app/store/actions.js
+++ b/src/DonorDashboards/resources/js/app/store/actions.js
@@ -16,6 +16,16 @@ export const setProfile = ( profile ) => {
 	};
 };
 
+export const setError = ( error ) => {
+	console.log('set application error!!', error)
+	return {
+		type: 'SET_ERROR',
+		payload: {
+			error,
+		},
+	};
+};
+
 export const setStates = ( states ) => {
 	return {
 		type: 'SET_STATES',

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/content.js
@@ -12,12 +12,26 @@ import { fetchAnnualReceiptsFromAPI } from './utils';
 const Content = () => {
 	const annualReceipts = useSelector( ( state ) => state.annualReceipts );
 	const querying = useSelector( ( state ) => state.querying );
+	const error = useSelector( ( state ) => state.error );
 
 	const annualReceiptsCount = annualReceipts ? Object.entries( annualReceipts ).length : 0;
 
 	useEffect( () => {
 		fetchAnnualReceiptsFromAPI();
 	}, [] );
+
+	if ( error ) {
+		return (
+			<Fragment>
+				<Heading icon="exclamation-triangle">
+					{ __( 'Error', 'give' ) }
+				</Heading>
+				<p style={ { color: '#6b6b6b' } }>
+					{ error }
+				</p>
+			</Fragment>
+		);
+	}
 
 	return querying === true && annualReceipts === null ? (
 		<Fragment>

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/actions.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/actions.js
@@ -16,3 +16,12 @@ export const setQuerying = ( querying ) => {
 	};
 };
 
+export const setError = ( error ) => {
+	return {
+		type: 'SET_ERROR',
+		payload: {
+			error,
+		},
+	};
+};
+

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/initialState.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/initialState.js
@@ -1,4 +1,5 @@
 export const initialState = {
 	annualReceipts: null,
 	querying: false,
+	error: null,
 };

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/reducer.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/store/reducer.js
@@ -12,6 +12,11 @@ export const reducer = ( state = initialState, action ) => {
 				...state,
 				querying: action.payload.querying,
 			};
+		case 'SET_ERROR': 
+			return {
+				...state,
+				error: action.payload.error,
+			}
 		default:
 			return state;
 	}

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { store } from '../store';
 import { getAPIRoot, isLoggedIn } from '../../../utils';
-import { setAnnualReceipts, setQuerying } from '../store/actions';
+import { setAnnualReceipts, setQuerying, setError } from '../store/actions';
 
 export const fetchAnnualReceiptsFromAPI = () => {
 
@@ -14,9 +14,15 @@ export const fetchAnnualReceiptsFromAPI = () => {
 			{} )
 			.then( ( response ) => response.data )
 			.then( ( data ) => {
+
 				const { receipts } = data;
 				dispatch( setAnnualReceipts( receipts ) );
 				dispatch( setQuerying( false ) );
+
+				if ( data.status === 400 ) {
+					dispatch( setError( data.body_response.message ) );
+				}
+
 			} )
 			.catch( () => {
 				dispatch( setQuerying( false ) );

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
@@ -39,9 +39,6 @@ const Content = () => {
 				<p style={ { color: '#6b6b6b' } }>
 					{ error }
 				</p>
-				<p style={ { color: '#6b6b6b' } }>
-					{ __( 'Contact a site administrator and have them search the logs at Donations > Tools > Logs for a more specific cause of the problem.', 'give' ) }
-				</p>
 			</Fragment>
 		);
 	}

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
@@ -33,9 +33,6 @@ const DashboardContent = () => {
 				<p style={ { color: '#6b6b6b' } }>
 					{ error }
 				</p>
-				<p style={ { color: '#6b6b6b' } }>
-					{ __( 'Contact a site administrator and have them search the logs at Donations > Tools > Logs for a more specific cause of the problem.', 'give' ) }
-				</p>
 			</Fragment>
 		);
 	}

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
@@ -19,6 +19,7 @@ import './style.scss';
 const Content = () => {
 	const subscriptions = useSelector( ( state ) => state.subscriptions );
 	const querying = useSelector( ( state ) => state.querying );
+	const error = useSelector( ( state ) => state.error );
 
 	const location = useLocation();
 	const route = location ? location.pathname.split( '/' )[ 2 ] : null;
@@ -31,6 +32,19 @@ const Content = () => {
 		}
 		return null;
 	};
+
+	if ( error ) {
+		return (
+			<Fragment>
+				<Heading icon="exclamation-triangle">
+					{ __( 'Error', 'give' ) }
+				</Heading>
+				<p style={ { color: '#6b6b6b' } }>
+					{ error }
+				</p>
+			</Fragment>
+		);
+	}
 
 	if ( id ) {
 		switch ( route ) {
@@ -108,7 +122,7 @@ const Content = () => {
 	} else {
 		return <Fragment>
 			<Heading icon="exclamation-triangle">
-				{ __( 'Error', 'give' ) }
+				{ __( 'No Subscriptions', 'give' ) }
 			</Heading>
 		</Fragment>
 	}

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
@@ -91,20 +91,26 @@ const Content = () => {
 		}
 	}
 
-	return querying && subscriptions === null ? (
-		<Fragment>
+	if ( querying && !subscriptions ) {
+		return <Fragment>
 			<Heading>
 				{ __( 'Loading...', 'give' ) }
 			</Heading>
 			<SubscriptionTable />
 		</Fragment>
-	) : (
-		<Fragment>
+	} else if ( subscriptions ) {
+		return <Fragment>
 			<Heading>
 				{ `${ Object.entries( subscriptions ).length } ${ __( 'Total Subscriptions', 'give' ) }` }
 			</Heading>
 			<SubscriptionTable subscriptions={ subscriptions } perPage={ 5 } />
 		</Fragment>
-	);
+	} else {
+		return <Fragment>
+			<Heading icon="exclamation-triangle">
+				{ __( 'Error', 'give' ) }
+			</Heading>
+		</Fragment>
+	}
 };
 export default Content;

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/actions.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/actions.js
@@ -15,3 +15,12 @@ export const setQuerying = ( querying ) => {
 		},
 	};
 };
+
+export const setError = ( error ) => {
+	return {
+		type: 'SET_ERROR',
+		payload: {
+			error,
+		},
+	};
+};

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/initialState.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/initialState.js
@@ -1,4 +1,5 @@
 export const initialState = {
 	subscriptions: null,
 	querying: false,
+	error: null,
 };

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/reducer.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/store/reducer.js
@@ -12,6 +12,11 @@ export const reducer = ( state = initialState, action ) => {
 				...state,
 				querying: action.payload.querying,
 			};
+		case 'SET_ERROR':
+			return {
+				...state,
+				error: action.payload.error,
+			};
 		default:
 			return state;
 	}

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { store } from '../store';
 import { getAPIRoot, isLoggedIn } from '../../../utils';
-import { setSubscriptions, setQuerying } from '../store/actions';
+import { setSubscriptions, setQuerying, setError } from '../store/actions';
 
 export const fetchSubscriptionsDataFromAPI = () => {
 	const { dispatch } = store;
@@ -15,6 +15,11 @@ export const fetchSubscriptionsDataFromAPI = () => {
 			.then( ( data ) => {
 				dispatch( setSubscriptions( data.subscriptions ) );
 				dispatch( setQuerying( false ) );
+
+				if ( data.status === 400 ) {
+					dispatch( setError( data.body_response.message ) );
+				}
+
 				return data;
 			} )
 			.catch( () => {


### PR DESCRIPTION
Resolves #5780 

## Description

This PR prevents donors from every being shown donations that do not belong to them.. Previously, in certain caching settings, if the system was unable to identify the current donor ID, then all donations would be returned on the Donations endpoint.

## Affects

This PR affects backend logic for the Donations endpoint of the Donor Dashboard.

## Visuals

N/A

## Testing Instructions

This is a very difficult bug to test. I have so far been unable to replicate the issue.

## Pre-review Checklist

-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

