### PR TITLE
Social sharing is now fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add maxlength attribute in input and textarea field template in legacy consumer. (#5955)
 - Prevent php notices which generate from offline -donations.php. (#5960)
 - Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
+- Social sharing is now fixed (#5964)
 
 ## 2.13.4 - 2021-09-03
 

--- a/assets/src/js/plugins/give-api/share.js
+++ b/assets/src/js/plugins/give-api/share.js
@@ -13,7 +13,7 @@ export default {
 			const top = targetWindow.innerHeight / 2 - 126;
 			const left = targetWindow.innerWidth / 2 - 280;
 			// Open new window with prompt for Twitter sharing
-			targetWindow.open( `https://twitter.com/intent/tweet?url=${ url }&text=${ text }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
+			targetWindow.open( `https://twitter.com/intent/tweet?url=${ encodeURIComponent( url ) }&text=${ encodeURIComponent( text ) }`, 'newwindow', `width=560,height=253,top=${ top },left=${ left }` );
 		},
 
 		/**
@@ -28,7 +28,7 @@ export default {
 			const top = targetWindow.innerHeight / 2 - 365;
 			const left = targetWindow.innerWidth / 2 - 280;
 			// Open new window with prompt for Facebook sharing
-			window.open( `https://www.facebook.com/sharer/sharer.php?u=${ url }`, 'newwindow', `width=560,height=730,top=${ top },left=${ left }` );
+			window.open( `https://www.facebook.com/sharer/sharer.php?u=${ encodeURIComponent( url ) }`, 'newwindow', `width=560,height=730,top=${ top },left=${ left }` );
 		},
 	},
 };

--- a/src/Views/Form/Templates/Sequoia/views/social-sharing.php
+++ b/src/Views/Form/Templates/Sequoia/views/social-sharing.php
@@ -34,7 +34,7 @@
 					url = window.Give.fn.removeURLParameter(url, 'payment-confirmation');
 					url = window.Give.fn.removeURLParameter(url, 'payment-id');
 					}
-					const text = `<?php echo urlencode( $options['thank-you']['twitter_message'] ); ?>`;
+					const text = `<?php echo $options['thank-you']['twitter_message']; ?>`;
 					// Open new window with prompt for Twitter sharing
 					window.Give.share.fn.twitter(url, text);
 					return false;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5963

## Description

This PR resolves the issue where users were not able to use the share functionality after donating because all data needed for sharing was not encoded.  The issue has been resolved by encoding all the required data ( URL and message ).  

## Testing Instructions

1. Make a donation
2. Share that on Twitter or Facebook. 


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

