### PR TITLE
fix: Remove trailing comma in function parameters.

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Actions.php
+++ b/src/Views/Form/Templates/Sequoia/Actions.php
@@ -74,7 +74,7 @@ class Actions {
 				  "color": "#e39f48"
 				}
 			}',
-			$this->isGoogleFontEnabled() ? 'Montserrat' : 'system-ui',
+			$this->isGoogleFontEnabled() ? 'Montserrat' : 'system-ui'
 		);
 
 		return json_decode( $styles );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6068

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes a trailing comma from a function parameter list, which isn't supported as of PHP7.2

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

The Multi-Step form should now load without throwing an error.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

