### PR TITLE
Support for the decimal amounts is now implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   The Indian state of Odisha (formerly Orissa) is now updated to reflect the legal name change (#5826)
+    
+### New
+
+-   Support for the decimal amounts is now implemented (#5827)
 
 ## Fixed
 

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -326,12 +326,12 @@ const Give = {
 		},
 
 		/**
-		 * Helper function used to determine if the given value is a float
+		 * Helper function used to determine if the given number has decimal
 		 * @param value
 		 * @returns {boolean}
 		 */
-		isFloat: function( value ) {
-			return Number( value ) === value && value % 1 !== 0;
+		numberHasDecimal: function( value ) {
+			return Math.floor( value ) !== Number( value );
 		}
 	},
 

--- a/assets/src/js/plugins/give-api/api.js
+++ b/assets/src/js/plugins/give-api/api.js
@@ -324,6 +324,15 @@ const Give = {
 			}
 			return url;
 		},
+
+		/**
+		 * Helper function used to determine if the given value is a float
+		 * @param value
+		 * @returns {boolean}
+		 */
+		isFloat: function( value ) {
+			return Number( value ) === value && value % 1 !== 0;
+		}
 	},
 
 	/**

--- a/src/Views/Form/Templates/Sequoia/Actions.php
+++ b/src/Views/Form/Templates/Sequoia/Actions.php
@@ -24,9 +24,16 @@ class Actions {
 		// Get Template options
 		$this->templateOptions = FormTemplateUtils::getOptions();
 
+		// Get decimal numbers option
+		$decimalNumbersOption = isset( $this->templateOptions['payment_amount']['decimals_enabled'] )
+			? $this->templateOptions['payment_amount']['decimals_enabled']
+			: 'disabled';
+
 		// Set zero number of decimal.
-		add_filter( 'give_get_currency_formatting_settings', [ $this, 'setupZeroNumberOfDecimalInCurrencyFormattingSetting' ], 1 );
-		add_filter( 'give_get_option_number_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
+		if ( 'disabled' === $decimalNumbersOption ) {
+			add_filter( 'give_get_currency_formatting_settings', [ $this, 'setupZeroNumberOfDecimalInCurrencyFormattingSetting' ], 1 );
+			add_filter( 'give_get_option_number_decimals', [ $this, 'setupZeroNumberOfDecimal' ], 1 );
+		}
 
 		// Handle personal section html template.
 		add_action( 'wp_ajax_give_cancel_login', [ $this, 'cancelLoginAjaxHanleder' ], 9 );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -455,6 +455,10 @@
 	setupFFMInputs();
 	setupInputIcons();
 
+	if ( 'enabled' === templateOptions.payment_amount.decimals_enabled ) {
+		updateFormDonationLevelsLabels();
+	}
+
 	/**
 	 * Limited scope of optional input labels, specifically to User Info, see issue #5160.
 	 */
@@ -848,5 +852,46 @@
 		if ( 'parentIFrame' in window ) {
 			window.parentIFrame.sendMessage( { action: 'giveScrollIframeInToView' } );
 		}
