### PR TITLE
Payment errors no longer revert to the default donation amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+-   Payment errors no longer revert to the default donation amount (#5913)
+
 ## 2.12.2 - 2020-07-30
 
 ### Added

--- a/assets/src/js/frontend/give.js
+++ b/assets/src/js/frontend/give.js
@@ -20,6 +20,10 @@ import './give-donor-wall';
 import iFrameResizer from '../plugins/form-template/iframe-content';
 import '../plugins/form-template/parent-page';
 
+window.addEventListener('load', function() {
+	window.Give.WINDOW_IS_LOADED = true;
+})
+
 const { init, fn, form, notice, cache, donor, util, share } = GiveAPI;
 window.Give = { init, fn, form, notice, cache, donor, util, share, initializeIframeResize };
 window.iFrameResizer = iFrameResizer;

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -558,9 +558,9 @@ export default {
 
 			// Is this a custom amount selection?
 			if ( 'custom' === level_price_id ) {
-				// It is, so focus on the custom amount input.
-				$form.find( '.give-amount-top' ).val( '' ).focus();
-				return false; // Bounce out
+				const custom_amount = Give.fn.getParameterByName( 'custom-amount' );
+				$form.find( '.give-amount-top' ).val( custom_amount ).focus();
+				return true;
 			}
 
 			// Update custom amount field

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -6,10 +6,11 @@ export default {
 		this.fn.field.formatCreditCard( jQuery( 'form.give-form' ) );
 		this.fn.__initialize_cache();
 
+		// Run code on after window load.
+		// If the window has already loaded then call directly.
 		if( window.Give.WINDOW_IS_LOADED ) {
 			Give.form.fn.__sendBackToForm();
 		} else {
-			// Run code on after window load.
 			window.addEventListener('load', function () {
 				Give.form.fn.__sendBackToForm();
 			});

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -6,10 +6,14 @@ export default {
 		this.fn.field.formatCreditCard( jQuery( 'form.give-form' ) );
 		this.fn.__initialize_cache();
 
-		// Run code on after window load.
-		window.addEventListener( 'load', function() {
+		if( window.Give.WINDOW_IS_LOADED ) {
 			Give.form.fn.__sendBackToForm();
-		} );
+		} else {
+			// Run code on after window load.
+			window.addEventListener('load', function () {
+				Give.form.fn.__sendBackToForm();
+			});
+		}
 	},
 
 	fn: {

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -193,6 +193,11 @@ function give_send_back_to_checkout( $args = [] ) {
 	// Set the $level_id.
 	if ( isset( $_POST['give-price-id'] ) ) {
 		$defaults['level-id'] = sanitize_text_field( $_POST['give-price-id'] );
+
+		// If custom, set amount
+		if( 'custom' === $defaults[ 'level-id' ] ) {
+			$defaults['custom-amount'] = sanitize_text_field( $_POST['give-amount'] );
+		}
 	}
 
 	// Check for backward compatibility.


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5912

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a flag when the page is loaded for reference to prevent a race condition when adding an event listener.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Intentionally triggering a payment error, ie card declined, should restore the user selected donation amount after the donation is attempted.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

