### PR TITLE
Creating a donation form programmatically no longer throws an undefined index error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add top margin to setting group page (#5864)
 -   Card declines on multi-step form now display an error message on first click (#5868)
 -   GiveWP is not causing deprecation warnings on PHP8 anymore (#5872)
+-   Creating a donation form programmatically no longer throws an undefined index error (#5882)
 
 ### Changes
 

--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -70,6 +70,14 @@ class LegacyFormSettingCompatibility {
 					continue;
 				}
 
+				/**
+				 * Prevents an undefined index error of the field id is not set in the settings group.
+				 * @unreleased
+				 */
+				if ( ! isset( $settings[ $groupId ] ) || ! isset( $settings[ $groupId ][ $field['id'] ] ) ) {
+					continue;
+				}
+
 				Give()->form_meta->update_meta( $formId, $field[ self::$key ], $settings[ $groupId ][ $field['id'] ] );
 				$alreadySavedLegacySettings[] = $field[ self::$key ];
 			}

--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -72,6 +72,7 @@ class LegacyFormSettingCompatibility {
 
 				/**
 				 * Prevents an undefined index error of the field id is not set in the settings group.
+				 * @link https://github.com/impress-org/givewp/pull/5882
 				 * @unreleased
 				 */
 				if ( ! isset( $settings[ $groupId ] ) || ! isset( $settings[ $groupId ][ $field['id'] ] ) ) {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I ran across this while create a donation form programmatically for Peer-to-peer, which was causing an undefined index error in the `LegacyFormSettingsCompatibility` class. This was likely also happening when creating a donation for programmatically during Onboarding, although the error was likely suppressed because of the AJAX request context.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

```php
use Give\Onboarding\DefaultFormFactory;

give( DefaultFormFactory::class )->make();
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

