### PR TITLE
Test Donation badge now only appears on test donations in Donor Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Donor Dashboard Logout now works while in the same session (#5800)
 -   SubscriptionsTable component no longer produces console error (#5793)
+-   Test Donation badge now only appears on test donations in Donor Dashboard (#5803)
 
 ### Changed
 

--- a/src/DonorDashboards/resources/js/app/components/donation-row/index.js
+++ b/src/DonorDashboards/resources/js/app/components/donation-row/index.js
@@ -31,7 +31,7 @@ const DonationRow = ( { donation } ) => {
 						{ payment.status.label }
 					</div>
 				</div>
-				{ payment.mode !== 'live' && (
+				{ payment.mode === 'test' && (
 					<div className="give-donor-dashboard-table__donation-test-tag">
 						{ __( 'Test Donation', 'give' ) }
 					</div>


### PR DESCRIPTION
Resolves #5802

## Description

This PR increases the specificity used in conditionally rendering the Test Donation badge for donations display in the Donor Dashboard.

## Affects

This PR affects frontend rendering of the Donor Dashboard.

## Visuals

N/A

## Testing Instructions

On a donor account with Renewals:

1. Go to the Donor Dashboard
2. View Donation History
3. Notice that all renewals are no longer marked with the Test Donation badge

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

