### PR TITLE
Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Admin can switch donation status on PHP8.0. (#5971)
 - Single donors can now be deleted via the donors table (#5992)
+- Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard. (#5998)
 
 ## 2.14.0 - 2021-09-27
 

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -366,7 +366,7 @@ class Donations {
 			]
 		);
 
-		return $formatted ?: (string) $amount;
+		return $formatted ?: $amount;
 	}
 
 	/**

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -348,17 +348,25 @@ class Donations {
 		];
 	}
 
-	protected function getAmountWithSeparators( $amount, $currency ) {
+	/**
+	 * @since 2.10.0
+	 *
+	 * @param string $amount
+	 * @param string $currencyCode
+	 *
+	 * @return string
+	 */
+	protected function getAmountWithSeparators( $amount, $currencyCode ) {
 		$formatted = give_format_amount(
 			$amount,
 			[
 				'decimal'  => false,
 				'sanitize' => false,
-				'currency' => $currency
+				'currency' => $currencyCode
 			]
 		);
 
-		return $formatted ? $formatted : (string) $amount;
+		return $formatted ?: (string) $amount;
 	}
 
 	/**

--- a/src/DonorDashboards/Repositories/Donations.php
+++ b/src/DonorDashboards/Repositories/Donations.php
@@ -1,10 +1,10 @@
 <?php
 namespace Give\DonorDashboards\Repositories;
 
-use Give\Receipt\LineItem;
-use Give\ValueObjects\Money;
 use Give\Framework\Database\DB;
 use Give\Receipt\DonationReceipt;
+use Give\Receipt\LineItem;
+use Give\ValueObjects\Money;
 use Give_Payment;
 
 /**
@@ -33,8 +33,12 @@ class Donations {
 	 * @return string
 	 */
 	public function getRevenue( $donorId ) {
-		$aggregate = $this->getDonationAggregate( 'sum(revenue.amount)', $donorId );
-		return $aggregate ? $this->getAmountWithSeparators( Money::ofMinor( $aggregate->result, give_get_option( 'currency' ) )->getAmount() ) : null;
+		$currencyCode = give_get_option( 'currency' );
+		$aggregate    = $this->getDonationAggregate( 'sum(revenue.amount)', $donorId );
+
+		return $aggregate ?
+			$this->getAmountWithSeparators( Money::ofMinor( $aggregate->result, $currencyCode )->getAmount(), $currencyCode ) :
+			null;
 	}
 
 	/**
@@ -46,8 +50,12 @@ class Donations {
 	 * @return string
 	 */
 	public function getAverageRevenue( $donorId ) {
-		$aggregate = $this->getDonationAggregate( 'avg(revenue.amount)', $donorId );
-		return $aggregate ? $this->getAmountWithSeparators( Money::ofMinor( $aggregate->result, give_get_option( 'currency' ) )->getAmount() ) : null;
+		$currencyCode = give_get_option( 'currency' );
+		$aggregate    = $this->getDonationAggregate( 'avg(revenue.amount)', $donorId );
+
+		return $aggregate ?
+			$this->getAmountWithSeparators( Money::ofMinor( $aggregate->result, $currencyCode )->getAmount(), $currencyCode ) :
+			null;
 	}
 
 	/**
@@ -340,11 +348,13 @@ class Donations {
 		];
 	}
 
-	protected function getAmountWithSeparators( $amount ) {
+	protected function getAmountWithSeparators( $amount, $currency ) {
 		$formatted = give_format_amount(
 			$amount,
 			[
-				'decimal' => false,
+				'decimal'  => false,
+				'sanitize' => false,
+				'currency' => $currency
 			]
 		);
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5997

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we are not passing currency `give_format_amount`. I updated logic to format aggregate on basis of currency.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![Donor Dashboard – give 2021-09-29 at 8 57 05 PM](https://user-images.githubusercontent.com/1784821/135300186-ae244ce0-a87c-4fc5-8dbd-e5084200423f.jpg)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Try to reproduce the issue with the instructions given in the issue description.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

