### PR TITLE
Prevent multiple donations on mobile devices

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -203,11 +203,22 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	/**
+	 * Used to determine if a donation is already in progress
+	 * @type {boolean}
+	 */
+	let inProgress = false;
+
+	/**
 	 * Donation Form AJAX Submission
 	 *
 	 * @description: Process the donation submit
 	 */
 	$( 'body' ).on( 'click touchend', 'form.give-form input[name="give-purchase"].give-submit', function( e ) {
+		if ( inProgress ) {
+			return;
+		}
+
+		inProgress = true;
 		//this form object
 		const $this = $( this );
 		const this_form = $this.parents( 'form.give-form' );
@@ -223,6 +234,7 @@ jQuery( document ).ready( function( $ ) {
 		if ( typeof give_purchase_form.checkValidity === 'function' && give_purchase_form.checkValidity() === false ) {
 			//Don't leave any hanging loading animations
 			loading_animation.fadeOut();
+			inProgress = false;
 			return;
 		}
 
@@ -240,6 +252,7 @@ jQuery( document ).ready( function( $ ) {
 
 		//Submit form via AJAX
 		$.post( Give.fn.getGlobalVar( 'ajaxurl' ), this_form.serialize() + '&action=give_process_donation&give_ajax=true', function( data ) {
+			inProgress = false;
 			if ( $.trim( data ) == 'success' ) {
 				//Remove any errors
 				this_form.find( '.give_errors' ).remove();


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5982

## Description

Although I was not able to reproduce this issue on multiple mobile devices and multiple browsers, I can understand, potentially, why this happens in the first place. The events attached to the Donate Now button are `touched` and `click`, so I suspect that some of the older mobile browsers handle those events incorrectly by firing both events at the same time. 

To be on the safe side and prevent potential double donations in the future, an additional JS check is added which will prevent this behavior. 

## Affects
Donate Now button


## Testing Instructions
I couldn't reproduce the issue I'm fixing in this PR, but the Support team says that on rare occasions, multiple and really fast clicks on Donate Now button trigger it. So, try to click multiple times very fast on the Donate Now button :sweat_smile: 

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

