### PR TITLE
Add missing help text support to Legacy Consumer’s label content and radio templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ###  Changed
 
-- Add missing help text support tto Legacy Consumer’s label content and radio templates. (#5921)
+- Add missing help text support to Legacy Consumer’s label content and radio templates. (#5921)
 - Wrap `<input>` element inside of `<label>` element for Legacy Consumer’s checkbox template. (#5920)
 - Add missing `required` and `readonly` attributes to Legacy Consumer’s select and textarea templates. (#5920)
 - Add screen reader text for required indicator to Legacy Consumer’s label content template. (#5920) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ###  Changed
 
-- Add missing help text support to Legacy Consumer’s label content and radio templates. (#5921)
+- Add missing help text tooltip to Legacy Consumer’s label content templates. (#5921)
 - Wrap `<input>` element inside of `<label>` element for Legacy Consumer’s checkbox template. (#5920)
 - Add missing `required` and `readonly` attributes to Legacy Consumer’s select and textarea templates. (#5920)
 - Add screen reader text for required indicator to Legacy Consumer’s label content template. (#5920) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ###  Changed
 
+- Add missing help text support tto Legacy Consumer’s label content and radio templates. (#5921)
 - Wrap `<input>` element inside of `<label>` element for Legacy Consumer’s checkbox template. (#5920)
 - Add missing `required` and `readonly` attributes to Legacy Consumer’s select and textarea templates. (#5920)
 - Add screen reader text for required indicator to Legacy Consumer’s label content template. (#5920) 

--- a/src/Form/LegacyConsumer/templates/label-content.html.php
+++ b/src/Form/LegacyConsumer/templates/label-content.html.php
@@ -6,3 +6,8 @@
 		<span class="screen-reader-text"><?php esc_html_e( 'Required', 'give' ); ?></span>
 	</span>
 <?php endif; ?>
+<?php
+echo ( $helpText = $field->getHelpText() ) ?
+	Give()->tooltips->render_help( $helpText ) :
+	'';
+?>

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -6,11 +6,6 @@
 	</legend>
 	<div class="give-label" aria-hidden="true">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
-		<?php
-		echo ( $helpText = $field->getHelpText() ) ?
-			Give()->tooltips->render_help( $helpText ) :
-			'';
-		?>
 	</div>
 	<?php foreach ( $field->getOptions() as $option ) : ?>
 	<label>

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -6,6 +6,11 @@
 	</legend>
 	<div class="give-label" aria-hidden="true">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
+		<?php
+		echo ( $helpText = $field->getHelpText() ) ?
+			Give()->tooltips->render_help( $helpText ) :
+			'';
+		?>
 	</div>
 	<?php foreach ( $field->getOptions() as $option ) : ?>
 	<label>


### PR DESCRIPTION
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

