### PR TITLE
Remove deprecation notices for hooks core is using

### DIFF
--- a/src/Form/LegacyConsumer/TemplateHooks.php
+++ b/src/Form/LegacyConsumer/TemplateHooks.php
@@ -20,7 +20,6 @@ class TemplateHooks {
 		'payment_mode_after_gateways_wrap',
 		'payment_mode_bottom',
 		'donation_form',
-		'donation_form_top',
 		'purchase_form_top',
 		'donation_form_register_login_fields',
 		'donation_form_before_cc_form',
@@ -31,8 +30,6 @@ class TemplateHooks {
 		'after_cc_fields',
 		'donation_form_after_cc_form',
 		'purchase_form_bottom',
-		'donation_form_before_personal_info',
-		'donation_form_after_personal_info',
 	];
 
 	public function walk( callable $callback ) {


### PR DESCRIPTION
Two commits in #5843 added deprecation notices for hooks that core was using. This removes the notices.

Reverts 59729b2c106434e30ac6fda23e4c888a4f1fe30f.
Reverts 2aff65a7f54f2367bcf562e741b361a0f835f51c.
