### PR TITLE
Validate input and textarea field value maxlength in field api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
 - Add min/max-length validation to text Fields API node types. (#5948)
 
+### Fixed
+- Add min/max-length validation to text Fields API node types and add max length attribute in input field template in legacy consumer. (#5955)
+
+
 ## 2.13.4 - 2021-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Pass form id to donation form action url which help to show notices from session. (#5933)
 - Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
 - Add min/max-length validation to text Fields API node types. (#5948)
+- Add min/max-length validation to text and textarea Fields API node types. (#5955)
 
 ### Fixed
-- Add min/max-length validation to text Fields API node types and add max length attribute in input field template in legacy consumer. (#5955)
+- Add min/max-length validation to text and textarea Fields API node types. (#5955)
+- Add maxlength attribute in input and textarea field template in legacy consumer. (#5955)
 
 
 ## 2.13.4 - 2021-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `enctype` attribute to form if file type custom field added to donation form. (#5933)
 - Pass form id to donation form action url which help to show notices from session. (#5933)
 - Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
-- Add min/max-length validation to text Fields API node types. (#5948)
-- Add min/max-length validation to text and textarea Fields API node types. (#5955)
+- Add min/max-length validation to text Fields API node types. (#5948, #5955)
 
 ### Fixed
 - Add min/max-length validation to text and textarea Fields API node types. (#5955)

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -70,6 +70,7 @@ class SetupFieldValidation implements HookCommandInterface {
 			}
 
 			if(
+				in_array( $field->getType(), [ Types::TEXT, Types::TEXTAREA ] ) &&
 				$field->getMaxLength() &&
 				isset( $_POST[ $field->getName() ] ) &&
 				strlen( $_POST[ $field->getName() ] ) > $field->getMaxLength()

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -6,6 +6,7 @@ use Give\Form\LegacyConsumer\Validators\FileUploadValidator;
 use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\File;
 use Give\Framework\FieldsAPI\Group;
+use Give\Framework\FieldsAPI\Text;
 use Give\Framework\FieldsAPI\Types;
 
 /**
@@ -50,7 +51,7 @@ class SetupFieldValidation implements HookCommandInterface {
 	 *
 	 * @unreleased
 	 *
-	 * @param Field|File $field
+	 * @param Field|File|Text $field
 	 *
 	 * @void
 	 */
@@ -66,6 +67,16 @@ class SetupFieldValidation implements HookCommandInterface {
 		} elseif ( in_array( $field->getType(), Types::all(), true ) ) {
 			if ( $field->isRequired() && ! isset( $_POST[ $field->getName() ] ) ) {
 				give_set_error( "give-{$field->getName()}-required-field-missing", $field->getRequiredError()['error_message'] );
+			}
+
+			if( $field->getMaxLength() && isset( $_POST[ $field->getName() ] ) && strlen( $_POST[ $field->getName() ] ) > $field->getMaxLength() ) {
+				give_set_error(
+					"give-{$field->getName()}-required-field-missing",
+					sprintf(
+						esc_html__( '%1$s field value exceed allowed character limit.', 'give' ),
+						$field->getName()
+					)
+				);
 			}
 		} else {
 			/**

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -69,7 +69,11 @@ class SetupFieldValidation implements HookCommandInterface {
 				give_set_error( "give-{$field->getName()}-required-field-missing", $field->getRequiredError()['error_message'] );
 			}
 
-			if( $field->getMaxLength() && isset( $_POST[ $field->getName() ] ) && strlen( $_POST[ $field->getName() ] ) > $field->getMaxLength() ) {
+			if(
+				$field->getMaxLength() &&
+				isset( $_POST[ $field->getName() ] ) &&
+				strlen( $_POST[ $field->getName() ] ) > $field->getMaxLength()
+			) {
 				give_set_error(
 					"give-{$field->getName()}-required-field-missing",
 					sprintf(

--- a/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
+++ b/src/Form/LegacyConsumer/Commands/SetupFieldValidation.php
@@ -49,7 +49,7 @@ class SetupFieldValidation implements HookCommandInterface {
 	/**
 	 * Validate the given field.
 	 *
-	 * @unreleased
+	 * @unreleased Add max length validation for input and textarea field
 	 *
 	 * @param Field|File|Text $field
 	 *

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -1,4 +1,4 @@
-<?php /** @var Give\Framework\FieldsAPI\Field|\Give\Framework\FieldsAPI\Text $field */ ?>
+<?php /** @var \Give\Framework\FieldsAPI\Text $field */ ?>
 <?php /** @var string $typeAttribute */ ?>
 <?php /** @var string $fieldIdAttribute */ ?>
 <input
@@ -9,4 +9,5 @@
 	value="<?php echo $field->getDefaultValue(); ?>"
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
+	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
 >

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -5,4 +5,5 @@
 	id="<?php echo $fieldIdAttribute; ?>"
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
+	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
 ></textarea>

--- a/src/Framework/FieldsAPI/Textarea.php
+++ b/src/Framework/FieldsAPI/Textarea.php
@@ -14,6 +14,7 @@ class Textarea extends Field {
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;
 	use Concerns\HasMaxLength;
+	use Concerns\HasMinLength;
 
 	const TYPE = 'textarea';
 }

--- a/src/Framework/FieldsAPI/Textarea.php
+++ b/src/Framework/FieldsAPI/Textarea.php
@@ -4,6 +4,7 @@ namespace Give\Framework\FieldsAPI;
 
 /**
  * @since 2.12.0
+ * @unreleased Add support for min/max length
  */
 class Textarea extends Field {
 

--- a/src/Framework/FieldsAPI/Textarea.php
+++ b/src/Framework/FieldsAPI/Textarea.php
@@ -13,6 +13,7 @@ class Textarea extends Field {
 	use Concerns\HasPlaceholder;
 	use Concerns\ShowInReceipt;
 	use Concerns\StoreAsMeta;
+	use Concerns\HasMaxLength;
 
 	const TYPE = 'textarea';
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I add maximum field value validation and also add support for mix/max length to texture field.

**Note: I did not add validation for min length.**

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

