### PR TITLE
Fields API: add Html node type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   Add `Html` node type to Fields API (#5898)
+
 ### Fixed
 
 -   Add missing `TYPE` to Fields API `Group` node type (#5895)
@@ -14,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add missing Fields API node types to `Types` (#5891)
 -   Remove placeholder from Legacy Consumer checkbox template (#5897)
 -   Use correct ID in Legacy Consumer checkbox label for attribute (#5897)
+
+### Changed
+
+-   Add `HTML` constant to `Give\Framework\FieldsAPI\Types` for `Html` node type (#5898)
 
 ## 2.12.1 - 2021-07-22
 

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -26,6 +26,12 @@ class FieldView {
 	public static function render( Node $field ) {
 		$type = $field->getType();
 
+		if ( $type === Types::HTML ) {
+			echo do_shortcode( $field->getHtml() );
+
+			return;
+		}
+
 		if ( $type === Types::HIDDEN ) {
 			include static::getTemplatePath( 'hidden' );
 

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -26,12 +26,6 @@ class FieldView {
 	public static function render( Node $field ) {
 		$type = $field->getType();
 
-		if ( $type === Types::HTML ) {
-			echo do_shortcode( $field->getHtml() );
-
-			return;
-		}
-
 		if ( $type === Types::HIDDEN ) {
 			include static::getTemplatePath( 'hidden' );
 
@@ -43,6 +37,7 @@ class FieldView {
 		echo "<div class=\"form-row form-row-wide\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";
 		// By default, new fields will use templates/label.html.php and templates/base.html.php
 		switch ( $type ) {
+			case Types::HTML:
 			case Types::CHECKBOX:
 			case Types::RADIO: // Radio provides its own label
 				include static::getTemplatePath( $type );

--- a/src/Form/LegacyConsumer/templates/html.html.php
+++ b/src/Form/LegacyConsumer/templates/html.html.php
@@ -1,2 +1,4 @@
+<?php
+
 /** @var Give\Framework\FieldsAPI\Html $field */
-<?= do_shortcode( $field->getHtml() ) ?>
+echo do_shortcode( $field->getHtml() );

--- a/src/Form/LegacyConsumer/templates/html.html.php
+++ b/src/Form/LegacyConsumer/templates/html.html.php
@@ -1,0 +1,2 @@
+/** @var Give\Framework\FieldsAPI\Html $field */
+<?= do_shortcode( $field->getHtml() ) ?>

--- a/src/Framework/FieldsAPI/Html.php
+++ b/src/Framework/FieldsAPI/Html.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Give\Framework\FieldsAPI;
+
+/**
+ * @unreleased
+ */
+class Html extends Element {
+
+	const TYPE = 'html';
+
+	/** @var string */
+	protected $html = '';
+
+	/**
+	 * Set the HTML for the element.
+	 *
+	 * @unreleased
+	 *
+	 * @param string $html
+	 * @return $this
+	 */
+	public function html( $html ) {
+		$this->html = $html;
+
+		return $this;
+	}
+
+	/**
+	 * Get the HTML for the element.
+	 *
+	 * @unreleased
+	 *
+	 * @return string
+	 */
+	public function getHtml() {
+		return $this->html;
+	}
+}

--- a/src/Framework/FieldsAPI/Types.php
+++ b/src/Framework/FieldsAPI/Types.php
@@ -4,7 +4,7 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
- * @unreleased add Form and Group
+ * @unreleased add Form, Group, and Html
  */
 class Types {
 	const CHECKBOX = Checkbox::TYPE;
@@ -14,6 +14,7 @@ class Types {
 	const FORM     = Form::TYPE;
 	const GROUP    = Group::TYPE;
 	const HIDDEN   = Hidden::TYPE;
+	const HTML     = Html::TYPE;
 	const PHONE    = Phone::TYPE;
 	const RADIO    = Radio::TYPE;
 	const SELECT   = Select::TYPE;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

As a part of updating the Form Field Manager addon to use the new Fields API, we need to support some of its types which are not all desirable to add to core. In the last cycle, we created an `Html` type which was a sort of back door for us to allow creating some of these types. It was also this particular type which helped us realize the helpful distinction between fields and non-fields in a form.

This is an `Element` type of `Node`. This means that it is a non-`Field` which means that can be filtered out of a collection when appropriate (e.g. registering "required" fields — this wouldn’t make sense for a non-field).

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Adds `Html` class to `Give\Framework\FieldsAPI`.
- Adds `HTML` constant to `Give\Framework\FieldsAPI\Types`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This is no manual testing required for this PR (other than making sure existing Fields API usage isn’t broken).

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
