### PR TITLE
Fix PHP warning Unsupported declare 'strict_types'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -  Update wp-env package to resolve project setup issue (#5850)
--  Fix "Unsupported declare strict_types" PHP warning (#5853)
+-  Fix "Unsupported declare strict_types" PHP warning (#5853, #5869)
 -  Add top margin to setting group page (#5864)
 
 ## 2.11.3 - 2021-07-06

--- a/src/License/LicenseServiceProvider.php
+++ b/src/License/LicenseServiceProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare( strict_types=1 );
-
 namespace Give\License;
 
 use Give\ServiceProviders\ServiceProvider;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I was getting the warning when running PHPUnit tests on PHP 5.6. I removed the code that causes this warning.

## Visuals

![give Shell 2021-07-09 at 12 25 22 PM](https://user-images.githubusercontent.com/1784821/125036558-c17d1c80-e0b0-11eb-907e-90d4cc4d007c.jpg)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] Run PHPUnit tests and review PHP notice

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

