### PR TITLE
Fixes for checkbox template

### DIFF
--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -1,12 +1,11 @@
 <?php /** @var Give\Framework\FieldsAPI\Checkbox $field */ ?>
 <?php /** @var string $typeAttribute */ ?>
-<label class="give-label" for="<?php echo $field->getName(); ?>">
+<label class="give-label" for="give-<?php echo $field->getName(); ?>">
 	<?php echo $field->getLabel(); ?></label>
 <input
 	type="checkbox"
 	id="give-<?php echo $field->getName(); ?>"
 	name="<?php echo $field->getName(); ?>"
-	placeholder="<?php echo $field->getLabel(); ?>"
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isChecked() ? 'checked' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>


### PR DESCRIPTION
## Description

the `placeholder` attribute does not have any effect on checkboxes. But if you happen to use HTML in your label, rendering it can lead to display errors, so remove it.

Also the `for` attribute of the label has to correspond to the `id` attribute of the checkbox, otherwise clicking the label will not affect the checkbox

## Affects

Labels on checkboxes are now clickable again and HTML labels don't break rendering

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

