### PR TITLE
Admin can now customize Donor Dashboard styles with a snippet

### DIFF
--- a/src/DonorDashboards/ServiceProvider.php
+++ b/src/DonorDashboards/ServiceProvider.php
@@ -52,7 +52,7 @@ class ServiceProvider implements ServiceProviderInterface {
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'register' );
 		Hooks::addFilter( 'give_settings_general', Settings::class, 'overrideLegacyDonationManagementPageSettings', 999 );
 
-		Hooks::addAction( 'give_embed_head', App::class, 'loadAssets' );
+		Hooks::addAction( 'give_embed_head', App::class, 'loadAssets', 2 );
 
 		Hooks::addFilter( 'query_vars', RequestHandler::class, 'filterQueryVars' );
 		Hooks::addAction( 'parse_request', RequestHandler::class, 'parseRequest' );


### PR DESCRIPTION
## Description

This PR introduces a minor fix to ensure that admin are able to use a snippet to modify Donor Dashboard styles on their site. Given the solution's incredibly small footprint, and the niche audience this fix is for, a quick PR without an issue seems appropriate.

The issues is addressed by setting a priority on the give_embed_head add action (now priority 2) in the Donor Dashboard ServiceProvider, so that Donor Dashboard assets are enqueued before the “wp_print_styles” action is called (priority 8).

## Affects

This PR affects asset loading for the Donor Dashboards app.

## Visuals

N/A

## Testing Instructions

1. Use this snippet to load custom styles into the Donor Dashboard (replacing "give-sequoia-template-css" with "give-donor-dashboards-app": https://github.com/impress-org/givewp-snippet-library/blob/master/form-customizations/css-customizations/multi-step-inline-styles.php
2. Check that the styles loaded correctly into your donor dashboard area
## Pre-review Checklist

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

