### PR TITLE
Add additional scroll to top functionality when switching between steps 2 (donation amount) and 3 (payment screen)

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -39,6 +39,7 @@
 			$( '.step-tracker' ).removeClass( 'current' );
 			$( '.step-tracker[data-step="' + step + '"]' ).addClass( 'current' );
 
+			// Handle introduction step (whether disabled or not).
 			if ( templateOptions.introduction.enabled === 'disabled' ) {
 				if ( $( '.step-tracker' ).length === 3 ) {
 					$( '.step-tracker' ).remove();
@@ -54,9 +55,14 @@
 				$( '.give-form-navigator', $container ).addClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '50px' );
 			} else if ( step === 0 ) {
+				// First  step is enabled.
 				$( '.give-form-navigator', $container ).removeClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '' );
 			} else {
+				// Other steps besides intro and payment amounts:
+				// Scroll to top after animation finished
+				// @see https://github.com/impress-org/givewp/issues/5969
+				scrollToIframeTop();
 				$( '.give-form-navigator', $container ).addClass( 'nav-visible' );
 				$( steps[ step ].selector ).css( 'padding-top', '50px' );
 			}
@@ -91,7 +97,7 @@
 					return navigator.firstFocus = true;
 				}
 				if ( steps[ navigator.currentStep ].firstFocus ) {
-					$( steps[ navigator.currentStep ].firstFocus ).focus();
+					$( steps[ navigator.currentStep ].firstFocus ).trigger('focus');
 				}
 			}, 200 );
 		},


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5969 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This work adds an additional scrolling feature to steps 2 and 3 of the donation process. When changing from the introduction to other slides you should have a better user experience, particularly on mobile.

I'd like to hear from @mathetos and @knowler on their opinions here. The Canny feedback post is here:  https://feedback.givewp.com/feature-requests/p/multistep-form-steps-should-start-at-top-of-viewport

_Questions:_

1. I'm leaning towards making this feature only enabled for mobile if not at all. Right now this is experimental because it's largely untested widely it touches a pretty important visual part of the multi-step donation form. 
2. Is there a better place to put the use of `scrolltoIframeTop()`?

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
- Donation Form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Before (Non-Auto Scroll)

![2021-09-29_20-47-03 (1)](https://user-images.githubusercontent.com/1571635/135377727-cd79df6a-6ed2-4cda-9018-b1955a7d5989.gif)

### After (Auto-Scroll)


![2021-09-29_20-45-27 (1)](https://user-images.githubusercontent.com/1571635/135377748-4af5f8cd-f1b7-49f9-a2fb-2d938e12544c.gif)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Checkout branch, npm run dev, checkout on mobile using devtools.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

