### PR TITLE
Donor addressed is now spaced out on the Donor Dashboard receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add maxlength attribute in input and textarea field template in legacy consumer. (#5955)
 - Prevent php notices which generate from offline -donations.php. (#5960)
 - Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
+- Donor addressed is now spaced out on the Donor Dashboard receipt (#5961)
 
 ## 2.13.4 - 2021-09-03
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -1,10 +1,11 @@
 <?php
 namespace Give\DonorDashboards\Repositories;
 
+use Give\Receipt\LineItem;
 use Give\ValueObjects\Money;
 use Give\Framework\Database\DB;
 use Give\Receipt\DonationReceipt;
-use InvalidArgumentException;
+use Give_Payment;
 
 /**
  * @since 2.10.0

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -212,7 +212,6 @@ class Donations {
 		$receiptArr = [];
 
 		$sectionIndex = 0;
-		$lineBreaks = [ '<br />','<br>','<br/>' ];
 		foreach ( $receipt as $section ) {
 			// Continue if section does not have line items.
 			if ( ! $section->getLineItems() ) {
@@ -247,8 +246,7 @@ class Donations {
 				}
 
 				$label = html_entity_decode( wp_strip_all_tags( $lineItem->label ) );
-				$value = str_ireplace( $lineBreaks, "\r\n", $lineItem->value );
-				$value = $lineItem->id === 'paymentStatus' ? $this->getFormattedStatus( $payment->status ) : html_entity_decode( wp_strip_all_tags( $value ) );
+				$value = $lineItem->id === 'paymentStatus' ? $this->getFormattedStatus( $payment->status ) : html_entity_decode( wp_strip_all_tags( $lineItem->value ) );
 
 				$receiptArr[ $sectionIndex ]['lineItems'][] = [
 					'class' => $detailRowClass,

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -212,6 +212,7 @@ class Donations {
 		$receiptArr = [];
 
 		$sectionIndex = 0;
+		$lineBreaks = [ '<br />','<br>','<br/>' ];
 		foreach ( $receipt as $section ) {
 			// Continue if section does not have line items.
 			if ( ! $section->getLineItems() ) {
@@ -246,7 +247,7 @@ class Donations {
 				}
 
 				$label = html_entity_decode( wp_strip_all_tags( $lineItem->label ) );
-				$value = str_replace( '<br>', ' ', $lineItem->value );
+				$value = str_ireplace( $lineBreaks, "\r\n", $lineItem->value );
 				$value = $lineItem->id === 'paymentStatus' ? $this->getFormattedStatus( $payment->status ) : html_entity_decode( wp_strip_all_tags( $value ) );
 
 				$receiptArr[ $sectionIndex ]['lineItems'][] = [

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -245,7 +245,8 @@ class Donations {
 				}
 
 				$label = html_entity_decode( wp_strip_all_tags( $lineItem->label ) );
-				$value = $lineItem->id === 'paymentStatus' ? $this->getFormattedStatus( $payment->status ) : html_entity_decode( wp_strip_all_tags( $lineItem->value ) );
+				$value = str_replace( '<br>', ' ', $lineItem->value );
+				$value = $lineItem->id === 'paymentStatus' ? $this->getFormattedStatus( $payment->status ) : html_entity_decode( wp_strip_all_tags( $value ) );
 
 				$receiptArr[ $sectionIndex ]['lineItems'][] = [
 					'class' => $detailRowClass,

--- a/src/DonorDashboards/resources/js/app/components/donation-receipt/style.scss
+++ b/src/DonorDashboards/resources/js/app/components/donation-receipt/style.scss
@@ -46,6 +46,7 @@
 		text-align: right;
 		display: flex;
 		align-items: center;
+		white-space: pre-line;
 	}
 
 	.give-donor-dashboard-donation-receipt__row--footer {

--- a/src/Receipt/DonationReceipt.php
+++ b/src/Receipt/DonationReceipt.php
@@ -134,9 +134,9 @@ class DonationReceipt extends Receipt {
 	private function getDonorBillingAddressLineItem() {
 		$address = getDonationDonorAddress( $this->donationId );
 		$address = sprintf(
-			'%1$s %2$s%3$s, %4$s%5$s %6$s',
+			'%1$s<br>%2$s%3$s, %4$s%5$s<br>%6$s',
 			$address['line1'],
-			! empty( $address['line2'] ) ? $address['line2'] . ' ' : '',
+			! empty( $address['line2'] ) ? $address['line2'] . '<br>' : '',
 			$address['city'],
 			$address['state'],
 			$address['zip'],

--- a/src/Receipt/DonationReceipt.php
+++ b/src/Receipt/DonationReceipt.php
@@ -62,7 +62,7 @@ class DonationReceipt extends Receipt {
 
 		// Add billing address line item only if donor has billing address.
 		if ( $hasAddress ) {
-			$section->addLineItem( $this->getDonorBillingAddressLineItem() );
+			$section->addLineItem( $billingAddressLineItem );
 		}
 	}
 
@@ -134,13 +134,14 @@ class DonationReceipt extends Receipt {
 	private function getDonorBillingAddressLineItem() {
 		$address = getDonationDonorAddress( $this->donationId );
 		$address = sprintf(
-			'%1$s<br>%2$s%3$s, %4$s%5$s<br>%6$s',
+			'%1$s%7$s%2$s%3$s, %4$s%5$s%7$s%6$s',
 			$address['line1'],
-			! empty( $address['line2'] ) ? $address['line2'] . '<br>' : '',
+			! empty( $address['line2'] ) ? $address['line2'] . "\r\n" : '',
 			$address['city'],
 			$address['state'],
 			$address['zip'],
-			$address['country']
+			$address['country'],
+			"\r\n"
 		);
 
 		return [

--- a/src/Receipt/DonationReceipt.php
+++ b/src/Receipt/DonationReceipt.php
@@ -134,9 +134,9 @@ class DonationReceipt extends Receipt {
 	private function getDonorBillingAddressLineItem() {
 		$address = getDonationDonorAddress( $this->donationId );
 		$address = sprintf(
-			'%1$s<br>%2$s%3$s,%4$s%5$s<br>%6$s',
+			'%1$s %2$s%3$s, %4$s%5$s %6$s',
 			$address['line1'],
-			! empty( $address['line2'] ) ? $address['line2'] . '<br>' : '',
+			! empty( $address['line2'] ) ? $address['line2'] . ' ' : '',
 			$address['city'],
 			$address['state'],
 			$address['zip'],


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5874

## Description
This PR resolves the issue where the Donor billing address was not spaced out. The reason for that is we used `<br>` tags to separate the address details instead of spaces. The issue has been resolved by simply replacing the `<br>` tags with spaces. 

## Affects

Donation receipt

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/4222590/133242201-0983231a-9b85-4120-8a0f-d1801d1a826f.png) | ![image](https://user-images.githubusercontent.com/4222590/133242083-55ff3884-1390-4bc9-8142-8c3f346bcb03.png) |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

