### PR TITLE
Give Session now reliably reflects currently logged in WP user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+-   Give Session now reliably reflects currently logged in WP user (#5796)
+
 ## 2.10.2 - 2021-04-14
 
 ### Changed

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -453,12 +453,13 @@ class Give_Session {
 	 * @param string  $wpUserLogin
 	 */
 	public function startSessionWhenLoginAsWPUser( $wpUserLogin, $wpUser ) {
+
 		$donor = Give()->donors->get_donor_by( 'user_id', $wpUser->ID );
 
 		// Setup session only if donor exist for specific WP user.
 		if ( $donor ) {
-			$this->destroy_session();
-			$this->set_session_cookies( true );
+			$this->maybe_start_session();
+			$this->set( 'give_email', $donor->email );
 		}
 	}
 
@@ -513,6 +514,7 @@ class Give_Session {
 	 * @access public
 	 */
 	public function destroy_session() {
+
 		give_setcookie( $this->cookie_name, '', time() - YEAR_IN_SECONDS, apply_filters( 'give_session_use_secure_cookie', false ) );
 		give_setcookie( $this->nonce_cookie_name, '', time() - YEAR_IN_SECONDS, apply_filters( 'give_session_use_secure_cookie', false ) );
 

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -457,7 +457,8 @@ class Give_Session {
 
 		// Setup session only if donor exist for specific WP user.
 		if ( $donor ) {
-			$this->maybe_start_session();
+			$this->destroy_session();
+			$this->set_session_cookies( true );
 		}
 	}
 

--- a/src/DonorDashboards/Routes/LogoutRoute.php
+++ b/src/DonorDashboards/Routes/LogoutRoute.php
@@ -43,9 +43,6 @@ class LogoutRoute implements RestRoute {
 	 */
 	public function handleRequest( WP_REST_Request $request ) {
 
-		// Prevent occurring of any custom action on wp_logout.
-		remove_all_actions( 'wp_logout' );
-
 		/**
 		 * Fires before processing user logout.
 		 *


### PR DESCRIPTION
Resolves #5794 

## Description

This PR implements logic to ensure that the Give Session reliably reflects the currently logged in WP user. This is done by setting the 'give-email' cookie whenever a donor is logged in, and ensuring that the session is destroyed properly when the donor logs out.

## Affects

This PR affects Give Session logic, specifically related to setting up sessions with a user logs in with a WP account.

## Visuals

N/A

## Testing Instructions

In an incognito window (to avoid affects of existing cookies):

1. Log into the WP admin area with an account known to have an associated GIve Donor ID. Now
2. Visit the donor dashboard page
3. Check that the correct account and donor information is displayed

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

