### PR TITLE
Show custom payment gateway label in donation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard. (#5998)
 - Resolve PHP 5.6 compatibility issue when run any WP cli command. (#6005)
 - Add change event to multi checkbox options correctly to field api fields. (#6009)
+- Show custom payment gateway label in donation form. (#6012)
 
 ## 2.14.0 - 2021-09-27
 

--- a/includes/class-give-cache-setting.php
+++ b/includes/class-give-cache-setting.php
@@ -228,6 +228,8 @@ class Give_Cache_Setting {
 	/**
 	 * Setup gateway list
 	 *
+	 * Note: use give_get_enabled_payment_gateways function to get list of registered gateway.
+	 *
 	 * @since 2.4.0
 	 * @unreleased Set payment gateway checkout label to  admin defined payment gateway checkout label.
 	 */
@@ -250,7 +252,7 @@ class Give_Cache_Setting {
 		 * @since 2.4.0
 		 */
 		$gateways = apply_filters( 'give_register_gateway', $gateways );
-		
+
 		$this->settings['gateways'] = $gateways;
 	}
 

--- a/includes/class-give-cache-setting.php
+++ b/includes/class-give-cache-setting.php
@@ -250,16 +250,7 @@ class Give_Cache_Setting {
 		 * @since 2.4.0
 		 */
 		$gateways = apply_filters( 'give_register_gateway', $gateways );
-
-		// Replace payment gateway checkout label with admin defined checkout label.
-		if ( ! empty( $this->settings['give_settings']['gateways_label'] ) ) {
-			foreach ( $this->settings['give_settings']['gateways_label'] as $gatewayId => $checkoutLabel ) {
-				if ( $checkoutLabel ) {
-					$gateways[ $gatewayId ]['checkout_label'] = $checkoutLabel;
-				}
-			}
-		}
-
+		
 		$this->settings['gateways'] = $gateways;
 	}
 

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -22,10 +22,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function give_get_payment_gateways() {
 	// Default, built-in gateways
-	$gateways = Give_Cache_Setting::get_option( 'gateways', [] );
+	$gateways      = apply_filters(
+		'give_payment_gateways',
+		Give_Cache_Setting::get_option( 'gateways', [] )
+	);
+	$gatewayLabels = give_get_option( 'gateways_label', [] );
 
-	return apply_filters( 'give_payment_gateways', $gateways );
+	// Replace payment gateway checkout label with admin defined checkout label.
+	if ( $gatewayLabels ) {
+		foreach ( $gatewayLabels as $gatewayId => $checkoutLabel ) {
+			if ( $checkoutLabel ) {
+				$gateways[ $gatewayId ]['checkout_label'] = $checkoutLabel;
+			}
+		}
+	}
 
+	return $gateways;
 }
 
 /**

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -31,7 +31,7 @@ function give_get_payment_gateways() {
 	// Replace payment gateway checkout label with admin defined checkout label.
 	if ( $gatewayLabels ) {
 		foreach ( $gatewayLabels as $gatewayId => $checkoutLabel ) {
-			if ( $checkoutLabel ) {
+			if ( $checkoutLabel && array_key_exists( $gatewayId, $gateways ) ) {
 				$gateways[ $gatewayId ]['checkout_label'] = $checkoutLabel;
 			}
 		}

--- a/src/Views/Form/Templates/Sequoia/Actions.php
+++ b/src/Views/Form/Templates/Sequoia/Actions.php
@@ -2,8 +2,8 @@
 
 namespace Give\Views\Form\Templates\Sequoia;
 
-use Give_Donate_Form;
 use Give\Helpers\Form\Template as FormTemplateUtils;
+use Give_Donate_Form;
 
 /**
  * Class Actions
@@ -310,7 +310,7 @@ class Actions {
 		foreach ( $gateways as $key => $value ) {
 			$gateways[ $key ]['checkout_label'] = sprintf(
 				__( 'Donate with %1$s', 'give' ),
-				$gateways[ $key ]['checkout_label']
+				$value['checkout_label']
 			);
 		}
 		return $gateways;

--- a/src/Views/Form/Templates/Sequoia/assets/css/legacy-consumer.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/legacy-consumer.scss
@@ -6,6 +6,8 @@
 }
 .give-section.payment > .form-row {
 	padding: 0 20px;
+	margin-top: 15px;
+	display: block;
 }
 #give-payment-mode-wrap > .form-row:not(:first-of-type) {
 	margin-top: 20px;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #5979

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we were not replacing the gateways checkout labels with admin-defined labels. I update the code to set the payment checkout label.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
this pull request will affect:
- `{payment_method} ` email tag output
- Payment method checkout label in the donation form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![give 2021-09-22 at 11 01 19 PM](https://user-images.githubusercontent.com/1784821/134392883-a8036cd9-334f-457e-8f01-a0c55dbef50b.jpg)
![GiveWP Settings ‹ give — WordPress 2021-09-22 at 11 01 42 PM](https://user-images.githubusercontent.com/1784821/134392936-a8eb72ee-f445-40c5-aff1-e1097ad746ac.jpg)
![Demo – give 2021-09-22 at 11 02 07 PM](https://user-images.githubusercontent.com/1784821/134392968-e7779f35-9a86-44ca-8090-8488d29b2c94.jpg)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Rename payment gateway and
- Donation with gateway and check receipt email
- Check the payment gateway label in the donation form
- Check payment gateway label on the donation detail page
- Check payment gateway label on gateway listing setting page

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

