### PR TITLE
Formatting button display correctly when decimals enabled in Multi-Step Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
 - Add min/max-length validation to text Fields API node types. (#5948)
 
+### Fixed
+- Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
+
 ## 2.13.4 - 2021-09-03
 
 ### Fixed

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -451,10 +451,6 @@
 	setupFFMInputs();
 	setupInputIcons();
 
-	if ( 'enabled' === templateOptions.payment_amount.decimals_enabled ) {
-		updateFormDonationLevelsLabels();
-	}
-
 	/**
 	 * Limited scope of optional input labels, specifically to User Info, see issue #5160.
 	 */
@@ -907,31 +903,5 @@
 		if ( 'parentIFrame' in window ) {
 			window.parentIFrame.sendMessage( { action: 'giveScrollIframeInToView' } );
 		}
-	}
-
-	/**
-	 * Update decimal donation levels amount
-	 *
-	 * @since 2.11.0
-	 */
-	function updateFormDonationLevelsLabels() {
-		$( '.give-form' ).each( ( i, form ) => {
-			const donationForm = $( form );
-			const donationLevels = Give.form.fn.getVariablePrices( donationForm );
-			const symbol = Give.form.fn.getInfo( 'currency_symbol', donationForm );
-			const position = Give.form.fn.getInfo( 'currency_position', donationForm );
-
-			$.each( donationLevels, function( j, level ) {
-				if ( 'custom' === level.price_id ) {
-					return;
-				}
-
-				const donationLevelLabel = '<div class="currency currency--' + position + '">' + symbol + '</div>' + level.amount;
-
-				donationForm
-					.find( '.give-btn-level-' + level.price_id  )
-					.html( donationLevelLabel );
-			} );
-		} );
 	}
 }( jQuery ) );

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -920,18 +920,13 @@
 			const donationLevels = Give.form.fn.getVariablePrices( donationForm );
 			const symbol = Give.form.fn.getInfo( 'currency_symbol', donationForm );
 			const position = Give.form.fn.getInfo( 'currency_position', donationForm );
-			const precision = Give.form.fn.getInfo( 'number_decimals', donationForm );
 
 			$.each( donationLevels, function( j, level ) {
 				if ( 'custom' === level.price_id ) {
 					return;
 				}
 
-				const amount = Give.fn.numberHasDecimal( level.amount )
-					? Give.fn.formatCurrency( level.amount, { symbol, position, precision }, donationForm )
-					: level.amount;
-
-				const donationLevelLabel = '<div class="currency currency--' + position + '">' + symbol + '</div>' + amount;
+				const donationLevelLabel = '<div class="currency currency--' + position + '">' + symbol + '</div>' + level.amount;
 
 				donationForm
 					.find( '.give-btn-level-' + level.price_id  )


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5956

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that a javascript logic was adding additional currency symbol in button title when decimal enabled in multi-step form template.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://user-images.githubusercontent.com/1784821/132740950-ff6f6436-424d-4475-9fa2-55a2146b952c.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Try to reproduce the issue as direction given in issue.
Note: run `npm run dev` before testing.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

