### PR TITLE
Improve  setting group page style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -  Update wp-env package to resolve project setup issue (#5850)
 -  Fix "Unsupported declare strict_types" PHP warning (#5853)
+-  Add top margin to setting group page (#5864)
 
 ## 2.11.3 - 2021-07-06
 

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -21,6 +21,7 @@
 		-webkit-box-shadow: 0 0 5px 0 rgba(221, 221, 221, 1);
 		-moz-box-shadow: 0 0 5px 0 rgba(221, 221, 221, 1);
 		box-shadow: 0 0 5px 0 rgba(221, 221, 221, 1);
+		margin-top: 20px;
 
 		.give-settings-section-group-menu {
 			width: 250px;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://feedback.givewp.com/text-to-give/p/settings-missing-top-margin

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
@DevinWalker  discovered that when the subsetting section does not define then the setting group does not have a top margin. I added the default top margin to a group setting.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affect group setting section like Strip payment gateway setting page, text to give setting page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![GiveWP Settings ‹ give — WordPress 2021-07-07 at 11 33 56 AM](https://user-images.githubusercontent.com/1784821/124708015-40d6e880-df17-11eb-9281-19bf859a403f.jpg)
![GiveWP Settings ‹ give — WordPress 2021-07-07 at 11 34 25 AM](https://user-images.githubusercontent.com/1784821/124708078-564c1280-df17-11eb-9952-ae0acd860453.jpg)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Run `npm run dev` before testing this pull request.
- [ ] Global Stripe setting page looks good with top margin
- [ ] Global StriText to givepe setting page looks good with top margin

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

