### PR TITLE
Fix form donation level migration to honor existing meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 2.13.4 - 2021-09-03
+
+### Fixed
+
+- Onboarding form donation level migration no longer clears extra donation level data (#5950)
+
 ## 2.13.3 - 2021-09-01
 
 ### Fixed

--- a/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
+++ b/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
@@ -52,16 +52,12 @@ class SetFormDonationLevelsToStrings extends Migration
 
 		$donationLevels = give_get_meta($formId, '_give_donation_levels', true);
 
-		$updatedLevels = [];
-		foreach ($donationLevels as $level) {
-			$updatedLevels[] = [
-				'_give_id' => [
-					'level_id' => (string)$level['_give_id']['level_id'],
-				],
-				'_give_amount' => give_sanitize_amount_for_db($level['_give_amount']),
-			];
+		foreach ($donationLevels as &$level) {
+			$level['_give_id']['level_id'] = (string)$level['_give_id']['level_id'];
+			$level['_give_amount'] = give_sanitize_amount_for_db($level['_give_amount']);
 		}
+		unset($level);
 
-		update_post_meta($formId, '_give_donation_levels', $updatedLevels);
+		update_post_meta($formId, '_give_donation_levels', $donationLevels);
 	}
 }

--- a/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
+++ b/src/Onboarding/Migrations/SetFormDonationLevelsToStrings.php
@@ -9,6 +9,7 @@ use Give\Onboarding\FormRepository;
  * This resolves an issue where the donation level data for the form created during onboarding was serialized as
  * integers instead of strings, causing issues throughout
  *
+ * @since 2.13.4 preserve additional donation level data
  * @since 2.13.3
  */
 class SetFormDonationLevelsToStrings extends Migration


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5949 

## Description

This resolves the issue of removing extra donation level data by updating the specific level elements in the original array, preserving any additional data.

## Affects

The `SetFormDonationLevelsToStrings` migration

## Testing Instructions

### Test original intent
1. Use GiveWP 2.13.2 on a fresh install
2. Create a form through the onboarding flow
3. Update to this PR and run the migration
4. The donation level fields should be cast to strings

### Test preserving data
1. Use GiveWP 2.13.2 on a fresh install
2. Create a form through the onboarding flow
3. Update the donation form levels in the Form to include additional data
3. Update to this PR and run the migration
4. The donation level fields should be cast to strings and the additional data should still exist

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

