### PR TITLE
fix: sepa payment form not submitted

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -244,7 +244,11 @@ jQuery( document ).ready( function( $ ) {
 				//Remove any errors
 				this_form.find( '.give_errors' ).remove();
 				//Submit form for normal processing
-				$( give_purchase_form ).submit();
+				if ( this_form.find( 'input.give-gateway:checked' ).val() == 'paypal' ) {
+					give_purchase_form.submit();
+				} else {
+					give_purchase_form.dispatchEvent(new Event('submit'));
+				}
 
 				this_form.trigger( 'give_form_validation_passed' );
 			} else {

--- a/assets/src/js/frontend/give-stripe-sepa.js
+++ b/assets/src/js/frontend/give-stripe-sepa.js
@@ -113,18 +113,21 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		} else {
 			giveStripeUnmountIbanElements( ibanElements );
 		}
+		
+		
+		// Process Donation using Stripe Elements on form submission.
+		formElement.addEventListener('submit', function(event) {
+			const $form = jQuery( this );
+			const $idPrefix = $form.find( 'input[name="give-form-id-prefix"]' ).val();
+
+			if ( 'stripe_sepa' === $form.find( 'input.give-gateway:checked' ).val() ) {
+				give_stripe_process_iban( $form, globalIbanElements[ $idPrefix ][ 0 ].item );
+				event.preventDefault();
+			}
+		});
 	} );
 
-	// Process Donation using Stripe Elements on form submission.
-	jQuery( 'body' ).on( 'submit', '.give-form', function( event ) {
-		const $form = jQuery( this );
-		const $idPrefix = $form.find( 'input[name="give-form-id-prefix"]' ).val();
 
-		if ( 'stripe_sepa' === $form.find( 'input.give-gateway:checked' ).val() ) {
-			give_stripe_process_iban( $form, globalIbanElements[ $idPrefix ][ 0 ].item );
-			event.preventDefault();
-		}
-	} );
 
 	/**
 	 * Mount Card Elements

--- a/assets/src/js/frontend/give-stripe.js
+++ b/assets/src/js/frontend/give-stripe.js
@@ -83,7 +83,7 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 		// Mount & unmount when the users selects a gateway
 		document.addEventListener( 'give_gateway_loaded', mountStripeElements );
 
-		formElement.onsubmit = ( e ) => {
+		formElement.addEventListener('submit', function(e) {
 			const { selectedGatewayId, isStripeModalCheckoutGateway } = getFormState();
 
 			// Bailout, if Stripe is not the selected gateway.
@@ -125,6 +125,6 @@ document.addEventListener( 'DOMContentLoaded', function( e ) {
 				}
 				e.preventDefault();
 			}
-		}
+		});
 	} );
 } );


### PR DESCRIPTION
The sepa payment form has not been submitted resulting in the following error:

> post_title:Stripe Payment Intent Error
> post_content:Unable to create a payment intent. Details: No such PaymentMethod: '0'


## Affects

SEPA Payment form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

