### PR TITLE
Fix: set correct path for Font Awesome icons

### DIFF
--- a/assets/src/css/icons/fa/_variables.scss
+++ b/assets/src/css/icons/fa/_variables.scss
@@ -3,7 +3,7 @@
 
 @use "sass:math";
 
-$fa-font-path: '../../fonts' !default;
+$fa-font-path: '../fonts' !default;
 $fa-font-size-base: 16px !default;
 $fa-font-display: auto !default;
 $fa-css-prefix: fa !default;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6078

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This just corrects the path to the Font Awesome icons. We were doing something a bit hacky prior where we were going up an extra directory. Since we’re doing stuff right, we can just go up a level instead of two.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Font Awesome icons in the admin area.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a donation form and check the icons are showing up.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
