### PR TITLE
Card declines on multi-step form now display an error message on first click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--  Update wp-env package to resolve project setup issue (#5850)
--  Fix "Unsupported declare strict_types" PHP warning (#5853)
--  Add top margin to setting group page (#5864)
+-   Update wp-env package to resolve project setup issue (#5850)
+-   Fix "Unsupported declare strict_types" PHP warning (#5853)
+-   Add top margin to setting group page (#5864)
+-   Card declines on multi-step form now display an error message on first click (#5868)
 
 ## 2.11.3 - 2021-07-06
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -484,6 +484,7 @@
 	/**
 	 * Move error notices to error notice container at the top of the payment section
 	 * @since 2.7.0
+	 * @unreleased Prevents a race condition that caused an error message not to be visible.
 	 * @param {node} node The error notice node to be moved
 	 */
 	function moveErrorNotice( node ) {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -497,13 +497,22 @@
 			$( '.payment' ).prepend( '<div class="donation-errors"></div>' );
 		}
 
-		// If a specific notice does not already exist, proceed with moving the error
-		if ( typeof $( '.donation-errors' ).html() !== undefined && ! $( '.donation-errors' ).html().includes( $( node ).html() ) ) {
-			$( node ).appendTo( '.donation-errors' );
-		} else {
-			// If the specific notice already exists, do not add it
-			$( node ).remove();
-		}
+		/**
+		 * @link https://github.com/impress-org/givewp/issues/5867
+		 *
+		 * This 1 millisecond timeout prevents a race condition between
+		 * the `.donation-errors` element being appended to the form
+		 * and relocation of the specific error message node.
+		 */
+		setTimeout(function(){
+			// If a specific notice does not already exist, proceed with moving the error
+			if ( typeof $( '.donation-errors' ).html() !== undefined && ! $( '.donation-errors' ).html().includes( $( node ).html() ) ) {
+				$( node ).appendTo( '.donation-errors' );
+			} else {
+				// If the specific notice already exists, do not add it
+				$( node ).remove();
+			}
+		}, 1);
 	}
 
 	/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5867

Prevent a race condition between the error container and the relocated error node.

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds a 1 millisecond timeout to prevent a race condition between the `.donation-errors` element being appended to the form and relocation of the specific error message node to that created element.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Enable Stripe Credit Card in **live** mode.
- Create a Donation Form with the Multi-Step Template (Sequoia)
- Attempt to make a donation with an _invalid_ card number, ie `4242 4242 4242 4244`
- Submitting the payment will should show a related error message.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

