### PR TITLE
Add min/max-length validation to text Fields API node types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add support for multiple file upload in legacy consumer for file template. (#5933)
 - Add `enctype` attribute to form if file type custom field added to donation form. (#5933)
 - Pass form id to donation form action url which help to show notices from session. (#5933)
+- Add min/max-length validation to text Fields API node types. (#5948)
 
 ## 2.13.3 - 2021-09-01
 

--- a/src/Framework/FieldsAPI/Concerns/HasMaxLength.php
+++ b/src/Framework/FieldsAPI/Concerns/HasMaxLength.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\Concerns;
+
+/**
+ * @unreleased
+ *
+ * @property ValidationRules $validationRules
+ */
+trait HasMaxLength {
+
+	/**
+	 * Set the value’s maximum length.
+	 *
+	 * @unreleased
+	 *
+	 * @param int $maxLength
+	 *
+	 * @return $this
+	 */
+	public function maxLength( $maxLength ) {
+		$this->validationRules->rule( 'maxLength', $maxLength );
+
+		return $this;
+	}
+
+	/**
+	 * Get the value’s maximum length.
+	 *
+	 * @unreleased
+	 *
+	 * @return int|null
+	 */
+	public function getMaxLength() {
+		return $this->validationRules->getRule( 'maxLength' );
+	}
+}

--- a/src/Framework/FieldsAPI/Concerns/HasMinLength.php
+++ b/src/Framework/FieldsAPI/Concerns/HasMinLength.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\Concerns;
+
+/**
+ * @unreleased
+ *
+ * @property ValidationRules $validationRules
+ */
+trait HasMinLength {
+
+	/**
+	 * Set the value’s minimum length.
+	 *
+	 * @unreleased
+	 *
+	 * @param int $minLength
+	 *
+	 * @return $this
+	 */
+	public function minLength( $minLength ) {
+		$this->validationRules->rule( 'minLength', $minLength );
+
+		return $this;
+	}
+
+	/**
+	 * Get the value’s minimum length.
+	 *
+	 * @unreleased
+	 *
+	 * @return int|null
+	 */
+	public function getMinLength() {
+		return $this->validationRules->getRule( 'minLength' );
+	}
+}

--- a/src/Framework/FieldsAPI/Email.php
+++ b/src/Framework/FieldsAPI/Email.php
@@ -4,6 +4,7 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased add min/max length validation
  */
 class Email extends Field {
 
@@ -11,6 +12,8 @@ class Email extends Field {
 	use Concerns\HasEmailTag;
 	use Concerns\HasHelpText;
 	use Concerns\HasLabel;
+	use Concerns\HasMaxLength;
+	use Concerns\HasMinLength;
 	use Concerns\HasPlaceholder;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;

--- a/src/Framework/FieldsAPI/Phone.php
+++ b/src/Framework/FieldsAPI/Phone.php
@@ -4,12 +4,15 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased add min/max length validation
  */
 class Phone extends Field {
 
 	use Concerns\HasEmailTag;
 	use Concerns\HasHelpText;
 	use Concerns\HasLabel;
+	use Concerns\HasMaxLength;
+	use Concerns\HasMinLength;
 	use Concerns\HasPlaceholder;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;

--- a/src/Framework/FieldsAPI/Text.php
+++ b/src/Framework/FieldsAPI/Text.php
@@ -4,12 +4,15 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased add min/max length validation
  */
 class Text extends Field {
 
 	use Concerns\HasEmailTag;
 	use Concerns\HasHelpText;
 	use Concerns\HasLabel;
+	use Concerns\HasMaxLength;
+	use Concerns\HasMinLength;
 	use Concerns\HasPlaceholder;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;

--- a/src/Framework/FieldsAPI/Url.php
+++ b/src/Framework/FieldsAPI/Url.php
@@ -4,12 +4,15 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased add min/max length validation
  */
 class Url extends Field {
 
 	use Concerns\HasEmailTag;
 	use Concerns\HasHelpText;
 	use Concerns\HasLabel;
+	use Concerns\HasMaxLength;
+	use Concerns\HasMinLength;
 	use Concerns\HasPlaceholder;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;

--- a/tests/unit/tests/Framework/FieldsAPI/Concerns/HasMaxLengthTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Concerns/HasMaxLengthTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Give\Framework\FieldsAPI\Concerns\HasMaxLength;
+use Give\Framework\FieldsAPI\Concerns\ValidationRules;
+use PHPUnit\Framework\TestCase;
+
+final class HasMaxLengthTest extends TestCase {
+
+	public function testHasMaxLength() {
+		$mock = new HasMaxLengthMock();
+
+		$mock->maxLength( 8 );
+
+		$this->assertEquals( 8, $mock->getMaxLength() );
+
+		$mock->maxLength( 16 );
+
+		$this->assertEquals( 16, $mock->getMaxLength() );
+	}
+}
+
+final class HasMaxLengthMock {
+	use HasMaxLength;
+
+	protected $validationRules;
+
+	public function __construct() {
+		$this->validationRules = new ValidationRules();
+	}
+}

--- a/tests/unit/tests/Framework/FieldsAPI/Concerns/HasMinLengthTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Concerns/HasMinLengthTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Give\Framework\FieldsAPI\Concerns\HasMinLength;
+use Give\Framework\FieldsAPI\Concerns\ValidationRules;
+use PHPUnit\Framework\TestCase;
+
+final class HasMinLengthTest extends TestCase {
+
+	public function testHasMinLength() {
+		$mock = new HasMinLengthMock();
+
+		$mock->minLength( 8 );
+
+		$this->assertEquals( 8, $mock->getMinLength() );
+
+		$mock->minLength( 16 );
+
+		$this->assertEquals( 16, $mock->getMinLength() );
+	}
+}
+
+final class HasMinLengthMock {
+	use HasMinLength;
+
+	protected $validationRules;
+
+	public function __construct() {
+		$this->validationRules = new ValidationRules();
+	}
+}
+


### PR DESCRIPTION

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5947

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We discovered that we needed to add validation rules for min/max length for Fields API text types in FFM. This PR implement these as traits (`HasMaxLength`, `HasMinLength`) and adds using them in `Text`, `Email`, `Phone`, and `Url`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

`Text`, `Email`, `Phone`, and `Url` in the Fields API.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Run the tests and try this code out in the root of the repo.

```php
<?php

namespace Give\Framework\FieldsAPI; // Cheating — do not do this for real.

require __DIR__ . '/vendor/autoload.php';

// Too bad if your name isn't Jason or Devin or Matt
Text::make('firstName')->maxLength(5)->minLength(4);

// Try switching out `Phone`, `Email`, and `Url`.
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@since` tags included in DocBlocks
- [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [x] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
