### PR TITLE
Dom element do not display in donation form if has give-hidden class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Resolve checkbox and radio (generated with field api) state related issues in Multi Step Form template. (#6013)
 - Refactor setup logic of checkbox and radio in Multi Step Form template. (#6013)
 - Show custom payment gateway label in donation form. (#6012)
+- Dom element do not display in donation form if it has give-hidden class. (#6017)
 
 ## 2.14.0 - 2021-09-27
 

--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -147,7 +147,7 @@ form.give-form {
 	padding: 0;
 
 	.give-hidden {
-		display: none;
+		display: none !important;
 	}
 
 	@media (min-width: 481px) {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that the `display` property does not set to important which makes it easy to overwrite as we can see conflict in the Multi-step form template. Now DOM element does not display in the form if has `give-hidden` class.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Create a custom field with FFM form editor and make display when `First Name (give_first)` field set to a specific value.
- Field show or hide on basis of the field value.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

