### PR TITLE
Fix: prevent PHP notice "Missing template conditional-visibility-attribute.html.php"

### DIFF
--- a/src/Form/LegacyConsumer/templates/checkbox.html.php
+++ b/src/Form/LegacyConsumer/templates/checkbox.html.php
@@ -31,7 +31,6 @@
 			<?php echo $field->isRequired() ? 'required' : ''; ?>
 			<?php echo $field->isChecked() ? 'checked' : ''; ?>
 			<?php echo $field->isReadOnly() ? 'readonly' : ''; ?>
-			<?php include plugin_dir_path( __FILE__ ) . 'conditional-visibility-attribute.html.php'; ?>
 		>
 		<?php echo $field->getLabel(); ?>
 	</label>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6066

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
https://github.com/impress-org/givewp/blob/12a05ad7ed814e160e53dcacdd628ce5275879b8/src/Form/LegacyConsumer/templates/checkbox.html.php#L34

Above code left unchanged when i refactor code in #6024. Previously visibility conditions were stored in the input field but now there stored in the input field container. 

Removing this line of code will resolve the issue.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Register a single checkbox and visit donation form with multi step for template.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

