### PR TITLE
Single donors can now be deleted via the donors table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Admin can switch donation status on PHP8.0. (#5971)
+- Single donors can now be deleted via the donors table (#5992)
 
 ## 2.14.0 - 2021-09-27
 

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -7,8 +7,8 @@
  * @license:     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  */
 /* globals Give, jQuery */
-import { GiveWarningAlert, GiveErrorAlert, GiveConfirmModal } from '../plugins/modal';
-import { GiveShortcodeButton } from './shortcode-button.js';
+import {GiveConfirmModal, GiveErrorAlert, GiveWarningAlert} from '../plugins/modal';
+import {GiveShortcodeButton} from './shortcode-button.js';
 import setupChosen from './utils/setupChosen';
 
 // Provided access to global level.
@@ -1995,14 +1995,14 @@ const gravatar = require( 'gravatar' );
 			 * @unreleased Added donor_id as a hidden input when deleting a single donor from the table.
 			 */
 			$body.on( 'click', '.give-single-donor-delete', function( e ) {
-				const donorId = $( this ).data( 'id' ),
-					donorSelector = $( 'tr#donor-' + donorId ).find( '.donor-selector' ),
-					selectAll = $( '[id^="cb-select-all-"]' ),
-					bulkDeleteList = $( '#give-bulk-donors' ),
-					donorName = donorSelector.data( 'name' ),
+				const donorId = $(this).data('id'),
+					donorSelector = $('tr#donor-' + donorId).find('.donor-selector'),
+					selectAll = $('[id^="cb-select-all-"]'),
+					bulkDeleteList = $('#give-bulk-donors'),
+					donorName = donorSelector.data('name'),
 					donorHtml = '<div id="give-donor-' + donorId + '" data-id="' + donorId + '">' +
-						'<a class="give-skip-donor" title="' + Give.fn.getGlobalVar( 'remove_from_bulk_delete' ) + '">X</a>' +
-						donorName + '<input type="hidden" name="donor_id" value="' + donorId + '" /></div>';
+						'<a class="give-skip-donor" title="' + Give.fn.getGlobalVar('remove_from_bulk_delete') + '">X</a>' +
+						donorName;
 
 				// Reset Donors List.
 				bulkDeleteList.html( '' );
@@ -2013,8 +2013,8 @@ const gravatar = require( 'gravatar' );
 				}
 
 				// Select the donor checkbox for which delete is clicked and others should be de-selected.
-				$( '.donor-selector' ).removeAttr( 'checked' );
-				donorSelector.attr( 'checked', 'checked' );
+				$('.donor-selector').removeAttr('checked');
+				donorSelector.prop('checked', true);
 
 				// Add Donor to the Bulk Delete List, if donor doesn't exists in the list.
 				if ( $( '#give-donor-' + donorId ).length === 0 ) {

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -1989,7 +1989,11 @@ const gravatar = require( 'gravatar' );
 				$( '#donor-' + donorId ).find( 'input[type="checkbox"]' ).removeAttr( 'checked' );
 			} );
 
-			// Clicking Event to Delete Single Donor.
+			/**
+			 * Clicking Event to Delete Single Donor.
+			 *
+			 * @unreleased Added donor_id as a hidden input when deleting a single donor from the table.
+			 */
 			$body.on( 'click', '.give-single-donor-delete', function( e ) {
 				const donorId = $( this ).data( 'id' ),
 					donorSelector = $( 'tr#donor-' + donorId ).find( '.donor-selector' ),
@@ -1998,7 +2002,7 @@ const gravatar = require( 'gravatar' );
 					donorName = donorSelector.data( 'name' ),
 					donorHtml = '<div id="give-donor-' + donorId + '" data-id="' + donorId + '">' +
 						'<a class="give-skip-donor" title="' + Give.fn.getGlobalVar( 'remove_from_bulk_delete' ) + '">X</a>' +
-						donorName + '</div>';
+						donorName + '<input type="hidden" name="donor_id" value="' + donorId + '" /></div>';
 
 				// Reset Donors List.
 				bulkDeleteList.html( '' );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5991

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a hidden input to identify the `donor_id` of the donor that is being deleted.

Note: The custom feedback suggests that this is specifically related to PHP 8, but I was able to also replicate the issue using PHP 7.4.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This specifically applies to deleting a single donor via the donors table, as opposed to the bulk delete donors or deleting from Edit Donor screen.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

In the "donors" submenu, click "delete" action item inline of a donor. Confirm that the donor should be deleted and click the "delete" button.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

