### PR TITLE
Donor Dashboard Logout now works while in the same session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Donor Dashboard Logout now works while in the same session (#5800)
+
 ## 2.10.2 - 2021-04-14
 
 ### Changed

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -515,6 +515,7 @@ class Give_Session {
 	 */
 	public function destroy_session() {
 
+		give_setcookie( 'give_nl', '', time() - YEAR_IN_SECONDS, apply_filters( 'give_session_use_secure_cookie', false ) );
 		give_setcookie( $this->cookie_name, '', time() - YEAR_IN_SECONDS, apply_filters( 'give_session_use_secure_cookie', false ) );
 		give_setcookie( $this->nonce_cookie_name, '', time() - YEAR_IN_SECONDS, apply_filters( 'give_session_use_secure_cookie', false ) );
 

--- a/src/DonorDashboards/Routes/LogoutRoute.php
+++ b/src/DonorDashboards/Routes/LogoutRoute.php
@@ -43,27 +43,37 @@ class LogoutRoute implements RestRoute {
 	 */
 	public function handleRequest( WP_REST_Request $request ) {
 
-		// Prevent occurring of any custom action on wp_logout.
-		remove_all_actions( 'wp_logout' );
+		// Check if WP user is logged in
+		if ( get_current_user_id() !== 0 ) {
 
-		/**
-		 * Fires before processing user logout.
-		 *
-		 * @since 1.0
-		 */
-		do_action( 'give_before_user_logout' );
+			// Handle logout logic for WP users
 
-		// Logout user.
-		wp_logout();
+			// Prevent occurring of any custom action on wp_logout.
+			remove_all_actions( 'wp_logout' );
 
-		/**
-		 * Fires after processing user logout.
-		 *
-		 * @since 1.0
-		 */
-		do_action( 'give_after_user_logout' );
+			/**
+			 * Fires before processing user logout.
+			 *
+			 * @since 1.0
+			 */
+			do_action( 'give_before_user_logout' );
 
-		give()->session->destroy_session();
+			// Logout user (and destroys current Give Session, via hook registered in Give_Session class)
+			wp_logout();
+
+			/**
+			 * Fires after processing user logout.
+			 *
+			 * @since 1.0
+			 */
+			do_action( 'give_after_user_logout' );
+
+		} else {
+
+			// Destroy current Give Session
+			give()->session->destroy_session();
+
+		}
 
 		return new WP_REST_Response(
 			[

--- a/src/DonorDashboards/Routes/LogoutRoute.php
+++ b/src/DonorDashboards/Routes/LogoutRoute.php
@@ -48,9 +48,6 @@ class LogoutRoute implements RestRoute {
 
 			// Handle logout logic for WP users
 
-			// Prevent occurring of any custom action on wp_logout.
-			remove_all_actions( 'wp_logout' );
-
 			/**
 			 * Fires before processing user logout.
 			 *

--- a/src/DonorDashboards/Routes/LogoutRoute.php
+++ b/src/DonorDashboards/Routes/LogoutRoute.php
@@ -63,6 +63,8 @@ class LogoutRoute implements RestRoute {
 		 */
 		do_action( 'give_after_user_logout' );
 
+		give()->session->destroy_session();
+
 		return new WP_REST_Response(
 			[
 				'status'        => 200,

--- a/src/DonorDashboards/resources/js/app/components/logout-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/logout-modal/index.js
@@ -1,5 +1,5 @@
 import Button from '../button';
-import { logoutWithAPI } from './utils';
+import { logoutWithAPI, getCleanParentHref } from './utils';
 
 import { __ } from '@wordpress/i18n';
 ;
@@ -7,9 +7,10 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 
 const LogoutModal = ( { onRequestClose } ) => {
+	
 	const handleLogout = async() => {
 		await logoutWithAPI();
-		window.location.reload();
+		window.parent.location.href = getCleanParentHref();
 	};
 
 	return (

--- a/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
@@ -1,7 +1,10 @@
-import axios from 'axios';
-import { getAPIRoot } from '../../../utils';
+import { donorDashboardApi, getQueryParam } from '../../../utils';
 
 export const logoutWithAPI = () => {
-	return axios.post( getAPIRoot() + 'give-api/v2/donor-dashboard/logout', {} )
+	return donorDashboardApi.post( 'logout', {} )
 		.then( ( response ) => response.data );
 };
+
+export const getCleanParentHref = () => {
+	return `${window.parent.location.origin}${window.parent.location.pathname}`;
+}


### PR DESCRIPTION
Resolves #5799 

## Description

This PR introduces logic to ensure that the current Give Session is consistently destroyed when a Donor clicks the "Logout" button in the Donor Dashboard. Previously, the current Give Session was only destroyed for Donors logged in as WP users, now the Give Session is destroyed even when a donor is not logged in as a WP user.

## Affects

This PR affects logout route logic for the Donor Dashboard.

## Visuals

N/A

## Testing Instructions

1. Create a donation under a new email (without an associated WP account)
2. Navigate to the Donor Dashboard page
3. See that the Donor Dashboard loads as expected
4. Click "Logout"
5. Notice that the dashboard logs out correctly

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

