### PR TITLE
PHP 5.6 compatibility issue when run any WP cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Donor addressed is now spaced out on the Donor Dashboard receipt (#5961)
 - Social sharing is now fixed (#5964)
 - Payment ID in donation email previews correctly reflects donation sequence ID. (#5967)
+- Resolve PHP 5.6 compatibility issue when run any WP cli command. (#5981)
 
 ## 2.13.4 - 2021-09-03
 

--- a/src/TestData/Addons/ManualDonations/ManualDonations.php
+++ b/src/TestData/Addons/ManualDonations/ManualDonations.php
@@ -2,7 +2,7 @@
 
 namespace Give\TestData\Addons\ManualDonations;
 
-use Throwable;
+use Exception;
 use Give\TestData\Framework\MetaRepository;
 
 /**
@@ -11,7 +11,7 @@ use Give\TestData\Framework\MetaRepository;
  */
 class ManualDonations {
 
-	private const GATEWAY = 'manual_donation';
+	const GATEWAY = 'manual_donation';
 
 	/**
 	 * @param  int  $donationID
@@ -36,7 +36,7 @@ class ManualDonations {
 
 			$wpdb->query( 'COMMIT' );
 
-		} catch ( Throwable $e ) {
+		} catch ( Exception $e ) {
 			$wpdb->query( 'ROLLBACK' );
 		}
 	}

--- a/src/TestData/Addons/ManualDonations/ManualDonations.php
+++ b/src/TestData/Addons/ManualDonations/ManualDonations.php
@@ -8,6 +8,8 @@ use Give\TestData\Framework\MetaRepository;
 /**
  * Class ManualDonations
  * @package Give\TestData\ManualDonations
+ *
+ * @unreleased update class code to maintain PHP 5.6 compatibility
  */
 class ManualDonations {
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I was getting a fatal error when run in the wp CLI command on PHP > 7.0.
```
[23-Sep-2021 06:21:37 UTC] PHP Parse error:  syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) in /Users/ravinderkumar/Local-Sites/give/app/public/wp-content/plugins/give/src/TestData/Addons/ManualDonations/ManualDonations.php on line 14
```

I updated the code to maintain compatibility with PHP 5.6.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Test WP CLI command on PHP 5.6 and PHP >= 7.0

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

