### PR TITLE
Empty value attributes are no longer used as the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Admin can switch donation status on PHP8.0. (#5971)
 - Single donors can now be deleted via the donors table (#5992)
+- Empty value attributes are no longer used as the default value (#5999)
 
 ## 2.14.0 - 2021-09-27
 

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -1203,6 +1203,7 @@ function give_email_preview_buttons( $field ) {
  *
  * @since  1.8
  * @since  2.1 Added support for donation_limit.
+ * @unreleased Checks for empty value before defaulting to the field attributes value.
  *
  * @param  array $field
  * @param  int   $postid

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -893,7 +893,6 @@ function give_radio( $field ) {
 	echo '<fieldset class="give-field-wrap ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><span class="give-field-label">' . wp_kses_post( $field['name'] ) . '</span><legend class="screen-reader-text">' . wp_kses_post( $field['name'] ) . '</legend><ul class="give-radios">';
 
 	foreach ( $field['options'] as $key => $value ) {
-
 		echo '<li><label><input
 				name="' . give_get_field_name( $field ) . '"
 				value="' . esc_attr( $key ) . '"
@@ -1211,7 +1210,7 @@ function give_email_preview_buttons( $field ) {
  * @return mixed
  */
 function give_get_field_value( $field, $postid ) {
-	if ( isset( $field['attributes']['value'] ) ) {
+	if ( isset( $field['attributes']['value'] ) && '' !== $field['attributes']['value'] ) {
 		return $field['attributes']['value'];
 	}
 


### PR DESCRIPTION
RELATED https://github.com/impress-org/give-recurring/pull/1092
RELATED https://github.com/impress-org/givewp/issues/5996

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR checks for empty values before defaulting to the `$field[ attributes ][ value ]`.

In the case of https://github.com/impress-org/give-recurring/pull/1092 the default value was not being applied because the attributes value was an empty string.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Using the Recurring Donations add-on, create a donation form set to "Admin Choice". Check that the recurring options of the donation levels are set to the default value. Note that https://github.com/impress-org/give-recurring/pull/1092 changes the default value.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

