### PR TITLE
Add context to PhpStorm to resolve objects to their proper class types

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PHPSTORM_META {
+	// Allow PHP Storm Editor to resolve return types when calling give( Object_Type::class ) or give( `Object_type` )
+	override(
+		\give( 0 ),
+		map( [
+			'' => '@',
+			'' => '@Class',
+		] )
+	);
+}

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace PHPSTORM_META {
-	// Allow PHP Storm Editor to resolve return types when calling give( Object_Type::class ) or give( `Object_type` )
+	// Allow PhpStorm IDE to resolve return types when calling give( Object_Type::class ) or give( `Object_Type` ).
 	override(
 		\give( 0 ),
 		map( [

--- a/give.php
+++ b/give.php
@@ -492,7 +492,7 @@ final class Give {
  *
  * @return object|Give
  */
-function Give( $abstract = null ) {
+function give( $abstract = null ) {
 	static $instance = null;
 
 	if ( $instance === null ) {
@@ -508,4 +508,4 @@ function Give( $abstract = null ) {
 
 require __DIR__ . '/vendor/autoload.php';
 
-Give()->boot();
+give()->boot();


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5806

## Description

This follows the work done in https://github.com/the-events-calendar/tribe-common/pull/1579 which implements this for our containers in Tribe Common, thought this would be handy for Give since you also use containers!

Allow PHPStorm Editor to resolve the different types when using the container to get an instance to an object, this works only when the container is called with a string that is either the full qualified class of the object or when the name is used on the container such as:

```php
give( Object_Type::class )->resolves_names_of_method_or_properties();
give( 'Object_Type' )->resolves_names_of_method_or_properties();
```

## Affects

Dev-only improvements for those using PhpStorm to contribute.

## Testing Instructions

1. Type `give( The_Class::class )->` in PhpStorm IDE
2. It should start to show the autocomplete options based on the properties/methods available in The_Class

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] ~~Relevant `@since` tags included in DocBlocks~~
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] ~~Includes unit and/or end-to-end tests~~
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

