### PR TITLE
Legacy Consumer: remove undefined variable in Textarea template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Payment errors no longer revert to the default donation amount (#5913)
+-   Removed an undefined variable error from being set as the class name for textareas rendered by the Legacy Consumer (#5918)
 
 ## 2.12.2 - 2020-07-30
 

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -1,7 +1,5 @@
 <?php /** @var Give\Framework\FieldsAPI\Textarea $field */ ?>
-<?php /** @var string $classAttribute */ ?>
 <textarea
-  class="<?php echo $classAttribute; ?>"
   name="give_<?php echo $field->getName(); ?>"
   id="give-<?php echo $field->getName(); ?>"
 	<?php if ( $field->isRequired() ) : ?>


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This removes an variable that was previously defined from being used in the textarea template. Right now the error doesn’t show up since it is being echo’d into the class attribute on the `<textarea>` elements.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Textareas rendered by the legacy consumer.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Check that textareas rendered by the legacy consumer don’t have a class attribute anymore.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
