### PR TITLE
Donation tooltips are now escaped properly

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -550,7 +550,7 @@ function give_output_levels( $form_id ) {
 					$level_classes,
 					$formatted_amount,
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					$level_text
+					esc_attr( $level_text )
 				);
 			}
 
@@ -562,7 +562,7 @@ function give_output_levels( $form_id ) {
 
 				$output .= sprintf(
 					'<li><button type="button" data-price-id="custom" class="give-donation-level-btn give-btn give-btn-level-custom" value="custom">%1$s</button></li>',
-					$custom_amount_text
+					esc_html( $custom_amount_text )
 				);
 			}
 
@@ -592,7 +592,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'checked="checked"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					$level_text
+					esc_html( $level_text )
 				);
 			}
 
@@ -603,7 +603,7 @@ function give_output_levels( $form_id ) {
 			) {
 				$output .= sprintf(
 					'<li><input type="radio" data-price-id="custom" class="give-radio-input give-radio-input-level give-radio-level-custom" name="give-radio-donation-level" id="give-radio-level-custom" value="custom"><label for="give-radio-level-custom">%1$s</label></li>',
-					$custom_amount_text
+					esc_html( $custom_amount_text )
 				);
 			}
 
@@ -640,7 +640,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'selected="selected"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					$level_text
+					esc_html( $level_text )
 				);
 			}
 
@@ -648,7 +648,7 @@ function give_output_levels( $form_id ) {
 			if ( give_is_setting_enabled( $custom_amount ) && ! empty( $custom_amount_text ) ) {
 				$output .= sprintf(
 					'<option data-price-id="custom" class="give-donation-level-custom" value="custom">%1$s</option>',
-					$custom_amount_text
+					esc_html( $custom_amount_text )
 				);
 			}
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -218,7 +218,11 @@
 					const compare = position === 'before' ? symbol + value : value + symbol;
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
-						const wrap = `<span class="give-tooltip hint--top hint--bounce ${ text.length < 50 ? 'narrow' : '' }" style="width: 100%" aria-label="${ text.length < 50 ? text : text.substr( 0, 50 ) + '...' }" rel="tooltip"></span>`;
+						const wrap = document.createElement('span');
+						wrap.classList.add('give-tooltip', 'hint--top', 'hint--bounce', text.length < 50 ? 'narrow' : '');
+						wrap.style.width = '100%';
+						wrap.setAttribute('aria-label', text.length < 50 ? text : text.substr( 0, 50 ) + '...');
+						wrap.setAttribute('rel', 'tooltip');
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -222,7 +222,6 @@
 						wrap.classList.add('give-tooltip', 'hint--top', 'hint--bounce', text.length < 50 ? 'narrow' : '');
 						wrap.style.width = '100%';
 						wrap.setAttribute('aria-label', text.length < 50 ? text : text.substr( 0, 50 ) + '...');
-						wrap.setAttribute('rel', 'tooltip');
 						$( this ).wrap( wrap );
 						$( this ).attr( 'has-tooltip', true );
 					}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5876 

## Description

This tackles the problem that tooltips weren't being escaped properly, allowing in side-effects. The issue was that the tooltip being rendered was simply grabbing the node text without escaping it, and applying it directly to the attribute as a string.

Now, the node element is created and constructed using the DOM functions, which handle escaping and such properly.

## Affects

Donation tooltip options

## Visuals

![Image 2021-07-13 at 2 58 31 PM](https://user-images.githubusercontent.com/2024145/125530761-09d918ea-ba21-46c2-af69-8a70aff47bfb.jpg)

![Image 2021-07-13 at 2 59 04 PM](https://user-images.githubusercontent.com/2024145/125530817-1e6b3bb4-5960-4f1c-b1ed-8b5baad226e8.jpg)


## Testing Instructions

Set the following as the Text for a Donation Option: `"onmouseover=alert(/OOPS/)//`, then hover over that donation option in the form. It **should now** open an alert.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

