### PR TITLE
Prevent javascript error when click on lock icon on email listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+-   Prevent javascript error when click on lock icon on email listing page (#5824)
+
 ## 2.10.4 - 2021-04-29
 
 ### Changes

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -476,14 +476,7 @@ div.give-field-description {
 	th.check-column {
 		.give-email-notification-status {
 			color: white;
-
-			i.dashicons {
-				cursor: pointer;
-
-				&.dashicons-lock {
-					cursor: default;
-				}
-			}
+			cursor: pointer;
 
 			&[data-edit='1'] i.dashicons {
 				border-radius: 1em;

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -476,7 +476,14 @@ div.give-field-description {
 	th.check-column {
 		.give-email-notification-status {
 			color: white;
-			cursor: pointer;
+
+			i.dashicons {
+				cursor: pointer;
+
+				&.dashicons-lock {
+					cursor: default;
+				}
+			}
 
 			&[data-edit='1'] i.dashicons {
 				border-radius: 1em;

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -112,7 +112,7 @@ jQuery( document ).ready( function( $ ) {
 			canEditEmailNotificationStatus = parseInt( $this.data( 'edit' ) );
 
 		if( ! canEditEmailNotificationStatus ) {
-			showNoticeIfEmailNotificationStatusIsNotEditable($this);
+			showEmailNotificationStatusIsNotEditableNotice($this);
 			return false;
 		}
 
@@ -297,7 +297,7 @@ jQuery( document ).ready( function( $ ) {
 	 * @param {object} noticeEditButton
 	 * @return {boolean}
 	 */
-	function showNoticeIfEmailNotificationStatusIsNotEditable( noticeEditButton ){
+	function showEmailNotificationStatusIsNotEditableNotice( noticeEditButton ){
 		$( 'div.give-email-notification-status-notice' ).remove();
 
 		// Add notice.

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -108,21 +108,11 @@ jQuery( document ).ready( function( $ ) {
 			$icon_container = $( 'i', $this ),
 			$loader = $( this ).next(),
 			set_notification_status = $( this ).hasClass( 'give-email-notification-enabled' ) ? 'disabled' : 'enabled',
-			notification_id = $( this ).data( 'id' );
+			notification_id = $( this ).data( 'id' ),
+			canEdit = parseInt( $this.data( 'edit' ) );
 
-		// Bailout if admin can not edit notification status setting.
-		if ( ! parseInt( $this.data( 'edit' ) ) ) {
-			$( 'div.give-email-notification-status-notice' ).remove();
-
-			// Add notice.
-			$( 'hr.wp-header-end' ).after( '<div class="updated error give-email-notification-status-notice"><p>' + $( this ).closest( '.give-email-notification-status' ).data( 'notice' ) + '</p></div>' );
-
-			// Scroll to notice.
-			var noticeContainer = $( 'div.give-email-notification-status-notice' );
-			if( noticeContainer.length ){
-				$( 'html, body' ).animate( { scrollTop: noticeContainer.position().top }, 'slow' );
-			}
-
+		if( ! canEdit ) {
+			showNoticeIfEmailNotificationStatusIsNotEditable($this);
 			return false;
 		}
 
@@ -299,6 +289,26 @@ jQuery( document ).ready( function( $ ) {
 
 		preview.val( Give.fn.formatCurrency( '123456.12345', formatterArgs, {} ) );
 	} );
+
+	/**
+	 * Show admin notice if email notification status is not editable.
+	 *
+	 * @unreleased
+	 * @param {object} noticeEditButton
+	 * @return {boolean}
+	 */
+	function showNoticeIfEmailNotificationStatusIsNotEditable( noticeEditButton ){
+		$( 'div.give-email-notification-status-notice' ).remove();
+
+		// Add notice.
+		$( '.wp-heading-inline' ).after( `<div class="updated error give-email-notification-status-notice"><p>${noticeEditButton.data( 'notice' )}</p></div>` );
+
+		// Scroll to notice.
+		let noticeContainer = $( 'div.give-email-notification-status-notice' );
+		if( noticeContainer.length ){
+			$( 'html, body' ).animate( { scrollTop: noticeContainer.position().top }, 'slow' );
+		}
+	}
 } );
 
 // Vertical tabs feature.

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -112,14 +112,16 @@ jQuery( document ).ready( function( $ ) {
 
 		// Bailout if admin can not edit notification status setting.
 		if ( ! parseInt( $this.data( 'edit' ) ) ) {
-			// Remove all notice.
 			$( 'div.give-email-notification-status-notice' ).remove();
 
 			// Add notice.
 			$( 'hr.wp-header-end' ).after( '<div class="updated error give-email-notification-status-notice"><p>' + $( this ).closest( '.give-email-notification-status' ).data( 'notice' ) + '</p></div>' );
 
 			// Scroll to notice.
-			$( 'html, body' ).animate( { scrollTop: $( 'div.give-email-notification-status-notice' ).position().top }, 'slow' );
+			var noticeContainer = $( 'div.give-email-notification-status-notice' );
+			if( noticeContainer.length ){
+				$( 'html, body' ).animate( { scrollTop: noticeContainer.position().top }, 'slow' );
+			}
 
 			return false;
 		}

--- a/assets/src/js/admin/admin-settings.js
+++ b/assets/src/js/admin/admin-settings.js
@@ -109,9 +109,9 @@ jQuery( document ).ready( function( $ ) {
 			$loader = $( this ).next(),
 			set_notification_status = $( this ).hasClass( 'give-email-notification-enabled' ) ? 'disabled' : 'enabled',
 			notification_id = $( this ).data( 'id' ),
-			canEdit = parseInt( $this.data( 'edit' ) );
+			canEditEmailNotificationStatus = parseInt( $this.data( 'edit' ) );
 
-		if( ! canEdit ) {
+		if( ! canEditEmailNotificationStatus ) {
 			showNoticeIfEmailNotificationStatusIsNotEditable($this);
 			return false;
 		}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5824

## Description

I made the following changes to fix the issue:
1. Set the cursor to default to prevent confusion. Admin understands that it is not clickable.
2. Fix javascript issue.

## Testing Instructions

You should not able to reproduce the issue when following the steps mention in the issue description.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

