### PR TITLE
Fields API: add missing type to `Group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Add missing `TYPE` to Fields API `Group` node type (#5895)
+
 ## 2.12.0 - 2021-07-21
 
 ### Added

--- a/src/Framework/FieldsAPI/Group.php
+++ b/src/Framework/FieldsAPI/Group.php
@@ -18,6 +18,11 @@ class Group implements Node, Collection {
 	use Concerns\SerializeAsJson;
 	use Concerns\WalkNodes;
 
+	/**
+	 * @unreleased
+	 */
+	const TYPE = 'group';
+
 	public function __construct( $name ) {
 		$this->name = $name;
 	}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds the missing `TYPE` constant to the `Group` node type.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

`Give\Framework\FieldsAPI\Group` and by effect `Give\Framework\FieldsAPI\Types` once #5891 is merged.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
