### PR TITLE
Show admin defined checkout payment gateway label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Donor addressed is now spaced out on the Donor Dashboard receipt (#5961)
 - Social sharing is now fixed (#5964)
 - Payment ID in donation email previews correctly reflects donation sequence ID. (#5967)
+- Show admin defined checkout payment gateway label. (#5980)
 
 ## 2.13.4 - 2021-09-03
 

--- a/includes/class-give-cache-setting.php
+++ b/includes/class-give-cache-setting.php
@@ -250,6 +250,14 @@ class Give_Cache_Setting {
 		 */
 		$gateways = apply_filters( 'give_register_gateway', $gateways );
 
+		if ( ! empty( $this->settings['give_settings']['gateways_label'] ) ) {
+			foreach ( $this->settings['give_settings']['gateways_label'] as $gatewayId => $checkoutLabel ) {
+				if ( $checkoutLabel ) {
+					$gateways[ $gatewayId ]['checkout_label'] = $checkoutLabel;
+				}
+			}
+		}
+
 		$this->settings['gateways'] = $gateways;
 	}
 

--- a/includes/class-give-cache-setting.php
+++ b/includes/class-give-cache-setting.php
@@ -229,6 +229,7 @@ class Give_Cache_Setting {
 	 * Setup gateway list
 	 *
 	 * @since 2.4.0
+	 * @unreleased Set payment gateway checkout label to  admin defined payment gateway checkout label.
 	 */
 	public function setup_gateways_list() {
 		// Default, built-in gateways
@@ -250,6 +251,7 @@ class Give_Cache_Setting {
 		 */
 		$gateways = apply_filters( 'give_register_gateway', $gateways );
 
+		// Replace payment gateway checkout label with admin defined checkout label.
 		if ( ! empty( $this->settings['give_settings']['gateways_label'] ) ) {
 			foreach ( $this->settings['give_settings']['gateways_label'] as $gatewayId => $checkoutLabel ) {
 				if ( $checkoutLabel ) {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1649,10 +1649,6 @@ function give_payment_mode_select( $form_id, $args ) {
 				 * Loop through the active payment gateways.
 				 */
 				$selected_gateway = give_get_chosen_gateway( $form_id );
-				$give_settings    = give_get_settings();
-				$gateways_label   = array_key_exists( 'gateways_label', $give_settings ) ?
-					$give_settings['gateways_label'] :
-					[];
 
 				foreach ( $gateways as $gateway_id => $gateway ) :
 					// Determine the default gateway.
@@ -1666,16 +1662,9 @@ function give_payment_mode_select( $form_id, $args ) {
 							<input type="radio" name="payment-mode" class="give-gateway"
 								   id="give-gateway-<?php echo esc_attr( $gateway_id . '-' . $id_prefix ); ?>"
 								   value="<?php echo esc_attr( $gateway_id ); ?>"<?php echo $checked; ?>>
-
-							<?php
-							$label = $gateway['checkout_label'];
-							if ( ! empty( $gateways_label[ $gateway_id ] ) ) {
-								$label = $gateways_label[ $gateway_id ];
-							}
-							?>
 							<label for="give-gateway-<?php echo esc_attr( $gateway_id . '-' . $id_prefix ); ?>"
 								   class="give-gateway-option"
-								   id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $label ); ?></label>
+								   id="give-gateway-option-<?php echo esc_attr( $gateway_id ); ?>"> <?php echo esc_html( $gateway['checkout_label'] ); ?></label>
 						</li>
 						<?php
 					}

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1603,27 +1603,23 @@ function give_payment_mode_select( $form_id, $args ) {
 	/**
 	 * Fires while selecting payment gateways, before the fields.
 	 *
+	 * @since 1.7
+	 *
 	 * @param int $form_id The form ID.
 	 *
-	 * @since 1.7
 	 */
 	do_action( 'give_payment_mode_top', $form_id );
 	?>
 
-	<fieldset id="give-payment-mode-select"
-		<?php
-		if ( count( $gateways ) <= 1 ) {
-			echo 'style="display: none;"';
-		}
-		?>
-	>
+	<fieldset id="give-payment-mode-select"<?php echo count( $gateways ) <= 1 ? ' style="display: none;"' : ''; ?>>
 		<?php
 		/**
 		 * Fires while selecting payment gateways, before the wrap div.
 		 *
+		 * @since 1.7
+		 *
 		 * @param int $form_id The form ID.
 		 *
-		 * @since 1.7
 		 */
 		do_action( 'give_payment_mode_before_gateways_wrap' );
 		?>

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -128,6 +128,7 @@ function give_get_gateway_admin_label( $gateway ) {
  * Returns the checkout label for the specified gateway
  *
  * @since 1.0
+ * @unreleased Code removed. Here no need to forcefully change manual payment gateway checkout label to "Test Donation".
  *
  * @param string $gateway Name of the gateway to retrieve a label for
  *

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -137,10 +137,6 @@ function give_get_gateway_checkout_label( $gateway ) {
 	$gateways = give_get_payment_gateways();
 	$label    = isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ]['checkout_label'] : $gateway;
 
-	if ( $gateway == 'manual' ) {
-		$label = __( 'Test Donation', 'give' );
-	}
-
 	return apply_filters( 'give_gateway_checkout_label', $label, $gateway );
 }
 

--- a/src/Receipt/DonationReceipt.php
+++ b/src/Receipt/DonationReceipt.php
@@ -3,7 +3,7 @@ namespace Give\Receipt;
 
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use function give_get_payment_meta as getDonationMetaData;
-use function give_get_gateway_admin_label as getGatewayLabel;
+use function give_get_gateway_checkout_label as getGatewayLabel;
 use function give_get_donation_donor_email as getDonationDonorEmail;
 use function give_get_donation_address as getDonationDonorAddress;
 use function give_format_amount as formatAmount;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5979

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we were not replacing the gateways checkout labels with admin-defined labels. I update the code to set the payment checkout label.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
this pull request will affect:
- `{payment_method} ` email tag output
- Payment method checkout label in the donation form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![give 2021-09-22 at 11 01 19 PM](https://user-images.githubusercontent.com/1784821/134392883-a8036cd9-334f-457e-8f01-a0c55dbef50b.jpg)
![GiveWP Settings ‹ give — WordPress 2021-09-22 at 11 01 42 PM](https://user-images.githubusercontent.com/1784821/134392936-a8eb72ee-f445-40c5-aff1-e1097ad746ac.jpg)
![Demo – give 2021-09-22 at 11 02 07 PM](https://user-images.githubusercontent.com/1784821/134392968-e7779f35-9a86-44ca-8090-8488d29b2c94.jpg)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Rename payment gateway and
- Donation with gateway and check receipt email
- Check payment gateway label in the donation form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

