### PR TITLE
Preview Emails are now sent to the authenticated user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Preview Emails are now sent to the authenticated user (#5990)
+
 ### Fixed
 
 - Admin can switch donation status on PHP8.0. (#5971)

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -318,7 +318,7 @@ function _give_register_admin_notices() {
 							[
 								'id'          => 'give-sent-test-email',
 								'type'        => 'updated',
-								'description' => __( 'The test email has been sent.', 'give' ),
+								'description' => sprintf( __( 'The test email has been sent to %s.', 'give' ), wp_get_current_user()->user_email ),
 								'show'        => true,
 							]
 						);

--- a/includes/admin/emails/abstract-email-notification.php
+++ b/includes/admin/emails/abstract-email-notification.php
@@ -695,6 +695,7 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 		 * Send preview email.
 		 *
 		 * @since  2.0
+		 * @unreleased Preview email recipient is now the current user.
 		 * @access public
 		 *
 		 * @param bool $send Flag to check if send email or not.
@@ -736,9 +737,11 @@ if ( ! class_exists( 'Give_Email_Notification' ) ) :
 				Give()->emails->from_address = give_get_meta( $form_id, '_give_from_email', true );
 			}
 
-			return $send
-				? Give()->emails->send( $this->get_preview_email_recipient( $form_id ), $subject, $message, $attachments )
-				: false;
+			if( $send ) {
+				Give()->emails->send( wp_get_current_user()->user_email, $subject, $message, $attachments );
+			}
+
+			return false;
 		}
 
 

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -373,10 +373,10 @@ class Give_Email_Setting_Field {
 	public static function get_preview_setting_field( Give_Email_Notification $email, $form_id = null ) {
 		return array(
 			'name' => __( 'Preview Email', 'give' ),
-			'desc' => __(
-				'Click the "Preview Email" button to preview the email in your browser. Click the "Send Test Email" button to send a test email directly to your inbox.',
+			'desc' => sprintf(__(
+				'Click the "Preview Email" button to preview the email in your browser.<br />Click the "Send Test Email" button to send a test email to yourself at %s.',
 				'give'
-			),
+			), wp_get_current_user()->user_email ),
 			'id'   => self::get_prefix( $email, $form_id ) . 'preview_buttons',
 			'type' => 'email_preview_buttons',
 		);

--- a/includes/admin/emails/class-email-setting-field.php
+++ b/includes/admin/emails/class-email-setting-field.php
@@ -373,10 +373,12 @@ class Give_Email_Setting_Field {
 	public static function get_preview_setting_field( Give_Email_Notification $email, $form_id = null ) {
 		return array(
 			'name' => __( 'Preview Email', 'give' ),
-			'desc' => sprintf(__(
-				'Click the "Preview Email" button to preview the email in your browser.<br />Click the "Send Test Email" button to send a test email to yourself at %s.',
-				'give'
-			), wp_get_current_user()->user_email ),
+			'desc' => sprintf(
+				'%1$s<br />%2$s <code>%3$s</code>.',
+				esc_html__( 'Click the "Preview Email" button to preview the email in your browser.', 'give' ),
+				esc_html__( 'Click the "Send Test Email" button to send a test email to yourself at', 'give' ),
+				wp_get_current_user()->user_email
+			),
 			'id'   => self::get_prefix( $email, $form_id ) . 'preview_buttons',
 			'type' => 'email_preview_buttons',
 		);

--- a/includes/admin/emails/filters.php
+++ b/includes/admin/emails/filters.php
@@ -51,6 +51,24 @@ function give_email_notification_row_actions_callback( $row_actions, $email ) {
 			__( 'Send test email', 'give' )
 		);
 
+		$send_preview_email_link = give()->tooltips->render_link( [
+			'tag_content' => esc_html__( 'Send test email', 'give' ),
+			'label'       => sprintf(
+				esc_html__( 'Click this link to send a test email to yourself at %s', 'give' ),
+				wp_get_current_user()->user_email
+			),
+			'link'        => wp_nonce_url(
+				add_query_arg(
+					array(
+						'give_action'     => 'send_preview_email',
+						'email_type'      => $email->config['id'],
+						'give-messages[]' => 'sent-test-email',
+					)
+				),
+				'give-send-preview-email'
+			)
+		] );
+
 		$row_actions['email_preview']      = $preview_link;
 		$row_actions['send_preview_email'] = $send_preview_email_link;
 	}


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5989 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the preview emails to send to the currently authenticated user's email address, as opposed to determining the recipient based on the settings.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This does change 2 existing translatable strings.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

The description for sending a preview email shows the recipient email address.

![Screenshot 2021-09-28 at 14-42-15 GiveWP Settings ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/135147066-fde77140-00d7-402a-a141-f4950abbb8e6.png)

Sending a preview email hows the recipient email address in the success notice.

![Screenshot 2021-09-28 at 14-41-49 GiveWP Settings ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/135147068-f966fe8f-8f6c-4f97-9eed-a9315587e5a0.png)

![Screenshot 2021-09-28 at 14-42-45 GiveWP Settings ‹ WordPress — WordPress](https://user-images.githubusercontent.com/10858303/135147061-088d3274-ddcf-4619-808f-2699367fc075.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Switch to a user with admin access, but that isn't the super admin and send a preview email.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

