### PR TITLE
Display sequential number as payment_id in email preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add maxlength attribute in input and textarea field template in legacy consumer. (#5955)
 - Prevent php notices which generate from offline -donations.php. (#5960)
 - Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
+- Payment ID in donation email previews correctly reflects donation sequence ID. (#5967)
 
 ## 2.13.4 - 2021-09-03
 

--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -840,6 +840,7 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 		/**
 		 * Decode preview email template tags.
 		 *
+		 * @unreleased display payment sequential number as id
 		 * @since 2.0
 		 *
 		 * @param string $message Email Template Message.
@@ -895,7 +896,7 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 					'amount'                  => $payment_id ? give_email_tag_amount( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
 					'price'                   => $payment_id ? give_email_tag_price( array( 'payment_id' => $payment_id ) ) : give_currency_filter( '10.50' ),
 					'payment_method'          => $payment_id ? give_email_tag_payment_method( array( 'payment_id' => $payment_id ) ) : __( 'PayPal', 'give' ),
-					'payment_id'              => $payment_id ? $payment_id : rand( 2000, 2050 ),
+					'payment_id'              => $payment_id ? $payment->number : rand( 2000, 2050 ),
 					'receipt_link_url'        => $receipt_link_url,
 					'receipt_link'            => $receipt_link,
 					'date'                    => $payment_id ? date( give_date_format(), strtotime( $payment->date ) ) : date( give_date_format(), current_time( 'timestamp' ) ),

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -152,6 +152,7 @@ function give_email_preview_buttons_callback( $field ) {
  *
  * Displays a header bar with the ability to change donations to preview actual data within the preview. Will not display if
  *
+ * @unreleased reduce number of queries
  * @since 1.6
  */
 function give_get_preview_email_header() {
@@ -168,26 +169,25 @@ function give_get_preview_email_header() {
 	$donations = new Give_Payments_Query(
 		array(
 			'number' => 100,
-			'output' => '',
-			'fields' => 'ids',
 		)
 	);
 	$donations = $donations->get_payments();
-	$options   = array();
+	$options   = [];
 
 	// Default option.
 	$options[0] = esc_html__( 'No donations found.', 'give' );
 
 	// Provide nice human readable options.
+	/** @var Give_Payment[] $donations */
 	if ( $donations ) {
 		$options[0] = esc_html__( '- Select a donation -', 'give' );
-		foreach ( $donations as $donation_id ) {
+		foreach ( $donations as $donation ) {
 
-			$options[ $donation_id ] = sprintf(
+			$options[ $donation->ID ] = sprintf(
 				'#%1$s - %2$s - %3$s',
-				$donation_id,
-				give_get_donation_donor_email( $donation_id ),
-				get_the_title( $donation_id )
+				$donation->ID,
+				$donation->email,
+				$donation->number
 			);
 		}
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5962 

## Description

This corrects the Payment ID in email previews by using the sequenced ID rather than the table ID. This is in consistency with how real emails actually work.

I also adjusted a query to load the `Give_Payment` objects and reduce the number of necessary queries.

## Affects

Email previews

## Testing Instructions

1. Go to Donations > Settings > Emails > Donation Receipts
2. Click Preview Email
3. Select a donation
4. Check that the Payment ID matches the sequence, not the table ID

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

