### PR TITLE
New: add invokable helper class

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,12 +1,17 @@
 <?php
 
 namespace PHPSTORM_META {
-	// Allow PhpStorm IDE to resolve return types when calling give( Object_Type::class ) or give( `Object_Type` ).
-	override(
-		\give( 0 ),
-		map( [
-			'' => '@',
-			'' => '@Class',
-		] )
-	);
+    // Allow PhpStorm IDE to resolve return types when calling give( Object_Type::class ) or give( `Object_Type` ).
+    override(
+        \give(0),
+        map([
+                '' => '@',
+                '' => '@Class',
+            ])
+    );
+
+    // Return the method call result when using Call
+    override(
+        \Give\Helpers\Call::invoke(0), type(0)
+    );
 }

--- a/src/Helpers/Call.php
+++ b/src/Helpers/Call.php
@@ -13,7 +13,7 @@ class Call {
 	 * @param  string  $class
 	 * @param  mixed  $args
 	 *
-	 * @return mixed
+	 * @return callable
 	 */
 	public static function invoke( $class, ...$args ) {
 		if ( ! method_exists( $class, '__invoke' ) ) {

--- a/src/Helpers/Call.php
+++ b/src/Helpers/Call.php
@@ -4,9 +4,9 @@ namespace Give\Helpers;
 
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 
-class Invokable {
+class Call {
 	/**
-	 * A function that calls an invokable class.
+	 * Call an invokable class.
 	 *
 	 * @unreleased
 	 *
@@ -15,11 +15,12 @@ class Invokable {
 	 *
 	 * @return mixed
 	 */
-	public static function execute( $class, ...$args ) {
+	public static function invoke( $class, ...$args ) {
 		if ( ! method_exists( $class, '__invoke' ) ) {
 			throw new InvalidArgumentException( "This class is not invokable" );
 		}
 
+		/** @var callable $instance */
 		$instance = give( $class );
 
 		return $instance(...$args);

--- a/src/Helpers/Call.php
+++ b/src/Helpers/Call.php
@@ -13,7 +13,7 @@ class Call {
 	 * @param  string  $class
 	 * @param  mixed  $args
 	 *
-	 * @return callable
+	 * @return mixed
 	 */
 	public static function invoke( $class, ...$args ) {
 		if ( ! method_exists( $class, '__invoke' ) ) {

--- a/src/Helpers/Invokable.php
+++ b/src/Helpers/Invokable.php
@@ -13,15 +13,15 @@ class Invokable {
 	 * @param  string  $class
 	 * @param  mixed  $args
 	 *
-	 * @return void
+	 * @return mixed
 	 */
-	public static function execute( $class, $args = null ) {
+	public static function execute( $class, ...$args ) {
 		if ( ! method_exists( $class, '__invoke' ) ) {
 			throw new InvalidArgumentException( "This class is not invokable" );
 		}
 
 		$instance = give( $class );
 
-		$instance($args);
+		return $instance(...$args);
 	}
 }

--- a/src/Helpers/Invokable.php
+++ b/src/Helpers/Invokable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Give\Helpers;
+
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+
+class Invokable {
+	/**
+	 * A function that calls an invokable class.
+	 *
+	 * @unreleased
+	 *
+	 * @param  string  $class
+	 * @param  mixed  $args
+	 *
+	 * @return void
+	 */
+	public static function execute( $class, $args = null ) {
+		if ( ! method_exists( $class, '__invoke' ) ) {
+			throw new InvalidArgumentException( "This class is not invokable" );
+		}
+
+		$instance = give( $class );
+
+		$instance($args);
+	}
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We all love invokable classes for their single responsibility and actionable nature.  The thing that's not so chill is always having to assign the class to a variable before calling it.  This is largely because PHP 5.6 does not support self-calling.  So to make our lives easier and code cleaner, here's a helper!

❌
```
/** @var Action $action */
$action = give(Action::class);

$action();
$action($args);
```

✅ 

```
Call::invoke(Action::class);
Call::invoke(Action::class, $args);
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Invoke an invokable class!

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

