### PR TITLE
Pulling product data from givewp.com can no longer break site

### DIFF
--- a/give.php
+++ b/give.php
@@ -43,6 +43,7 @@ use Give\Container\Container;
 use Give\Framework\Exceptions\UncaughtExceptionLogger;
 use Give\Framework\Migrations\MigrationsServiceProvider;
 use Give\Form\Templates;
+use Give\License\LicenseServiceProvider;
 use Give\Revenue\RevenueServiceProvider;
 use Give\Route\Form as FormRoute;
 use Give\ServiceProviders\PaymentGateways;
@@ -155,6 +156,7 @@ final class Give {
 		LogServiceProvider::class,
 		FormLegacyConsumerServiceProvider::class,
 		ShimsServiceProvider::class,
+		LicenseServiceProvider::class,
 	];
 
 	/**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -853,7 +853,7 @@ function give_get_plugins( $args = [] ) {
 	}
 
 	if ( ! empty( $args['only_premium_add_ons'] ) ) {
-		$premiumAddonsListManger = new PremiumAddonsListManager();
+		$premiumAddonsListManger = give( PremiumAddonsListManager::class );
 
 		foreach ( $plugins as $key => $plugin ) {
 			if ( 'add-on' !== $plugin['Type'] ) {

--- a/src/License/LicenseServiceProvider.php
+++ b/src/License/LicenseServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Give\License;
+
+use Give\ServiceProviders\ServiceProvider;
+
+class LicenseServiceProvider implements ServiceProvider {
+	/**
+	 * @unreleased
+	 */
+	public function register() {
+		give()->singleton( PremiumAddonsListManager::class );
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function boot() {
+	}
+}

--- a/src/License/PremiumAddonsListManager.php
+++ b/src/License/PremiumAddonsListManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Give\License;
 
 /**
@@ -17,24 +18,43 @@ class PremiumAddonsListManager {
 	 */
 	const PRODUCTS_LIST_API_URL = 'https://givewp.com/edd-api/products';
 
+	/**
+	 * Cached addon values for the same request, prevents subsequent transient queries
+	 *
+	 * @unreleased
+	 */
+	private $addonIds;
 
 	/**
 	 * Get premium addons slugs as addons ids.
 	 *
+	 * @unreleased Always cache to avoid timeouts on givewp.com
 	 * @since 2.9.2
+	 *
 	 * @return array
 	 */
 	private function getAddonsIds() {
-		$optionName   = 'give_premium_addons_ids';
-		$cachedResult = get_transient( $optionName );
-		if ( $cachedResult ) {
-			return  $cachedResult;
+		if ( isset( $this->addonIds ) ) {
+			return $this->addonIds;
 		}
 
-		$response            = wp_remote_get( self::PRODUCTS_LIST_API_URL . '?number=-1' );
+		$optionName   = 'give_premium_addons_ids';
+		$cachedResult = get_transient( $optionName );
+		if ( $cachedResult !== false ) {
+			return $this->addonIds = $cachedResult;
+		}
+
+		$response            = wp_remote_get(
+			self::PRODUCTS_LIST_API_URL . '?number=-1',
+			[
+				'timeout' => 3,
+			]
+		);
 		$productsInformation = wp_remote_retrieve_body( $response );
 		if ( ! $productsInformation ) {
-			return [];
+			set_transient( $optionName, [], HOUR_IN_SECONDS );
+
+			return $this->addonIds = [];
 		}
 
 		$productsInformation = json_decode( $productsInformation, true );
@@ -47,7 +67,7 @@ class PremiumAddonsListManager {
 			set_transient( $optionName, $productsIds, DAY_IN_SECONDS );
 		}
 
-		return $productsIds;
+		return $this->addonIds = $productsIds;
 	}
 
 	/**

--- a/src/Tracking/TrackingData/PluginsData.php
+++ b/src/Tracking/TrackingData/PluginsData.php
@@ -54,7 +54,7 @@ class PluginsData implements TrackData {
 	 * @return array The formatted array.
 	 */
 	private function formatPlugin( $plugin ) {
-		$premiumAddonsListManger = new PremiumAddonsListManager();
+		$premiumAddonsListManger = give( PremiumAddonsListManager::class );
 
 		return [
 			'plugin'         => $plugin['Path'],


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5862 

## Description

This PR tackles the problem that givewp.com going down can bring down other sites, as they're making requests to get EDD product data in order to determine whether add-ons are premium.

A couple layers of caching are applied:
1. The request times out after 3 seconds
2. If the request returns invalid for any reason, an empty array is cached for an hour
3. Multiple checks in the same request (i.e. multiple add-ons) will only query or check the cache one time.

With this in place, there should be only one possible query per hour to givewp.com that can hang up a single request for 3 seconds. Also, in any case, multiple queries to wp_options (transient) are reduced to 1, no matter how many add-ons are installed.

## Affects

Checking whether a given add-on is premium or not.

## Testing Instructions

1. Make a local site with an endpoint that times out
2. Change `PremiumAddonsListManager::PRODUCTS_LIST_API_URL` to point do that endpoint.

Also, check for other givewp.com requests to make sure we haven't missed anything that can have this problem.

Finally, make turn off your server and point to the right endpoint. Make sure that it still works as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

