### PR TITLE
Match PayPal email to receiver or business email to prevent IPN failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Formatting button display correctly when decimals enabled in Multi-Step Form. (#5957)
 - Social sharing is now fixed (#5964)
 - Payment ID in donation email previews correctly reflects donation sequence ID. (#5967)
+- Prevent PayPal IPN failure because of business email mismatch. (#5976)
 
 ## 2.13.4 - 2021-09-03
 

--- a/includes/gateways/paypal/paypal-standard.php
+++ b/includes/gateways/paypal/paypal-standard.php
@@ -314,11 +314,16 @@ function give_process_paypal_web_accept( $data, $payment_id ) {
 	}
 
 	// Collect donation payment details.
-	$paypal_amount  = $data['mc_gross'];
-	$payment_status = strtolower( $data['payment_status'] );
-	$currency_code  = strtolower( $data['mc_currency'] );
-	$business_email = isset( $data['business'] ) && is_email( $data['business'] ) ? trim( $data['business'] ) : trim( $data['receiver_email'] );
-	$payment_meta   = give_get_payment_meta( $payment_id );
+	$paypal_amount              = $data['mc_gross'];
+	$payment_status             = strtolower( $data['payment_status'] );
+	$currency_code              = strtolower( $data['mc_currency'] );
+	$paypal_merchant_emails[]   = strtolower( trim( $data['receiver_email'] ) );
+	$payment_meta               = give_get_payment_meta( $payment_id );
+	$give_paypal_merchant_email = strtolower( trim( give_get_option( 'paypal_email' ) ) ); // Only for comparison.
+
+	if ( isset( $data['business'] ) && is_email( $data['business'] ) ) {
+		$paypal_merchant_emails[] = strtolower( trim( $data['business'] ) );
+	}
 
 	// Must be a PayPal standard IPN.
 	if ( 'paypal' !== give_get_payment_gateway( $payment_id ) ) {
@@ -326,7 +331,7 @@ function give_process_paypal_web_accept( $data, $payment_id ) {
 	}
 
 	// Verify payment recipient.
-	if ( strcasecmp( $business_email, trim( give_get_option( 'paypal_email' ) ) ) !== 0 ) {
+	if ( ! in_array( $give_paypal_merchant_email, $paypal_merchant_emails ) ) {
 
 		give_record_gateway_error(
 			__( 'IPN Error', 'give' ),

--- a/includes/gateways/paypal/paypal-standard.php
+++ b/includes/gateways/paypal/paypal-standard.php
@@ -295,11 +295,14 @@ add_action( 'give_verify_paypal_ipn', 'give_process_paypal_ipn' );
 /**
  * Process web accept (one time) payment IPNs.
  *
- * @param array $data       The IPN Data.
- * @param int   $payment_id The payment ID from Give.
+ * @since 1.0
+ * @unreleased verify PayPal email with business and receiver email
+ *
+ * @param int $payment_id The payment ID from Give.
+ *
+ * @param array $data The IPN Data.
  *
  * @return void
- * @since 1.0
  */
 function give_process_paypal_web_accept( $data, $payment_id ) {
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5977 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Explanation of the `business` param of IPN in the PayPal document is confusing.  As per @rickalday findings, we are not getting merchant email address or [value set during PayPal payment.](https://github.com/impress-org/givewp/blob/508b5e462cd8a8c503125b27d96b4a04ee9b337b/includes/gateways/paypal/paypal-standard.php#L665)

One I am sure that either `business` or `receiver_email` param in PayPal IPN will contain a correct merchant email address, so I updated logic to compare GiveWP PayPal email address with both of them.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Follow @rickalday instructions to reproduce the issue. Instructions are given here. https://feedback.givewp.com/bug-reports/p/paypal-standard-donations-fail-in-givewp-but-go-through-in-paypal

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

