### PR TITLE
Multi checkbox work fine in Multi Step Form template generated with field api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Preview Emails are now sent to the authenticated user (#5990)
+- Donor dashboard response messages are now updated (#6003)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Format amount correctly in 'Lifetime Donations' and 'Average Donation' in donation dashboard. (#5998)
 - Resolve PHP 5.6 compatibility issue when run any WP cli command. (#6005)
 - Add change event to multi checkbox options correctly to field api fields. (#6009)
+- Resolve checkbox and radio (generated with field api) state related issues in Multi Step Form template. (#6013)
+- Refactor setup logic of checkbox and radio in Multi Step Form template. (#6013)
 
 ## 2.14.0 - 2021-09-27
 

--- a/src/DonorDashboards/Routes/VerifyEmailRoute.php
+++ b/src/DonorDashboards/Routes/VerifyEmailRoute.php
@@ -80,7 +80,7 @@ class VerifyEmailRoute implements RestRoute {
 
 			if ( $sent === true ) {
 
-				$sentMessage = (string) apply_filters( 'give_email_access_mail_send_notice', esc_html__( 'Please check your email and click on the link to access your complete donation history.', 'give' ) );
+				$sentMessage = (string) apply_filters( 'give_email_access_mail_send_notice', esc_html__( 'Email sent. If not received, make sure it is a valid donor email.', 'give' ) );
 
 				return new WP_REST_Response(
 					[
@@ -113,7 +113,7 @@ class VerifyEmailRoute implements RestRoute {
 			$spamMessage = (string) apply_filters(
 				'give_email_access_requests_exceed_notice',
 				sprintf(
-					esc_html__( 'Too many access email requests detected. Please wait %s before requesting a new donation history access link.', 'give' ),
+					esc_html__( 'Email sent. If not received, make sure it is a valid donor email.', 'give' ),
 					sprintf( _n( '%s minute', '%s minutes', $value, 'give' ), $value )
 				),
 				$value

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1145,12 +1145,12 @@ fieldset {
 	display: none !important;
 }
 
-//input[type='checkbox'],
-//input[type='radio']{
-//	opacity: 0 !important;
-//	position: absolute !important;
-//	left: -60px;
-//}
+input[type='checkbox'],
+input[type='radio'] {
+	opacity: 0 !important;
+	position: absolute !important;
+	left: -60px;
+}
 
 input[type='checkbox'] + label {
 	font-weight: 500;

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -1145,12 +1145,12 @@ fieldset {
 	display: none !important;
 }
 
-input[type='checkbox'],
-input[type='radio']{
-	opacity: 0 !important;
-	position: absolute !important;
-	left: -60px;
-}
+//input[type='checkbox'],
+//input[type='radio']{
+//	opacity: 0 !important;
+//	position: absolute !important;
+//	left: -60px;
+//}
 
 input[type='checkbox'] + label {
 	font-weight: 500;

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -545,17 +545,17 @@
 			switch ( $( this ).prop( 'type' ) ) {
 				case 'checkbox': {
 					if ( $( this ).prop( 'checked' ) ) {
-						$( this ).parent().addClass( 'checked' );
+						$(this).parent().addClass('active');
 					} else {
-						$( this ).parent().removeClass( 'checked' );
+						$(this).parent().removeClass('active');
 					}
 					break;
 				}
 				case 'radio': {
 					if ( $( this ).prop( 'checked' ) ) {
-						$( this ).parent().addClass( 'selected' );
+						$(this).parent().addClass('active');
 					} else {
-						$( this ).parent().removeClass( 'selected' );
+						$(this).parent().removeClass('active');
 					}
 					break;
 				}
@@ -573,12 +573,12 @@
 		if ( $( evt.target ).is( 'input' ) ) {
 			switch ( $( evt.target ).prop( 'type' ) ) {
 				case 'checkbox': {
-					$( evt.target ).closest( 'label' ).toggleClass( 'checked' );
+					$(evt.target).closest('label').toggleClass('active');
 					break;
 				}
 				case 'radio': {
-					$( evt.target ).closest( 'label' ).addClass( 'selected' );
-					$( evt.target ).parent().siblings().removeClass( 'selected' );
+					$(evt.target).closest('label').addClass('active');
+					$(evt.target).parent().siblings().removeClass('active');
 					break;
 				}
 			}
@@ -809,10 +809,8 @@
 
 		// Persist checkbox input border when selected
 		$(document).on('click', label, function (evt) {
-			if (container === label) {
-				evt.stopPropagation();
-				evt.preventDefault();
-				$(input).prop('checked', !$(input).prop('checked')).focus();
+			if (evt.target.nodeName === 'INPUT') {
+				return;
 			}
 
 			$(container).toggleClass('active');
@@ -826,18 +824,34 @@
 	 * @param {object} evt Reference to FFM input element click event
 	 */
 	function setupRadio( { label, input } ) {
-		// If checkbox is opted in by default, add border on load
+		// If radio is opted in by default, add border on load
 		if ( $( input ).prop( 'checked' ) === true ) {
 			$( label ).addClass( 'active' );
 		}
 
-		// Persist checkbox input border when selected
+		// Persist radio input border when selected
 		$( document ).on( 'click', label, function( evt ) {
 			evt.stopPropagation();
+			evt.preventDefault();
 
-			$( evt.target.parentElement ).find('label')
-				.not( evt.target ).removeClass( 'active' );
-			$( evt.target ).toggleClass( 'active' );
+			const label = $(evt.target);
+			const inputField = label.find('input');
+
+			if (inputField.prop('checked') === true) {
+				return;
+			}
+
+			$(evt.target.parentElement).find('label')
+				.not(evt.target).removeClass('active');
+
+			$(evt.target.parentElement).find('input')
+				.prop('checked', false);
+
+			const changeEvent = new Event('input');
+
+			inputField.prop('checked', true);
+			$(evt.target).toggleClass('active');
+			document.querySelector(input).dispatchEvent(changeEvent);
 		} );
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -773,25 +773,26 @@
 	 * @since 2.14.0
 	 */
 	function setupLegacyConsumerCheckboxAndRadio(){
-		const customCheckboxes = document.querySelectorAll( '[data-field-type="checkbox"]' );
-		const customRadios = document.querySelectorAll( '[data-field-type="radio"] input' );
-		Array.from( customCheckboxes ).forEach( ( el ) => {
-			const containerSelector = '[data-field-name="' + el.getAttribute( 'data-field-name' ) + '"]';
-			setupCheckbox( {
-				container: containerSelector + ' label',
-				label: containerSelector + ' label',
-				input: containerSelector + ' input[type="checkbox"]',
-			} );
-		} );
-
-		Array.from( customRadios ).forEach( ( el ) => {
-			const uniqueInputSelector = `#${el.getAttribute( 'id' )}`;
-			const uniqueLabelSelector = `label[for=${el.getAttribute( 'id' )}]`;
-			setupRadio( {
+		const customCheckboxes = document.querySelectorAll('[data-field-type="checkbox"] input');
+		const customRadios = document.querySelectorAll('[data-field-type="radio"] input');
+		Array.from(customCheckboxes).forEach((el) => {
+			const uniqueInputSelector = `#${el.getAttribute('id')}`;
+			const uniqueLabelSelector = `label[for=${el.getAttribute('id')}]`;
+			setupCheckbox({
+				container: uniqueLabelSelector,
 				label: uniqueLabelSelector,
 				input: uniqueInputSelector,
-			} );
-		} );
+			});
+		});
+
+		Array.from(customRadios).forEach((el) => {
+			const uniqueInputSelector = `#${el.getAttribute('id')}`;
+			const uniqueLabelSelector = `label[for=${el.getAttribute('id')}]`;
+			setupRadio({
+				label: uniqueLabelSelector,
+				input: uniqueInputSelector,
+			});
+		});
 	}
 
 	/**
@@ -802,21 +803,20 @@
 	 */
 	function setupCheckbox( { container, label, input } ) {
 		// If checkbox is opted in by default, add border on load
-		if ( $( input ).prop( 'checked' ) === true ) {
-			$( container ).addClass( 'active' );
+		if ($(input).prop('checked') === true) {
+			$(container).addClass('active');
 		}
 
 		// Persist checkbox input border when selected
-		$( document ).on( 'click', label, function( evt ) {
-			if ( container === label ) {
+		$(document).on('click', label, function (evt) {
+			if (container === label) {
 				evt.stopPropagation();
 				evt.preventDefault();
-
-				$( input ).prop( 'checked', ! $( input ).prop( 'checked' ) ).focus();
+				$(input).prop('checked', !$(input).prop('checked')).focus();
 			}
 
-			$( container ).toggleClass( 'active' );
-		} );
+			$(container).toggleClass('active');
+		});
 	}
 
 	/**

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -809,8 +809,11 @@
 
 		// Persist checkbox input border when selected
 		$(document).on('click', label, function (evt) {
-			if (evt.target.nodeName === 'INPUT') {
-				return;
+			if (container === label) {
+				evt.stopPropagation();
+				evt.preventDefault();
+
+				$(input).prop('checked', !$(input).prop('checked')).focus();
 			}
 
 			$(container).toggleClass('active');
@@ -824,34 +827,18 @@
 	 * @param {object} evt Reference to FFM input element click event
 	 */
 	function setupRadio( { label, input } ) {
-		// If radio is opted in by default, add border on load
+		// If checkbox is opted in by default, add border on load
 		if ( $( input ).prop( 'checked' ) === true ) {
 			$( label ).addClass( 'active' );
 		}
 
-		// Persist radio input border when selected
+		// Persist checkbox input border when selected
 		$( document ).on( 'click', label, function( evt ) {
 			evt.stopPropagation();
-			evt.preventDefault();
-
-			const label = $(evt.target);
-			const inputField = label.find('input');
-
-			if (inputField.prop('checked') === true) {
-				return;
-			}
 
 			$(evt.target.parentElement).find('label')
 				.not(evt.target).removeClass('active');
-
-			$(evt.target.parentElement).find('input')
-				.prop('checked', false);
-
-			const changeEvent = new Event('input');
-
-			inputField.prop('checked', true);
 			$(evt.target).toggleClass('active');
-			document.querySelector(input).dispatchEvent(changeEvent);
 		} );
 	}
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -799,6 +799,7 @@
 	 * Setup prominent checkboxes (that use persistent borders on select)
 	 *
 	 * @since 2.7.0
+	 * @unreleased update click handler callback
 	 * @param {object} args Argument object containing: container, label, input selectors
 	 */
 	function setupCheckbox( { container, label, input } ) {
@@ -821,6 +822,7 @@
 	 * Handle updating label classes for FFM radios and checkboxes
 	 *
 	 * @since 2.7.0
+	 * @unreleased update click handler callback
 	 * @param {object} evt Reference to FFM input element click event
 	 */
 	function setupRadio( { label, input } ) {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -545,17 +545,17 @@
 			switch ( $( this ).prop( 'type' ) ) {
 				case 'checkbox': {
 					if ( $( this ).prop( 'checked' ) ) {
-						$(this).parent().addClass('active');
+						$(this).parent().addClass('checked');
 					} else {
-						$(this).parent().removeClass('active');
+						$(this).parent().removeClass('checked');
 					}
 					break;
 				}
 				case 'radio': {
 					if ( $( this ).prop( 'checked' ) ) {
-						$(this).parent().addClass('active');
+						$(this).parent().addClass('selected');
 					} else {
-						$(this).parent().removeClass('active');
+						$(this).parent().removeClass('selected');
 					}
 					break;
 				}
@@ -573,12 +573,12 @@
 		if ( $( evt.target ).is( 'input' ) ) {
 			switch ( $( evt.target ).prop( 'type' ) ) {
 				case 'checkbox': {
-					$(evt.target).closest('label').toggleClass('active');
+					$(evt.target).closest('label').toggleClass('checked');
 					break;
 				}
 				case 'radio': {
-					$(evt.target).closest('label').addClass('active');
-					$(evt.target).parent().siblings().removeClass('active');
+					$(evt.target).closest('label').addClass('selected');
+					$(evt.target).parent().siblings().removeClass('selected');
 					break;
 				}
 			}

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -809,11 +809,8 @@
 
 		// Persist checkbox input border when selected
 		$(document).on('click', label, function (evt) {
-			if (container === label) {
-				evt.stopPropagation();
-				evt.preventDefault();
-
-				$(input).prop('checked', !$(input).prop('checked')).focus();
+			if ('INPUT' === evt.target.nodeName) {
+				return;
 			}
 
 			$(container).toggleClass('active');
@@ -834,7 +831,9 @@
 
 		// Persist checkbox input border when selected
 		$( document ).on( 'click', label, function( evt ) {
-			evt.stopPropagation();
+			if ('INPUT' === evt.target.nodeName) {
+				return;
+			}
 
 			$(evt.target.parentElement).find('label')
 				.not(evt.target).removeClass('active');

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -915,8 +915,39 @@
 	 * @since 2.9.0
 	 */
 	function scrollToIframeTop() {
-		if ( 'parentIFrame' in window ) {
-			window.parentIFrame.sendMessage( { action: 'giveScrollIframeInToView' } );
+		if ('parentIFrame' in window) {
+			window.parentIFrame.sendMessage({action: 'giveScrollIframeInToView'});
 		}
 	}
-}( jQuery ) );
+}(jQuery));
+
+/**
+ * Support to FFM restore custom field value logic.
+ *
+ * FFM restore value of custom fields correctly but field state does not reflect correctly
+ * in donation form because we are using custom styling for Radio and Checkbox.
+ *
+ * Below code will add class to Checkbox and Radio label if checked.
+ *
+ * @unreleased
+ */
+document.addEventListener('readystatechange', function (evt) {
+	if (evt.target.readyState !== 'complete') {
+		return;
+	}
+
+
+	const customCheckboxes = document.querySelectorAll('[data-field-type="checkbox"] input');
+	const customRadios = document.querySelectorAll('[data-field-type="radio"] input');
+
+	const addActiveClass = el => {
+		if (el.checked) {
+			el.parentElement.classList.add('active');
+		} else {
+			el.parentElement.classList.remove('active');
+		}
+	}
+
+	customCheckboxes.forEach(addActiveClass)
+	customRadios.forEach(addActiveClass)
+})


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6010

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I refactored multi-step form template javascript to handle radio and checkbox correctly.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
- I also added support for FFM restores state from browser session logic.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
### Note: 
- I keep the radio and checkbox visible which makes testing easy. I will reset styling once the pull request is approved by the reviewer.
- Test before listing with legacy and multi-step form template.
- Existing checkbox renders within label or outside of the label. I added a test to test both scenarios. [Checkboxes List](https://github.com/impress-org/givewp/blob/07da09593530e8a353b483055e88c98b9839f7c7/src/Views/Form/Templates/Sequoia/assets/js/form.js#L256).

### Tests
- Radio and Checkbox added by field API should correct state
   - when default value set
   - when ffm restore the previous state
  
 - "Agree to Terms?" checkbox should work fine.
- "Make this an anonymous donation. " checkbox should work fine.
-  "Donor's Choice" checkbox should work fine


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

