### PR TITLE
Store donor address with formatting from donor profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Store donor address with formatting from donor profile (#5829)
 -   Prevent javascript error when click on lock icon on email listing page (#5824)
 -   Amount passed to Stripe matches the stored value (#5823)
 

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -984,7 +984,7 @@ function give_get_user_roles() {
  *
  * @since 2.0
  * @unreleased decode url before parsing and sanitizing url when set $post.
- * @return string
+ * @return void
  */
 function __give_ajax_donor_manage_addresses() {
 	// Bailout.

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -998,7 +998,7 @@ function __give_ajax_donor_manage_addresses() {
 		);
 	}
 
-	$post                  = give_clean( wp_parse_args( $_POST ) );
+	$post                  = give_clean( wp_parse_args( urldecode_deep( $_POST ) ) );
 	$donorID               = absint( $post['donorID'] );
 	$form_data             = give_clean( wp_parse_args( $post['form'] ) );
 	$is_multi_address_type = ( 'billing' === $form_data['address-id'] || false !== strpos( $form_data['address-id'], '_' ) );

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -983,6 +983,7 @@ function give_get_user_roles() {
  * Ajax handle for donor address.
  *
  * @since 2.0
+ * @unreleased decode url before parsing and sanitizing url when set $post.
  * @return string
  */
 function __give_ajax_donor_manage_addresses() {


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5828 

## Description

I find out that we are not decoding url before parsing and sanitizing url values and donor address was loosing formatting because this logic. I added fix for this.

## Affects

This only affect donor profile  page address edit or add logic.

## Testing Instructions

You should not able to reproduce issue if you follow steps as mentioned in issue.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

