### PR TITLE
Add a log_content for the donation log to prevent the log_content to be "Something went wrong"

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -377,6 +377,7 @@ function give_field_is_required( $field, $form_id ) {
  */
 function give_record_donation_in_log( $give_form_id = 0, $payment_id, $price_id = false, $donation_date = null ) {
 	$log_data = [
+		'log_content'  => 'Payment log info',
 		'log_parent'   => $payment_id,
 		'log_type'     => 'sale',
 		'log_date'     => isset( $donation_date ) ? $donation_date : null,


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This pull request fixes a small problem, whenever a donation happen there's a function calling to record the donation info in the log in this line:
https://github.com/impress-org/givewp/blob/develop/includes/forms/functions.php#L378

but the log description is storing as "Something went wrong" although there's no any error so this description confusing the people like what happened to me.

So this PR just add a more clear description to prevent confusing via adding "log_content" to the log data to prevent the default text "Something went wrong" when there's no "log_content" as that exist in this line:
https://github.com/impress-org/givewp/blob/develop/includes/class-give-logging.php#L106

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
This is the log in the logs list page:
![Screenshot from 2021-04-14 12-12-34](https://user-images.githubusercontent.com/2883734/114685650-bd906700-9d1a-11eb-838b-0a9ffae06813.png)

This is the log info:
![Screenshot from 2021-04-14 12-11-32](https://user-images.githubusercontent.com/2883734/114685661-c1bc8480-9d1a-11eb-810d-0527379c4d31.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

