### PR TITLE
Fields API: add missing types to `Types` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Add missing `TYPE` to Fields API `Group` node type (#5895)
+-   Add missing Fields API node types to `Types` (#5891)
 
 ## 2.12.1 - 2021-07-22
 

--- a/src/Framework/FieldsAPI/Types.php
+++ b/src/Framework/FieldsAPI/Types.php
@@ -4,12 +4,15 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased add Form and Group
  */
 class Types {
 	const CHECKBOX = Checkbox::TYPE;
 	const DATE     = Date::TYPE;
 	const EMAIL    = Email::TYPE;
 	const FILE     = File::TYPE;
+	const FORM     = Form::TYPE;
+	const GROUP    = Group::TYPE;
 	const HIDDEN   = Hidden::TYPE;
 	const PHONE    = Phone::TYPE;
 	const RADIO    = Radio::TYPE;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I just noticed that this file was incomplete so I added the missing types. This could prevent bugs if the class was being used as an exhaustive reference for all the node types (the `Factory` class is doing this).

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->


`Give\Framework\FieldsAPI\Types` and anything that uses it.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
