### PR TITLE
PHP 5.6 compatibility issue when run any WP cli command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Admin can switch donation status on PHP8.0. (#5971)
 - Single donors can now be deleted via the donors table (#5992)
 - Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard. (#5998)
+- Resolve PHP 5.6 compatibility issue when run any WP cli command. (#6005)
 
 ## 2.14.0 - 2021-09-27
 

--- a/src/TestData/Addons/CurrencySwitcher/CurrencySwitcher.php
+++ b/src/TestData/Addons/CurrencySwitcher/CurrencySwitcher.php
@@ -2,7 +2,7 @@
 
 namespace Give\TestData\Addons\CurrencySwitcher;
 
-use Throwable;
+use Exception;
 use Give\TestData\Framework\MetaRepository;
 
 class CurrencySwitcher {
@@ -56,7 +56,7 @@ class CurrencySwitcher {
 
 			$wpdb->query( 'COMMIT' );
 
-		} catch ( Throwable $e ) {
+		} catch ( Exception $e ) {
 			$wpdb->query( 'ROLLBACK' );
 		}
 	}

--- a/src/TestData/Addons/FeeRecovery/FeeRecovery.php
+++ b/src/TestData/Addons/FeeRecovery/FeeRecovery.php
@@ -2,7 +2,7 @@
 
 namespace Give\TestData\Addons\FeeRecovery;
 
-use Throwable;
+use Exception;
 use Give\TestData\Framework\MetaRepository;
 
 class FeeRecovery {
@@ -38,7 +38,7 @@ class FeeRecovery {
 
 			$wpdb->query( 'COMMIT' );
 
-		} catch ( Throwable $e ) {
+		} catch ( Exception $e ) {
 			$wpdb->query( 'ROLLBACK' );
 		}
 	}

--- a/src/TestData/Addons/Funds/FundCommand.php
+++ b/src/TestData/Addons/Funds/FundCommand.php
@@ -2,8 +2,8 @@
 
 namespace Give\TestData\Addons\Funds;
 
+use Exception;
 use WP_CLI;
-use Throwable;
 
 /**
  * Class FundCommand
@@ -81,7 +81,7 @@ class FundCommand {
 
 				$progress->finish();
 
-			} catch ( Throwable $e ) {
+			} catch ( Exception $e ) {
 				$wpdb->query( 'ROLLBACK' );
 
 				WP_CLI::error( $e->getMessage() );

--- a/src/TestData/Addons/RecurringDonations/RecurringDonations.php
+++ b/src/TestData/Addons/RecurringDonations/RecurringDonations.php
@@ -2,7 +2,7 @@
 
 namespace Give\TestData\Addons\RecurringDonations;
 
-use Throwable;
+use Exception;
 use Give\TestData\Framework\MetaRepository;
 
 /**
@@ -74,7 +74,7 @@ class RecurringDonations {
 
 			$wpdb->query( 'COMMIT' );
 
-		} catch ( Throwable $e ) {
+		} catch ( Exception $e ) {
 			$wpdb->query( 'ROLLBACK' );
 		}
 	}

--- a/src/TestData/Commands/DonationSeedCommand.php
+++ b/src/TestData/Commands/DonationSeedCommand.php
@@ -2,10 +2,10 @@
 
 namespace Give\TestData\Commands;
 
-use WP_CLI;
-use Throwable;
+use Exception;
 use Give\TestData\Factories\DonationFactory as DonationFactory;
 use Give\TestData\Repositories\DonationRepository as DonationRepository;
+use WP_CLI;
 
 /**
  * Class DonationSeedCommand
@@ -108,7 +108,7 @@ class DonationSeedCommand {
 			// Generate donations
 			$donations = $this->donationFactory->consistent( $consistent )->make( $count );
 
-		} catch ( Throwable $e ) {
+		} catch ( Exception $e ) {
 			return WP_CLI::error( $e->getMessage() );
 		}
 
@@ -135,7 +135,7 @@ class DonationSeedCommand {
 
 				$progress->finish();
 
-			} catch ( Throwable $e ) {
+			} catch ( Exception $e ) {
 				$wpdb->query( 'ROLLBACK' );
 
 				WP_CLI::error( $e->getMessage() );

--- a/src/TestData/Commands/FormSeedCommand.php
+++ b/src/TestData/Commands/FormSeedCommand.php
@@ -2,9 +2,9 @@
 
 namespace Give\TestData\Commands;
 
-use WP_CLI;
 use Give\TestData\Factories\DonationFormFactory;
 use Give\TestData\Repositories\DonationFormRepository;
+use WP_CLI;
 
 /**
  * Class FormSeedCommand
@@ -119,7 +119,7 @@ class FormSeedCommand {
 
 				$progress->finish();
 
-			} catch ( Throwable $e ) {
+			} catch ( \Exception $e ) {
 				$wpdb->query( 'ROLLBACK' );
 
 				WP_CLI::error( $e->getMessage() );

--- a/src/TestData/Commands/FormSeedCommand.php
+++ b/src/TestData/Commands/FormSeedCommand.php
@@ -11,7 +11,7 @@ use WP_CLI;
  * Class FormSeedCommand
  * @package Give\TestData\Commands
  *
- * A WP-CLI command to generate Donatoion Forms
+ * A WP-CLI command to generate Donation Forms
  */
 class FormSeedCommand {
 

--- a/src/TestData/Commands/FormSeedCommand.php
+++ b/src/TestData/Commands/FormSeedCommand.php
@@ -2,6 +2,7 @@
 
 namespace Give\TestData\Commands;
 
+use Exception;
 use Give\TestData\Factories\DonationFormFactory;
 use Give\TestData\Repositories\DonationFormRepository;
 use WP_CLI;
@@ -119,7 +120,7 @@ class FormSeedCommand {
 
 				$progress->finish();
 
-			} catch ( \Exception $e ) {
+			} catch ( Exception $e ) {
 				$wpdb->query( 'ROLLBACK' );
 
 				WP_CLI::error( $e->getMessage() );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I left a few instances of `Throwable` in code while cleanup in pull request https://github.com/impress-org/givewp/pull/5981

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Test WP CLI command on PHP 5.6 and PHP >= 7.0

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

