### PR TITLE
Conditional check for is_give_form() now uses correct post type slug

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -487,7 +487,7 @@ if ( ! function_exists( 'is_give_form' ) ) {
 	 * @return bool
 	 */
 	function is_give_form() {
-		return is_singular( array( 'give_form' ) );
+		return is_singular( array( 'give_forms' ) );
 	}
 }
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5801

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Updates the `is_give_form()` conditional logic to use the correct plural used by the registered post type.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

As recorded in the [original issue](https://github.com/impress-org/givewp/issues/5801#issuecomment-827030500), this has always been wrong and is not used in GiveWP or any of the add-ons.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

https://github.com/impress-org/givewp/issues/5801#issuecomment-824591461

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

