### PR TITLE
fix: Filtering the lost password URL no longer causes a Fatal Error

### DIFF
--- a/src/Controller/Form.php
+++ b/src/Controller/Form.php
@@ -118,19 +118,22 @@ class Form {
 	 * Load donation form view.
 	 *
 	 * @since 2.7.0
+     * @unreleased Co-locate $formTemplate with related conditional and usage.
 	 * @global WP_Post $post
 	 */
 	public function loadDonationFormView() {
-		/* @var Template $formTemplate */
-		$formTemplate = Give()->templates->getTemplate();
 
 		// Handle failed donation error.
 		if ( FormUtils::canShowFailedDonationError() ) {
 			add_action( 'give_pre_form', [ $this, 'setFailedTransactionError' ] );
 		}
 
-			// Handle donation form.
+        // Handle donation form.
 		if ( FormUtils::isViewingForm() ) {
+
+            /* @var Template $formTemplate */
+            $formTemplate = Give()->templates->getTemplate();
+
 			// Set header.
 			nocache_headers();
 			header( 'HTTP/1.1 200 OK' );

--- a/src/Form/Templates.php
+++ b/src/Form/Templates.php
@@ -107,8 +107,10 @@ class Templates {
 	 *
 	 * @return Template
 	 * @since 2.7.0
+     * @unreleased Add default value for $templateId
 	 */
 	private function getTemplateObject( $templateId ) {
-		return new $this->templates[ $templateId ]();
-	}
+        $templateId = $templateId ?: 'legacy';
+        return new $this->templates[$templateId]();
+    }
 }

--- a/src/Form/Templates.php
+++ b/src/Form/Templates.php
@@ -107,10 +107,8 @@ class Templates {
 	 *
 	 * @return Template
 	 * @since 2.7.0
-     * @unreleased Add default value for $templateId
 	 */
 	private function getTemplateObject( $templateId ) {
-        $templateId = $templateId ?: 'legacy';
-        return new $this->templates[$templateId]();
-    }
+		return new $this->templates[ $templateId ]();
+	}
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6060

## Description

When filtering the `lostpassword_url` - for whatever reason - a Give template functions was being called on a page that did not contain a form. The resulting `false` value caused a fatal error.

This PR adds a default value of `legacy` for when the value of `false` is being passed instead of a string representing a template.

The default value is set as `legacy`, which matches a related issue, see https://github.com/impress-org/givewp/pull/4878

## Affects

From what I can tell this shouldn't cause any issues, but @ravinderk would know better.

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a Multi-Step Form
- Enable "login" for the Registration form field setting
- Filter the `loastpassword_url`
- View the form and click "Reset Password"

```php
add_filter( 'lostpassword_url', function() {
    return site_url('/donor-login/');
}, 10, 0 );
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

