### PR TITLE
Implement conditional visibility in legacy consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Pass form id to donation form action url which help to show notices from session. (#5933)
 - Add hooks to legacy consumer to handle rendering, validating and saving for custom fields. (#5944)
 - Add min/max-length validation to text Fields API node types. (#5948, #5955)
+- Implement conditional visibility support in Legacy Consumer. (#5966)
 
 ### Fixed
 - Add min/max-length validation to text and textarea Fields API node types. (#5955)

--- a/assets/src/js/frontend/give.js
+++ b/assets/src/js/frontend/give.js
@@ -19,6 +19,7 @@ import './give-misc';
 import './give-donor-wall';
 import iFrameResizer from '../plugins/form-template/iframe-content';
 import '../plugins/form-template/parent-page';
+import '../../../../src/Form/LegacyConsumer/resources/js/conditinal-fields';
 
 window.addEventListener('load', function() {
 	window.Give.WINDOW_IS_LOADED = true;

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -107,8 +107,8 @@ document.addEventListener('readystatechange', event => {
 	 *
 	 * @unreleased
 	 */
-	async function addVisibilityConditionsToStateForAllDonationForm() {
-		await document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
+	function addVisibilityConditionsToStateForAllDonationForm() {
+		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
 	}
 
 	/**
@@ -165,29 +165,26 @@ document.addEventListener('readystatechange', event => {
 		}
 	}
 
-	addVisibilityConditionsToStateForAllDonationForm()
-		.then(
-			r => {
-				applyVisibilityConditionsToAllDonationForm();
+	addVisibilityConditionsToStateForAllDonationForm();
+	applyVisibilityConditionsToAllDonationForm();
 
-				// Apply visibility conditions to donation form when donor switch gateway.
-				document.addEventListener(
-					'give_gateway_loaded',
-					event => {
-						const donationForm = document.getElementById(event.detail.formIdAttribute);
-						addVisibilityConditionsToStateForDonationForm(donationForm);
-						applyVisibilityConditionsToDonationForm(donationForm);
-					}
-				);
+	// Apply visibility conditions to donation form when donor switch gateway.
+	document.addEventListener(
+		'give_gateway_loaded',
+		event => {
+			const donationForm = document.getElementById(event.detail.formIdAttribute);
+			addVisibilityConditionsToStateForDonationForm(donationForm);
+			applyVisibilityConditionsToDonationForm(donationForm);
+		}
+	);
 
 
-				// Look for change in watched elements.
-				document.addEventListener(
-					'change',
-					event => applyVisibilityConditionsAttachedToWatchedField(
-						event.target.closest('form.give-form'),
-						event.target.getAttribute('name')
-					)
-				);
-			});
+	// Look for change in watched elements.
+	document.addEventListener(
+		'change',
+		event => applyVisibilityConditionsAttachedToWatchedField(
+			event.target.closest('form.give-form'),
+			event.target.getAttribute('name')
+		)
+	);
 });

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -48,8 +48,8 @@ window.addEventListener('load', async () => {
 	 * Handle fields visibility.
 	 * @unreleased
 	 */
-	function handleVisibility(donationForm, visibilityConditions) {
-		for (const [inputFieldName, visibilityConditions] of Object.entries(visibilityConditions)) {
+	function handleVisibility(donationForm, visibilityConditionsForWatchedField) {
+		for (const [inputFieldName, visibilityConditions] of Object.entries(visibilityConditionsForWatchedField)) {
 			const inputField = donationForm.querySelector(`[name="${inputFieldName}"]`);
 			const fieldWrapper = inputField.closest('.form-row');
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -102,16 +102,6 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * Setup state for condition visibility settings.
-	 * state contains list of watched elements per donation form.
-	 *
-	 * @unreleased
-	 */
-	function addVisibilityConditionsToStateForAllDonationForm() {
-		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
-	}
-
-	/**
 	 * @unreleased
 	 */
 	function applyVisibilityConditionsAttachedToWatchedField(donationForm, fieldName) {
@@ -153,21 +143,6 @@ document.addEventListener('readystatechange', event => {
 	/**
 	 * @unreleased
 	 */
-	function applyVisibilityConditionsToAllDonationForm() {
-		for (const [uniqueDonationFormId, donationFormState] of Object.entries(state)) {
-			for (const [watchedFieldName, visibilityConditions] of Object.entries(donationFormState)) {
-				handleVisibility(
-					document.querySelector(`form[data-id="${uniqueDonationFormId}"]`)
-						.closest('.give-form'),
-					visibilityConditions
-				);
-			}
-		}
-	}
-
-	/**
-	 * @unreleased
-	 */
 	function addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId) {
 		const donationForm = document
 			.querySelector(`form.give-form[data-id="${donationFormUniqueId}"`)
@@ -193,15 +168,25 @@ document.addEventListener('readystatechange', event => {
 	/**
 	 * @unreleased
 	 */
-	function addChangeEventToWatchedElementsForAllDonationForms() {
-		Object.entries(state).forEach(
-			([donationFormUniqueId]) => addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId)
-		)
+	function bootVisibilityConditionsFormAllDonationForm() {
+		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
+
+		// Apply visibility conditions.
+		// Add change event to watched field.
+		for (const [donationFormUniqueId, donationFormState] of Object.entries(state)) {
+			for (const [watchedFieldName, visibilityConditions] of Object.entries(donationFormState)) {
+				handleVisibility(
+					document.querySelector(`form[data-id="${donationFormUniqueId}"]`)
+						.closest('.give-form'),
+					visibilityConditions
+				);
+			}
+
+			addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId);
+		}
 	}
 
-	addVisibilityConditionsToStateForAllDonationForm();
-	applyVisibilityConditionsToAllDonationForm();
-	addChangeEventToWatchedElementsForAllDonationForms();
+	bootVisibilityConditionsFormAllDonationForm();
 
 	// Apply visibility conditions to donation form when donor switch gateway.
 	document.addEventListener(

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -11,21 +11,19 @@ window.addEventListener('load', () => {
 			for (const {field, value} of visibilityConditions) {
 				const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
 
-				if (!inputs) {
-					return;
-				}
+				if (inputs) {
+					inputs.forEach((input) => {
+						const fieldType = input.getAttribute('type');
 
-				inputs.forEach((input) => {
-					const fieldType = input.getAttribute('type');
-
-					if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
-						if (input.checked && input.value === value) {
+						if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
+							if (input.checked && input.value === value) {
+								visible = true;
+							}
+						} else if (input.value === value) {
 							visible = true;
 						}
-					} else if (input.value === value) {
-						visible = true;
-					}
-				});
+					});
+				}
 			}
 
 			visible ?

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -1,4 +1,4 @@
-window.addEventListener('load', async () => {
+window.addEventListener('load', () => {
 	const state = {};
 
 	/**
@@ -110,24 +110,9 @@ window.addEventListener('load', async () => {
 	 * state contains list of watched elements per donation form.
 	 *
 	 * @unreleased
-	 * @returns {Promise<void>}
 	 */
 	function addVisibilityConditionsToStateForAllDonationForm() {
-		document.querySelectorAll('form.give-form')
-			.forEach(function (donationForm) {
-				const uniqueDonationFormId = donationForm.getAttribute('data-id');
-				const watchedFields = getWatchedElementNames(donationForm);
-
-				// Add donation form to state only if visibility conditions exiting for at least form field.
-				if (!uniqueDonationFormId || !Object.entries(watchedFields).length) {
-					return false;
-				}
-
-				state[uniqueDonationFormId] = {
-					watchedElements: watchedFields,
-					...state[uniqueDonationFormId]
-				}
-			});
+		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
 	}
 
 	/**
@@ -197,7 +182,7 @@ window.addEventListener('load', async () => {
 		}
 	}
 
-	await addVisibilityConditionsToStateForAllDonationForm();
+	addVisibilityConditionsToStateForAllDonationForm();
 	applyVisibilityConditionsToAllDonationForm();
 
 	// Apply visibility conditions to donation form when donor switch gateway.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -95,8 +95,15 @@ window.addEventListener('load', async () => {
 		document.querySelectorAll('form.give-form')
 			.forEach(function (donationForm) {
 				const uniqueDonationFormId = donationForm.getAttribute('data-id');
+				const watchedFields = getWatchedElementNames(donationForm);
+
+				// Add donation form to state only if visibility conditions exiting for at least form field.
+				if( ! uniqueDonationFormId || ! Object.entries( watchedFields ).length ) {
+					return false;
+				}
+
 				state[uniqueDonationFormId] = {
-					watchedElements: getWatchedElementNames(donationForm),
+					watchedElements: watchedFields,
 					...state[uniqueDonationFormId]
 				}
 			});
@@ -118,13 +125,17 @@ window.addEventListener('load', async () => {
 	// Look for change in watched elements.
 	document.addEventListener('change', function (event) {
 		const donationForm = event.target.closest('form.give-form');
+		const uniqueDonationFormId = donationForm.getAttribute('data-id');
 
 		// Exit if field is not element of donation form.
-		if (!donationForm) {
+		if (
+			!donationForm ||
+			!uniqueDonationFormId ||
+			! state.hasOwnProperty( uniqueDonationFormId )
+		) {
 			return false;
 		}
 
-		const uniqueDonationFormId = donationForm.getAttribute('data-id');
 		const formState = state[uniqueDonationFormId];
 		const fieldName = event.target.getAttribute('name');
 		const watchedElementNames = Object.keys(formState.watchedElements);

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -4,34 +4,34 @@ window.addEventListener('load', () => {
 	 * @unreleased
 	 */
 	function handleVisibility(donationForm) {
-		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (field) {
-			const fieldWrapper = field.closest('.form-row');
-			const visibilityConditions = JSON.parse(field.getAttribute('data-field-visibility-conditions'));
+		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (inputField) {
+			const fieldWrapper = inputField.closest('.form-row');
+			const visibilityConditions = JSON.parse(inputField.getAttribute('data-field-visibility-conditions'));
+			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			let visible = false;
-			let hasAtleastOneFieldController = false;
-			for (const {field, value} of visibilityConditions) {
-				const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
-				hasAtleastOneFieldController = hasAtleastOneFieldController ? hasAtleastOneFieldController : !! inputs.length;
+			const {field, value} = visibilityCondition;
 
-				if (inputs) {
-					inputs.forEach((input) => {
-						const fieldType = input.getAttribute('type');
+			const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
+			let hasFieldController = !! inputs.length;
 
-						if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
-							if (input.checked && input.value === value) {
-								visible = true;
-							}
-						} else if (input.value === value) {
-							visible = true;
-						}
-					});
-				}
-			}
-
-			if( ! hasAtleastOneFieldController ) {
+			// Do not apply visibility conditions if field controller does not exit in DOM.
+			if ( ! hasFieldController ) {
 				return;
 			}
 
+			inputs.forEach((input) => {
+				const fieldType = input.getAttribute('type');
+
+				if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
+					if (input.checked && input.value === value) {
+						visible = true;
+					}
+				} else if (input.value === value) {
+					visible = true;
+				}
+			});
+
+			// Show or Hide field wrapper.
 			visible ?
 				fieldWrapper.classList.remove('give-hidden') :
 				fieldWrapper.classList.add('give-hidden');

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -165,26 +165,54 @@ document.addEventListener('readystatechange', event => {
 		}
 	}
 
+	/**
+	 * @unreleased
+	 */
+	function addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId) {
+		const donationForm = document
+			.querySelector(`form.give-form[data-id="${donationFormUniqueId}"`)
+			.closest('form.give-form');
+
+		if (!donationForm || !state.hasOwnProperty(donationFormUniqueId)) {
+			return;
+		}
+
+		for (const [watchedElementName, VisibilityConditions] of Object.entries(state[donationFormUniqueId])) {
+			document.querySelectorAll(`[name = "${watchedElementName}"]`)
+				.forEach(field => {
+					field.classList.add('js-condition-visibility-watcher');
+					field.addEventListener(
+						'change',
+						event => applyVisibilityConditionsAttachedToWatchedField(
+							event.target.closest('form.give-form'),
+							event.target.getAttribute('name')
+						));
+				});
+		}
+	}
+
+	/**
+	 * @unreleased
+	 */
+	function addChangeEventToWatchedElementsForAllDonationForms() {
+		Object.entries(state).forEach(
+			([donationFormUniqueId]) => addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId)
+		)
+	}
+
 	addVisibilityConditionsToStateForAllDonationForm();
 	applyVisibilityConditionsToAllDonationForm();
+	addChangeEventToWatchedElementsForAllDonationForms();
 
 	// Apply visibility conditions to donation form when donor switch gateway.
 	document.addEventListener(
 		'give_gateway_loaded',
 		event => {
 			const donationForm = document.getElementById(event.detail.formIdAttribute);
+			const uniqueDonationFormId = donationForm.getAttribute('data-id');
 			addVisibilityConditionsToStateForDonationForm(donationForm);
 			applyVisibilityConditionsToDonationForm(donationForm);
+			addChangeEventToWatchedElementsForDonationForm(uniqueDonationFormId)
 		}
-	);
-
-
-	// Look for change in watched elements.
-	document.addEventListener(
-		'change',
-		event => applyVisibilityConditionsAttachedToWatchedField(
-			event.target.closest('form.give-form'),
-			event.target.getAttribute('name')
-		)
 	);
 });

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -49,3 +49,4 @@ window.addEventListener('load', () => {
 				.forEach(field => field.addEventListener('change', handleVisibilityOnChangeHandler));
 		});
 });
+// @todo: attach event when form reload on gateway switch.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -42,7 +42,6 @@ window.addEventListener('load', () => {
 		handleVisibility(event.target.closest('.give-form') );
 	}
 
-
 	document.querySelectorAll('form.give-form')
 		.forEach(function (donationForm) {
 			handleVisibility(donationForm);

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -25,6 +25,26 @@ window.addEventListener('load', async () => {
 	}
 
 	/**
+	 * @unreleased
+	 *
+	 * @param operator
+	 * @param firstData
+	 * @param secondData
+	 *
+	 * @return boolean
+	 */
+	function compareWithOperator( operator, firstData, secondData ){
+		return {
+			'=': firstData === secondData,
+			'!=': firstData != secondData,
+			'>': firstData > secondData,
+			'>=': firstData >= secondData,
+			'<': firstData < secondData,
+			'<=': firstData <=secondData
+		}[operator]
+	}
+
+	/**
 	 * Handle fields visibility.
 	 * @unreleased
 	 */
@@ -34,7 +54,7 @@ window.addEventListener('load', async () => {
 			const fieldWrapper = inputField.closest('.form-row');
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			let visible = false;
-			const {field, value} = visibilityCondition;
+			const {field, operator, value} = visibilityCondition;
 
 			const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
 			let hasFieldController = !!inputs.length;
@@ -46,12 +66,13 @@ window.addEventListener('load', async () => {
 
 			inputs.forEach((input) => {
 				const fieldType = input.getAttribute('type');
+				const comparisonResult = compareWithOperator( operator, input.value, value );
 
 				if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
-					if (input.checked && input.value === value) {
+					if (input.checked && comparisonResult ) {
 						visible = true;
 					}
-				} else if (input.value === value) {
+				} else if ( comparisonResult ) {
 					visible = true;
 				}
 			});

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -1,4 +1,25 @@
 window.addEventListener('load', () => {
+	const state = {};
+
+	/**
+	 * @unreleased
+	 *
+	 * @return array
+	 */
+	function getWatchedElementNames( donationForm ){
+		const fields = [];
+
+		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (inputField) {
+			const visibilityConditions = JSON.parse(inputField.getAttribute('data-field-visibility-conditions'));
+			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
+			const {field} = visibilityCondition;
+
+			fields.push(field);
+		})
+
+		return fields;
+	}
+
 	/**
 	 * Handle fields visibility
 	 * @unreleased
@@ -46,11 +67,25 @@ window.addEventListener('load', () => {
 		handleVisibility(event.target.closest('.give-form') );
 	}
 
+	// Setup state for condition visibility settings.
+	// state contains list of watched elements per donation form.
 	document.querySelectorAll('form.give-form')
 		.forEach(function (donationForm) {
-			handleVisibility(donationForm);
-			donationForm.querySelectorAll('input, select, textarea')
-				.forEach(field => field.addEventListener('change', handleVisibilityOnChangeHandler));
+			const donationFormId = donationForm.querySelector('input[name="give-form-id"]').value;
+			state[donationFormId] = {
+				watchedElementNames: getWatchedElementNames( donationForm ),
+				...state[donationFormId]
+			}
 		});
+
+	// Look for change in watched elements.
+	document.addEventListener( 'change', function( event ){
+		const donationForm = event.target.closest( 'form.give-form' );
+
+		// Exit if field is not element of donation form.
+		if( ! donationForm ){
+			return false;
+		}
+	});
 });
 // @todo: attach event when form reload on gateway switch.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -112,7 +112,7 @@ window.addEventListener('load', async () => {
 	/**
 	 * @unreleased
 	 */
-	function applyVisibilityConditionsForWatchedField(donationForm, fieldName) {
+	function applyVisibilityConditionsAttachedToWatchedField(donationForm, fieldName) {
 		const uniqueDonationFormId = donationForm.getAttribute('data-id');
 
 		// Exit if field is not element of donation form.
@@ -140,7 +140,7 @@ window.addEventListener('load', async () => {
 	 * @unreleased
 	 * @param donationForm
 	 */
-	function applyVisibilityConditionsForDonationForm(donationForm) {
+	function applyVisibilityConditionsToDonationForm(donationForm) {
 		const uniqueDonationFormId = donationForm.getAttribute('data-id');
 
 		// Exit if field is not element of donation form.
@@ -165,7 +165,7 @@ window.addEventListener('load', async () => {
 	/**
 	 * @unreleased
 	 */
-	function applyVisibilityConditionsAll() {
+	function applyVisibilityConditionsToAllDonationForm() {
 		for (const [uniqueDonationFormId, donationFormState] of Object.entries(state)) {
 			for (const [watchedFieldName, visibilityConditions] of Object.entries(donationFormState.watchedElements)) {
 				handleVisibility(
@@ -178,12 +178,12 @@ window.addEventListener('load', async () => {
 	}
 
 	await setupState();
-	applyVisibilityConditionsAll();
+	applyVisibilityConditionsToAllDonationForm();
 
 	// Apply visibility conditions to donation form when donor switch gateway.
 	document.addEventListener(
 		'give_gateway_loaded',
-		event => applyVisibilityConditionsForDonationForm(
+		event => applyVisibilityConditionsToDonationForm(
 			document.getElementById(event.detail.formIdAttribute)
 		)
 	);
@@ -192,7 +192,7 @@ window.addEventListener('load', async () => {
 	// Look for change in watched elements.
 	document.addEventListener(
 		'change',
-		event => applyVisibilityConditionsForWatchedField(
+		event => applyVisibilityConditionsAttachedToWatchedField(
 			event.target.closest('form.give-form'),
 			event.target.getAttribute('name')
 		)

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -1,0 +1,52 @@
+window.addEventListener('load', () => {
+	/**
+	 * Handle fields visibility
+	 * @unreleased
+	 */
+	function handleVisibility(donationForm) {
+		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (field) {
+			const fieldWrapper = field.closest('.form-row');
+			const visibilityConditions = JSON.parse(field.getAttribute('data-field-visibility-conditions'));
+			let visible = false;
+			for (const {type, field, value} of visibilityConditions) {
+				const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
+
+				if (!inputs) {
+					return;
+				}
+
+				inputs.forEach((input) => {
+					const fieldType = input.getAttribute('type');
+
+					if (fieldType && (fieldType === 'radio' || fieldType === 'checkbox')) {
+						if (input.checked && input.value === value) {
+							visible = true;
+						}
+					} else if (input.value === value) {
+						visible = true;
+					}
+				});
+			}
+
+			visible ?
+				fieldWrapper.classList.remove('give-hidden') :
+				fieldWrapper.classList.add('give-hidden');
+		});
+	}
+
+	/**
+	 * @unreleased
+	 * @param event
+	 */
+	function handleVisibilityOnChangeHandler(event) {
+		handleVisibility(event.target.closest('.give-form') );
+	}
+
+
+	document.querySelectorAll('form.give-form')
+		.forEach(function (donationForm) {
+			handleVisibility(donationForm);
+			donationForm.querySelectorAll('input, select, textarea')
+				.forEach(field => field.addEventListener('change', handleVisibilityOnChangeHandler));
+		});
+});

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -89,9 +89,30 @@ window.addEventListener('load', async () => {
 	 * state contains list of watched elements per donation form.
 	 *
 	 * @unreleased
+	 */
+	function addVisibilityConditionsToStateForDonationForm(donationForm) {
+		const uniqueDonationFormId = donationForm.getAttribute('data-id');
+		const watchedFields = getWatchedElementNames(donationForm);
+
+		// Add donation form to state only if visibility conditions exiting for at least form field.
+		if (!uniqueDonationFormId || !Object.entries(watchedFields).length) {
+			return false;
+		}
+
+		state[uniqueDonationFormId] = {
+			watchedElements: watchedFields,
+			...state[uniqueDonationFormId]
+		}
+	}
+
+	/**
+	 * Setup state for condition visibility settings.
+	 * state contains list of watched elements per donation form.
+	 *
+	 * @unreleased
 	 * @returns {Promise<void>}
 	 */
-	 function setupState() {
+	function addVisibilityConditionsToStateForAllDonationForm() {
 		document.querySelectorAll('form.give-form')
 			.forEach(function (donationForm) {
 				const uniqueDonationFormId = donationForm.getAttribute('data-id');
@@ -176,15 +197,17 @@ window.addEventListener('load', async () => {
 		}
 	}
 
-	await setupState();
+	await addVisibilityConditionsToStateForAllDonationForm();
 	applyVisibilityConditionsToAllDonationForm();
 
 	// Apply visibility conditions to donation form when donor switch gateway.
 	document.addEventListener(
 		'give_gateway_loaded',
-		event => applyVisibilityConditionsToDonationForm(
-			document.getElementById(event.detail.formIdAttribute)
-		)
+		event => {
+			const donationForm = document.getElementById(event.detail.formIdAttribute);
+			addVisibilityConditionsToStateForDonationForm(donationForm);
+			applyVisibilityConditionsToDonationForm(donationForm);
+		}
 	);
 
 

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -14,7 +14,10 @@ window.addEventListener('load', () => {
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			const {field} = visibilityCondition;
 
-			fields.push(field);
+			fields[field] = {
+				...fields[field],
+				[ inputField.name ]: visibilityConditions
+			}
 		})
 
 		return fields;
@@ -86,6 +89,17 @@ window.addEventListener('load', () => {
 		if( ! donationForm ){
 			return false;
 		}
+
+		const donationFormId = donationForm.querySelector('input[name="give-form-id"]').value;
+		const formState = state.[donationFormId];
+		const fieldName = event.target.getAttribute('name');
+
+		// Exit if field is not in list of watched elements.
+		if( ! formState.watchedElementNames.includes( fieldName ) ) {
+			return false;
+		}
 	});
+
+	console.log(state);
 });
 // @todo: attach event when form reload on gateway switch.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -107,8 +107,8 @@ document.addEventListener('readystatechange', event => {
 	 *
 	 * @unreleased
 	 */
-	function addVisibilityConditionsToStateForAllDonationForm() {
-		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
+	async function addVisibilityConditionsToStateForAllDonationForm() {
+		await document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
 	}
 
 	/**
@@ -165,26 +165,29 @@ document.addEventListener('readystatechange', event => {
 		}
 	}
 
-	addVisibilityConditionsToStateForAllDonationForm();
-	applyVisibilityConditionsToAllDonationForm();
+	addVisibilityConditionsToStateForAllDonationForm()
+		.then(
+			r => {
+				applyVisibilityConditionsToAllDonationForm();
 
-	// Apply visibility conditions to donation form when donor switch gateway.
-	document.addEventListener(
-		'give_gateway_loaded',
-		event => {
-			const donationForm = document.getElementById(event.detail.formIdAttribute);
-			addVisibilityConditionsToStateForDonationForm(donationForm);
-			applyVisibilityConditionsToDonationForm(donationForm);
-		}
-	);
+				// Apply visibility conditions to donation form when donor switch gateway.
+				document.addEventListener(
+					'give_gateway_loaded',
+					event => {
+						const donationForm = document.getElementById(event.detail.formIdAttribute);
+						addVisibilityConditionsToStateForDonationForm(donationForm);
+						applyVisibilityConditionsToDonationForm(donationForm);
+					}
+				);
 
 
-	// Look for change in watched elements.
-	document.addEventListener(
-		'change',
-		event => applyVisibilityConditionsAttachedToWatchedField(
-			event.target.closest('form.give-form'),
-			event.target.getAttribute('name')
-		)
-	);
+				// Look for change in watched elements.
+				document.addEventListener(
+					'change',
+					event => applyVisibilityConditionsAttachedToWatchedField(
+						event.target.closest('form.give-form'),
+						event.target.getAttribute('name')
+					)
+				);
+			});
 });

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -2,6 +2,7 @@ window.addEventListener('load', () => {
 	const state = {};
 
 	/**
+	 * Get list of watched fields.
 	 * @unreleased
 	 *
 	 * @return array
@@ -24,13 +25,13 @@ window.addEventListener('load', () => {
 	}
 
 	/**
-	 * Handle fields visibility
+	 * Handle fields visibility.
 	 * @unreleased
 	 */
-	function handleVisibility(donationForm) {
-		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (inputField) {
+	function handleVisibility( donationForm, visibilityConditions ) {
+		for (const [ inputFieldName, visibilityConditions ] of Object.entries( visibilityConditions ) ) {
+			const inputField = donationForm.querySelector(`[name="${inputFieldName}"]`);
 			const fieldWrapper = inputField.closest('.form-row');
-			const visibilityConditions = JSON.parse(inputField.getAttribute('data-field-visibility-conditions'));
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			let visible = false;
 			const {field, value} = visibilityCondition;
@@ -59,15 +60,7 @@ window.addEventListener('load', () => {
 			visible ?
 				fieldWrapper.classList.remove('give-hidden') :
 				fieldWrapper.classList.add('give-hidden');
-		});
-	}
-
-	/**
-	 * @unreleased
-	 * @param event
-	 */
-	function handleVisibilityOnChangeHandler(event) {
-		handleVisibility(event.target.closest('.give-form') );
+		}
 	}
 
 	// Setup state for condition visibility settings.
@@ -76,7 +69,7 @@ window.addEventListener('load', () => {
 		.forEach(function (donationForm) {
 			const donationFormId = donationForm.querySelector('input[name="give-form-id"]').value;
 			state[donationFormId] = {
-				watchedElementNames: getWatchedElementNames( donationForm ),
+				watchedElement: getWatchedElementNames( donationForm ),
 				...state[donationFormId]
 			}
 		});
@@ -91,15 +84,16 @@ window.addEventListener('load', () => {
 		}
 
 		const donationFormId = donationForm.querySelector('input[name="give-form-id"]').value;
-		const formState = state.[donationFormId];
+		const formState = state[donationFormId];
 		const fieldName = event.target.getAttribute('name');
+		const watchedElementNames = Object.keys( formState.watchedElement );
 
 		// Exit if field is not in list of watched elements.
-		if( ! formState.watchedElementNames.includes( fieldName ) ) {
+		if( ! watchedElementNames.includes( fieldName ) ) {
 			return false;
 		}
-	});
 
-	console.log(state);
+		const watchedFieldState = formState.watchedElement[fieldName];
+		handleVisibility( donationForm, watchedFieldState )
+	});
 });
-// @todo: attach event when form reload on gateway switch.

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -180,7 +180,6 @@ document.addEventListener('readystatechange', event => {
 		for (const [watchedElementName, VisibilityConditions] of Object.entries(state[donationFormUniqueId])) {
 			document.querySelectorAll(`[name = "${watchedElementName}"]`)
 				.forEach(field => {
-					field.classList.add('js-condition-visibility-watcher');
 					field.addEventListener(
 						'change',
 						event => applyVisibilityConditionsAttachedToWatchedField(

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -132,8 +132,7 @@ window.addEventListener('load', async () => {
 			return false;
 		}
 
-		const watchedFieldState = formState.watchedElements[fieldName];
-		handleVisibility(donationForm, watchedFieldState)
+		handleVisibility(donationForm, formState.watchedElements[fieldName])
 	}
 
 	/**

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -131,11 +131,10 @@ window.addEventListener('load', () => {
 		}
 
 		const formState = state[uniqueDonationFormId];
-		const watchedElementNames = Object.keys(formState.watchedElements);
 
 		// Exit if field is not in list of watched elements.
-		if (!watchedElementNames.includes(fieldName)) {
-			return false;
+		if (!(fieldName in formState.watchedElements)) {
+			return;
 		}
 
 		handleVisibility(donationForm, formState.watchedElements[fieldName])

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -97,10 +97,7 @@ document.addEventListener('readystatechange', event => {
 
 		// Add donation form to state only if visibility conditions exiting for at least form field.
 		if (uniqueDonationFormId && Object.keys(watchedFields).length) {
-			state[uniqueDonationFormId] = {
-				watchedElements: watchedFields,
-				...state[uniqueDonationFormId]
-			}
+			state[uniqueDonationFormId] = watchedFields;
 		}
 	}
 
@@ -127,8 +124,8 @@ document.addEventListener('readystatechange', event => {
 		) {
 			const formState = state[uniqueDonationFormId];
 
-			if (fieldName in formState.watchedElements) {
-				handleVisibility(donationForm, formState.watchedElements[fieldName])
+			if (fieldName in formState) {
+				handleVisibility(donationForm, formState[fieldName])
 			}
 		}
 	}
@@ -143,7 +140,7 @@ document.addEventListener('readystatechange', event => {
 		if (uniqueDonationFormId && (uniqueDonationFormId in state)) {
 			const formState = state[uniqueDonationFormId];
 
-			for (const [watchedFieldName, visibilityConditions] of Object.entries(formState.watchedElements)) {
+			for (const [watchedFieldName, visibilityConditions] of Object.entries(formState)) {
 				handleVisibility(
 					document.querySelector(`form[data-id="${uniqueDonationFormId}"]`)
 						.closest('.give-form'),
@@ -158,7 +155,7 @@ document.addEventListener('readystatechange', event => {
 	 */
 	function applyVisibilityConditionsToAllDonationForm() {
 		for (const [uniqueDonationFormId, donationFormState] of Object.entries(state)) {
-			for (const [watchedFieldName, visibilityConditions] of Object.entries(donationFormState.watchedElements)) {
+			for (const [watchedFieldName, visibilityConditions] of Object.entries(donationFormState)) {
 				handleVisibility(
 					document.querySelector(`form[data-id="${uniqueDonationFormId}"]`)
 						.closest('.give-form'),

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -8,8 +8,10 @@ window.addEventListener('load', () => {
 			const fieldWrapper = field.closest('.form-row');
 			const visibilityConditions = JSON.parse(field.getAttribute('data-field-visibility-conditions'));
 			let visible = false;
+			let hasAtleastOneFieldController = false;
 			for (const {field, value} of visibilityConditions) {
 				const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
+				hasAtleastOneFieldController = hasAtleastOneFieldController ? hasAtleastOneFieldController : !! inputs.length;
 
 				if (inputs) {
 					inputs.forEach((input) => {
@@ -24,6 +26,10 @@ window.addEventListener('load', () => {
 						}
 					});
 				}
+			}
+
+			if( ! hasAtleastOneFieldController ) {
+				return;
 			}
 
 			visible ?

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -8,7 +8,7 @@ window.addEventListener('load', () => {
 			const fieldWrapper = field.closest('.form-row');
 			const visibilityConditions = JSON.parse(field.getAttribute('data-field-visibility-conditions'));
 			let visible = false;
-			for (const {type, field, value} of visibilityConditions) {
+			for (const {field, value} of visibilityConditions) {
 				const inputs = donationForm.querySelectorAll(`[name="${field}"]`);
 
 				if (!inputs) {

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -1,4 +1,8 @@
-window.addEventListener('load', () => {
+document.addEventListener('readystatechange', event => {
+	if (event.target.readyState !== 'complete') {
+		return null;
+	}
+
 	const state = {};
 
 	/**
@@ -98,35 +102,36 @@ window.addEventListener('load', () => {
 				...state[uniqueDonationFormId]
 			}
 		}
+	}
 
-		/**
-		 * Setup state for condition visibility settings.
-		 * state contains list of watched elements per donation form.
-		 *
-		 * @unreleased
-		 */
-		function addVisibilityConditionsToStateForAllDonationForm() {
-			document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
-		}
+	/**
+	 * Setup state for condition visibility settings.
+	 * state contains list of watched elements per donation form.
+	 *
+	 * @unreleased
+	 */
+	function addVisibilityConditionsToStateForAllDonationForm() {
+		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);
+	}
 
-		/**
-		 * @unreleased
-		 */
-		function applyVisibilityConditionsAttachedToWatchedField(donationForm, fieldName) {
-			const uniqueDonationFormId = donationForm.getAttribute('data-id');
+	/**
+	 * @unreleased
+	 */
+	function applyVisibilityConditionsAttachedToWatchedField(donationForm, fieldName) {
+		const uniqueDonationFormId = donationForm.getAttribute('data-id');
 
-			if (
-				donationForm &&
-				uniqueDonationFormId &&
-				(uniqueDonationFormId in state)
-			) {
-				const formState = state[uniqueDonationFormId];
+		if (
+			donationForm &&
+			uniqueDonationFormId &&
+			(uniqueDonationFormId in state)
+		) {
+			const formState = state[uniqueDonationFormId];
 
-				if (fieldName in formState.watchedElements) {
-					handleVisibility(donationForm, formState.watchedElements[fieldName])
-				}
+			if (fieldName in formState.watchedElements) {
+				handleVisibility(donationForm, formState.watchedElements[fieldName])
 			}
 		}
+	}
 
 	/**
 	 * @unreleased

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -10,5 +10,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php include './conditional-visibility-attribute.html.php'; ?>
+	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -10,5 +10,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php echo ( $conditions = esc_attr( json_encode( $field->getVisibilityConditions() ) ) ) ? "data-field-visibility-conditions=\"$conditions\"" : ''; ?>
+	<?php include './conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -10,4 +10,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
+	<?php echo ( $conditions = esc_attr( json_encode( $field->getVisibilityConditions() ) ) ) ? "data-field-visibility-conditions=\"$conditions\"" : ''; ?>
 >

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -10,5 +10,10 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php
+	if ( $conditions = $field->getVisibilityConditions() ) {
+		$conditions = esc_attr( json_encode( $conditions ) );
+		echo "data-field-visibility-conditions=\"$conditions\"";
+	}
+	?>
 >

--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -10,5 +10,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -6,7 +6,7 @@
 		<?php echo $field->isRequired() ? 'required' : ''; ?>
 		<?php echo $field->isChecked() ? 'checked' : ''; ?>
 		<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-		<?php include './conditional-visibility-attribute.html.php'; ?>
+		<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 	>
 	<?php echo $field->getLabel(); ?>
 </label>

--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -6,7 +6,12 @@
 		<?php echo $field->isRequired() ? 'required' : ''; ?>
 		<?php echo $field->isChecked() ? 'checked' : ''; ?>
 		<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-		<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+		<?php
+		if ( $conditions = $field->getVisibilityConditions() ) {
+			$conditions = esc_attr( json_encode( $conditions ) );
+			echo "data-field-visibility-conditions=\"$conditions\"";
+		}
+		?>
 	>
 	<?php echo $field->getLabel(); ?>
 </label>

--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -6,6 +6,7 @@
 		<?php echo $field->isRequired() ? 'required' : ''; ?>
 		<?php echo $field->isChecked() ? 'checked' : ''; ?>
 		<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
+		<?php include './conditional-visibility-attribute.html.php'; ?>
 	>
 	<?php echo $field->getLabel(); ?>
 </label>

--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -6,7 +6,7 @@
 		<?php echo $field->isRequired() ? 'required' : ''; ?>
 		<?php echo $field->isChecked() ? 'checked' : ''; ?>
 		<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-		<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+		<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 	>
 	<?php echo $field->getLabel(); ?>
 </label>

--- a/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
+++ b/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
@@ -1,0 +1,3 @@
+<?php
+/* @var \Give\Framework\FieldsAPI\Field $field */
+echo ( $conditions = esc_attr( json_encode( $field->getVisibilityConditions() ) ) ) ? "data-field-visibility-conditions=\"$conditions\"" : '';

--- a/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
+++ b/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
@@ -1,6 +1,0 @@
-<?php
-/* @var \Give\Framework\FieldsAPI\Field $field */
-if( $conditions = $field->getVisibilityConditions() ) {
-	$conditions = esc_attr( json_encode( $conditions ) );
-	echo "data-field-visibility-conditions=\"$conditions\"";
-}

--- a/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
+++ b/src/Form/LegacyConsumer/templates/conditional-visibility-attribute.html.php
@@ -1,3 +1,6 @@
 <?php
 /* @var \Give\Framework\FieldsAPI\Field $field */
-echo ( $conditions = esc_attr( json_encode( $field->getVisibilityConditions() ) ) ) ? "data-field-visibility-conditions=\"$conditions\"" : '';
+if( $conditions = $field->getVisibilityConditions() ) {
+	$conditions = esc_attr( json_encode( $conditions ) );
+	echo "data-field-visibility-conditions=\"$conditions\"";
+}

--- a/src/Form/LegacyConsumer/templates/file.html.php
+++ b/src/Form/LegacyConsumer/templates/file.html.php
@@ -7,5 +7,5 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php include './conditional-visibility-attribute.html.php'; ?>
+	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/file.html.php
+++ b/src/Form/LegacyConsumer/templates/file.html.php
@@ -7,5 +7,10 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php
+	if ( $conditions = $field->getVisibilityConditions() ) {
+		$conditions = esc_attr( json_encode( $conditions ) );
+		echo "data-field-visibility-conditions=\"$conditions\"";
+	}
+	?>
 >

--- a/src/Form/LegacyConsumer/templates/file.html.php
+++ b/src/Form/LegacyConsumer/templates/file.html.php
@@ -7,4 +7,5 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
+	<?php include './conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/file.html.php
+++ b/src/Form/LegacyConsumer/templates/file.html.php
@@ -7,5 +7,5 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -2,7 +2,7 @@
 <?php /** @var string $fieldIdAttribute */ ?>
 <?php /* Fieldsets + legends are terrible to style, so we just use the semantic markup and style something else. */ ?>
 <fieldset
-	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >
 	<legend class="screen-reader-text">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -1,7 +1,14 @@
 <?php /** @var Give\Framework\FieldsAPI\Radio $field */ ?>
 <?php /** @var string $fieldIdAttribute */ ?>
 <?php /* Fieldsets + legends are terrible to style, so we just use the semantic markup and style something else. */ ?>
-<fieldset <?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>>
+<fieldset
+	<?php
+	if ( $conditions = $field->getVisibilityConditions() ) {
+		$conditions = esc_attr( json_encode( $conditions ) );
+		echo "data-field-visibility-conditions=\"$conditions\"";
+	}
+	?>
+>
 	<legend class="screen-reader-text">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
 	</legend>
@@ -9,7 +16,7 @@
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
 	</div>
 	<?php foreach ( $field->getOptions() as $index => $option ) : ?>
-		<?php $id = $fieldIdAttribute. '-' . $index; ?>
+		<?php $id = $fieldIdAttribute . '-' . $index; ?>
 		<label for="<?php echo $id; ?>">
 			<input
 				type="radio"

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -1,7 +1,9 @@
 <?php /** @var Give\Framework\FieldsAPI\Radio $field */ ?>
 <?php /** @var string $fieldIdAttribute */ ?>
 <?php /* Fieldsets + legends are terrible to style, so we just use the semantic markup and style something else. */ ?>
-<fieldset>
+<fieldset
+	<?php include './conditional-visibility-attribute.html.php'; ?>
+>
 	<legend class="screen-reader-text">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
 	</legend>

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -1,9 +1,7 @@
 <?php /** @var Give\Framework\FieldsAPI\Radio $field */ ?>
 <?php /** @var string $fieldIdAttribute */ ?>
 <?php /* Fieldsets + legends are terrible to style, so we just use the semantic markup and style something else. */ ?>
-<fieldset
-	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
->
+<fieldset <?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>>
 	<legend class="screen-reader-text">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>
 	</legend>

--- a/src/Form/LegacyConsumer/templates/radio.html.php
+++ b/src/Form/LegacyConsumer/templates/radio.html.php
@@ -2,7 +2,7 @@
 <?php /** @var string $fieldIdAttribute */ ?>
 <?php /* Fieldsets + legends are terrible to style, so we just use the semantic markup and style something else. */ ?>
 <fieldset
-	<?php include './conditional-visibility-attribute.html.php'; ?>
+	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >
 	<legend class="screen-reader-text">
 		<?php include plugin_dir_path( __FILE__ ) . '/label-content.html.php'; ?>

--- a/src/Form/LegacyConsumer/templates/select.html.php
+++ b/src/Form/LegacyConsumer/templates/select.html.php
@@ -6,7 +6,7 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php include './conditional-visibility-attribute.html.php'; ?>
+	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >
 	<?php
 	if ( $placeholder = $field->getPlaceholder() ) {

--- a/src/Form/LegacyConsumer/templates/select.html.php
+++ b/src/Form/LegacyConsumer/templates/select.html.php
@@ -6,7 +6,12 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php
+	if ( $conditions = $field->getVisibilityConditions() ) {
+		$conditions = esc_attr( json_encode( $conditions ) );
+		echo "data-field-visibility-conditions=\"$conditions\"";
+	}
+	?>
 >
 	<?php
 	if ( $placeholder = $field->getPlaceholder() ) {

--- a/src/Form/LegacyConsumer/templates/select.html.php
+++ b/src/Form/LegacyConsumer/templates/select.html.php
@@ -6,6 +6,7 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
+	<?php include './conditional-visibility-attribute.html.php'; ?>
 >
 	<?php
 	if ( $placeholder = $field->getPlaceholder() ) {

--- a/src/Form/LegacyConsumer/templates/select.html.php
+++ b/src/Form/LegacyConsumer/templates/select.html.php
@@ -6,7 +6,7 @@
 	<?php echo $field->getAllowMultiple() ? 'multiple' : ''; ?>
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 >
 	<?php
 	if ( $placeholder = $field->getPlaceholder() ) {

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -6,5 +6,10 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php
+	if ( $conditions = $field->getVisibilityConditions() ) {
+		$conditions = esc_attr( json_encode( $conditions ) );
+		echo "data-field-visibility-conditions=\"$conditions\"";
+	}
+	?>
 ></textarea>

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -6,4 +6,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
+	<?php include './conditional-visibility-attribute.html.php'; ?>
 ></textarea>

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -6,5 +6,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php include './conditional-visibility-attribute.html.php'; ?>
+	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 ></textarea>

--- a/src/Form/LegacyConsumer/templates/textarea.html.php
+++ b/src/Form/LegacyConsumer/templates/textarea.html.php
@@ -6,5 +6,5 @@
 	<?php echo $field->isRequired() ? 'required' : ''; ?>
 	<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
 	<?php echo ( $maxLength = $field->getMaxLength() ) ? "maxlength=\"$maxLength\"" : ''; ?>
-	<?php echo include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
+	<?php include dirname( __FILE__ ) . '/conditional-visibility-attribute.html.php'; ?>
 ></textarea>

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1149,6 +1149,7 @@ input[type='checkbox'],
 input[type='radio']{
 	opacity: 0 !important;
 	position: absolute !important;
+	left: -60px;
 }
 
 input[type='checkbox'] + label {

--- a/src/Views/Form/Templates/Sequoia/assets/css/legacy-consumer.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/legacy-consumer.scss
@@ -5,7 +5,7 @@
 	padding: 20px 30px 0;
 }
 .give-section.payment > .form-row {
-	padding: 5px 20px 5px;
+	padding: 0 20px;
 }
 #give-payment-mode-wrap > .form-row:not(:first-of-type) {
 	margin-top: 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -409,6 +409,7 @@
 			setTimeout( setupTabOrder, 200 );
 
 			moveFieldsUnderPaymentGateway();
+			setupLegacyConsumerCheckboxAndRadio();
 			setupRegistrationFormInputFields();
 			setupFFMInputs();
 			setupInputIcons();


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5965 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Field API already have logic to define conditional visibility settings for field. This pull request adds support for conditional visibility setting support in Legacy Consumer.

This pull request also has a styling fix for the radio and a checkbox for the multi-step form template. I find out that the hidden checkbox and radio button renders on the label which interrupts the label click, to prevent clitch i moved them away from view.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Either you can define your custom field with visibility conditions or [you can test with the Form field manager addon](https://github.com/impress-org/give-form-field-manager/pull/351).

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

