### PR TITLE
GiveWP is not causing deprecation warnings on PHP8 anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  Update wp-env package to resolve project setup issue (#5850)
 -  Fix "Unsupported declare strict_types" PHP warning (#5853, #5869)
 -  Add top margin to setting group page (#5864)
+-  GiveWP is not causing deprecation warnings on PHP8 anymore (#5872)
 
 ## 2.11.3 - 2021-07-06
 

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -132,7 +132,7 @@ add_filter( 'admin_title', 'give_view_donation_details_title', 10, 2 );
  * @param $context
  * @return string
  */
-function give_override_edit_post_for_payment_link( $url, $post_id = 0, $context ) {
+function give_override_edit_post_for_payment_link( $url, $post_id, $context ) {
 
 	$post = get_post( $post_id );
 

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -131,6 +131,8 @@ add_filter( 'admin_title', 'give_view_donation_details_title', 10, 2 );
  * @param $post_id
  * @param $context
  * @return string
+ *
+ * @unreleased default value for the $post_id parameter is removed to prevent PHP8 warnings.
  */
 function give_override_edit_post_for_payment_link( $url, $post_id, $context ) {
 

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -375,7 +375,7 @@ function give_field_is_required( $field, $form_id ) {
  *
  * @return void
  */
-function give_record_donation_in_log( $give_form_id = 0, $payment_id, $price_id = false, $donation_date = null ) {
+function give_record_donation_in_log( $give_form_id, $payment_id, $price_id = false, $donation_date = null ) {
 	$log_data = [
 		'log_content'  => 'Payment log info',
 		'log_parent'   => $payment_id,
@@ -469,7 +469,7 @@ function give_decrease_donation_count( $form_id = 0, $quantity = 1 ) {
  *
  * @return bool|int
  */
-function give_increase_earnings( $give_form_id = 0, $amount, $payment_id = 0 ) {
+function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
 	/** @var \Give_Donate_Form $form */
 	$form = new Give_Donate_Form( $give_form_id );
 
@@ -491,7 +491,7 @@ function give_increase_earnings( $give_form_id = 0, $amount, $payment_id = 0 ) {
  *
  * @return bool|int
  */
-function give_decrease_form_earnings( $form_id = 0, $amount, $payment_id = 0 ) {
+function give_decrease_form_earnings( $form_id, $amount, $payment_id = 0 ) {
 	/** @var \Give_Donate_Form $form */
 	$form = new Give_Donate_Form( $form_id );
 

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -373,6 +373,8 @@ function give_field_is_required( $field, $form_id ) {
  * @param bool|int    $price_id      Price ID, if any.
  * @param string|null $donation_date The date of the donation.
  *
+ * @unreleased default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ *
  * @return void
  */
 function give_record_donation_in_log( $give_form_id, $payment_id, $price_id = false, $donation_date = null ) {
@@ -467,6 +469,8 @@ function give_decrease_donation_count( $form_id = 0, $quantity = 1 ) {
  * @param int $amount       Earnings
  * @param int $payment_id   Donation ID.
  *
+ * @unreleased default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ *
  * @return bool|int
  */
 function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
@@ -488,6 +492,8 @@ function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
  * @param int $form_id    Give Form ID
  * @param int $amount     Earnings
  * @param int $payment_id Donation ID.
+ *
+ * @unreleased default value for the $form_id parameter is removed to prevent PHP8 warnings.
  *
  * @return bool|int
  */

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -577,6 +577,8 @@ function give_get_payment_status_keys() {
  *
  * @since 1.0
  *
+ * @unreleased default value for the $day parameter is removed to prevent PHP8 warnings.
+ *
  * @return int $earnings Earnings
  */
 function give_get_earnings_by_date( $day, $month_num, $year = null, $hour = null ) {

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -579,7 +579,7 @@ function give_get_payment_status_keys() {
  *
  * @return int $earnings Earnings
  */
-function give_get_earnings_by_date( $day = null, $month_num, $year = null, $hour = null ) {
+function give_get_earnings_by_date( $day, $month_num, $year = null, $hour = null ) {
 	// This is getting deprecated soon. Use Give_Payment_Stats with the get_earnings() method instead.
 	global $wpdb;
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -724,7 +724,6 @@ class Container implements ArrayAccess {
 	 * @return array
 	 * @throws BindingResolutionException
 	 * @throws ReflectionException
-	 * @note ReflectionParameter::getType() is not supported before PHP7
 	 */
 	protected function resolveDependencies( array $dependencies ) {
 		$results = [];
@@ -739,14 +738,16 @@ class Container implements ArrayAccess {
 				continue;
 			}
 
-			// If the class is null, it means the dependency is a string or some other
-			// primitive type which we can not resolve since it is not a class and
-			// we will just bomb out with an error since we have no-where to go.
-			// Note: ReflectionParameter::getClass() is deprecated since PHP 8
+
+			// @note: ReflectionParameter::getClass() is deprecated since PHP 8
+			// @note: ReflectionParameter::getType() is not supported before PHP7
 			$name = version_compare( PHP_VERSION, '8.0', '<' )
 				? $dependency->getClass()
 				: $dependency->getType()->getName();
 
+			// If the class is null, it means the dependency is a string or some other
+			// primitive type which we can not resolve since it is not a class and
+			// we will just bomb out with an error since we have no-where to go.
 			$result = is_null( $name )
 				? $this->resolvePrimitive( $dependency )
 				: $this->resolveClass( $dependency );
@@ -821,11 +822,11 @@ class Container implements ArrayAccess {
 	 * @return mixed
 	 * @throws BindingResolutionException
 	 * @throws ReflectionException
-	 * @note ReflectionParameter::getType() is not supported before PHP7
 	 */
 	protected function resolveClass( ReflectionParameter $parameter ) {
 		try {
-			// Note: ReflectionParameter::getClass() is deprecated since PHP 8
+			// @note: ReflectionParameter::getClass() is deprecated since PHP 8
+			// @note: ReflectionParameter::getType() is not supported before PHP7
 			return version_compare( PHP_VERSION, '8.0', '<' )
 				? $this->make( $parameter->getClass()->name )
 				: $this->make( $parameter->getType()->getName() );

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -724,6 +724,7 @@ class Container implements ArrayAccess {
 	 * @return array
 	 * @throws BindingResolutionException
 	 * @throws ReflectionException
+	 * @note ReflectionParameter::getType() is not supported before PHP7
 	 */
 	protected function resolveDependencies( array $dependencies ) {
 		$results = [];
@@ -820,6 +821,7 @@ class Container implements ArrayAccess {
 	 * @return mixed
 	 * @throws BindingResolutionException
 	 * @throws ReflectionException
+	 * @note ReflectionParameter::getType() is not supported before PHP7
 	 */
 	protected function resolveClass( ReflectionParameter $parameter ) {
 		try {

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -741,7 +741,12 @@ class Container implements ArrayAccess {
 			// If the class is null, it means the dependency is a string or some other
 			// primitive type which we can not resolve since it is not a class and
 			// we will just bomb out with an error since we have no-where to go.
-			$result = is_null( $dependency->getClass() )
+			// Note: ReflectionParameter::getClass() is deprecated since PHP 8
+			$name = version_compare( PHP_VERSION, '8.0', '<' )
+				? $dependency->getClass()
+				: $dependency->getType()->getName();
+
+			$result = is_null( $name )
 				? $this->resolvePrimitive( $dependency )
 				: $this->resolveClass( $dependency );
 
@@ -818,7 +823,10 @@ class Container implements ArrayAccess {
 	 */
 	protected function resolveClass( ReflectionParameter $parameter ) {
 		try {
-			return $this->make( $parameter->getClass()->name );
+			// Note: ReflectionParameter::getClass() is deprecated since PHP 8
+			return version_compare( PHP_VERSION, '8.0', '<' )
+				? $this->make( $parameter->getClass()->name )
+				: $this->make( $parameter->getType()->getName() );
 		}
 
 			// If we can not resolve the class instance, we will check to see if the value


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5871

## Description

GiveWP is not causing deprecation warnings on PHP8 anymore. The issue has been resolved by refactoring the code which was throwing deprecation warning on PHP 8.

## Testing Instructions

1.  Enable WP_DEBUG
2. Change PHP version to 8.0
3. Go to GiveWP admin dashboard

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

