### PR TITLE
SubscriptionsTable component no longer produces console error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+-   SubscriptionsTable component no longer produces console error (#5793)
+
 ## 2.10.2 - 2021-04-14
 
 ### Changed

--- a/src/DonorDashboards/resources/js/app/components/subscription-table/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-table/index.js
@@ -22,7 +22,7 @@ const SubscriptionTable = ( { subscriptions, perPage } ) => {
 	const getSubscriptionRows = () => {
 		return subscriptionsArray.reduce( ( rows, subscription, index ) => {
 			if ( index >= start && index < end ) {
-				rows.push( <SubscriptionRow subscription={ subscription } /> );
+				rows.push( <SubscriptionRow subscription={ subscription } key={index} /> );
 			}
 			return rows;
 		}, [] );


### PR DESCRIPTION
Resolves #5792 

## Description

This PR resolves a minor bug causing the SubscriptionsTable component to produce a console error related to an undefined Key prop. To fix the issue, the  subscription's array index is now passed to the SubscriptionRow as a Key prop. 

## Affects

This PR affects frontend rendering logic of the Subscriptions Table. Previously, when in development, the SubscriptionsTable component would produce a console error related to a missing Key prop. Now, it does not produce any errors.

## Visuals

N/A

## Testing Instructions

On an account with multiple recurring donations
1. Start a development build of GiveWP with `npm run dev` (or `npm run watch`)
2. Go to the Donor Dashboard, and navigate to the Recurring Donations tab
3. Open browser console, notice that no errors were logged

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

