### PR TITLE
Donation level id and amount value store as string for donation form generate in on-boarding process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+ 
+- Donation level id and amount value store as string for donation form generate in on-boarding process. (#5940)
+
 ## 2.13.2 - 2021-08-26
 
 ## Fixed

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -69,7 +69,7 @@ class Donations {
 					INNER JOIN {$wpdb->prefix}give_donationmeta as donationmeta ON revenue.donation_id = donationmeta.donation_id
 				WHERE donationmeta.meta_key = '_give_payment_donor_id'
 					AND donationmeta.meta_value = %d
-					AND posts.post_status IN ( 'publish', 'give_subscription' )
+					AND posts.post_status IN ( 'publish', 'give_subscription', 'pending' )
 			",
 				$donorId
 			)

--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -58,7 +58,7 @@ abstract class Route implements RestRoute {
 					'methods'             => 'POST',
 					'callback'            => [ $this, 'handleRequestWithDonorIdCheck' ],
 					'permission_callback' => function() {
-						return Give()->session->get_session_expiration() !== false;
+						return is_user_logged_in() || Give()->session->get_session_expiration() !== false;
 					},
 				],
 				'args' => $this->args(),

--- a/src/Onboarding/DefaultFormFactory.php
+++ b/src/Onboarding/DefaultFormFactory.php
@@ -152,38 +152,38 @@ class DefaultFormFactory {
 			[
 				'_give_id'     =>
 					[
-						'level_id' => 0,
+						'level_id' => '0',
 					],
-				'_give_amount' => 10,
+				'_give_amount' => give_sanitize_amount_for_db( 10 ),
 			],
 			[
 				'_give_id'     =>
 					[
-						'level_id' => 1,
+						'level_id' => '1',
 					],
-				'_give_amount' => 25,
+				'_give_amount' => give_sanitize_amount_for_db( 25 ),
 			],
 			[
 				'_give_id'     =>
 					[
-						'level_id' => 2,
+						'level_id' => '2',
 					],
-				'_give_amount' => 50,
+				'_give_amount' => give_sanitize_amount_for_db( 50 ),
 			],
 			[
 				'_give_id'      =>
 					[
-						'level_id' => 3,
+						'level_id' => '3',
 					],
-				'_give_amount'  => 100,
+				'_give_amount'  => give_sanitize_amount_for_db( 100 ),
 				'_give_default' => 'default',
 			],
 			[
 				'_give_id'     =>
 					[
-						'level_id' => 5,
+						'level_id' => '5',
 					],
-				'_give_amount' => 250,
+				'_give_amount' => give_sanitize_amount_for_db( 250 ),
 			],
 		];
 	}

