### PR TITLE
[Field API] Add change event to multi checkbox options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Donors can now properly set custom amounts in the donor dashboard (#6001)
 - Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard. (#5998)
 - Resolve PHP 5.6 compatibility issue when run any WP cli command. (#6005)
+- Add change event to multi checkbox options correctly to field api fields. (#6009)
 
 ## 2.14.0 - 2021-09-27
 

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -40,6 +40,8 @@ document.addEventListener('readystatechange', event => {
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			let fieldSelector = getFieldSelector(inputField);
 			let {field} = visibilityCondition;
+
+			// Get field. It will tell use real name of field.
 			field = document.querySelector(`[name="${field}"], [name="${field}[]"]`);
 
 			if (field) {

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -138,7 +138,10 @@ document.addEventListener('readystatechange', event => {
 			uniqueDonationFormId &&
 			(uniqueDonationFormId in state)
 		) {
+
+
 			const formState = state[uniqueDonationFormId];
+			fieldName = fieldName.replace('[]', '');
 
 			if (fieldName in formState) {
 				handleVisibility(donationForm, formState[fieldName])
@@ -179,7 +182,7 @@ document.addEventListener('readystatechange', event => {
 		}
 
 		for (const [watchedElementName, VisibilityConditions] of Object.entries(state[donationFormUniqueId])) {
-			document.querySelectorAll(`[name = "${watchedElementName}"]`)
+			document.querySelectorAll(`[name = "${watchedElementName}"], [name="${watchedElementName}[]"]`)
 				.forEach(field => {
 					field.addEventListener(
 						'change',

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -77,7 +77,7 @@ document.addEventListener('readystatechange', event => {
 	 * Handle fields visibility.
 	 * @unreleased
 	 */
-	function handleVisibility(donationForm, visibilityConditionsForWatchedField) {
+	function handleVisibility(donationForm, watchedFieldName, visibilityConditionsForWatchedField) {
 		for (const [inputFieldName, visibilityConditions] of Object.entries(visibilityConditionsForWatchedField)) {
 			const inputField = -1 === inputFieldName.indexOf('data-field-name') ?
 				donationForm.querySelector(`[name="${inputFieldName}"]`) :
@@ -86,9 +86,9 @@ document.addEventListener('readystatechange', event => {
 			const fieldWrapper = fieldWrapperWithoutInputField ? inputField : inputField.closest('.form-row');
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
 			let visible = false;
-			const {field, operator, value} = visibilityCondition;
+			const {operator, value} = visibilityCondition;
 
-			const inputs = donationForm.querySelectorAll(`[name="${field}"], [name="${field}[]"]`);
+			const inputs = donationForm.querySelectorAll(`[name="${watchedFieldName}"]`);
 			let hasFieldController = !!inputs.length;
 
 			if (hasFieldController) {
@@ -131,26 +131,6 @@ document.addEventListener('readystatechange', event => {
 
 	/**
 	 * @unreleased
-	 */
-	function applyVisibilityConditionsAttachedToWatchedField(donationForm, fieldName) {
-		const uniqueDonationFormId = donationForm.getAttribute('data-id');
-
-		if (
-			donationForm &&
-			uniqueDonationFormId &&
-			(uniqueDonationFormId in state)
-		) {
-
-
-			const formState = state[uniqueDonationFormId];
-			if (fieldName in formState) {
-				handleVisibility(donationForm, formState[fieldName])
-			}
-		}
-	}
-
-	/**
-	 * @unreleased
 	 * @param donationForm
 	 */
 	function applyVisibilityConditionsToDonationForm(donationForm) {
@@ -186,10 +166,8 @@ document.addEventListener('readystatechange', event => {
 				.forEach(field => {
 					field.addEventListener(
 						'change',
-						event => applyVisibilityConditionsAttachedToWatchedField(
-							event.target.closest('form.give-form'),
-							event.target.getAttribute('name')
-						));
+						() => handleVisibility(donationForm, watchedElementName, VisibilityConditions)
+					);
 				});
 		}
 	}
@@ -207,6 +185,7 @@ document.addEventListener('readystatechange', event => {
 				handleVisibility(
 					document.querySelector(`form[data-id="${donationFormUniqueId}"]`)
 						.closest('.give-form'),
+					watchedFieldName,
 					visibilityConditions
 				);
 			}

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -6,7 +6,7 @@ document.addEventListener('readystatechange', event => {
 	const state = {};
 
 	/**
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 *
 	 * @param {HTMLElement} inputField
 	 * @return {string}
@@ -28,7 +28,7 @@ document.addEventListener('readystatechange', event => {
 
 	/**
 	 * Get list of watched fields.
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 *
 	 * @return object
 	 */
@@ -56,7 +56,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 *
 	 * @param operator
 	 * @param firstData
@@ -77,7 +77,7 @@ document.addEventListener('readystatechange', event => {
 
 	/**
 	 * Handle fields visibility.
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 */
 	function handleVisibility(donationForm, watchedFieldName, visibilityConditionsForWatchedField) {
 		for (const [inputFieldName, visibilityConditions] of Object.entries(visibilityConditionsForWatchedField)) {
@@ -119,7 +119,7 @@ document.addEventListener('readystatechange', event => {
 	 * Setup state for condition visibility settings.
 	 * state contains list of watched elements per donation form.
 	 *
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 */
 	function addVisibilityConditionsToStateForDonationForm(donationForm) {
 		const uniqueDonationFormId = donationForm.getAttribute('data-id');
@@ -132,7 +132,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 * @param donationForm
 	 */
 	function applyVisibilityConditionsToDonationForm(donationForm) {
@@ -152,7 +152,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 */
 	function addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId) {
 		const donationForm = document
@@ -175,7 +175,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @unreleased
+	 * @since [[UNRELEASED]]
 	 */
 	function bootVisibilityConditionsFormAllDonationForm() {
 		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -6,7 +6,7 @@ document.addEventListener('readystatechange', event => {
 	const state = {};
 
 	/**
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 *
 	 * @param {HTMLElement} inputField
 	 * @return {string}
@@ -28,7 +28,7 @@ document.addEventListener('readystatechange', event => {
 
 	/**
 	 * Get list of watched fields.
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 *
 	 * @return object
 	 */
@@ -56,7 +56,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 *
 	 * @param operator
 	 * @param firstData
@@ -77,7 +77,7 @@ document.addEventListener('readystatechange', event => {
 
 	/**
 	 * Handle fields visibility.
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 */
 	function handleVisibility(donationForm, watchedFieldName, visibilityConditionsForWatchedField) {
 		for (const [inputFieldName, visibilityConditions] of Object.entries(visibilityConditionsForWatchedField)) {
@@ -119,7 +119,7 @@ document.addEventListener('readystatechange', event => {
 	 * Setup state for condition visibility settings.
 	 * state contains list of watched elements per donation form.
 	 *
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 */
 	function addVisibilityConditionsToStateForDonationForm(donationForm) {
 		const uniqueDonationFormId = donationForm.getAttribute('data-id');
@@ -132,7 +132,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 * @param donationForm
 	 */
 	function applyVisibilityConditionsToDonationForm(donationForm) {
@@ -153,7 +153,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 */
 	function addChangeEventToWatchedElementsForDonationForm(donationFormUniqueId) {
 		const donationForm = document
@@ -176,7 +176,7 @@ document.addEventListener('readystatechange', event => {
 	}
 
 	/**
-	 * @since [[UNRELEASED]]
+	 * @unreleased
 	 */
 	function bootVisibilityConditionsFormAllDonationForm() {
 		document.querySelectorAll('form.give-form').forEach(addVisibilityConditionsToStateForDonationForm);

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -145,6 +145,7 @@ document.addEventListener('readystatechange', event => {
 				handleVisibility(
 					document.querySelector(`form[data-id="${uniqueDonationFormId}"]`)
 						.closest('.give-form'),
+					watchedFieldName,
 					visibilityConditions
 				);
 			}

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -38,13 +38,15 @@ document.addEventListener('readystatechange', event => {
 		donationForm.querySelectorAll('[data-field-visibility-conditions]').forEach(function (inputField) {
 			const visibilityConditions = JSON.parse(inputField.getAttribute('data-field-visibility-conditions'));
 			const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
-			const {field} = visibilityCondition;
 			let fieldSelector = getFieldSelector(inputField);
+			let {field} = visibilityCondition;
+			field = document.querySelector(`[name="${field}"], [name="${field}[]"]`);
 
-
-			fields[field] = {
-				...fields[field],
-				[fieldSelector]: visibilityConditions
+			if (field) {
+				fields[field.name] = {
+					...fields[field],
+					[fieldSelector]: visibilityConditions
+				}
 			}
 		});
 
@@ -141,8 +143,6 @@ document.addEventListener('readystatechange', event => {
 
 
 			const formState = state[uniqueDonationFormId];
-			fieldName = fieldName.replace('[]', '');
-
 			if (fieldName in formState) {
 				handleVisibility(donationForm, formState[fieldName])
 			}
@@ -182,7 +182,7 @@ document.addEventListener('readystatechange', event => {
 		}
 
 		for (const [watchedElementName, VisibilityConditions] of Object.entries(state[donationFormUniqueId])) {
-			document.querySelectorAll(`[name = "${watchedElementName}"], [name="${watchedElementName}[]"]`)
+			document.querySelectorAll(`[name = "${watchedElementName}"]`)
 				.forEach(field => {
 					field.addEventListener(
 						'change',


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Recently we added multi-checkbox support in field API. I find out that condition visibility on the client-side is not working as expected. I find out that the change event does not add to multi checkbox options because of mane contains `[]`. I updated the code to handle the use case

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Test whether or not visibility conditions work with simple and array(`[]`) name.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

