### PR TITLE
Add custom donation level choice to select field if donation donated with custom amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+-  Add custom donation level choice to select field if donation donated with custom amount (#5866)
+
 ### Fixed
 
 -  Update wp-env package to resolve project setup issue (#5850)

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1669,7 +1669,11 @@ function give_get_form_variable_price_dropdown( $args = [], $echo = false ) {
 	$variable_price_options = [];
 
 	// Check if multi donation form support custom donation or not.
-	if ( $form->is_custom_price_mode() ) {
+	// Check if donation amount is a custom or not.
+	if (
+		$form->is_custom_price_mode() ||
+		'custom' === $args['selected']
+	) {
 		$variable_price_options['custom'] = _x( 'Custom', 'custom donation dropdown item', 'give' );
 	}
 

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1648,6 +1648,7 @@ function give_get_form_dropdown( $args = [], $echo = false ) {
  * @param bool  $echo This parameter decide if print form dropdown html output or not.
  *
  * @since 1.6
+ * @unreleased Show "Custom" choice in select field if donation created with cusotm amount
  *
  * @return string|bool
  */

--- a/tests/unit/tests/Helpers/DonationFormVariablePricesDropdownTest.php
+++ b/tests/unit/tests/Helpers/DonationFormVariablePricesDropdownTest.php
@@ -31,8 +31,7 @@ class DonationFormVariablePricesDropdownTest extends Give_Unit_Test_Case {
 			'selected' => $this->donation->price_id
 		];
 
-
-		$this->assertTrue( false !== strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+		$this->assertContains( 'Custom', give_get_form_variable_price_dropdown( $args ) );
 	}
 
 	public function testShowCustomDonationLevelChoiceInDropDownIfDonationFormCustomAmountModeDisabledAndDonationDonatedWithCustomLevel() {
@@ -45,8 +44,7 @@ class DonationFormVariablePricesDropdownTest extends Give_Unit_Test_Case {
 			'selected' => $this->donation->price_id
 		];
 
-
-		$this->assertTrue( false !== strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+		$this->assertContains( 'Custom', give_get_form_variable_price_dropdown( $args ) );
 	}
 
 	public function testDoNotShowCustomDonationLevelChoiceInDropDownIfDonationFormCustomAmountModeDisabledAndDonationNotDonatedWithCustomLevel() {
@@ -59,7 +57,6 @@ class DonationFormVariablePricesDropdownTest extends Give_Unit_Test_Case {
 			'selected' => $this->donation->price_id
 		];
 
-
-		$this->assertTrue( false === strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+		$this->assertNotContains( 'Custom', give_get_form_variable_price_dropdown( $args ) );
 	}
 }

--- a/tests/unit/tests/Helpers/DonationFormVariablePricesDropdownTest.php
+++ b/tests/unit/tests/Helpers/DonationFormVariablePricesDropdownTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Class DonationFormVariablePricesDropdownTest
+ *
+ * Test give_get_form_variable_price_dropdown function output
+ *
+ * @unreleased
+ */
+class DonationFormVariablePricesDropdownTest extends Give_Unit_Test_Case {
+	/**
+	 * @var Give_Payment
+	 */
+	private $donation;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->donation = new Give_Payment( Give_Helper_Payment::create_multilevel_payment() );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testShowCustomDonationLevelChoiceInDropDownIfDonationFormCustomAmountModeActivated() {
+		give()->form_meta->update_meta( $this->donation->form_id, '_give_custom_amount', 'enabled' );
+
+		$args = [
+			'id'       => $this->donation->form_id,
+			'selected' => $this->donation->price_id
+		];
+
+
+		$this->assertTrue( false !== strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+	}
+
+	public function testShowCustomDonationLevelChoiceInDropDownIfDonationFormCustomAmountModeDisabledAndDonationDonatedWithCustomLevel() {
+		give()->form_meta->update_meta( $this->donation->form_id, '_give_custom_amount', 'disabled' );
+		$this->donation->price_id = 'custom';
+		$this->donation->save();
+
+		$args = [
+			'id'       => $this->donation->form_id,
+			'selected' => $this->donation->price_id
+		];
+
+
+		$this->assertTrue( false !== strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+	}
+
+	public function testDoNotShowCustomDonationLevelChoiceInDropDownIfDonationFormCustomAmountModeDisabledAndDonationNotDonatedWithCustomLevel() {
+		give()->form_meta->update_meta( $this->donation->form_id, '_give_custom_amount', 'disabled' );
+		$this->donation->price_id = 1;
+		$this->donation->save();
+
+		$args = [
+			'id'       => $this->donation->form_id,
+			'selected' => $this->donation->price_id
+		];
+
+
+		$this->assertTrue( false === strpos( give_get_form_variable_price_dropdown( $args ), 'Custom' ) );
+	}
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Admin can disable custom amount on donation form with form settings. If that donation already has a donation with a 'custom' price id then the admin will not see the correct donation level on the donation detail page because of the missing `Custom` choice from the select field.

This pull request resolves the above issue by inserting a 'Custom' donation level choice./


Note: in the Text To Give addon we create donation with the custom amount (mostly) even `custom amount` disabled in the donation form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affect donation detail page view and `give_get_form_variable_price_dropdown` function output.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Enable custom donation amount.  Create a donation with a custom amount.
 - [ ] Donation level on donation detail page set to `Custom`.
  - [ ] Donation level on donation detail page set to `Custom` if custom donation amount in donation form disabled.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

