### PR TITLE
Option to make Donor Last Name filed required is now implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### New
+
+- Option to make Donor Last Name filed required is now implemented (#6004)
+
 ### Changed
 
 - Preview Emails are now sent to the authenticated user (#5990)

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -355,7 +355,7 @@ class Give_MetaBox_Form_Data {
 								],
 							],
 							[
-								'name'    => __( 'Last Name Required', 'give' ),
+								'name'    => __( 'Last Name Field Required', 'give' ),
 								'desc'    => __( 'Do you want to force the Last Name field to be required?', 'give' ),
 								'id'      => $prefix . 'last_name_field_required',
 								'type'    => 'radio_inline',

--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -355,6 +355,18 @@ class Give_MetaBox_Form_Data {
 								],
 							],
 							[
+								'name'    => __( 'Last Name Required', 'give' ),
+								'desc'    => __( 'Do you want to force the Last Name field to be required?', 'give' ),
+								'id'      => $prefix . 'last_name_field_required',
+								'type'    => 'radio_inline',
+								'default' => 'global',
+								'options' => [
+									'global'   => __( 'Global Option', 'give' ),
+									'required' => __( 'Required', 'give' ),
+									'optional' => __( 'Optional', 'give' ),
+								],
+							],
+							[
 								'name'    => __( 'Anonymous Donations', 'give' ),
 								'desc'    => __( 'Do you want to provide donors the ability mark themselves anonymous while giving? This will prevent their information from appearing publicly on your website but you will still receive their information for your records in the admin panel.', 'give' ),
 								'id'      => "{$prefix}anonymous_donation",

--- a/includes/admin/settings/class-settings-display.php
+++ b/includes/admin/settings/class-settings-display.php
@@ -88,6 +88,17 @@ if ( ! class_exists( 'Give_Settings_Display' ) ) :
 							],
 						],
 						[
+							'name'    => __( 'Last Name Required', 'give' ),
+							'desc'    => __( 'Do you want to force the Last Name field to be required?', 'give' ),
+							'id'      => 'last_name_field_required',
+							'type'    => 'radio_inline',
+							'default' => 'optional',
+							'options' => [
+								'required' => __( 'Required', 'give' ),
+								'optional' => __( 'Optional', 'give' ),
+							],
+						],
+						[
 							'name'    => __( 'Anonymous Donations', 'give' ),
 							'desc'    => __( 'Do you want to provide donors the ability mark themselves anonymous while giving. This will prevent their information from appearing publicly on your website but you will still receive their information for your records in the admin panel.', 'give' ),
 							'id'      => 'anonymous_donation',

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -514,6 +514,7 @@ class Give_Scripts {
 						// Field name               Validation message.
 						'payment-mode'           => __( 'Please select payment mode.', 'give' ),
 						'give_first'             => __( 'Please enter your first name.', 'give' ),
+						'give_last'              => __( 'Please enter your last name.', 'give' ),
 						'give_email'             => __( 'Please enter a valid email address.', 'give' ),
 						'give_user_login'        => __( 'Invalid email address or username.', 'give' ),
 						'give_user_pass'         => __( 'Enter a password.', 'give' ),

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1758,6 +1758,29 @@ function give_is_company_field_enabled( $form_id ) {
 }
 
 /**
+ * Check if Last Name field is required
+ *
+ * @param $form_id
+ *
+ * @return bool
+ * @unreleased
+ */
+function give_is_last_name_required( $form_id ) {
+	$form_setting_val   = give_get_meta( $form_id, '_give_last_name_field_required', true );
+	$global_setting_val = give_get_option( 'last_name_field_required' );
+
+	if ( ! empty( $form_setting_val ) ) {
+		if ( 'required' === $form_setting_val ) {
+			return true;
+		}
+
+		return 'global' === $form_setting_val && 'required' === $global_setting_val;
+	}
+
+	return 'required' === $global_setting_val;
+}
+
+/**
  * Check if anonymous donation field enabled or not for form or globally.
  *
  * @param $form_id

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -740,6 +740,13 @@ function give_get_required_fields( $form_id ) {
 		}
 	}
 
+	if ( give_is_last_name_required( $form_id ) ) {
+		$required_fields['give_last'] = [
+			'error_id'      => 'invalid_last_name',
+			'error_message' => __( 'Please enter your last name.', 'give' ),
+		];
+	}
+
 	/**
 	 * Filters the donation form required field.
 	 *


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5994

## Description

This PR adds an option to make Donor Last Name filed required. The option is added as a _global option_ in the `Settings > Default Options > Form Fields` screen, and per donation form as well.

## Affects

 Donor Last Name filed

## Visuals

| Global | Donation Form |
|---|---|
| ![image](https://user-images.githubusercontent.com/4222590/135421943-955f455a-7e6d-4550-adc8-811c354752df.png) | ![image](https://user-images.githubusercontent.com/4222590/135422011-45a3aef2-173f-4fa6-9cee-b5df8ff6b77e.png) |


## Testing Instructions

1. Make the Last Name field required ( global option or per donation form option ) 
2. Try to make donation without entering the last name

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

