### PR TITLE
Donor dashboard response messages are now updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Preview Emails are now sent to the authenticated user (#5990)
+- Donor dashboard response messages are now updated (#6003)
 
 ### Fixed
 

--- a/src/DonorDashboards/Routes/VerifyEmailRoute.php
+++ b/src/DonorDashboards/Routes/VerifyEmailRoute.php
@@ -80,7 +80,7 @@ class VerifyEmailRoute implements RestRoute {
 
 			if ( $sent === true ) {
 
-				$sentMessage = (string) apply_filters( 'give_email_access_mail_send_notice', esc_html__( 'Please check your email and click on the link to access your complete donation history.', 'give' ) );
+				$sentMessage = (string) apply_filters( 'give_email_access_mail_send_notice', esc_html__( 'Email sent. If not received, make sure it is a valid donor email.', 'give' ) );
 
 				return new WP_REST_Response(
 					[
@@ -113,7 +113,7 @@ class VerifyEmailRoute implements RestRoute {
 			$spamMessage = (string) apply_filters(
 				'give_email_access_requests_exceed_notice',
 				sprintf(
-					esc_html__( 'Too many access email requests detected. Please wait %s before requesting a new donation history access link.', 'give' ),
+					esc_html__( 'Email sent. If not received, make sure it is a valid donor email.', 'give' ),
 					sprintf( _n( '%s minute', '%s minutes', $value, 'give' ), $value )
 				),
 				$value


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5993

## Description
This PR updates the response messages which are displayed to the user after he tries to log in to the Donor Dashboard with an email. Both "success" and "failed" messages are now the same in order to prevent malicious users/bots to reveal anything about the user accounts.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

