### PR TITLE
Fix: Donation summary accounts for gateway change

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -350,6 +350,8 @@ function give_load_gateway( form_object, payment_mode ) {
 			jQuery( '.give-no-js' ).hide();
 			jQuery( form_object ).find( '#give-payment-mode-select .give-loading-text' ).fadeOut();
 
+            jQuery( document ).trigger( 'Give:onGatewayLoadSuccess' )
+
 			return res( response );
 		}
 		);

--- a/src/DonationSummary/ServiceProvider.php
+++ b/src/DonationSummary/ServiceProvider.php
@@ -23,6 +23,15 @@ class ServiceProvider implements \Give\ServiceProviders\ServiceProvider {
 
         Hooks::addAction( 'give_pre_form_output', SummaryView::class );
 
+        // Include the summary when changing payment gateways.
+        if( wp_doing_ajax() ) {
+            add_action('give_donation_form', function ($formID) {
+                $summary = new SummaryView();
+                $summary->__invoke($formID);
+                $summary->render();
+            });
+        }
+
         Hooks::addAction( 'wp_enqueue_scripts', Assets::class, 'loadFrontendAssets' );
     }
 }

--- a/src/DonationSummary/resources/js/summary.js
+++ b/src/DonationSummary/resources/js/summary.js
@@ -1,61 +1,91 @@
-jQuery(document).on('give:postInit', function() {
-
-    /**
-     * Amount
-     * @unreleased
-     */
-    GiveDonationSummary.observe( '[name="give-amount"]', function( targetNode, $form ) {
-        $form.find( '[data-tag="amount"]' ).html(
-            GiveDonationSummary.format_amount( targetNode.value, $form )
-        )
-    })
-
-    /**
-     * Frequency (and Recurring)
-     * @unreleased
-     */
-    GiveDonationSummary.observe( '[name="give-recurring-period"]', function( targetNode, $form ) {
-        $form.find( '.js-give-donation-summary-frequency-help-text' ).toggle( ! targetNode.checked )
-        $form.find( '[data-tag="frequency"]' ).toggle( ! targetNode.checked)
-        $form.find( '[data-tag="recurring"]' ).toggle( targetNode.checked ).html( targetNode.dataset['periodLabel'] )
-    })
-
-    /**
-     * Fees
-     * @unreleased
-     */
-    GiveDonationSummary.observe('.give_fee_mode_checkbox', function (targetNode, $form) {
-        $form.find('.fee-break-down-message').hide()
-        $form.find('.js-give-donation-summary-fees').toggle(targetNode.checked)
-
-        // Hack: (Currency Switcher) The total is always stored using a the decimal seperator as set by the primary currency.
-        const fee = document.querySelector('[name="give-fee-amount"]').value.replace('.', Give.form.fn.getInfo( 'decimal_separator', $form ))
-        $form.find('[data-tag="fees"]').html(
-            GiveDonationSummary.format_amount(fee, $form)
-        )
-    })
-
-    /**
-     * Total
-     * @unreleased
-     */
-    GiveDonationSummary.observe( '.give-final-total-amount', function( targetNode, $form ) {
-        // Hack: (Currency Switcher) The total is always stored using a the decimal seperator as set by the primary currency.
-        const total = targetNode.dataset.total.replace('.', Give.form.fn.getInfo( 'decimal_separator', $form ))
-        $form.find( '[data-tag="total"]' ).html(
-            GiveDonationSummary.format_amount( total, $form )
-        )
-    })
-
-    // Hack: Force an initial mutation for the Total Amount observer
-    const totalAmount = document.querySelector('.give-final-total-amount')
-    totalAmount.dataset.total = totalAmount.dataset.total
-})
-
 /**
  * @unreleased
  */
