### PR TITLE
Uninstalling no longer checks for updates (which throws exception)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Uncaught exception handler no longer breaks on Errors (#5846)
+-   Uninstalling GiveWP no longer throws an exception (#5846)
+
 ## 2.11.1 - 2021-05-24
 
 ### New

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -522,7 +522,7 @@ function give_deactivation_popup() {
 					);
 				?>
 				</p>
-				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea disabled>
+				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea>
 			</div>
 		</div>
 

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -543,7 +543,7 @@ function give_deactivation_popup() {
 					);
 				?>
 				</p>
-				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea disabled>
+				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea>
 			</div>
 		</div>
 
@@ -555,7 +555,7 @@ function give_deactivation_popup() {
 
 			<div class="give-survey-extra-field">
 				<p><?php esc_html_e( "Please describe why you're deactivating Give", 'give' ); ?></p>
-				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea disabled>
+				<textarea disabled name="user-reason" class="widefat" rows="6"></textarea>
 			</div>
 		</div>
 

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -641,21 +641,14 @@ function give_deactivation_form_submit() {
 
 	if ( 'true' === $response ) {
 		if ( '1' === $delete_data ) {
-			wp_send_json_success(
-				[
-					'delete_data' => true,
-				]
-			);
-		} else {
-			wp_send_json_success(
-				[
-					'delete_data' => false,
-				]
-			);
+			give_update_option( 'uninstall_on_delete', 'enabled' );
+			wp_send_json_success( [ 'delete_data' => true ] );
 		}
-	} else {
-		wp_send_json_error();
+
+		wp_send_json_success( [ 'delete_data' => false ] );
 	}
+
+	wp_send_json_error();
 }
 
 add_action( 'wp_ajax_deactivation_form_submit', 'give_deactivation_form_submit' );

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -24,13 +24,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array An array of updated action links.
  */
 function give_plugin_action_links( $actions ) {
-	$new_actions = array(
+	$new_actions = [
 		'settings' => sprintf(
 			'<a href="%1$s">%2$s</a>',
 			admin_url( 'edit.php?post_type=give_forms&page=give-settings' ),
 			__( 'Settings', 'give' )
 		),
-	);
+	];
 
 	return array_merge( $new_actions, $actions );
 }
@@ -53,16 +53,16 @@ function give_plugin_row_meta( $plugin_meta, $plugin_file ) {
 		return $plugin_meta;
 	}
 
-	$new_meta_links = array(
+	$new_meta_links = [
 		sprintf(
 			'<a href="%1$s" target="_blank">%2$s</a>',
 			esc_url(
 				add_query_arg(
-					array(
+					[
 						'utm_source'   => 'plugins-page',
 						'utm_medium'   => 'plugin-row',
 						'utm_campaign' => 'admin',
-					),
+					],
 					'https://givewp.com/documentation/'
 				)
 			),
@@ -72,17 +72,17 @@ function give_plugin_row_meta( $plugin_meta, $plugin_file ) {
 			'<a href="%1$s" target="_blank">%2$s</a>',
 			esc_url(
 				add_query_arg(
-					array(
+					[
 						'utm_source'   => 'plugins-page',
 						'utm_medium'   => 'plugin-row',
 						'utm_campaign' => 'admin',
-					),
+					],
 					'https://givewp.com/addons/'
 				)
 			),
 			__( 'Add-ons', 'give' )
 		),
-	);
+	];
 
 	return array_merge( $plugin_meta, $new_meta_links );
 }
@@ -133,7 +133,7 @@ function give_recently_activated_addons() {
 	// Check if action is set.
 	if ( isset( $_REQUEST['action'] ) ) {
 		$plugin_action = ( '-1' !== $_REQUEST['action'] ) ? $_REQUEST['action'] : ( isset( $_REQUEST['action2'] ) ? $_REQUEST['action2'] : '' );
-		$plugins       = array();
+		$plugins       = [];
 
 		switch ( $plugin_action ) {
 			case 'activate': // Single add-on activation.
@@ -178,7 +178,7 @@ add_action( 'activated_plugin', 'give_recently_activated_addons', 10 );
 function give_filter_addons_do_filter_addons( $plugin_menu ) {
 	global $plugins;
 
-	$give_addons = wp_list_pluck( give_get_plugins( array( 'only_add_on' => true ) ), 'Name' );
+	$give_addons = wp_list_pluck( give_get_plugins( [ 'only_add_on' => true ] ), 'Name' );
 
 	if ( ! empty( $give_addons ) ) {
 		foreach ( $plugins['all'] as $file => $plugin_data ) {
@@ -360,11 +360,11 @@ function give_get_plugin_upgrade_notice( $new_version ) {
  */
 function give_parse_plugin_update_notice( $content, $new_version ) {
 	$version_parts     = explode( '.', $new_version );
-	$check_for_notices = array(
+	$check_for_notices = [
 		$version_parts[0] . '.0',
 		$version_parts[0] . '.0.0',
 		$version_parts[0] . '.' . $version_parts[1] . '.' . '0',
-	);
+	];
 
 	// Regex to extract Upgrade notice from the readme.txt file.
 	$notice_regexp = '~==\s*Upgrade Notice\s*==\s*=\s*(.*)\s*=(.*)(=\s*' . preg_quote( $new_version ) . '\s*=|$)~Uis';
@@ -444,7 +444,7 @@ add_action( 'admin_head', 'give_plugin_notice_css' );
  * @return mixed|array list of recently activated add-on
  */
 function give_get_recently_activated_addons() {
-	return get_option( 'give_recently_activated_addons', array() );
+	return get_option( 'give_recently_activated_addons', [] );
 }
 
 /**
@@ -459,7 +459,7 @@ function give_deactivation_popup() {
 		give_die();
 	}
 
-	$results = array();
+	$results = [];
 
 	// Start output buffering.
 	ob_start();
@@ -626,14 +626,14 @@ function give_deactivation_form_submit() {
 	 */
 	$response = wp_remote_post(
 		'http://survey.givewp.com/wp-json/give/v2/survey/',
-		array(
-			'body' => array(
+		[
+			'body' => [
 				'radio_value'        => $radio_value,
 				'user_reason'        => $user_reason,
 				'current_user_email' => $user_email,
 				'site_url'           => $site_url,
-			),
-		)
+			],
+		]
 	);
 
 	// Check if the data is sent and stored correctly.
@@ -642,15 +642,15 @@ function give_deactivation_form_submit() {
 	if ( 'true' === $response ) {
 		if ( '1' === $delete_data ) {
 			wp_send_json_success(
-				array(
+				[
 					'delete_data' => true,
-				)
+				]
 			);
 		} else {
 			wp_send_json_success(
-				array(
+				[
 					'delete_data' => false,
-				)
+				]
 			);
 		}
 	} else {

--- a/src/Framework/Exceptions/UncaughtExceptionLogger.php
+++ b/src/Framework/Exceptions/UncaughtExceptionLogger.php
@@ -30,6 +30,7 @@ class UncaughtExceptionLogger {
 	/**
 	 * Handles an uncaught exception by checking if the Exception is native to GiveWP and then logging it if it is
 	 *
+	 * @unreleased remove parameter typing as it may be an Error
 	 * @since 2.11.1
 	 *
 	 * @param Exception|Error $exception

--- a/src/Framework/Exceptions/UncaughtExceptionLogger.php
+++ b/src/Framework/Exceptions/UncaughtExceptionLogger.php
@@ -2,6 +2,7 @@
 
 namespace Give\Framework\Exceptions;
 
+use Error;
 use Exception;
 use Give\Framework\Exceptions\Contracts\LoggableException;
 use Give\Framework\Exceptions\Traits\Loggable;
@@ -31,9 +32,9 @@ class UncaughtExceptionLogger {
 	 *
 	 * @since 2.11.1
 	 *
-	 * @param Exception $exception
+	 * @param Exception|Error $exception
 	 */
-	public function handleException( Exception $exception ) {
+	public function handleException( $exception ) {
 		if ( $exception instanceof LoggableException ) {
 			/** @var LoggableException|Loggable $exception */
 			Log::error( $exception->getLogMessage(), $exception->getLogContext() );

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,6 +25,9 @@ include_once( 'give.php' );
  */
 give()->init();
 
+// Prevent checking for plugin updates
+remove_filter( 'pre_set_site_transient_update_plugins', 'give_check_addon_updates', 999 );
+
 global $wpdb, $wp_roles;
 
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -61,7 +61,19 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 	// Delete All the Terms & Taxonomies.
 	foreach ( array_unique( array_filter( $give_taxonomies ) ) as $taxonomy ) {
 
-		$terms = $wpdb->get_results( $wpdb->prepare( "SELECT t.*, tt.* FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('%s') ORDER BY t.name ASC", $taxonomy ) );
+		$terms = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+				SELECT t.*, tt.*
+				FROM $wpdb->terms AS t
+				INNER JOIN $wpdb->term_taxonomy AS tt
+					ON t.term_id = tt.term_id
+				WHERE tt.taxonomy IN ('%s')
+				ORDER BY t.name ASC
+				",
+				$taxonomy
+			)
+		);
 
 		// Delete Terms.
 		if ( $terms ) {
@@ -106,7 +118,11 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 	// Get all options.
 	$give_option_names = $wpdb->get_col(
 		$wpdb->prepare(
-			"SELECT option_name FROM {$wpdb->options} where option_name LIKE '%%%s%%'",
+			"
+			SELECT option_name
+			FROM {$wpdb->options}
+			WHERE option_name LIKE '%%%s%%'
+			",
 			'give'
 		)
 	);

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,10 +3,10 @@
  * Uninstall Give
  *
  * @package     Give
- * @subpackage  Uninstall
+ * @since       1.0
  * @copyright   Copyright (c) 2016, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
- * @since       1.0
+ * @subpackage  Uninstall
  */
 
 // Exit if accessed directly.
@@ -38,8 +38,11 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 	$give_post_types = [ 'give_forms', 'give_payment' ];
 	foreach ( $give_post_types as $post_type ) {
 
-		$give_taxonomies = array_merge( $give_taxonomies, get_object_taxonomies( $post_type ) );
-		$items           = get_posts(
+		foreach ( get_object_taxonomies( $post_type ) as $taxonomy ) {
+			$give_taxonomies[] = $taxonomy;
+		}
+
+		$items = get_posts(
 			[
 				'post_type'   => $post_type,
 				'post_status' => 'any',
@@ -90,20 +93,9 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 		remove_role( $role );
 	}
 
-	// Remove all database tables.
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donors" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donormeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_donationmeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_formmeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_comments" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_commentmeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sequential_ordering" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_sessions" );
-
-	// Remove tables which are supported with backward compatibility.
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_customers" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_customermeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}give_paymentmeta" );
+	// Remove all give database tables.
+	$give_tables = $wpdb->get_col( "SHOW TABLES LIKE '{$wpdb->prefix}give_%'" );
+	$wpdb->query( 'DROP TABLE ' . implode( ',', $give_tables ) );
 
 	// Cleanup Cron Events.
 	wp_clear_scheduled_hook( 'give_daily_scheduled_events' );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5845 

## Description

This fix removes a hook during uninstalling which is used to check for addon updates. Obviously, when uninstalling we don't care if there are any updates. Just uninstall.

This also sneaks in a fix wherein uncaught errors in PHP 7 could be an Error instead of an Exception, so typing the class is a problem.

## Affects

Uninstallation flow

## Testing Instructions

1. Install GiveWP
2. Uninstall GiveWP

Try installing both with and without add-ons present.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

