### PR TITLE
Legacy Consumer: allow custom class name on root element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### New
+
+- Add `give_form_{ID}_field_classes_{fieldName}` hook to legacy consumer for setting classes on field wrapper (#5917)
+
 ## 2.13.1 - 2021-08-20
 
 ### Fixed
@@ -22,7 +26,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add conditional visibility functionality to `FieldsAPI` `Field`, `Element`, and `Group` types (#5919)
 - Introduce `BasicCondition` and `NestedCondition` classes for expressing conditional logic in the Fields API (#5919)
 
-###  Changed
+### Changed
 
 - Add missing help text tooltip to Legacy Consumer’s label content templates. (#5921)
 - Wrap `<input>` element inside of `<label>` element for Legacy Consumer’s checkbox template. (#5920)

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -21,10 +21,14 @@ class SetupNewTemplateHook implements HookCommandInterface {
 		// On the old hook, run the new hook and render the fields.
 		add_action(
 			"give_$hook",
-			function ( $formID ) use ( $hook ) {
+			static function ( $formID ) use ( $hook ) {
 				$collection = Group::make( $hook );
 				do_action( "give_fields_$hook", $collection, $formID );
-				$collection->walk( [ FieldView::class, 'render' ] );
+				$collection->walk(
+					static function ( $node ) use ( $formID ) {
+						FieldView::render( $node, $formID );
+					}
+				);
 			}
 		);
 	}

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -7,6 +7,7 @@ use Give\Framework\FieldsAPI\Contracts\Node;
 
 /**
  * @since 2.10.2
+ * @unreleased Add field classes hook for setting custom class names on the wrapper.
  */
 class FieldView {
 	const INPUT_TYPE_ATTRIBUTES = [
@@ -17,12 +18,14 @@ class FieldView {
 
 	/**
 	 * @since 2.10.2
+	 * @unreleased add $formID as a param
 	 *
 	 * @param Node $field
+	 * @param int $formID
 	 *
 	 * @return void
 	 */
-	public static function render( Node $field ) {
+	public static function render( Node $field, $formID ) {
 		$type = $field->getType();
 
 		if ( $type === Types::HIDDEN ) {
@@ -31,7 +34,7 @@ class FieldView {
 			return;
 		}
 
-		$classList = apply_filters( "give_form_field_classes_{$field->getName()}", [ 'form-row', 'form-row-wide' ] );
+		$classList = apply_filters( "give_form_{$formID}_field_classes_{$field->getName()}", [ 'form-row', 'form-row-wide' ] );
 		$className = implode( ' ', array_unique( $classList ) );
 
 		echo "<div class=\"{$className}\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -31,7 +31,7 @@ class FieldView {
 			return;
 		}
 
-		$classList = apply_filters( "give_form_field_class_name_{$field->getName()}", [ 'form-row', 'form-row-wide' ] );
+		$classList = apply_filters( "give_form_field_classes_{$field->getName()}", [ 'form-row', 'form-row-wide' ] );
 		$className = implode( ' ', array_unique( $classList ) );
 
 		echo "<div class=\"{$className}\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -31,7 +31,8 @@ class FieldView {
 			return;
 		}
 
-		$className = apply_filters( "give_form_field_class_name_{$field->getName()}", "form-row form-row-wide" );
+		$classList = apply_filters( "give_form_field_class_name_{$field->getName()}", [ 'form-row', 'form-row-wide' ] );
+		$className = implode( ' ', array_unique( $classList ) );
 
 		echo "<div class=\"{$className}\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";
 		// By default, new fields will use templates/label.html.php and templates/base.html.php

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -12,7 +12,6 @@ class FieldView {
 	const INPUT_TYPE_ATTRIBUTES = [
 		Types::PHONE    => 'tel',
 		Types::EMAIL    => 'email',
-		Types::CHECKBOX => 'checkbox',
 		Types::URL      => 'url',
 	];
 

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -32,9 +32,9 @@ class FieldView {
 			return;
 		}
 
-		// Set the class for the input element (used in the templates)
+		$className = apply_filters( "give_form_field_class_name_{$field->getName()}", "form-row form-row-wide" );
 
-		echo "<div class=\"form-row form-row-wide\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";
+		echo "<div class=\"{$className}\" data-field-type=\"{$field->getType()}\" data-field-name=\"{$field->getName()}\">";
 		// By default, new fields will use templates/label.html.php and templates/base.html.php
 		switch ( $type ) {
 			case Types::HTML:


### PR DESCRIPTION

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5916

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Since the Fields API does not support setting class names, we decided that consumers should use hooks for this instead. This pull request adds a hook/filter for setting a custom class name on the root element for a field.

The hook name is `give_form_{ID}_field_classes_{fieldName}`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Legacy consumer renderer

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Try the filter out when registering fields.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
