### PR TITLE
Donation processing does not throw PHP notices when process payment with Strip Plaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Amount passed to Stripe matches the stored value (#5823)
 -   Remove extraneous main landmarks from setup guide page (#5835)
 -   Donor Dashboard is now fully translatable (#5819)
--   Access property from Stripe API response in right way 
+-   Prevent PHP notices when access non-exiting property from Stripe API response (#5838)
 
 ## 2.10.4 - 2021-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Prevent javascript error when click on lock icon on email listing page (#5824)
 -   Amount passed to Stripe matches the stored value (#5823)
 -   Remove extraneous main landmarks from setup guide page (#5835)
--   Donor Dashboard is now fully translatable #5819
+-   Donor Dashboard is now fully translatable (#5819)
+-   Access property from Stripe API response in right way 
 
 ## 2.10.4 - 2021-04-29
 

--- a/includes/gateways/stripe/includes/class-give-stripe-customer.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-customer.php
@@ -631,12 +631,15 @@ class Give_Stripe_Customer {
 	 * @param  stdClass  $newStripeSource
 	 */
 	private function doesSourceFingerPrintMatch( $stripeSource, $newStripeSource ) {
-		if ( isset( $stripeSource->card->fingerprint ) ) {
-			return $stripeSource->card->fingerprint === $newStripeSource->fingerprint;
-		}
-
 		if ( isset( $stripeSource->fingerprint ) ) {
 			return $stripeSource->fingerprint === $newStripeSource->fingerprint;
+		}
+
+		if (
+			property_exists( $stripeSource, 'card' ) &&
+			isset( $stripeSource->card->fingerprint )
+		) {
+			return $stripeSource->card->fingerprint === $newStripeSource->fingerprint;
 		}
 
 		return false;

--- a/includes/gateways/stripe/includes/class-give-stripe-customer.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-customer.php
@@ -394,6 +394,7 @@ class Give_Stripe_Customer {
 	 * This function is used to attach source to the customer, if not exists.
 	 *
 	 * @since  2.1
+	 * @unreleased Use Give_Stripe_Customer::doesSourceFingerPrintMatch function to verify source finger print
 	 * @access public
 	 *
 	 * @return void

--- a/includes/gateways/stripe/includes/class-give-stripe-customer.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-customer.php
@@ -430,7 +430,7 @@ class Give_Stripe_Customer {
 			// Check to ensure that new card is already attached with customer or not.
 			if ( count( $all_sources->data ) > 0 ) {
 				foreach ( $all_sources->data as $source_item ) {
-					if ( $this->doesSourceFingerPrintMatch( $source_item, $newSourcePaymentMethodDetail ) ) {
+					if ( $this->isSourceFingerPrintMatch( $source_item, $newSourcePaymentMethodDetail ) ) {
 						// Set the existing card as default source.
 						$this->customer_data->default_source = $source_item->id;
 						$this->customer_data->save();
@@ -642,7 +642,7 @@ class Give_Stripe_Customer {
 	 * @param  stdClass  $stripeSource
 	 * @param  stdClass  $newStripeSource
 	 */
-	private function doesSourceFingerPrintMatch( $stripeSource, $newStripeSource ) {
+	private function isSourceFingerPrintMatch( $stripeSource, $newStripeSource ) {
 		if ( isset( $stripeSource->fingerprint ) ) {
 			return $stripeSource->fingerprint === $newStripeSource->fingerprint;
 		}

--- a/includes/gateways/stripe/includes/class-give-stripe-customer.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-customer.php
@@ -410,7 +410,7 @@ class Give_Stripe_Customer {
 			// Fetch the new card or source object to match with customer attached card fingerprint.
 			if ( give_stripe_is_source_type( $this->payment_method_id, 'tok' ) ) {
 				$token_details = $this->stripe_gateway->get_token_details( $this->payment_method_id );
-				$new_card      = $token_details->card;
+				$new_card      = $token_details->bank_account;
 			} elseif ( give_stripe_is_source_type( $this->payment_method_id, 'src' ) ) {
 				$source_details = $this->stripe_gateway->get_source_details( $this->payment_method_id );
 				$new_card       = $source_details->card;
@@ -427,16 +427,7 @@ class Give_Stripe_Customer {
 			if ( count( $all_sources->data ) > 0 ) {
 				foreach ( $all_sources->data as $source_item ) {
 
-					if (
-						(
-							isset( $source_item->card->fingerprint ) &&
-							$source_item->card->fingerprint === $new_card->fingerprint
-						) ||
-						(
-							isset( $source_item->fingerprint ) &&
-							$source_item->fingerprint === $new_card->fingerprint
-						)
-					) {
+					if ( $this->doesSourceFingerPrintMatch( $source_item, $new_card ) ) {
 
 						// Set the existing card as default source.
 						$this->customer_data->default_source = $source_item->id;
@@ -631,5 +622,23 @@ class Give_Stripe_Customer {
 	 */
 	public function is_bank_account( $id ) {
 		return give_stripe_is_source_type( $id, 'ba' );
+	}
+
+	/**
+	 * @unreleased
+	 *
+	 * @param  stdClass  $stripeSource
+	 * @param  stdClass  $newStripeSource
+	 */
+	private function doesSourceFingerPrintMatch( $stripeSource, $newStripeSource ) {
+		if ( isset( $stripeSource->card->fingerprint ) ) {
+			return $stripeSource->card->fingerprint === $newStripeSource->fingerprint;
+		}
+
+		if ( isset( $stripeSource->fingerprint ) ) {
+			return $stripeSource->fingerprint === $newStripeSource->fingerprint;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

I caught this issue while working on https://github.com/impress-org/give-recurring/pull/1058#issuecomment-840600168.

## Description

Donation processing with Stripe Plaid causes generating two PHP notices. I find out that we were accessing the nonexisting property (`card`) from Stripe response object and these notices log by Stripe library. I update the code to prevent these notices.

```
[13-May-2021 13:38:43 UTC] Stripe Notice: Undefined property of Stripe\Token instance: card
[13-May-2021 13:38:44 UTC] Stripe Notice: Undefined property of Stripe\BankAccount instance: card
```

## Testing Instructions

You should not get PHP notice if processing recurring donations with Stripe Plaid.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

