### PR TITLE
Convert only strings to lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add maxlength attribute in input and textarea field template in legacy consumer. (#5955)
 - Prevent php notices which generate from offline -donations.php. (#5960)
 - Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
+- Admin can switch donation status on PHP8.0. (#5971)
 
 ## 2.13.4 - 2021-09-03
 

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -123,6 +123,7 @@ add_action( 'admin_menu', 'give_add_add_ons_option_link', 999999 );
  *
  * @since 1.0
  * @since 2.1 Simplified function.
+ * @unreleased Use anonymous function in array_map to convert only strings to lowercase.
  *
  * @param string $passed_page Optional. Main page's slug
  * @param string $passed_view Optional. Page view ( ex: `edit` or `delete` )

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -134,7 +134,7 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 
 	$found          = true;
 	$get_query_args = ! empty( $_GET ) ?
-		@array_map( function ( $data ) {
+		array_map( function ( $data ) {
 			return is_string( $data ) ? strtolower( $data ) : $data;
 		}, $_GET ) :
 		[];

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -133,10 +133,21 @@ function give_is_admin_page( $passed_page = '', $passed_view = '' ) {
 	global $pagenow, $typenow;
 
 	$found          = true;
-	$get_query_args = ! empty( $_GET ) ? @array_map( 'strtolower', $_GET ) : [];
+	$get_query_args = ! empty( $_GET ) ?
+		@array_map( function ( $data ) {
+			return is_string( $data ) ? strtolower( $data ) : $data;
+		}, $_GET ) :
+		[];
 
 	// Set default argument, if not passed.
-	$query_args = wp_parse_args( $get_query_args, array_fill_keys( [ 'post_type', 'action', 'taxonomy', 'page', 'view', 'tab' ], false ) );
+	$query_args = wp_parse_args( $get_query_args, array_fill_keys( [
+		'post_type',
+		'action',
+		'taxonomy',
+		'page',
+		'view',
+		'tab'
+	], false ) );
 
 	switch ( $passed_page ) {
 		case 'categories':


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5970 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we are suppressing `array_map` errors with `@` but this does not work in PHP8.0. I fixed the issue by taking care of logic in the anonymous function.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should be able to update the donation status on PHP8.0

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

