### PR TITLE
Prevent legacy logging from throwing unhandled exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Logs table creation is now backward compatible with MySQL 5.6 (#5776) 
+-   Logs will no longer cause an exception (#5788)
 
 ## 2.10.1 - 2021-03-30
 

--- a/includes/class-give-logging.php
+++ b/includes/class-give-logging.php
@@ -1,6 +1,7 @@
 <?php
 
 use Give\Log\Log;
+use Give\Log\LogFactory;
 use Give\Log\LogRepository;
 use Give\Log\ValueObjects\LogType;
 use Give\Log\Helpers\LogTypeHelper;
@@ -207,12 +208,14 @@ class Give_Logging {
 			$data['context']['class']    = $backtrace[1]['class'];
 		}
 
-		$data['source'] = 'n/a';
-		$type           = $data['type'];
-		$message        = $data['message'];
-		unset( $data['message'] );
+		try {
+			$log = LogFactory::makeFromArray( $data );
+			$log->save();
 
-		return Log::$type( $message, $data );
+			return $log->getId();
+		} catch ( Exception $exception ) {
+			error_log( $exception->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/class-give-logging.php
+++ b/includes/class-give-logging.php
@@ -1,6 +1,6 @@
 <?php
 
-use Give\Log\LogFactory;
+use Give\Log\Log;
 use Give\Log\LogRepository;
 use Give\Log\ValueObjects\LogType;
 use Give\Log\Helpers\LogTypeHelper;
@@ -207,17 +207,12 @@ class Give_Logging {
 			$data['context']['class']    = $backtrace[1]['class'];
 		}
 
-		$log = LogFactory::make(
-			$data['type'],
-			$data['message'],
-			$data['category'],
-			'n/a',
-			$data['context']
-		);
+		$data['source'] = 'n/a';
+		$type           = $data['type'];
+		$message        = $data['message'];
+		unset( $data['message'] );
 
-		$log->save();
-
-		return $log->getId();
+		return Log::$type( $message, $data );
 	}
 
 	/**

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -66,7 +66,10 @@ class Log {
 		$data['type'] = $type;
 
 		try {
-			LogFactory::makeFromArray( $data )->save();
+			$log = LogFactory::makeFromArray( $data );
+			$log->save();
+
+			return $log;
 		} catch ( Exception $exception ) {
 			error_log( $exception->getMessage() );
 		}

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -12,6 +12,45 @@ use Exception;
  * @package Give\Log
  * @since 2.10.0
  *
+ * @note There are two special keywords used in the context that are representing category and source.
+ * The default value for the Category is "Core" and for the source is "Give Core"
+ * If you want to change the category and/or source, you should provide them as context attributes.
+ * Source and category attributes should be written lowercase.
+ *
+ * @example
+ *
+ * Log::error( 'Error message', [
+ *     'category' => 'Payment',
+ *     'source' => 'Stripe add-on'
+ * ] );
+ *
+ * @note Use as many contexts attributes as you need. The more the better.
+ *
+ * @example
+ *
+ *  Log::error( 'Error message', [
+ *     'category' => 'Payment',
+ *     'source' => 'Stripe add-on',
+ *     'donation_id' => $donationId,
+ *     'donor_id' => $donorId
+ * ] );
+ *
+ * @note You can use an array or object as a context attribute value.
+ *
+ * @example
+ *
+ * try {
+ *     something();
+ * } catch ( Exception $exception ) {
+ *   Log::error( 'Something went wrong', [
+ *      'exception' => $exception,
+ *      'additional_info' => [
+ *          'donation_id' => $donationId
+ *       ]
+ *   ] );
+ * }
+ *
+ *
  * @method static error( string $message, array $context = [] )
  * @method static warning( string $message, array $context = [] )
  * @method static notice( string $message, array $context = [] )


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5786 

## Description

The new `Log` facade does not allow unhandled exceptions, but the legacy system still does as it's using the `LegacyFactory` directly. We should just have the various systems use the facade unless they have a specific reason to generate the log (such as the migration runner which handles the exception itself).

## Affects

The legacy migration system

## Testing Instructions

Add a line to throw an exception in the new logging repository and then trigger the legacy logging system to insert a log.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

