### PR TITLE
Set focus on donation amount field when click on "Custom" donation level id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Set focus on donation amount field when click on "Custom" donation level id. (#5943)
+
 ## 2.13.2 - 2021-08-26
 
 ## Fixed

--- a/assets/src/js/plugins/give-api/form.js
+++ b/assets/src/js/plugins/give-api/form.js
@@ -577,12 +577,20 @@ export default {
 					)
 				);
 
-			// Manually trigger blur event with two params:
-			// (a) form jquery object
-			// (b) price id
-			// (c) donation amount
-			$form.find( '.give-donation-amount .give-text-input' )
-				.trigger( 'blur', [ $form, level_amount, level_price_id ] );
+			if( 'custom' === level_price_id && ! level_amount ) {
+				// If level amount is empty for custom field that means donor clicked on button.
+				// Set focus on amount field and allow donor to add custom donation amount.
+				$form.find( '.give-donation-amount .give-text-input' ).focus();
+			} else{
+				// Manually trigger blur event with two params:
+				// (a) form jquery object
+				// (b) price id
+				// (c) donation amount
+				// Note: "custom" donation level id has donation amount only if donor redirect back to donation form with error.
+				// Dummy url: http://give.test/donations/help-feed-america/?form-id=16&payment-mode=manual&level-id=custom&custom-amount=555,00
+				$form.find( '.give-donation-amount .give-text-input' )
+					.trigger( 'blur', [ $form, level_amount, level_price_id ] );
+			}
 		},
 
 		/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5942

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I updated logic to set focus on donation amount input field when donor click on "Custom" donation level button.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
Multi Step Donation Form Template:
![Screen Recording 2021-09-01 at 01 06 31 PM](https://user-images.githubusercontent.com/1784821/131631649-16aaa055-daec-4ca6-9a16-a1479c8e2fa8.gif)

Legacy Donation Form Template (Show all fields)
![Screen Recording 2021-09-01 at 01 07 21 PM](https://user-images.githubusercontent.com/1784821/131631694-1567e15e-cb99-4961-bd93-d4e6201d3d2a.gif)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- You should not able to reproduce issue as mentioned in video added in Rick's comment https://feedback.givewp.com/bug-reports/p/custom-amount-button-does-not-work-well Rick's comment.
- You should not able reproduce issue https://github.com/impress-org/givewp/issues/5912

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

