### PR TITLE
Exception Handler passes along exceptions and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Uncaught exception handler no longer breaks on Errors (#5846)
 -   Uninstalling GiveWP no longer throws an exception (#5846)
+-   Caught GiveWP exceptions no longer display a white screen (#5861)
 
 ## 2.11.1 - 2021-05-24
 

--- a/src/Framework/Exceptions/UncaughtExceptionLogger.php
+++ b/src/Framework/Exceptions/UncaughtExceptionLogger.php
@@ -34,6 +34,8 @@ class UncaughtExceptionLogger {
 	 * @since 2.11.1
 	 *
 	 * @param Exception|Error $exception
+	 *
+	 * @throws LoggableException
 	 */
 	public function handleException( $exception ) {
 		if ( $exception instanceof LoggableException ) {
@@ -44,6 +46,8 @@ class UncaughtExceptionLogger {
 		if ( $this->previousHandler !== null ) {
 			$previousHandler = $this->previousHandler;
 			$previousHandler( $exception );
+		} elseif ( $exception instanceof Exception ) {
+			throw $exception;
 		}
 	}
 }

--- a/src/Framework/Exceptions/UncaughtExceptionLogger.php
+++ b/src/Framework/Exceptions/UncaughtExceptionLogger.php
@@ -30,6 +30,7 @@ class UncaughtExceptionLogger {
 	/**
 	 * Handles an uncaught exception by checking if the Exception is native to GiveWP and then logging it if it is
 	 *
+	 * @unreleased re-throw the exception so it displays
 	 * @since 2.11.2 remove parameter typing as it may be an Error
 	 * @since 2.11.1
 	 *

--- a/src/Framework/FieldsAPI/Factory/Exception/TypeNotSupported.php
+++ b/src/Framework/FieldsAPI/Factory/Exception/TypeNotSupported.php
@@ -2,12 +2,9 @@
 
 namespace Give\Framework\FieldsAPI\Factory\Exception;
 
-use Exception;
-use Give\Framework\Exceptions\Traits\Loggable;
+use Give\Framework\Exceptions\Primitives\Exception;
 
 class TypeNotSupported extends Exception {
-	use Loggable;
-
 	public function __construct( $type, $code = 0, $previous = null ) {
 		$message = "Field type $type is not supported";
 		parent::__construct( $message, $code, $previous );

--- a/tests/unit/tests/Framework/Exceptions/UncaughtExceptionLoggerTest.php
+++ b/tests/unit/tests/Framework/Exceptions/UncaughtExceptionLoggerTest.php
@@ -18,6 +18,8 @@ class UncaughtExceptionLoggerTest extends Give_Unit_Test_Case {
 			return $mock;
 		} );
 
+		$this->expectException(ExceptionLogged::class);
+
 		$logger->handleException( new ExceptionLogged() );
 	}
 
@@ -32,6 +34,8 @@ class UncaughtExceptionLoggerTest extends Give_Unit_Test_Case {
 
 			return $mock;
 		} );
+
+		$this->expectException(ExceptionNotLogged::class);
 
 		$logger->handleException( new ExceptionNotLogged() );
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5860 

## Description

This resolves the issue wherein handled exceptions weren't being passed to the system for display (or whatever else), resulting in a demoralizing white screen.

A couple things to consider in this solution:
1. It seems that Errors (not Exceptions) work differently. Regardless of whether they're handled, they still get passed along and, in this case, are rendered in the browser. That's why I'm checking to see if the variable is, in fact, an Exception.
2. The solution seems to be to just throw the error. PHP is apparently smart enough to recognize the exception is being thrown within the handler, so it doesn't create a loop.
3. I figure if there's another handler in place, we can let them determine whether it should be re-thrown or not. This _may_ be problematic if multiple handlers are throwing, but I think we're good.

## Visuals

![Image 2021-07-02 at 2 52 44 PM](https://user-images.githubusercontent.com/2024145/124331992-41513700-db45-11eb-9a7c-6fc4fb6be0e8.jpg)

## Testing Instructions

Try throwing Errors (`trigger_error()`) and Exceptions in a few places. Make sure that in all cases it works the same as if our handler code wasn't there at all. Try throwing the Exception, then disable our handler code, and try again. The goal is that there should be no difference.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

