### PR TITLE
Replace `main` elements with `div` elements in GiveWP Setup Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Store donor address with formatting from donor profile (#5829)
 -   Prevent javascript error when click on lock icon on email listing page (#5824)
 -   Amount passed to Stripe matches the stored value (#5823)
+-   Remove extraneous main landmarks from setup guide page (#5835)
 
 ## 2.10.4 - 2021-04-29
 

--- a/src/Onboarding/Setup/templates/section.html
+++ b/src/Onboarding/Setup/templates/section.html
@@ -3,8 +3,8 @@
         <h2>{{ title }}</h2>
         {{ badge }}
     </header>
-    <main>
+    <div>
         {{ contents }}
-    </main>
+    </div>
     {{ footer }}
 </section>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5834

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The GiveWP Setup Guide’s UI had 4 extra `main` elements in its template. I replaced these with `div` elements since there didn’t really need to be any new semantics introduced in place of the incorrect ones. I double checked [the related stylesheet](https://github.com/impress-org/givewp/blob/0fe4d3ded43bf47fb5131a9396f3e5ff2e4c5899/assets/src/css/admin/setup.scss) to confirm that the `main` elements weren’t used as a selector and they were not, so there were no CSS changes which needed to be made. I tested it in the WordPress admin as well to confirm there were no side effects.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- GiveWP Setup Guide

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. First of all, get yourself to the GiveWP Setup Guide. Then if you want to test with VoiceOver for macOS, you can activate it by pressing <kbd>command ⌘</kbd> <kbd>F5</kbd> (you might need to presss <kbd>fn</kbd> as well) or open the macOS accessibility settings and enable VoiceOver.
2. Open the web item rotor using <kbd>control</kbd> <kbd>option</kbd> <kbd>u</kbd>.
3. The "Landmarks" menu should be the first one that shows up. If not, you can navigate been them by pressing <kbd>control</kbd> <kbd>option</kbd> <kbd>left/right arrow</kbd>.
4. Observe that there is only one main landmark in the landmarks list. It should be the `#wpbody` element.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