-const GiveDonationSummary = {
+window.GiveDonationSummary = {
+
+    init: function() {
+        GiveDonationSummary.initAmount()
+        GiveDonationSummary.initFrequency()
+        GiveDonationSummary.initFees()
+        GiveDonationSummary.initTotal()
+    },
+
+    /**
+     * @unreleased
+     */
+    initAmount: function() {
+        GiveDonationSummary.observe( '[name="give-amount"]', function( targetNode, $form ) {
+            $form.find( '[data-tag="amount"]' ).html(
+                GiveDonationSummary.format_amount( targetNode.value, $form )
+            )
+        })
+    },
+
+    /**
+     * @unreleased
+     */
+    initFrequency: function() {
+        GiveDonationSummary.observe( '[name="give-recurring-period"]', function( targetNode, $form ) {
+            $form.find( '.js-give-donation-summary-frequency-help-text' ).toggle( ! targetNode.checked )
+            $form.find( '[data-tag="frequency"]' ).toggle( ! targetNode.checked)
+            $form.find( '[data-tag="recurring"]' ).toggle( targetNode.checked ).html( targetNode.dataset['periodLabel'] )
+        })
+    },
+
+    /**
+     * @unreleased
+     */
+    initFees: function() {
+        GiveDonationSummary.observe('.give_fee_mode_checkbox', function (targetNode, $form) {
+            $form.find('.fee-break-down-message').hide()
+            $form.find('.js-give-donation-summary-fees').toggle(targetNode.checked)
+
+            // Hack: (Currency Switcher) The total is always stored using a the decimal seperator as set by the primary currency.
+            const fee = document.querySelector('[name="give-fee-amount"]').value.replace('.', Give.form.fn.getInfo( 'decimal_separator', $form ))
+            $form.find('[data-tag="fees"]').html(
+                GiveDonationSummary.format_amount(fee, $form)
+            )
+        })
+    },
+
+    /**
+     * @unreleased
+     */
+    initTotal: function() {
+        GiveDonationSummary.observe('.give-final-total-amount', function (targetNode, $form) {
+            // Hack: (Currency Switcher) The total is always stored using a the decimal seperator as set by the primary currency.
+            const total = targetNode.dataset.total.replace('.', Give.form.fn.getInfo('decimal_separator', $form))
+            $form.find('[data-tag="total"]').html(
+                GiveDonationSummary.format_amount(total, $form)
+            )
+        })
+
+        // Hack: Force an initial mutation for the Total Amount observer
+        const totalAmount = document.querySelector('.give-final-total-amount')
+        totalAmount.dataset.total = totalAmount.dataset.total
+    },
+
+    /**
+     * Hack: Placeholder callback, which is only used when the gateway changes.
+     */
+    handleNavigateBack: function() {},
+
+    /**
+     * Hack: Changing gateways re-renders parts of the form via AJAX.
+     */
+    onGatewayLoadSuccess: function() {
+        const inserted = jQuery('#give_purchase_form_wrap .give-donation-summary-section').detach()
+        jQuery('.give-donation-summary-section').remove()
+        inserted.appendTo("#donate-fieldset")
+        GiveDonationSummary.initTotal()
+
+        // Overwrite the handler because updating the gateway breaks the original binding.
+        GiveDonationSummary.handleNavigateBack = function( e ) {
+            e.stopPropagation()
+            e.preventDefault()
+            window.formNavigator.back()
+        }
+    },
 
     /**
      * Observe an element and respond to changes to that element.
@@ -110,3 +140,6 @@ const GiveDonationSummary = {
         } )
     }
 }
+
+jQuery(document).on('give:postInit', GiveDonationSummary.init)
+jQuery(document).on( 'Give:onGatewayLoadSuccess', GiveDonationSummary.onGatewayLoadSuccess )

--- a/src/DonationSummary/resources/views/summary.php
+++ b/src/DonationSummary/resources/views/summary.php
@@ -10,7 +10,7 @@
             <thead>
                 <tr>
                     <th>Donation Summary</th>
-                    <th><button class="back-btn">edit donation</button></th>
+                    <th><button class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">edit donation</button></th>
                 </tr>
             </thead>
             <tbody>
@@ -36,7 +36,7 @@
                             <img src="<?php echo GIVE_PLUGIN_URL . 'src/DonationSummary/resources/images/info.svg'; ?>" alt="">
                             <?php
                                 /* translators: 1: <button> open tag 2: close tag. */
-                                echo sprintf( __( 'Consider making this donation %srecurring%s', 'give' ), '<button class="back-btn">', '</button>' );
+                                echo sprintf( __( 'Consider making this donation %srecurring%s', 'give' ), '<button class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">', '</button>' );
                             ?>
                         </span>
                         <?php endif; ?>

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -18,7 +18,8 @@
 		} );
 	}
 
-	const navigator = {
+	// Attach the navigator to the window as an API for changing parts.
+	const navigator = window.formNavigator = {
 		currentStep: templateOptions.introduction.enabled === 'enabled' ? 0 : 1,
 		animating: false,
 		firstFocus: false,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Depends on #6061

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR addresses an issue where changing the payment method removed the Donation Summary from the DOM. This was because changing the payment triggers an AJAX request that re-renders part of the form, which in this case included the Donation Summary.

Below are the important parts of this PR (which is chained off of #6061):

Re-render the Donation Summary along with the AJAX request to render the payment method fields.
```php
        // Include the summary when changing payment gateways.
        if( wp_doing_ajax() ) {
            add_action('give_donation_form', function ($formID) {
                $summary = new SummaryView();
                $summary->__invoke($formID);
                $summary->render();
            });
        }
```

After the gateway is re-rendered, re-position the Donation Summary to the correct location.
```js
    /**
     * Hack: Changing gateways re-renders parts of the form via AJAX.
     */
    onGatewayLoadSuccess: function() {
        const inserted = jQuery('#give_purchase_form_wrap .give-donation-summary-section').detach()
        jQuery('.give-donation-summary-section').remove()
        inserted.appendTo("#donate-fieldset")
        GiveDonationSummary.initTotal()

        // Overwrite the handler because updating the gateway breaks the original binding.
        GiveDonationSummary.handleNavigateBack = function( e ) {
            e.stopPropagation()
            e.preventDefault()
            window.formNavigator.back()
        }
    },
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Attaches the `navigator` to the `window`.
- Adds an event when a gateway changes, `Give:onGatewayLoadSuccess`

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

