### PR TITLE
Fields API: set `File` validation rules using `ValidationRules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Add missing `TYPE` to Fields API `Group` node type (#5895)
+-   Set validation rules correcetly for Fields API `File` (#5892)
 
 ## 2.12.1 - 2021-07-22
 

--- a/src/Framework/FieldsAPI/File.php
+++ b/src/Framework/FieldsAPI/File.php
@@ -18,11 +18,15 @@ class File extends Field {
 
 	const TYPE = 'file';
 
-	/** @var int */
-	protected $maxSize = 1024;
+	/**
+	 * @param $name
+	 */
+	public function __construct( $name ) {
+		parent::__construct( $name );
 
-	/** @var string[] */
-	protected $allowedTypes = [ '*' ];
+		$this->validationRules->rule( 'maxSize', 1024 );
+		$this->validationRules->rule( 'allowedTypes', [ '*' ] );
+	}
 
 	/**
 	 * Set the maximum file size.
@@ -31,7 +35,7 @@ class File extends Field {
 	 * @return $this
 	 */
 	public function maxSize( $maxSize ) {
-		$this->maxSize = $maxSize;
+		$this->validationRules->rule( 'maxSize', $maxSize );
 		return $this;
 	}
 
@@ -41,7 +45,7 @@ class File extends Field {
 	 * @return int
 	 */
 	public function getMaxSize() {
-		return $this->maxSize;
+		return $this->validationRules->getRule( 'maxSize' );
 	}
 
 	/**
@@ -50,8 +54,8 @@ class File extends Field {
 	 * @param string[] $allowedTypes
 	 * @return $this
 	 */
-	public function allowedTypes( $allowedTypes = [ '*' ] ) {
-		$this->allowedTypes = $allowedTypes;
+	public function allowedTypes( $allowedTypes ) {
+		$this->validationRules->rule( 'allowedTypes', $allowedTypes );
 		return $this;
 	}
 
@@ -61,6 +65,6 @@ class File extends Field {
 	 * @return string[]
 	 */
 	public function getAllowedTypes() {
-		return $this->allowedTypes;
+		return $this->validationRules->getRule( 'allowedTypes' );
 	}
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The custom validation rules set in `File` were not updated to use the `ValidationRules $validationRules` property on the `Field` class. This PR updates them to do that. This is important since otherwise the rules will appear top-level instead of with all the validation rules during serialization.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

`Give\Framework\FieldsAPI\File`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