+	}
+
+	/**
+	 * Update decimal donation levels amount
+	 *
+	 * @unreleased
+	 */
+	function updateFormDonationLevelsLabels() {
+		$( '.give-form' ).each( ( i, form ) => {
+			const donationForm = $( form );
+			const donationLevels = Give.form.fn.getVariablePrices( donationForm );
+
+			$.each( donationLevels, function( i, level ) {
+				if ( 'custom' === level.price_id ) {
+					return;
+				}
+
+				const symbol = Give.form.fn.getInfo( 'currency_symbol', donationForm );
+				const position = Give.form.fn.getInfo( 'currency_position', donationForm );
+				const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
+
+				const amount = isFloat( level.amount )
+					? Give.fn.formatCurrency( level.amount, { symbol, position, precision }, donationForm )
+					: level.amount;
+
+				const donationLevelLabel = '<div class="currency currency--' + position + '">' + symbol + '</div>' + amount;
+
+				donationForm
+					.find( '.give-btn-level-' + level.price_id + ', *[for="give-radio-level-' + level.price_id + '"], .give-donation-level-' + level.price_id )
+					.html( donationLevelLabel );
+			} );
+		} );
+	}
+
+	/**
+	 * Helper function used to determine if the given value is a float
+	 * @param value
+	 * @returns {boolean}
+	 */
+	function isFloat( value ) {
+		return Number( value ) === value && value % 1 !== 0;
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -864,7 +864,7 @@
 			const donationForm = $( form );
 			const donationLevels = Give.form.fn.getVariablePrices( donationForm );
 
-			$.each( donationLevels, function( i, level ) {
+			$.each( donationLevels, function( j, level ) {
 				if ( 'custom' === level.price_id ) {
 					return;
 				}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -873,7 +873,7 @@
 				const position = Give.form.fn.getInfo( 'currency_position', donationForm );
 				const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
 
-				const amount = isFloat( level.amount )
+				const amount = Give.fn.isFloat( level.amount )
 					? Give.fn.formatCurrency( level.amount, { symbol, position, precision }, donationForm )
 					: level.amount;
 
@@ -884,14 +884,5 @@
 					.html( donationLevelLabel );
 			} );
 		} );
-	}
-
-	/**
-	 * Helper function used to determine if the given value is a float
-	 * @param value
-	 * @returns {boolean}
-	 */
-	function isFloat( value ) {
-		return Number( value ) === value && value % 1 !== 0;
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -873,7 +873,7 @@
 				const position = Give.form.fn.getInfo( 'currency_position', donationForm );
 				const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
 
-				const amount = Give.fn.isFloat( level.amount )
+				const amount = Give.fn.numberHasDecimal( level.amount )
 					? Give.fn.formatCurrency( level.amount, { symbol, position, precision }, donationForm )
 					: level.amount;
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -863,15 +863,14 @@
 		$( '.give-form' ).each( ( i, form ) => {
 			const donationForm = $( form );
 			const donationLevels = Give.form.fn.getVariablePrices( donationForm );
+			const symbol = Give.form.fn.getInfo( 'currency_symbol', donationForm );
+			const position = Give.form.fn.getInfo( 'currency_position', donationForm );
+			const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
 
 			$.each( donationLevels, function( j, level ) {
 				if ( 'custom' === level.price_id ) {
 					return;
 				}
-
-				const symbol = Give.form.fn.getInfo( 'currency_symbol', donationForm );
-				const position = Give.form.fn.getInfo( 'currency_position', donationForm );
-				const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
 
 				const amount = Give.fn.numberHasDecimal( level.amount )
 					? Give.fn.formatCurrency( level.amount, { symbol, position, precision }, donationForm )

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -880,7 +880,7 @@
 				const donationLevelLabel = '<div class="currency currency--' + position + '">' + symbol + '</div>' + amount;
 
 				donationForm
-					.find( '.give-btn-level-' + level.price_id + ', *[for="give-radio-level-' + level.price_id + '"], .give-donation-level-' + level.price_id )
+					.find( '.give-btn-level-' + level.price_id  )
 					.html( donationLevelLabel );
 			} );
 		} );

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -104,6 +104,17 @@ return [
 				],
 				'default'    => __( 'Continue', 'give' ),
 			],
+			[
+				'id'      => 'decimals_enabled',
+				'name'    => __( 'Decimal amounts', 'give' ),
+				'desc'    => __( 'Do you want to enable decimal amounts?', 'give' ),
+				'type'    => 'radio_inline',
+				'default' => 'disabled',
+				'options' => [
+					'disabled' => __( 'Disabled', 'give' ),
+					'enabled'  => __( 'Enabled', 'give' ),
+				],
+			],
 		],
 	],
 	'payment_information' => [

--- a/src/Views/Form/Templates/Sequoia/optionConfig.php
+++ b/src/Views/Form/Templates/Sequoia/optionConfig.php
@@ -107,7 +107,7 @@ return [
 			[
 				'id'      => 'decimals_enabled',
 				'name'    => __( 'Decimal amounts', 'give' ),
-				'desc'    => __( 'Do you want to enable decimal amounts?', 'give' ),
+				'desc'    => __( 'Do you want to enable decimal amounts? When the setting is disabled, decimal values are rounded.', 'give' ),
 				'type'    => 'radio_inline',
 				'default' => 'disabled',
 				'options' => [


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5815

## Description

This PR adds an option in the Donation Form Options section for the site admin to enable or disable decimal amounts when the Multi-step template is used. This option is disabled by default. 

## Affects

Multi-step form donation amount input field and donation level amounts.

## Visuals


| Option Location | Donation form - Option Disabled | Donation form - Option Enabled |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/4222590/118002757-3a2d5a00-b348-11eb-94b4-8dcdb5c71c0b.png) | ![image](https://user-images.githubusercontent.com/4222590/118001991-7e6c2a80-b347-11eb-9bc8-41eb419adc8c.png) | ![image](https://user-images.githubusercontent.com/4222590/118001837-6399b600-b347-11eb-8f5f-b3ea488991b2.png) |

## Testing Instructions

1. Create a new donation form that uses multi-step form template
2. Enable/Disable _Decimal Amounts_ option under the _Step 2: Payment Amount_
3. Viewdonation  form on the frontend

**Note:** 
If wording used to describe the new option doesn't make sense, please update it! 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

