### PR TITLE
Donors without donations no longer see others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add missing Fields API node types to `Types` (#5891)
 -   Remove placeholder from Legacy Consumer checkbox template (#5897)
 -   Use correct ID in Legacy Consumer checkbox label for attribute (#5897)
+-   Donors with no donations no longer see others (#5908)
 
 ### Changed
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -117,7 +117,7 @@ class Donations {
 
 		$ids = $this->getDonationIds( $donorId );
 
-		if ( $ids === null ) {
+		if ( empty( $ids ) ) {
 			return null;
 		}
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -109,8 +109,11 @@ class Donations {
 	/**
 	 * Get all donations by donor ID
 	 *
-	 * @param int $donorId
+	 * @unreleased return null if donation ids is empty
 	 * @since 2.10.0
+	 *
+	 * @param int $donorId
+	 *
 	 * @return array Donations
 	 */
 	public function getDonations( $donorId ) {

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
@@ -83,20 +83,12 @@ const Content = () => {
 		</Fragment>
 	) : (
 		<Fragment>
-			{ ( ! donations ) ? (
-				<Fragment>
-					<Heading icon="exclamation-triangle">
-						{ __( 'No Donations', 'give' ) }
-					</Heading>
-				</Fragment>
-			) : (
-				<Fragment>
-					<Heading>
-						{ `${ donations ? Object.entries( donations ).length : 0 } ${ __( 'Total Donations', 'give' ) }` }
-					</Heading>
-					<DonationTable donations={ donations } perPage={ 5 } />
-				</Fragment>
-			) }
+			 <Fragment>
+				 <Heading>
+					  { `${ donations ? Object.entries( donations ).length : 0 } ${ __( 'Total Donations', 'give' ) }` }
+				 </Heading>
+				 <DonationTable donations={ donations } perPage={ 5 } />
+			 </Fragment>
 		</Fragment>
 	);
 };

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
@@ -36,16 +36,6 @@ const DashboardContent = () => {
 		);
 	}
 
-	if ( ! donations ) {
-		return (
-			<Fragment>
-				<Heading icon="exclamation-triangle">
-					{ __( 'No Donations', 'give' ) }
-				</Heading>
-			</Fragment>
-		);
-	}
-
 	return (
 		<Fragment>
 			<Heading icon="chart-line">


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5907 

## Description

This PR makes sure that when an admin deletes a donor's donations, and that donor logs in, that donor does not see others donations. It was a very simple fix, as a null check was being done on an empty array, but it's an important fix.

## Affects

Donor Dashboard donation details

## Visuals

![Image 2021-07-30 at 9 59 51 AM](https://user-images.githubusercontent.com/2024145/127700763-4b425b4c-d160-419f-aaff-968a31e6cf92.jpg)


## Testing Instructions

1. Make a donation as a new donor
2. Log in as an admin
3. Delete that donor's donation(s)
4. View the Donor Dashboard as that donor
5. There should be no donations

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

