### PR TITLE
Add hooks to legacy consumer to handle rendering, validating and saving for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add support for multiple file upload in legacy consumer for file template. (#5933)
 - Add `enctype` attribute to form if file type custom field added to donation form. (#5933)
 - Pass form id to donation form action url which help to show notices from session. (#5933)
+- Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
 
 ## 2.13.2 - 2021-08-26
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldConfirmation.php
@@ -2,6 +2,9 @@
 
 namespace Give\Form\LegacyConsumer\Commands;
 
+use Give\Framework\FieldsAPI\Concerns\HasLabel;
+use Give\Framework\FieldsAPI\Concerns\ShowInReceipt;
+use Give\Framework\FieldsAPI\Concerns\StoreAsMeta;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Group;
 
@@ -46,6 +49,7 @@ class SetupFieldConfirmation {
 	 * @return void
 	 */
 	public function render( Field $field ) {
+		/** @var Field|HasLabel|StoreAsMeta|ShowInReceipt $field */
 
 		if ( ! $field->shouldShowInReceipt() ) {
 			return;

--- a/src/Form/LegacyConsumer/Commands/SetupFieldEmailTag.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldEmailTag.php
@@ -2,6 +2,9 @@
 
 namespace Give\Form\LegacyConsumer\Commands;
 
+use Give\Framework\FieldsAPI\Concerns\HasEmailTag;
+use Give\Framework\FieldsAPI\Concerns\HasLabel;
+use Give\Framework\FieldsAPI\Concerns\StoreAsMeta;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Group;
 
@@ -33,6 +36,7 @@ class SetupFieldEmailTag {
 	 * @return void
 	 */
 	public function register( Field $field ) {
+		/** @var Field|HasLabel|HasEmailTag|StoreAsMeta $field */
 		give_add_email_tag(
 			[
 				'tag'      => $field->getEmailTag() ?: $field->getName(), // The tag name.

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -59,6 +59,19 @@ class SetupFieldPersistence implements HookCommandInterface {
 	 *
 	 */
 	public function process( Field $field ) {
+		/**
+		 * Use this filter to save custom field which does not exist in field api.
+		 *
+		 * @unreleased
+		 *
+		 * @param Field $field
+		 * @param int $donationId
+		 * @param array $donationData
+		 */
+		if( apply_filters( 'give_fields_save_field', false, $field, $this->donationId, $this->donationData ) ) {
+			return;
+		}
+
 		switch ( $field->getType() ) {
 			case 'file':
 				if ( isset( $_FILES[ $field->getName() ] ) ) {

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -3,14 +3,11 @@
 namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Form\LegacyConsumer\Actions\UploadFilesAction;
+use Give\Framework\FieldsAPI\Concenrs\StoreAsMeta;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\File;
 use Give\Framework\FieldsAPI\Group;
-use Give\Framework\FieldsAPI\Text;
-use function do_action;
-use function give_clean;
-use function give_get_payment_meta;
-use function give_update_payment_meta;
+use Give\Framework\FieldsAPI\Types;
 
 /**
  * Persist custom field values as donation meta.
@@ -49,61 +46,59 @@ class SetupFieldPersistence implements HookCommandInterface {
 	}
 
 	/**
-	 * @param Field|Text|File $field
+	 * Process the given field.
+	 *
+	 * @since 2.10.2
+	 * @unreleased Handle File field type and custom field type separately
+	 *
+	 * @param Field $field
 	 *
 	 * @return void
-	 * @since 2.10.2
-	 * @unreleased  Add filter to allow saving logic for custom fields
-	 *
 	 */
-	public function process( Field $field ) {
-		/**
-		 * Use this filter to save custom field which does not exist in field api.
-		 *
-		 * @unreleased
-		 *
-		 * @param Field $field
-		 * @param int $donationId
-		 * @param array $donationData
-		 */
-		if( apply_filters( "give_fields_api_save_{$field->getType()}", false, $field, $this->donationId, $this->donationData ) ) {
-			return;
-		}
+	protected function process( Field $field ) {
+		if ( $field->getType() === Types::FILE ) {
+			/** @var File $field */
+			if ( isset( $_FILES[ $field->getName() ] ) ) {
+				$fileUploader = new UploadFilesAction( $field );
+				$fileIds      = $fileUploader();
 
-		switch ( $field->getType() ) {
-			case 'file':
-				if ( isset( $_FILES[ $field->getName() ] ) ) {
-
-					$fileUploader = new UploadFilesAction( $field );
-					$fileIds      = $fileUploader();
-
-					foreach ( $fileIds as $fileId ) {
-						if ( $field->shouldStoreAsDonorMeta() ) {
-							$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
-							Give()->donor_meta->add_meta( $donorID, $field->getName(), $fileId );
-						} else {
-							// Store as Donation Meta - default behavior.
-							give()->payment_meta->add_meta( $this->donationId, $field->getName(), $fileId );
-						}
-					}
-				}
-				break;
-
-			default:
-				if ( isset( $_POST[ $field->getName() ] ) ) {
-					$data  = give_clean( $_POST[ $field->getName() ] );
-					$value = is_array( $data ) ?
-						implode( '| ', array_values( array_filter( $data ) ) ) :
-						$data;
-
+				foreach ( $fileIds as $fileId ) {
 					if ( $field->shouldStoreAsDonorMeta() ) {
 						$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
-						Give()->donor_meta->update_meta( $donorID, $field->getName(), $value );
+						Give()->donor_meta->add_meta( $donorID, $field->getName(), $fileId );
 					} else {
 						// Store as Donation Meta - default behavior.
-						give_update_payment_meta( $this->donationId, $field->getName(), $value );
+						give()->payment_meta->add_meta( $this->donationId, $field->getName(), $fileId );
 					}
 				}
+			}
+		} elseif ( in_array( $field->getType(), Types::all(), true ) ) {
+			if ( isset( $_POST[ $field->getName() ] ) ) {
+				$data  = give_clean( $_POST[ $field->getName() ] );
+				$value = is_array( $data ) ?
+					implode( '| ', array_values( array_filter( $data ) ) ) :
+					$data;
+
+				/** @var StoreAsMeta $field */
+				if ( $field->shouldStoreAsDonorMeta() ) {
+					$donorID = give_get_payment_meta( $this->donationId, '_give_payment_donor_id' );
+					Give()->donor_meta->update_meta( $donorID, $field->getName(), $value );
+				} else {
+					// Store as Donation Meta - default behavior.
+					give_update_payment_meta( $this->donationId, $field->getName(), $value );
+				}
+			}
+		} else {
+			/**
+			 * Use this action to save custom field which does not exist in fields API.
+			 *
+			 * @unreleased
+			 *
+			 * @param Field $field
+			 * @param int $donationId
+			 * @param array $donationData
+			 */
+			do_action( 'give_fields_save_field', $field, $this->donationId, $this->donationData );
 		}
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -98,7 +98,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 			 * @param int $donationId
 			 * @param array $donationData
 			 */
-			do_action( 'give_fields_save_field', $field, $this->donationId, $this->donationData );
+			do_action( 'give_fields_api_save_field', $field, $this->donationId, $this->donationData );
 		}
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -18,21 +18,17 @@ use function give_update_payment_meta;
  * @since 2.10.2
  */
 class SetupFieldPersistence implements HookCommandInterface {
-	/**
-	 * @var int
-	 */
+
+	/** @var int */
 	private $donationId;
-	/**
-	 * @var array
-	 */
+	/** @var array */
 	private $donationData;
 
 	/**
-	 * @param int $donationId
-	 * @param array $donationData
-	 *
 	 * @since 2.10.2
 	 *
+	 * @param int $donationId
+	 * @param array $donationData
 	 */
 	public function __construct( $donationId, $donationData ) {
 		$this->donationId   = $donationId;
@@ -40,10 +36,11 @@ class SetupFieldPersistence implements HookCommandInterface {
 	}
 
 	/**
-	 * @param string $hook
-	 *
 	 * @since 2.10.2
 	 *
+	 * @param string $hook
+	 *
+	 * @void
 	 */
 	public function __invoke( $hook ) {
 		$collection = Group::make( $hook );

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -56,6 +56,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 	 *
 	 * @return void
 	 * @since 2.10.2
+	 * @unreleased  Add filter to allow saving logic for custom fields
 	 *
 	 */
 	public function process( Field $field ) {

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -69,7 +69,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 		 * @param int $donationId
 		 * @param array $donationData
 		 */
-		if( apply_filters( "give_fields_api_save_field_{$field->getType()}", false, $field, $this->donationId, $this->donationData ) ) {
+		if( apply_filters( "give_fields_api_save_{$field->getType()}", false, $field, $this->donationId, $this->donationData ) ) {
 			return;
 		}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -69,7 +69,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 		 * @param int $donationId
 		 * @param array $donationData
 		 */
-		if( apply_filters( 'give_fields_api_save_field', false, $field, $this->donationId, $this->donationData ) ) {
+		if( apply_filters( "give_fields_api_save_field_{$field->getType()}", false, $field, $this->donationId, $this->donationData ) ) {
 			return;
 		}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -55,7 +55,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 	 *
 	 * @return void
 	 */
-	protected function process( Field $field ) {
+	public function process( Field $field ) {
 		if ( $field->getType() === Types::FILE ) {
 			/** @var File $field */
 			if ( isset( $_FILES[ $field->getName() ] ) ) {

--- a/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldPersistence.php
@@ -68,7 +68,7 @@ class SetupFieldPersistence implements HookCommandInterface {
 		 * @param int $donationId
 		 * @param array $donationData
 		 */
-		if( apply_filters( 'give_fields_save_field', false, $field, $this->donationId, $this->donationData ) ) {
+		if( apply_filters( 'give_fields_api_save_field', false, $field, $this->donationId, $this->donationData ) ) {
 			return;
 		}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -4,11 +4,8 @@ namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Form\LegacyConsumer\Validators\FileUploadValidator;
 use Give\Framework\FieldsAPI\Field;
-use Give\Framework\FieldsAPI\File;
 use Give\Framework\FieldsAPI\Group;
-use function do_action;
-use function give_set_error;
-
+use Give\Framework\FieldsAPI\Types;
 
 /**
  * Setup field validation for custom fields on the checkout error check fields hook.
@@ -19,10 +16,9 @@ use function give_set_error;
  * @package Give\Form\LegacyConsumer\Commands
  * @since 2.10.2
  */
-class SetupFieldValidation {
-	/**
-	 * @var int
-	 */
+class SetupFieldValidation implements HookCommandInterface {
+
+	/** @var int */
 	private $formId;
 
 	/**
@@ -36,46 +32,50 @@ class SetupFieldValidation {
 
 	/**
 	 * @since 2.10.2
-	 * @unreleased  Add support for file field validation
-	 * @unreleased Add filter to allow validation for custom field.
+	 * @unreleased Handle File field type and custom field type separately
 	 *
 	 * @param string $hook
+	 *
+	 * @void
 	 */
 	public function __invoke( $hook ) {
 		$collection = Group::make( $hook );
 		do_action( "give_fields_$hook", $collection, $this->formId );
-		$collection->walkFields(
-			/* @var File $field */
-			function( $field ) {
-				/**
-				 * Use this filter to validate custom field which does not exist in field api.
-				 *
-				 * @unreleased
-				 *
-				 * @param Field $field
-				 * @param int $formId
-				 */
-				if( apply_filters( "give_fields_api_validate_{$field->getType()}", false, $field, $this->formId ) ) {
-					return;
-				}
+		$collection->walkFields( [ $this, 'validate ' ] );
+	}
 
-				switch ( $field->getType() ) {
-					case 'file':
-						// Are we processing donation form validation on ajax?
-						if( isset( $_POST['give_ajax'] ) ) {
-							return;
-						}
-
-						$validator = new FileUploadValidator( $field );
-						$validator();
-						break;
-
-					default:
-						if ( $field->isRequired() && ! isset( $_POST[ $field->getName() ] ) ) {
-							give_set_error( "give-{$field->getName()}-required-field-missing", $field->getRequiredError()['error_message'] );
-						}
-				}
+	/**
+	 * Validate the given field.
+	 *
+	 * @unreleased
+	 *
+	 * @param Field $field
+	 *
+	 * @void
+	 */
+	protected function validate( Field $field ) {
+		if ( $field->getType() === Types::FILE ) {
+			// Are we processing donation form validation on ajax?
+			if( isset( $_POST['give_ajax'] ) ) {
+				return;
 			}
-		);
+
+			$validator = new FileUploadValidator( $field );
+			$validator();
+		} elseif ( in_array( $field->getType(), Types::all(), true ) ) {
+			if ( $field->isRequired() && ! isset( $_POST[ $field->getName() ] ) ) {
+				give_set_error( "give-{$field->getName()}-required-field-missing", $field->getRequiredError()['error_message'] );
+			}
+		} else {
+			/**
+			 * Use this action to validate custom field which does not exist in field api.
+			 *
+			 * @unreleased
+			 *
+			 * @param Field $field
+			 * @param int $formId
+			 */
+			do_action( 'give_fields_validate_field', false, $field, $this->formId ) ;
+		}
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -75,7 +75,7 @@ class SetupFieldValidation implements HookCommandInterface {
 			 * @param Field $field
 			 * @param int $formId
 			 */
-			do_action( 'give_fields_validate_field', false, $field, $this->formId ) ;
+			do_action( 'give_fields_validate_field', $field, $this->formId ) ;
 		}
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -41,7 +41,7 @@ class SetupFieldValidation implements HookCommandInterface {
 	public function __invoke( $hook ) {
 		$collection = Group::make( $hook );
 		do_action( "give_fields_$hook", $collection, $this->formId );
-		$collection->walkFields( [ $this, 'validate ' ] );
+		$collection->walkFields( [ $this, 'validate' ] );
 	}
 
 	/**

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -3,6 +3,7 @@
 namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Form\LegacyConsumer\Validators\FileUploadValidator;
+use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\File;
 use Give\Framework\FieldsAPI\Group;
 use function do_action;
@@ -45,6 +46,18 @@ class SetupFieldValidation {
 		$collection->walkFields(
 			/* @var File $field */
 			function( $field ) {
+				/**
+				 * Use this filter to validate custom field which does not exist in field api.
+				 *
+				 * @unreleased
+				 *
+				 * @param Field $field
+				 * @param int $formId
+				 */
+				if( apply_filters( 'give_fields_validate_field', false, $field, $this->formId ) ) {
+					return;
+				}
+
 				switch ( $field->getType() ) {
 					case 'file':
 						// Are we processing donation form validation on ajax?

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -53,7 +53,7 @@ class SetupFieldValidation implements HookCommandInterface {
 	 *
 	 * @void
 	 */
-	protected function validate( Field $field ) {
+	public function validate( Field $field ) {
 		if ( $field->getType() === Types::FILE ) {
 			// Are we processing donation form validation on ajax?
 			if( isset( $_POST['give_ajax'] ) ) {

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -55,7 +55,7 @@ class SetupFieldValidation {
 				 * @param Field $field
 				 * @param int $formId
 				 */
-				if( apply_filters( 'give_fields_api_validate_field', false, $field, $this->formId ) ) {
+				if( apply_filters( "give_fields_api_validate_field_{$field->getType()}", false, $field, $this->formId ) ) {
 					return;
 				}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -55,7 +55,7 @@ class SetupFieldValidation {
 				 * @param Field $field
 				 * @param int $formId
 				 */
-				if( apply_filters( "give_fields_api_validate_field_{$field->getType()}", false, $field, $this->formId ) ) {
+				if( apply_filters( "give_fields_api_validate_{$field->getType()}", false, $field, $this->formId ) ) {
 					return;
 				}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -54,7 +54,7 @@ class SetupFieldValidation {
 				 * @param Field $field
 				 * @param int $formId
 				 */
-				if( apply_filters( 'give_fields_validate_field', false, $field, $this->formId ) ) {
+				if( apply_filters( 'give_fields_api_validate_field', false, $field, $this->formId ) ) {
 					return;
 				}
 

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -75,7 +75,7 @@ class SetupFieldValidation implements HookCommandInterface {
 			 * @param Field $field
 			 * @param int $formId
 			 */
-			do_action( 'give_fields_validate_field', $field, $this->formId ) ;
+			do_action( 'give_fields_legacy_consumer_validate_field', $field, $this->formId ) ;
 		}
 	}
 }

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -37,6 +37,7 @@ class SetupFieldValidation {
 	/**
 	 * @since 2.10.2
 	 * @unreleased  Add support for file field validation
+	 * @unreleased Add filter to allow validation for custom field.
 	 *
 	 * @param string $hook
 	 */

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -3,7 +3,6 @@
 namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Form\LegacyConsumer\FieldView;
-use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Group;
 
 /**
@@ -27,21 +26,6 @@ class SetupNewTemplateHook implements HookCommandInterface {
 				do_action( "give_fields_$hook", $collection, $formId );
 				$collection->walk(
 					static function ( $node ) use ( $formId ) {
-
-						/**
-						 * Use this filter to render custom field which does not exist in field api.
-						 *
-						 * @unreleased
-						 *
-						 * @param Field $field
-						 * @param int $formId
-						 */
-						$html = apply_filters( 'give_fields_render_field', '', $node, $formId );
-						if( $html ){
-							echo $html;
-							return;
-						}
-
 						FieldView::render( $node, $formId );
 					}
 				);

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -3,6 +3,7 @@
 namespace Give\Form\LegacyConsumer\Commands;
 
 use Give\Form\LegacyConsumer\FieldView;
+use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Group;
 
 /**
@@ -21,12 +22,27 @@ class SetupNewTemplateHook implements HookCommandInterface {
 		// On the old hook, run the new hook and render the fields.
 		add_action(
 			"give_$hook",
-			static function ( $formID ) use ( $hook ) {
+			static function ( $formId ) use ( $hook ) {
 				$collection = Group::make( $hook );
-				do_action( "give_fields_$hook", $collection, $formID );
+				do_action( "give_fields_$hook", $collection, $formId );
 				$collection->walk(
-					static function ( $node ) use ( $formID ) {
-						FieldView::render( $node, $formID );
+					static function ( $node ) use ( $formId ) {
+
+						/**
+						 * Use this filter to render custom field which does not exist in field api.
+						 *
+						 * @unreleased
+						 *
+						 * @param Field $field
+						 * @param int $formId
+						 */
+						$html = apply_filters( 'give_fields_field_view', '', $node, $formId );
+						if( $html ){
+							echo $html;
+							return;
+						}
+
+						FieldView::render( $node, $formId );
 					}
 				);
 			}

--- a/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
+++ b/src/Form/LegacyConsumer/Commands/SetupNewTemplateHook.php
@@ -36,7 +36,7 @@ class SetupNewTemplateHook implements HookCommandInterface {
 						 * @param Field $field
 						 * @param int $formId
 						 */
-						$html = apply_filters( 'give_fields_field_view', '', $node, $formId );
+						$html = apply_filters( 'give_fields_render_field', '', $node, $formId );
 						if( $html ){
 							echo $html;
 							return;

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -19,6 +19,7 @@ class FieldView {
 	/**
 	 * @since 2.10.2
 	 * @unreleased add $formId as a param
+	 * @unreleased Add filter to allow rendering logic for custom fields
 	 *
 	 * @param Node $field
 	 * @param int $formId

--- a/src/Form/LegacyConsumer/FieldView.php
+++ b/src/Form/LegacyConsumer/FieldView.php
@@ -27,7 +27,7 @@ class FieldView {
 	 */
 	public static function render( Node $field, $formId ) {
 		$type = $field->getType();
-		$fieldIdAttribute = give( UniqueIdAttributeGenerator::class)->getId( $formId, $field->getName() );
+		$fieldIdAttribute = give( UniqueIdAttributeGenerator::class )->getId( $formId, $field->getName() );
 
 		if ( $type === Types::HIDDEN ) {
 			include static::getTemplatePath( 'hidden' );
@@ -54,12 +54,28 @@ class FieldView {
 				include static::getTemplatePath( $type );
 				break;
 			// By default, include a template and use the base input template.
-			default:
+			case Types::DATE:
+			case Types::EMAIL:
+			case Types::PHONE:
+			case Types::TEXT:
+			case Types::URL:
 				// Used in the template
 				$typeAttribute = array_key_exists( $type, static::INPUT_TYPE_ATTRIBUTES ) ? static::INPUT_TYPE_ATTRIBUTES[ $type ] : 'text';
 				include static::getTemplatePath( 'label' );
 				include static::getTemplatePath( 'base' );
 				break;
+			default:
+				/**
+				 * Provide a custom function to render for a custom node type.
+				 *
+				 * @unreleased
+				 *
+				 * @param Node $field The node to render.
+				 * @param int $formId The form ID that the node is a part of.
+				 *
+				 * @void
+				 */
+				do_action( "give_fields_api_render_{$field->getType()}", $field, $formId );
 		}
 		echo '</div>';
 	}

--- a/src/Framework/FieldsAPI/Types.php
+++ b/src/Framework/FieldsAPI/Types.php
@@ -2,11 +2,15 @@
 
 namespace Give\Framework\FieldsAPI;
 
+use ReflectionClass;
+
 /**
  * @since 2.12.0
  * @since 2.12.2 add Form, Group, and Html
+ * @unreleased add Types::all static method
  */
 class Types {
+
 	const CHECKBOX = Checkbox::TYPE;
 	const DATE     = Date::TYPE;
 	const EMAIL    = Email::TYPE;
@@ -21,4 +25,17 @@ class Types {
 	const TEXT     = Text::TYPE;
 	const TEXTAREA = Textarea::TYPE;
 	const URL      = Url::TYPE;
+
+	/**
+	 * Get all the type strings in an array.
+	 *
+	 * @unreleased
+	 *
+	 * @return string[]
+	 */
+	public static function all() {
+		$reflection = new ReflectionClass( static::class );
+
+		return array_values( $reflection->getConstants() );
+	}
 }

--- a/tests/unit/tests/Framework/FieldsAPI/TypesTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/TypesTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Give\Framework\FieldsAPI\Types;
+use PHPUnit\Framework\TestCase;
+
+final class TypesTest extends TestCase {
+
+	public function testCanGetAllTypes() {
+		$this->assertContainsOnly( 'string', Types::all() );
+	}
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I and @knowler add three filter which support rendering, validating and saving for custom field.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You can test this pull request with FFM: https://github.com/impress-org/give-form-field-manager/pull/352

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