--- a/src/Onboarding/DefaultFormFactory.php
+++ b/src/Onboarding/DefaultFormFactory.php
@@ -146,6 +146,7 @@ class DefaultFormFactory {
 	 * @return array
 	 *
 	 * @since 2.8.0
+	 * @unreleased Donation level id and amount value changed to string
 	 */
 	public function getDonationLevels() {
 		return [

--- a/src/Onboarding/DefaultFormFactory.php
+++ b/src/Onboarding/DefaultFormFactory.php
@@ -2,7 +2,7 @@
 
 namespace Give\Onboarding;
 
-use Give\Form\Template\Options as TempalteOptions;
+use Give\Form\Template\Options as TemplateOptions;
 
 /**
  * @since 2.8.0
@@ -127,7 +127,7 @@ class DefaultFormFactory {
 				'header_label' => __( 'Add Your Information', 'give' ),
 				'headline'     => __( "Who's giving today?", 'give' ),
 				'description'  => __( 'We’ll never share this information with anyone.', 'give' ),
-				TempalteOptions::getCheckoutLabelField(),
+				TemplateOptions::getCheckoutLabelField(),
 			],
 			'thank-you'           => [
 				'image'               => '',

--- a/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
+++ b/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Give\Onboarding\Migrations;
+
+use Give\Framework\Migrations\Contracts\Migration;
+use Give\Onboarding\FormRepository;
+
+/**
+ * This resolves an issue where the donation level data for the form created during onboarding was serialized as
+ * integers instead of strings, causing issues throughout
+ *
+ * @since 2.13.3
+ */
+class SetFormDonationLevelsToStrings extends Migration
+{
+	/**
+	 * @inheritDoc
+	 */
+	public static function id()
+	{
+		return 'set-form-donation-levels-to-strings';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function timestamp()
+	{
+		return strtotime('2020-09-01 11:47:00');
+	}
+
+	/**
+	 * @var FormRepository
+	 */
+	private $formRepository;
+
+	public function __construct(FormRepository $formRepository)
+	{
+		$this->formRepository = $formRepository;
+	}
+
+	public function run()
+	{
+		$formId = $this->formRepository->getDefaultFormID();
+
+		if (empty($formId)) {
+			return;
+		}
+
+		$donationLevels = give_get_meta($formId, '_give_donation_levels', true);
+
+		$updatedLevels = [];
+		foreach ($donationLevels as $level) {
+			$updatedLevels[] = [
+				'_give_id' => [
+					'level_id' => (string)$level['_give_id']['level_id'],
+				],
+				'_give_amount' => give_sanitize_amount_for_db($level['_give_amount']),
+			];
+		}
+
+		update_post_meta($formId, '_give_donation_levels', $updatedLevels);
+	}
+}

--- a/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
+++ b/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
@@ -14,6 +14,11 @@ use Give\Onboarding\FormRepository;
 class SetFormDonationLevelsToStrings extends Migration
 {
 	/**
+	 * @var FormRepository
+	 */
+	private $formRepository;
+
+	/**
 	 * @inheritDoc
 	 */
 	public static function id()
@@ -29,16 +34,14 @@ class SetFormDonationLevelsToStrings extends Migration
 		return strtotime('2020-09-01 11:47:00');
 	}
 
-	/**
-	 * @var FormRepository
-	 */
-	private $formRepository;
-
 	public function __construct(FormRepository $formRepository)
 	{
 		$this->formRepository = $formRepository;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function run()
 	{
 		$formId = $this->formRepository->getDefaultFormID();

--- a/src/ServiceProviders/Onboarding.php
+++ b/src/ServiceProviders/Onboarding.php
@@ -2,7 +2,9 @@
 
 namespace Give\ServiceProviders;
 
+use Give\Framework\Migrations\MigrationsRegister;
 use Give\Helpers\Hooks;
+use Give\Onboarding\Migrations\SetFormDonationLevelsToStrings;
 use Give\Onboarding\SettingsRepository;
 use Give\Onboarding\FormRepository;
 use Give\Onboarding\DefaultFormFactory;
@@ -53,6 +55,7 @@ class Onboarding implements ServiceProvider {
 	 * @inheritDoc
 	 */
 	public function boot() {
+		$this->registerMigrations();
 
 		// Onboarding Wizard and Setup page require WP v5.0.x or greater
 		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<=' ) ) {
@@ -84,5 +87,17 @@ class Onboarding implements ServiceProvider {
 			Hooks::addAction( 'admin_enqueue_scripts', SetupPage::class, 'enqueue_scripts' );
 			Hooks::addAction( 'admin_post_dismiss_setup_page', SetupPage::class, 'dismissSetupPage' );
 		}
+	}
+
+	/**
+	 * Registers migrations
+	 *
+	 * @since 2.13.3
+	 */
+	private function registerMigrations()
+	{
+		give(MigrationsRegister::class)->addMigrations([
+			SetFormDonationLevelsToStrings::class
+		]);
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5940

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Converted donation level id and amount value to string in `DefaultFormFactory::getDonationLevels` function which we use to get value for `_give_donation_levels` meta key.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Donate with donation form generated in onboarding process. Donation level and donation amount should store correctely in dopnation meta table and revenue table.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

