### PR TITLE
Lodash is now an external dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+-   Lodash is now an external dependency (#5925)
+
 ## 2.13.0 - 2021-08-19
 
 ### New

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
                 "iframe-resizer": "^4.2.10",
                 "jquery-chosen": "latest",
                 "jquery.payment": "latest",
-                "lodash": "^4.17.21",
                 "magnific-popup": "latest",
                 "moment": "^2.24.0",
                 "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
         "iframe-resizer": "^4.2.10",
         "jquery-chosen": "latest",
         "jquery.payment": "latest",
-        "lodash": "^4.17.21",
         "magnific-popup": "latest",
         "moment": "^2.24.0",
         "prop-types": "^15.7.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ const config = {
 	externals: {
 		$: 'jQuery',
 		jquery: 'jQuery',
+		lodash: 'lodash',
 		'@wordpress/i18n' : 'wp.i18n',
 	},
 	devtool: ! inProduction ? 'source-map' : '',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5926

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The Stripe UI updates added Lodash as an NPM dependency (and removed Lodash from the webpack externals). Since WordPress ships with Lodash we are creating a version conflict by bundling our own copy of Lodash.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

