### PR TITLE
Fix: creating a form during onboarding no longer throws warnings

### DIFF
--- a/src/Onboarding/DefaultFormFactory.php
+++ b/src/Onboarding/DefaultFormFactory.php
@@ -123,6 +123,11 @@ class DefaultFormFactory {
 				'content'      => sprintf( __( 'How much would you like to donate? As a contributor to %s we make sure your donation goes directly to supporting our cause.', 'give' ), get_bloginfo( 'sitename' ) ),
 				'next_label'   => __( 'Continue', 'give' ),
 			],
+            'visual_appearance' => [
+                'decimals_enabled'  => 'disabled',
+                'primary_color'     => '#28C77B',
+                'google-fonts'      => 'enabled'
+            ],
 			'payment_information' => [
 				'header_label' => __( 'Add Your Information', 'give' ),
 				'headline'     => __( "Who's giving today?", 'give' ),

--- a/src/Onboarding/DefaultFormFactory.php
+++ b/src/Onboarding/DefaultFormFactory.php
@@ -106,6 +106,7 @@ class DefaultFormFactory {
 	 *
 	 * @return array
 	 *
+     * @unreleased add new visual appearance settings
 	 * @since 2.8.0
 	 */
 	public function getTemplateConfig() {


### PR DESCRIPTION
Resolves #6080 

## Description

Turns out the warnings were occurring because new settings were introduced (or moved, I couldn't quite tell) in 2.16.0 to the multi-step form. The settings were not added to the onboarding form defaults, so the generated form didn't contain all the necessary data.

While this does fix the immediate problem, I am worried about future issues of the same kind. There's no tie between the settings and the defaults introduced, so it's up to whomever is modifying settings to simply know to update the onboarding defaults.

## Affects

Onboarding form creation

## Testing Instructions

1. Create a fresh GiveWP install
2. Turn on `WP_DEBUG` and `WP_DEBUG_DISPLAY`
3. Activate GiveWP
4. Go through the onboarding until the page that displays the new form
5. There should be no warnings, just a happy form! ☀️

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

