### PR TITLE
Filtered donation level text no longer breaks form HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Filtered donation level text no longer breaks form HTML (#5894)
+
 ## 2.12.0 - 2021-07-21
 
 ### Added

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -551,7 +551,7 @@ function give_output_levels( $form_id ) {
 					$level_classes,
 					$formatted_amount,
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_attr( strip_tags( $level_text ) )
+					$level_text
 				);
 			}
 
@@ -593,7 +593,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'checked="checked"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					strip_tags( $level_text )
+					$level_text
 				);
 			}
 
@@ -641,7 +641,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'selected="selected"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					strip_tags( $level_text )
+					$level_text
 				);
 			}
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -500,7 +500,6 @@ add_action( 'give_donation_form_top', 'give_output_donation_amount_top', 10, 2 )
  * Outputs the Donation Levels in various formats such as dropdown, radios, and buttons.
  *
  * @since  1.0
- * @unreleased Stripe HTML tags from rendered level text https://github.com/impress-org/givewp/pull/5894
  *
  * @param int $form_id The form ID.
  * @return string Donation levels.

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -499,10 +499,11 @@ add_action( 'give_donation_form_top', 'give_output_donation_amount_top', 10, 2 )
 /**
  * Outputs the Donation Levels in various formats such as dropdown, radios, and buttons.
  *
- * @param int $form_id The form ID.
- *
- * @return string Donation levels.
  * @since  1.0
+ * @unreleased Stripe HTML tags from rendered level text https://github.com/impress-org/givewp/pull/5894
+ *
+ * @param int $form_id The form ID.
+ * @return string Donation levels.
  */
 function give_output_levels( $form_id ) {
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -593,7 +593,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'checked="checked"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_html( strip_tags( $level_text ) )
+					strip_tags( $level_text )
 				);
 			}
 
@@ -641,7 +641,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'selected="selected"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_html( strip_tags( $level_text ) )
+					strip_tags( $level_text )
 				);
 			}
 

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -550,7 +550,7 @@ function give_output_levels( $form_id ) {
 					$level_classes,
 					$formatted_amount,
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_attr( $level_text )
+					esc_attr( strip_tags( $level_text ) )
 				);
 			}
 
@@ -592,7 +592,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'checked="checked"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_html( $level_text )
+					esc_html( strip_tags( $level_text ) )
 				);
 			}
 
@@ -640,7 +640,7 @@ function give_output_levels( $form_id ) {
 					$formatted_amount,
 					( give_is_default_level_id( $price ) ? 'selected="selected"' : '' ),
 					array_key_exists( '_give_default', $price ) ? 1 : 0,
-					esc_html( $level_text )
+					esc_html( strip_tags( $level_text ) )
 				);
 			}
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -219,7 +219,10 @@
 					// Setup tooltip unless for custom donation level, or if level label matches value
 					if ( value !== 'custom' && text !== compare ) {
 						const wrap = document.createElement('span');
-						wrap.classList.add('give-tooltip', 'hint--top', 'hint--bounce', text.length < 50 ? 'narrow' : '');
+						wrap.classList.add('give-tooltip', 'hint--top', 'hint--bounce');
+						if( text.length < 50 ) {
+							wrap.classList.add( 'narrow' );
+						}
 						wrap.style.width = '100%';
 						wrap.setAttribute('aria-label', text.length < 50 ? text : text.substr( 0, 50 ) + '...');
 						$( this ).wrap( wrap );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5893

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

There are two things going on here.

First, a class is conditionally added if the text is "short" (less than 50 characters) - otherwise the value is an empty string.. This is done with a ternary inside of `classList.add()`. When passing an empty class `classList` throws an error. Instead, this PR conditionally adds the class as a separate statement.

Second, the Recurring Donations add-on (or any use of the `give_form_level_text` that included HTML would show escaped HTML in the rendered text. This PR strips HTML tags when outputting the text.

Note: While originally reported as a conflict with the Recurring Donation add-on, the issue is replicated with a simple filter of the level text. Therefor all changes are made in GiveWP.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Sequoia
| Before | After |
| --- | --- |
| ![Screenshot from 2021-07-22 14-27-38](https://user-images.githubusercontent.com/10858303/126693005-4953da02-a651-4fc8-8fdd-dbdfb48953c1.png) | ![Screenshot from 2021-07-22 14-27-50](https://user-images.githubusercontent.com/10858303/126693004-198a8a9a-1091-44bf-bdda-a8dd6e96e4e0.png) |

### Legacy
| Before | After |
| --- | --- |
| ![Screenshot from 2021-07-22 14-28-13](https://user-images.githubusercontent.com/10858303/126693003-fb7bbab3-0a41-46c1-b9fa-d8453850830e.png) | ![Screenshot from 2021-07-22 14-28-24](https://user-images.githubusercontent.com/10858303/126693002-17756d07-7794-494e-a4f5-7ccbbb294423.png) |

| Buttons | Radio | Select |
| --- | --- | --- |
| ![Screenshot from 2021-07-22 14-39-18](https://user-images.githubusercontent.com/10858303/126692993-f87c0e49-c601-4e0f-9c80-3bb1d0fd79cb.png) | ![Screenshot from 2021-07-22 14-39-07](https://user-images.githubusercontent.com/10858303/126692997-ab00851a-834c-4527-ad37-9f2e4358b394.png) | ![Screenshot from 2021-07-22 14-38-52](https://user-images.githubusercontent.com/10858303/126693001-e855b398-be79-4463-b522-77b9e72703b1.png) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

### Reduced test case

```php
add_filter( 'give_form_level_text', function( $level_text, $form_id, $level ) {
    return $level_text . ' ' . "<span>Hello World</span>";
}, 10, 3);

```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

