### PR TITLE
Fix PHP warning Unsupported declare 'strict_types'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -  Update wp-env package to resolve project setup issue (#5850)
+-  Fix "Unsupported declare strict_types" PHP warning (#)
 
 ## 2.11.2 - 2021-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -  Update wp-env package to resolve project setup issue (#5850)
--  Fix "Unsupported declare strict_types" PHP warning (#)
+-  Fix "Unsupported declare strict_types" PHP warning (#5853)
 
 ## 2.11.2 - 2021-06-08
 

--- a/src/Framework/Exceptions/Contracts/LoggableException.php
+++ b/src/Framework/Exceptions/Contracts/LoggableException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare( strict_types=1 );
-
 namespace Give\Framework\Exceptions\Contracts;
 
 interface LoggableException {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I was getting the following warning when the exception occurred on PHP 5.6. I removed the code that causes this warning.

```
[16-Jun-2021 13:52:02 UTC] PHP Warning:  Unsupported declare 'strict_types' in /Users/ravinderkumar/Local-Sites/give/app/public/wp-content/plugins/give/src/Framework/Exceptions/Contracts/LoggableException.php on line 3
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- throw an uncaught exception in givewp and exception must implements `LoggableException`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

