### PR TITLE
Onboarding LocaleCollection has parity with WooCommerce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   The Indian state of Odisha (formerly Orissa) is now updated to reflect the legal name change (#5826)
-    
+-   Onboarding LocaleCollection has parity with WooCommerce (#5831)    
+
 ### New
 
 -   Support for the decimal amounts is now implemented (#5827)

--- a/src/Onboarding/LocaleCollection.php
+++ b/src/Onboarding/LocaleCollection.php
@@ -6,6 +6,7 @@ namespace Give\Onboarding;
  * Fork of woocommerce/18n/locale-info
  *
  * @since 2.8.0
+ * @unreleased Added KR locale info (#5831)
  */
 class LocaleCollection {
 

--- a/src/Onboarding/LocaleCollection.php
+++ b/src/Onboarding/LocaleCollection.php
@@ -172,6 +172,15 @@ class LocaleCollection {
 			'weight_unit'    => 'kg',
 			'dimension_unit' => 'cm',
 		],
+		'KR' => [
+			'currency_code'  => 'KRW',
+			'currency_pos'   => 'right',
+			'thousand_sep'   => ',',
+			'decimal_sep'    => '.',
+			'num_decimals'   => 0,
+			'weight_unit'    => 'kg',
+			'dimension_unit' => 'cm',
+		],
 		'LI' => [
 			'currency_code'  => 'CHF',
 			'currency_pos'   => 'left_space',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5830

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

In maintaining parity with the upstream WooCommerce woocommerce/18n/locale-info for locale/currency information, the Onboarding LocaleCollection now includes KR locale info, see woocommerce/woocommerce@0656ad5#diff-122b62121f7a3deb664f05d12fb2af1c40cf819712b5f2db935017ce4a4c45cb

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Updates `Give\Onboarding\LocaleCollection::$localeInfo`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

