### PR TITLE
Allow Fields API Text fields to repeat

### DIFF
--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -52,6 +52,12 @@ class FieldView {
 				include static::getTemplatePath( 'label' );
 				include static::getTemplatePath( $type );
 				break;
+			case Types::TEXT:
+				/** @var \Give\Framework\FieldsAPI\Text $field */
+				$typeAttribute = 'text';
+				include static::getTemplatePath( 'label' );
+				include static::getTemplatePath( $field->isRepeatable() ? 'repeatable-text' : 'base' );
+				break;
 			// By default, include a template and use the base input template.
 			default:
 				// Used in the template

--- a/src/Form/LegacyConsumer/templates/repeatable-text.html.php
+++ b/src/Form/LegacyConsumer/templates/repeatable-text.html.php
@@ -21,7 +21,7 @@
 					<i class="give-icon give-icon-plus"></i>
 				</span>
 				<span
-					class="ffm-clone-field give-tooltip hint--top"
+					class="ffm-remove-field give-tooltip hint--top"
 					data-tooltip="Click here to remove this field"
 					aria-label="Click here to remove this field"
 				>

--- a/src/Form/LegacyConsumer/templates/repeatable-text.html.php
+++ b/src/Form/LegacyConsumer/templates/repeatable-text.html.php
@@ -1,0 +1,33 @@
+<?php /** @var Give\Framework\FieldsAPI\Text $field */ ?>
+<table id="<?= $field->getName() ?>" class="give-repeater-table" data-max-repeat="" data-field-type="repeat">
+	<tbody>
+		<tr>
+			<td>
+				<input
+					type="text"
+					name="<?= "{$field->getName()}[]" ?>"
+					value="<?= $field->getDefaultValue() ?>"
+					placeholder="<?= $field->getPlaceholder() ?>"
+					<?= $field->isRequired() ? 'required' : '' ?>
+					<?= $field->isReadOnly() ? 'readonly' : '' ?>
+			   >
+			</td>
+			<td>
+				<span
+					class="ffm-clone-field give-tooltip hint--top"
+					data-tooltip="Click here to add another field"
+					aria-label="Click here to add another field"
+				>
+					<i class="give-icon give-icon-plus"></i>
+				</span>
+				<span
+					class="ffm-clone-field give-tooltip hint--top"
+					data-tooltip="Click here to remove this field"
+					aria-label="Click here to remove this field"
+				>
+					<i class="give-icon give-icon-minus"></i>
+				</span>
+			</td>
+		</tr>
+	</tbody>
+</table>

--- a/src/Form/LegacyConsumer/templates/repeatable-text.html.php
+++ b/src/Form/LegacyConsumer/templates/repeatable-text.html.php
@@ -1,5 +1,5 @@
 <?php /** @var Give\Framework\FieldsAPI\Text $field */ ?>
-<table id="<?= $field->getName() ?>" class="give-repeater-table" data-max-repeat="" data-field-type="repeat">
+<table id="<?= $field->getName() ?>" class="give-repeater-table" data-max-repeat="<?= (int) $field->getMaxRepeatable() ?>" data-field-type="repeat">
 	<tbody>
 		<tr>
 			<td>

--- a/src/Framework/FieldsAPI/Concerns/IsRepeatable.php
+++ b/src/Framework/FieldsAPI/Concerns/IsRepeatable.php
@@ -4,6 +4,8 @@ namespace Give\Framework\FieldsAPI\Concerns;
 
 /**
  * @unreleased
+ *
+ * @property ValidationRules $validationRules
  */
 trait IsRepeatable {
 
@@ -33,5 +35,31 @@ trait IsRepeatable {
 	 */
 	public function isRepeatable() {
 		return $this->repeatable;
+	}
+
+	/**
+	 * Set how many times this field can repeat.
+	 *
+	 * @unreleased
+	 *
+	 * @param int|null $maxRepeatable
+	 *
+	 * @return $this
+	 */
+	public function maxRepeatable( $maxRepeatable ) {
+		$this->validationRules->rule( 'maxRepeatable', $maxRepeatable );
+
+		return $this;
+	}
+
+	/**
+	 * Get how many times this field can repeat.
+	 *
+	 * @unreleased
+	 *
+	 * @return int|null
+	 */
+	public function getMaxRepeatable() {
+		return $this->validationRules->getRule( 'maxRepeatable' );
 	}
 }

--- a/src/Framework/FieldsAPI/Concerns/IsRepeatable.php
+++ b/src/Framework/FieldsAPI/Concerns/IsRepeatable.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\Concerns;
+
+/**
+ * @unreleased
+ */
+trait IsRepeatable {
+
+	/** @var bool */
+	protected $repeatable = false;
+
+	/**
+	 * Set if the field should be repeatable.
+	 *
+	 * @unreleased
+	 *
+	 * @param bool $isRepeatable
+	 *
+	 * @return $this
+	 */
+	public function repeatable( $isRepeatable = true ) {
+		$this->repeatable = $isRepeatable;
+		return $this;
+	}
+
+	/**
+	 * Get if the field should be repeatable.
+	 *
+	 * @unreleased
+	 *
+	 * @return bool
+	 */
+	public function isRepeatable() {
+		return $this->repeatable;
+	}
+}

--- a/src/Framework/FieldsAPI/Text.php
+++ b/src/Framework/FieldsAPI/Text.php
@@ -4,6 +4,7 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased Allow field to be repeated
  */
 class Text extends Field {
 
@@ -11,6 +12,7 @@ class Text extends Field {
 	use Concerns\HasHelpText;
 	use Concerns\HasLabel;
 	use Concerns\HasPlaceholder;
+	use Concerns\IsRepeatable;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;
 

--- a/tests/unit/tests/Framework/FieldsAPI/Concerns/IsRepeatableTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Concerns/IsRepeatableTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Give\Framework\FieldsAPI\Concerns\IsRepeatable;
+use Give\Framework\FieldsAPI\Text;
 use PHPUnit\Framework\TestCase;
 
 final class IsRepeatableTest extends TestCase {
@@ -19,5 +20,15 @@ final class IsRepeatableTest extends TestCase {
 		// Try setting back to false
 		$mock->repeatable( false );
 		$this->assertFalse( $mock->isRepeatable() );
+	}
+
+	public function testIsRepeatableValidation() {
+		$mock = Text::make( 'text' )->repeatable();
+
+		$this->assertNull( $mock->getMaxRepeatable() );
+
+		$mock->maxRepeatable( 4 );
+
+		$this->assertEquals( 4, $mock->getMaxRepeatable() );
 	}
 }

--- a/tests/unit/tests/Framework/FieldsAPI/Concerns/IsRepeatableTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Concerns/IsRepeatableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Give\Framework\FieldsAPI\Concerns\IsRepeatable;
+use PHPUnit\Framework\TestCase;
+
+final class IsRepeatableTest extends TestCase {
+
+	public function testIsRepeatable() {
+		/** @var IsRepeatable $mock */
+		$mock = $this->getMockForTrait( IsRepeatable::class );
+
+		// Default is false
+		$this->assertFalse( $mock->isRepeatable() );
+
+		// Try setting true
+		$mock->repeatable();
+		$this->assertTrue( $mock->isRepeatable() );
+
+		// Try setting back to false
+		$mock->repeatable( false );
+		$this->assertFalse( $mock->isRepeatable() );
+	}
+}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5904

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We’ve determined that fields should be allowed to repeat in the Fields API. This adds a trait to describe that capability. Right now, we are limiting this feature to just `Text` field types as that is the only type we need it for.

Repeatability is really just a descriptor, so there’s no complex API that needs to be implemented in the Fields API. The complexity is in the legacy consumer. All this adds is a getter and a setter for a protected property.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `Text` Fields API type.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

```php
<?php

$text = Give\Framework\FieldsAPI\Text::make('middleName');

$text->isRepeatable(); // false

$text->repeatable();

$text->isRepeatable(); // true

$text->maxRepeatable( 4 );

$text->repeatable( false ); 

$text->isRepeatable(); // false

echo json_encode($text, JSON_PRETTY_PRINT); // See repeatable prop on object
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [x] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
