### PR TITLE
Only walk fields for commands that deal with fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   Update field descriptions to be more legible for accessibility (#5875)
--   Refactor `Give\Framework\FieldsAPI` to include classes for each node type (#5843)
+-   Refactor `Give\Framework\FieldsAPI` to include classes for each node type (#5843, #5885)
 
 ## 2.11.3 - 2021-07-06
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
@@ -35,7 +35,7 @@ class SetupFieldConfirmation {
 		$collection = Group::make( $hook );
 		do_action( "give_fields_{$hook}", $collection, $formID );
 
-		$collection->walk( [ $this, 'render' ] );
+		$collection->walkFields( [ $this, 'render' ] );
 	}
 
 	/**

--- a/src/Form/LegacyConsumer/Commands/SetupFieldReceipt.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldReceipt.php
@@ -35,7 +35,7 @@ class SetupFieldReceipt {
 		$collection = Group::make( $hook );
 		do_action( "give_fields_{$hook}", $collection, $formID );
 
-		$collection->walk( [ $this, 'apply' ] );
+		$collection->walkFields( [ $this, 'apply' ] );
 	}
 
 	/**

--- a/src/Form/LegacyConsumer/Commands/SetupPaymentDetailsDisplay.php
+++ b/src/Form/LegacyConsumer/Commands/SetupPaymentDetailsDisplay.php
@@ -32,7 +32,7 @@ class SetupPaymentDetailsDisplay {
 		$collection = Group::make( $hook );
 		do_action( "give_fields_{$hook}", $collection, get_the_ID() );
 
-		$collection->walk( [ $this, 'render' ] );
+		$collection->walkFields( [ $this, 'render' ] );
 	}
 
 	/**


### PR DESCRIPTION
This fixes an issue where some Legacy Consumer commands were walking more than just fields. This updates the commands to use `walkFields` method instead of `walk`.
