### PR TITLE
Catch uncaught exceptions and log them

### DIFF
--- a/give.php
+++ b/give.php
@@ -40,6 +40,7 @@
  */
 
 use Give\Container\Container;
+use Give\Framework\Exceptions\LogUncaughtGiveExceptions;
 use Give\Framework\Migrations\MigrationsServiceProvider;
 use Give\Form\Templates;
 use Give\Revenue\RevenueServiceProvider;
@@ -223,6 +224,7 @@ final class Give {
 		$this->bindClasses();
 
 		$this->loadServiceProviders();
+		$this->setupExceptionHandler();
 
 		// Load form template
 		$this->templates->load();
@@ -249,6 +251,7 @@ final class Give {
 	private function bindClasses() {
 		$this->container->singleton( 'templates', Templates::class );
 		$this->container->singleton( 'routeForm', FormRoute::class );
+		$this->container->singleton( LogUncaughtGiveExceptions::class );
 	}
 
 	/**
@@ -472,6 +475,18 @@ final class Give {
 	 */
 	public function __call( $name, $arguments ) {
 		return call_user_func_array( [ $this->container, $name ], $arguments );
+	}
+
+	/**
+	 * Sets up the Exception Handler to catch and handle uncaught exceptions
+	 *
+	 * @unreleased
+	 */
+	private function setupExceptionHandler() {
+		/** @var LogUncaughtGiveExceptions $handler */
+		$handler = $this->container->make( LogUncaughtGiveExceptions::class );
+
+		$handler->setupExceptionHandler();
 	}
 }
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -6,8 +6,8 @@ use ArrayAccess;
 use Closure;
 use Exception;
 use Give\Container\Exceptions\BindingResolutionException;
-use InvalidArgumentException;
-use LogicException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\LogicException;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
@@ -544,7 +544,7 @@ class Container implements ArrayAccess {
 	 * @param string $id Identifier of the entry to look for.
 	 *
 	 * @return mixed Entry.
-	 * @throws Exception
+	 * @throws InvalidArgumentException|BindingResolutionException
 	 */
 	public function get( $id ) {
 		try {

--- a/src/Container/Exceptions/BindingResolutionException.php
+++ b/src/Container/Exceptions/BindingResolutionException.php
@@ -3,7 +3,8 @@
 namespace Give\Container\Exceptions;
 
 use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
 
 class BindingResolutionException extends Exception {
-	//
+	use Loggable;
 }

--- a/src/Controller/PayPalWebhooks.php
+++ b/src/Controller/PayPalWebhooks.php
@@ -2,7 +2,7 @@
 
 namespace Give\Controller;
 
-use Exception;
+use Give\Framework\Exceptions\Primitives\Exception;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
 use Give\PaymentGateways\PayPalCommerce\DataTransferObjects\PayPalWebhookHeaders;

--- a/src/DonorDashboards/Exceptions/DuplicateTabException.php
+++ b/src/DonorDashboards/Exceptions/DuplicateTabException.php
@@ -3,22 +3,38 @@
 namespace Give\DonorDashboards\Exceptions;
 
 use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
 
 /**
  * @since 2.10.0
  */
 class DuplicateTabException extends Exception {
+	use Loggable;
 
-	// Redefine the exception so message is pre-defined
-	public function __construct( $message = 'A tab can only be added once. Make sure there are not id conflicts.', $code = 0, Exception $previous = null ) {
-		// some code
-
-		// make sure everything is assigned properly
-		parent::__construct( $message, $code, $previous );
+	/**
+	 * DuplicateTabException constructor.
+	 *
+	 * @since 2.10.0
+	 *
+	 * @param int            $code
+	 * @param Exception|null $previous
+	 */
+	public function __construct( $code = 0, Exception $previous = null ) {
+		parent::__construct(
+			__( 'A tab can only be added once. Make sure there are not id conflicts.', 'give' ),
+			$code,
+			$previous
+		);
 	}
 
-	// custom string representation of object
+	/**
+	 * Allows the exception to be cast to a string format
+	 *
+	 * @since 2.10.0
+	 *
+	 * @return string
+	 */
 	public function __toString() {
-		return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+		return __CLASS__ . ": [$this->code]: $this->message\n";
 	}
 }

--- a/src/DonorDashboards/Exceptions/MissingTabException.php
+++ b/src/DonorDashboards/Exceptions/MissingTabException.php
@@ -3,23 +3,37 @@
 namespace Give\DonorDashboards\Exceptions;
 
 use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
 
 /**
  * @since 2.10.0
  */
 class MissingTabException extends Exception {
+	use Loggable;
 
-	// Redefine the exception so tab ID isn't optional
+	/**
+	 * MissingTabException constructor.
+	 *
+	 * @since 2.10.0
+	 *
+	 * @param                $tabId
+	 * @param int            $code
+	 * @param Exception|null $previous
+	 */
 	public function __construct( $tabId, $code = 0, Exception $previous = null ) {
+		$message = __( 'No tab exists with the ID: ', 'give' ) . $tabId;
 
-		$message = "No tab exists with the ID {$tabId}";
-
-		// make sure everything is assigned properly
 		parent::__construct( $message, $code, $previous );
 	}
 
-	// custom string representation of object
+	/**
+	 * Allows the exception to be cast to a string
+	 *
+	 * @since 2.10.0
+	 *
+	 * @return string
+	 */
 	public function __toString() {
-		return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+		return __CLASS__ . ": [$this->code]: $this->message\n";
 	}
 }

--- a/src/DonorDashboards/Tabs/Contracts/Tab.php
+++ b/src/DonorDashboards/Tabs/Contracts/Tab.php
@@ -2,7 +2,7 @@
 
 namespace Give\DonorDashboards\Tabs\Contracts;
 
-use RuntimeException;
+use Give\Framework\Exceptions\Primitives\RuntimeException;
 use Give\DonorDashboards\Tabs\Contracts\Route as RouteAbstract;
 
 /**

--- a/src/DonorDashboards/Tabs/TabsRegister.php
+++ b/src/DonorDashboards/Tabs/TabsRegister.php
@@ -5,7 +5,6 @@ namespace Give\DonorDashboards\Tabs;
 use Give\DonorDashboards\Tabs\Contracts\Tab;
 use Give\DonorDashboards\Exceptions\MissingTabException;
 use Give\DonorDashboards\Exceptions\DuplicateTabException;
-use http\Exception\InvalidArgumentException;
 
 /**
  * @since 2.10.0

--- a/src/FormAPI/Fields.php
+++ b/src/FormAPI/Fields.php
@@ -2,7 +2,7 @@
 namespace Give\FormAPI;
 
 use Give\FormAPI\Form\File;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\FormAPI\Form\Colorpicker;
 use Give\FormAPI\Form\Media;
 use Give\FormAPI\Form\Radio;

--- a/src/FormAPI/Form/Field.php
+++ b/src/FormAPI/Form/Field.php
@@ -1,7 +1,7 @@
 <?php
 namespace Give\FormAPI\Form;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 abstract class Field {
 

--- a/src/FormAPI/Form/Group.php
+++ b/src/FormAPI/Form/Group.php
@@ -2,7 +2,7 @@
 
 namespace Give\FormAPI\Form;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 class Group extends Field {
 	/**

--- a/src/FormAPI/Section.php
+++ b/src/FormAPI/Section.php
@@ -2,7 +2,7 @@
 
 namespace Give\FormAPI;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class Options

--- a/src/Framework/Exceptions/Contracts/LoggableException.php
+++ b/src/Framework/Exceptions/Contracts/LoggableException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Give\Framework\Exceptions\Contracts;
+
+interface LoggableException {
+	/**
+	 * Returns the human-readable message for the log
+	 *
+	 * @unreleased
+	 *
+	 * @return string
+	 */
+	public function getLogMessage();
+
+	/**
+	 * Returns an associated array with additional context for the log
+	 *
+	 * @unreleased
+	 *
+	 * @return array
+	 */
+	public function getLogContext();
+}

--- a/src/Framework/Exceptions/LogUncaughtGiveExceptions.php
+++ b/src/Framework/Exceptions/LogUncaughtGiveExceptions.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Give\Framework\Exceptions;
+
+use Exception;
+use Give\Framework\Exceptions\Contracts\LoggableException;
+use Give\Log\Log;
+
+class LogUncaughtGiveExceptions {
+	/**
+	 * @var callable|null
+	 */
+	private $previousHandler;
+
+	/**
+	 * Registers the class with the set_exception_handler to receive uncaught exceptions
+	 *
+	 * @unreleased
+	 */
+	public function setupExceptionHandler() {
+		if ( $this->previousHandler !== null ) {
+			return;
+		}
+
+		$this->previousHandler = @set_exception_handler( [ $this, 'handleException' ] );
+	}
+
+	public function handleException( Exception $exception ) {
+		if ( $exception instanceof LoggableException ) {
+			Log::error( $exception->getLogMessage(), $exception->getLogContext() );
+		}
+
+		if ( $this->previousHandler !== null ) {
+			$previousHandler = $this->previousHandler;
+			$previousHandler( $exception );
+		}
+	}
+}

--- a/src/Framework/Exceptions/Primitives/Exception.php
+++ b/src/Framework/Exceptions/Primitives/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Give\Framework\Exceptions\Primitives;
+
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class Exception extends \Exception {
+	use Loggable;
+}

--- a/src/Framework/Exceptions/Primitives/HttpHeaderException.php
+++ b/src/Framework/Exceptions/Primitives/HttpHeaderException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Give\Framework\Exceptions\Primitives;
+
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class HttpHeaderException extends \HttpHeaderException {
+	use Loggable;
+}

--- a/src/Framework/Exceptions/Primitives/InvalidArgumentException.php
+++ b/src/Framework/Exceptions/Primitives/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Give\Framework\Exceptions\Primitives;
+
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class InvalidArgumentException extends \InvalidArgumentException {
+	use Loggable;
+}

--- a/src/Framework/Exceptions/Primitives/LogicException.php
+++ b/src/Framework/Exceptions/Primitives/LogicException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Give\Framework\Exceptions\Primitives;
+
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class LogicException extends \LogicException {
+	use Loggable;
+}

--- a/src/Framework/Exceptions/Primitives/RuntimeException.php
+++ b/src/Framework/Exceptions/Primitives/RuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Give\Framework\Exceptions\Primitives;
+
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class RuntimeException extends \RuntimeException {
+	use Loggable;
+}

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Give\Framework\Exceptions\Traits;
+
+trait Loggable {
+	/**
+	 * Gets the Exception::getMessage() method
+	 *
+	 * @unreleased
+	 *
+	 * @return string
+	 */
+	abstract public function getMessage();
+
+	/**
+	 * Returns the human-readable log message
+	 *
+	 * @unreleased
+	 *
+	 * @return string
+	 */
+	public function getLogMessage() {
+		return $this->getMessage();
+	}
+
+	/**
+	 * Returns an array with the basic context details
+	 *
+	 * @unreleased
+	 *
+	 * @return array
+	 */
+	public function getLogContext() {
+		return [
+			'category'  => 'Uncaught Exception',
+			'exception' => $this,
+		];
+	}
+}

--- a/src/Framework/FieldsAPI/Factory/Exception/TypeNotSupported.php
+++ b/src/Framework/FieldsAPI/Factory/Exception/TypeNotSupported.php
@@ -3,10 +3,13 @@
 namespace Give\Framework\FieldsAPI\Factory\Exception;
 
 use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
 
 class TypeNotSupported extends Exception {
-	public function __construct( $type, $code = 0 ) {
+	use Loggable;
+
+	public function __construct( $type, $code = 0, $previous = null ) {
 		$message = "Field type $type is not supported";
-		parent::__construct( $message, $code );
+		parent::__construct( $message, $code, $previous );
 	}
 }

--- a/src/Framework/FieldsAPI/FieldCollection/Exception/ReferenceNodeNotFoundException.php
+++ b/src/Framework/FieldsAPI/FieldCollection/Exception/ReferenceNodeNotFoundException.php
@@ -2,10 +2,15 @@
 
 namespace Give\Framework\FieldsAPI\FieldCollection\Exception;
 
+use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
+
 /**
  * @since 2.10.2
  */
-class ReferenceNodeNotFoundException extends \Exception {
+class ReferenceNodeNotFoundException extends Exception {
+	use Loggable;
+
 	public function __construct( $name, $code = 0, Exception $previous = null ) {
 		$message = "Reference node with the name \"$name\" not found - cannot insert new node.";
 		parent::__construct( $message, $code, $previous );

--- a/src/Framework/Migrations/Actions/ClearCompletedUpgrade.php
+++ b/src/Framework/Migrations/Actions/ClearCompletedUpgrade.php
@@ -2,7 +2,7 @@
 
 namespace Give\Framework\Migrations\Actions;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class ClearCompletedUpgrade

--- a/src/Framework/Migrations/Contracts/Migration.php
+++ b/src/Framework/Migrations/Contracts/Migration.php
@@ -2,7 +2,7 @@
 
 namespace Give\Framework\Migrations\Contracts;
 
-use RuntimeException;
+use Give\Framework\Exceptions\Primitives\RuntimeException;
 
 /**
  * Class Migration

--- a/src/Framework/Migrations/Exceptions/DatabaseMigrationException.php
+++ b/src/Framework/Migrations/Exceptions/DatabaseMigrationException.php
@@ -3,9 +3,13 @@
 namespace Give\Framework\Migrations\Exceptions;
 
 use Exception;
+use Give\Framework\Exceptions\Traits\Loggable;
+
 /**
  * Class DatabaseMigrationException
  *
  * Represents an exception that occurred when executing a migration within the database
  */
-class DatabaseMigrationException extends Exception {}
+class DatabaseMigrationException extends Exception {
+	use Loggable;
+}

--- a/src/Framework/Migrations/MigrationsRegister.php
+++ b/src/Framework/Migrations/MigrationsRegister.php
@@ -3,7 +3,7 @@
 namespace Give\Framework\Migrations;
 
 use Give\Framework\Migrations\Contracts\Migration;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 class MigrationsRegister {
 	/**

--- a/src/Helpers/Hooks.php
+++ b/src/Helpers/Hooks.php
@@ -2,7 +2,7 @@
 
 namespace Give\Helpers;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 class Hooks {
 	/**

--- a/src/Log/LogRepository.php
+++ b/src/Log/LogRepository.php
@@ -2,7 +2,7 @@
 
 namespace Give\Log;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\Database\DB;
 use WP_REST_Request;
 use DateTime;

--- a/src/Log/ValueObjects/Enum.php
+++ b/src/Log/ValueObjects/Enum.php
@@ -2,7 +2,7 @@
 
 namespace Give\Log\ValueObjects;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
 

--- a/src/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeaders.php
+++ b/src/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeaders.php
@@ -2,7 +2,7 @@
 
 namespace Give\PaymentGateways\PayPalCommerce\DataTransferObjects;
 
-use HttpHeaderException;
+use Give\Framework\Exceptions\Primitives\HttpHeaderException;
 
 class PayPalWebhookHeaders {
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Models/MerchantDetail.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/MerchantDetail.php
@@ -2,8 +2,7 @@
 
 namespace Give\PaymentGateways\PayPalCommerce\Models;
 
-use Give\PaymentGateways\PayPalCommerce\PayPalClient;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class MerchantDetail

--- a/src/PaymentGateways/PayPalCommerce/Models/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/PayPalOrder.php
@@ -3,9 +3,7 @@
 namespace Give\PaymentGateways\PayPalCommerce\Models;
 
 use Give\Helpers\ArrayDataSet;
-use Give\PaymentGateways\PayPalCommerce\Models\PayPalPayment;
-use Give_Payment;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use stdClass;
 
 /**

--- a/src/PaymentGateways/PayPalCommerce/Models/PayPalPayment.php
+++ b/src/PaymentGateways/PayPalCommerce/Models/PayPalPayment.php
@@ -2,7 +2,7 @@
 namespace Give\PaymentGateways\PayPalCommerce\Models;
 
 use Give\Helpers\ArrayDataSet;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class PayPalPayment

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -4,10 +4,10 @@ namespace Give\PaymentGateways\PayPalCommerce\Repositories;
 
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\Exception;
 use PayPalCheckoutSdk\Orders\OrdersCaptureRequest;
 use PayPalCheckoutSdk\Orders\OrdersCreateRequest;
-use Exception;
 use PayPalCheckoutSdk\Payments\CapturesRefundRequest;
 use function give_record_gateway_error as logError;
 

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Traits/HasMode.php
@@ -1,7 +1,7 @@
 <?php
 namespace Give\PaymentGateways\PayPalCommerce\Repositories\Traits;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 trait HasMode {
 	/**

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Webhooks.php
@@ -2,7 +2,7 @@
 
 namespace Give\PaymentGateways\PayPalCommerce\Repositories;
 
-use Exception;
+use Give\Framework\Exceptions\Primitives\Exception;
 use Give\PaymentGateways\PayPalCommerce\Models\WebhookConfig;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Traits\HasMode;

--- a/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
+++ b/src/PaymentGateways/PayPalCommerce/Webhooks/WebhookRegister.php
@@ -6,7 +6,7 @@ use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\EventListener;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureCompleted;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureDenied;
 use Give\PaymentGateways\PayPalCommerce\Webhooks\Listeners\PayPalCommerce\PaymentCaptureRefunded;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 class WebhookRegister {
 	/**

--- a/src/PaymentGateways/Stripe/Models/AccountDetail.php
+++ b/src/PaymentGateways/Stripe/Models/AccountDetail.php
@@ -3,7 +3,7 @@
 namespace Give\PaymentGateways\Stripe\Models;
 
 use Give\Helpers\ArrayDataSet;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class AccountDetail

--- a/src/Receipt/DonationReceipt.php
+++ b/src/Receipt/DonationReceipt.php
@@ -1,7 +1,7 @@
 <?php
 namespace Give\Receipt;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use function give_get_payment_meta as getDonationMetaData;
 use function give_get_gateway_admin_label as getGatewayLabel;
 use function give_get_donation_donor_email as getDonationDonorEmail;

--- a/src/Receipt/Section.php
+++ b/src/Receipt/Section.php
@@ -3,7 +3,7 @@
 namespace Give\Receipt;
 
 use ArrayAccess;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Iterator;
 
 /**

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -4,7 +4,7 @@ namespace Give\Revenue\Repositories;
 
 use Give\Framework\Database\DB;
 use Give\Framework\Database\Exceptions\DatabaseQueryException;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class Revenue

--- a/src/Session/Accessor.php
+++ b/src/Session/Accessor.php
@@ -2,7 +2,7 @@
 
 namespace Give\Session;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use stdClass;
 
 /**

--- a/src/Session/SessionDonation/SessionObjects/Donation.php
+++ b/src/Session/SessionDonation/SessionObjects/Donation.php
@@ -7,7 +7,7 @@ use Give\Session\Objects;
 use Give\ValueObjects\CardInfo;
 use Give\ValueObjects\DonorInfo;
 use Give\ValueObjects\ValueObjects;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 
 /**

--- a/src/Session/SessionDonation/SessionObjects/FormEntry.php
+++ b/src/Session/SessionDonation/SessionObjects/FormEntry.php
@@ -4,7 +4,7 @@ namespace Give\Session\SessionDonation\SessionObjects;
 
 use Give\Helpers\ArrayDataSet;
 use Give\Session\Objects;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class FormEntry

--- a/src/TestData/Factories/DonationFactory.php
+++ b/src/TestData/Factories/DonationFactory.php
@@ -4,7 +4,7 @@ namespace Give\TestData\Factories;
 
 use Give\TestData\Framework\Factory;
 use DateTime;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class DonationFactory

--- a/src/TestData/ServiceProvider.php
+++ b/src/TestData/ServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Give\TestData;
 
 use WP_CLI;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Give\TestData\Commands\DonorSeedCommand;

--- a/src/ValueObjects/Address.php
+++ b/src/ValueObjects/Address.php
@@ -2,7 +2,7 @@
 
 namespace Give\ValueObjects;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class Address.

--- a/src/ValueObjects/CardInfo.php
+++ b/src/ValueObjects/CardInfo.php
@@ -2,8 +2,7 @@
 
 namespace Give\ValueObjects;
 
-use Give\Helpers\ArrayDataSet;
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 /**
  * Class CardInfo

--- a/src/ValueObjects/DonorInfo.php
+++ b/src/ValueObjects/DonorInfo.php
@@ -2,7 +2,7 @@
 
 namespace Give\ValueObjects;
 
-use InvalidArgumentException;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
 class DonorInfo implements ValueObjects {
 	/**


### PR DESCRIPTION
Resolves #5836 

## Description

This PR tackles the issue that exceptions in GiveWP are otherwise unlogged if not explicitly caught. It does this in a couple ways:

First, it registers with [set_exception_handler](https://php.net/manual/en/function.set-exception-handler.php) to handle any uncaught exceptions. If a previous handler was registered (by another plugin, theme, or whatever) then it passes the Exception along.

It introduces a `LoggableException` interface which helps to identify an exception as coming from GiveWP, and gets data from the exception in a way that gets logged nicely into our system. I also provided a `Loggable` trait that provides the methods as a quick applier. Since traits can't implement interfaces, this is by convention.

When an uncaught exception occurs, the handler checks to see if the Exception is native to GiveWP. If it is, then it logs the exception.

## Affects

Anywhere exceptions were thrown within GiveWP

## Testing Instructions

Just throw a random exception somewhere in the code that uses the `Loggable` trait or `LoggableException` interface.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

