### PR TITLE
Use WP time format in donor dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Custom fields have unique ID attribute in legacy consumer. (#5938)
 - Form field manager custom fields rendered with field api look good in multi-step form template. (#5946)
 - Use add meta function to persist field value in field api. (#5954)
+- Use WP time format in donor dashboard. (#5975)
 
 ### New
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -163,8 +163,11 @@ class Donations {
 	/**
 	 * Get payment info
 	 *
-	 * @param Give_Payment $payment
 	 * @since 2.10.0
+	 * @unreleased Use WP time format for donation time.
+	 *
+	 * @param Give_Payment $payment
+	 *
 	 * @return array Payment info
 	 */
 	protected function getPaymentInfo( $payment ) {

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -184,7 +184,7 @@ class Donations {
 			'method'        => isset( $gateways[ $payment->gateway ]['checkout_label'] ) ? $gateways[ $payment->gateway ]['checkout_label'] : '',
 			'status'        => $this->getFormattedStatus( $payment->status ),
 			'date'          => date_i18n( give_date_format( 'checkout' ), strtotime( $payment->date ) ),
-			'time'          => date_i18n( 'g:i a', strtotime( $payment->date ) ),
+			'time'          => date_i18n( get_option( 'time_format' ), strtotime( $payment->date ) ),
 			'mode'          => $payment->get_meta( '_give_payment_mode' ),
 			'pdfReceiptUrl' => $pdfReceiptUrl,
 			'serialCode'    => give_is_setting_enabled( give_get_option( 'sequential-ordering_status', 'disabled' ) ) ? Give()->seq_donation_number->get_serial_code( $payment ) : $payment->ID,


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5974

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I update logic to display time format in WP time format setting in donor dashboard in donation history and dashboard.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![Donor Dashboard – give 2021-09-21 at 6 57 50 PM](https://user-images.githubusercontent.com/1784821/134179293-4fcdda8b-59b0-4174-bfa9-21f191cd3d38.jpg)
![General Settings ‹ give — WordPress 2021-09-21 at 6 58 17 PM](https://user-images.githubusercontent.com/1784821/134179353-448479c0-5b29-400f-bfc1-5857132b4a0c.jpg)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Change time format in `Settings -> General -> Time Format` and review time format in donor dashboard.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

