### PR TITLE
Fix: update PayPal Commerce payment request data to create order for donation

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -39,8 +39,9 @@ class PayPalCommerce implements PaymentGateway {
 	}
 
 	/**
-	 * @inheritDoc
-	 */
+     * @inheritDoc
+     * @unreleased Add setting "Transaction type".
+     */
 	public function getOptions() {
 		$settings = [
 			[

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -72,13 +72,6 @@ class PayPalCommerce implements PaymentGateway {
                 'type' => 'paypal_commerce_account_manger',
             ],
             [
-                'name'  => esc_html__('PayPal Donations Gateway Settings Docs Link', 'give'),
-                'id'    => 'paypal_commerce_gateway_settings_docs_link',
-                'url'   => esc_url('http://docs.givewp.com/paypal-donations'),
-                'title' => esc_html__('PayPal Donations Gateway Settings', 'give'),
-                'type'  => 'give_docs_link',
-            ],
-            [
                 'name'    => esc_html__('Transaction Type', 'give'),
                 'desc'    => esc_html__(
                     'Nonprofits must verify their status to withdraw donations they receive via PayPal. PayPal users that are not verified nonprofits must demonstrate how their donations will be used, once they raise more than $10,000. By default, GiveWP transactions are sent to PayPal as donations. You may change the transaction type using this option if you feel you may not meet PayPal\'s donation requirements.',
@@ -91,6 +84,13 @@ class PayPalCommerce implements PaymentGateway {
                     'standard' => esc_html__('Standard Transaction', 'give'),
                 ],
                 'default' => 'donation',
+            ],
+            [
+                'name'  => esc_html__('PayPal Donations Gateway Settings Docs Link', 'give'),
+                'id'    => 'paypal_commerce_gateway_settings_docs_link',
+                'url'   => esc_url('http://docs.givewp.com/paypal-donations'),
+                'title' => esc_html__('PayPal Donations Gateway Settings', 'give'),
+                'type'  => 'give_docs_link',
             ],
             [
                 'type' => 'sectionend',

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -47,42 +47,56 @@ class PayPalCommerce implements PaymentGateway {
 				'type'       => 'title',
 				'id'         => 'give_gateway_settings_1',
 				'table_html' => false,
-			],
-			[
-				'id'   => 'paypal_commerce_introduction',
-				'type' => 'paypal_commerce_introduction',
-			],
-			[
-				'type'       => 'sectionend',
-				'id'         => 'give_gateway_settings_1',
-				'table_html' => false,
-			],
-			[
-				'type' => 'title',
-				'id'   => 'give_gateway_settings_2',
-			],
-			[
-				'name' => esc_html__( 'Account Country', 'give' ),
-				'id'   => 'paypal_commerce_account_country',
-				'type' => 'paypal_commerce_account_country',
-			],
-			[
-				'name' => esc_html__( 'Connect With Paypal', 'give' ),
-				'id'   => 'paypal_commerce_account_manger',
-				'type' => 'paypal_commerce_account_manger',
-			],
-			[
-				'name'  => esc_html__( 'PayPal Donations Gateway Settings Docs Link', 'give' ),
-				'id'    => 'paypal_commerce_gateway_settings_docs_link',
-				'url'   => esc_url( 'http://docs.givewp.com/paypal-donations' ),
-				'title' => esc_html__( 'PayPal Donations Gateway Settings', 'give' ),
-				'type'  => 'give_docs_link',
-			],
-			[
-				'type' => 'sectionend',
-				'id'   => 'give_gateway_settings_2',
-			],
-		];
+            ],
+            [
+                'id'   => 'paypal_commerce_introduction',
+                'type' => 'paypal_commerce_introduction',
+            ],
+            [
+                'type'       => 'sectionend',
+                'id'         => 'give_gateway_settings_1',
+                'table_html' => false,
+            ],
+            [
+                'type' => 'title',
+                'id'   => 'give_gateway_settings_2',
+            ],
+            [
+                'name' => esc_html__('Account Country', 'give'),
+                'id'   => 'paypal_commerce_account_country',
+                'type' => 'paypal_commerce_account_country',
+            ],
+            [
+                'name' => esc_html__('Connect With Paypal', 'give'),
+                'id'   => 'paypal_commerce_account_manger',
+                'type' => 'paypal_commerce_account_manger',
+            ],
+            [
+                'name'  => esc_html__('PayPal Donations Gateway Settings Docs Link', 'give'),
+                'id'    => 'paypal_commerce_gateway_settings_docs_link',
+                'url'   => esc_url('http://docs.givewp.com/paypal-donations'),
+                'title' => esc_html__('PayPal Donations Gateway Settings', 'give'),
+                'type'  => 'give_docs_link',
+            ],
+            [
+                'name'    => esc_html__('Transaction Type', 'give'),
+                'desc'    => esc_html__(
+                    'Nonprofits must verify their status to withdraw donations they receive via PayPal. PayPal users that are not verified nonprofits must demonstrate how their donations will be used, once they raise more than $10,000. By default, GiveWP transactions are sent to PayPal as donations. You may change the transaction type using this option if you feel you may not meet PayPal\'s donation requirements.',
+                    'give'
+                ),
+                'id'      => 'paypal_commerce_transaction_type',
+                'type'    => 'radio_inline',
+                'options' => [
+                    'donation' => esc_html__('Donation', 'give'),
+                    'standard' => esc_html__('Standard Transaction', 'give'),
+                ],
+                'default' => 'donation',
+            ],
+            [
+                'type' => 'sectionend',
+                'id'   => 'give_gateway_settings_2',
+            ],
+        ];
 
 		if ( give( MerchantDetail::class )->accountIsReady ) {
 			$settings = give_settings_array_insert(

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -143,7 +143,7 @@ class PayPalOrder
 
         // Set PayPal transaction as donation.
         if ($this->settings->isTransactionTypeDonation()) {
-            $request->body['purchase_units']['items'] = [
+            $request->body['purchase_units'][0]['items'] = [
                 [
                     'name'        => get_post_field('post_name', $formId),
                     'unit_amount' => [
@@ -155,7 +155,7 @@ class PayPalOrder
                 ]
             ];
 
-            $request->body['purchase_units']['amount']['breakdown'] = [
+            $request->body['purchase_units'][0]['amount']['breakdown'] = [
                 'item_total' => [
                     'currency_code' => $donationCurrency,
                     'value'         => $donationAmount,

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -2,10 +2,10 @@
 
 namespace Give\PaymentGateways\PayPalCommerce\Repositories;
 
+use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\PayPalClient;
-use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
-use Give\Framework\Exceptions\Primitives\Exception;
 use PayPalCheckoutSdk\Orders\OrdersCaptureRequest;
 use PayPalCheckoutSdk\Orders\OrdersCreateRequest;
 use PayPalCheckoutSdk\Payments\CapturesRefundRequest;
@@ -18,180 +18,206 @@ use function give_record_gateway_error as logError;
  *
  * @since 2.9.0
  */
-class PayPalOrder {
-	/**
-	 * @since 2.9.0
-	 *
-	 * @var PayPalClient
-	 */
-	private $paypalClient;
+class PayPalOrder
+{
+    /**
+     * @since 2.9.0
+     *
+     * @var PayPalClient
+     */
+    private $paypalClient;
 
-	/**
-	 * @since 2.9.0
-	 *
-	 * @var MerchantDetail
-	 */
-	private $merchantDetails;
+    /**
+     * @since 2.9.0
+     *
+     * @var MerchantDetail
+     */
+    private $merchantDetails;
 
-	/**
-	 * PayPalOrder constructor.
-	 *
-	 * @since 2.9.0
-	 *
-	 * @param  MerchantDetail  $merchantDetails
-	 *
-	 * @param  PayPalClient  $paypalClient
-	 */
-	public function __construct( PayPalClient $paypalClient, MerchantDetail $merchantDetails ) {
-		$this->paypalClient    = $paypalClient;
-		$this->merchantDetails = $merchantDetails;
-	}
+    /**
+     * PayPalOrder constructor.
+     *
+     * @since 2.9.0
+     *
+     * @param MerchantDetail $merchantDetails
+     *
+     * @param PayPalClient $paypalClient
+     */
+    public function __construct(PayPalClient $paypalClient, MerchantDetail $merchantDetails)
+    {
+        $this->paypalClient    = $paypalClient;
+        $this->merchantDetails = $merchantDetails;
+    }
 
-	/**
-	 * Approve order.
-	 *
-	 * @since 2.9.0
-	 *
-	 * @param  string  $orderId
-	 *
-	 * @return string
-	 * @throws Exception
-	 */
-	public function approveOrder( $orderId ) {
-		$request = new OrdersCaptureRequest( $orderId );
+    /**
+     * Approve order.
+     *
+     * @since 2.9.0
+     *
+     * @param string $orderId
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function approveOrder($orderId)
+    {
+        $request = new OrdersCaptureRequest($orderId);
 
-		try {
-			return $this->paypalClient->getHttpClient()->execute( $request )->result;
-		} catch ( Exception $ex ) {
-			logError(
-				'Capture PayPal Commerce payment failure',
-				sprintf(
-					'<strong>Response</strong><pre>%1$s</pre>',
-					print_r( json_decode( $ex->getMessage(), true ), true )
-				)
-			);
+        try {
+            return $this->paypalClient->getHttpClient()->execute($request)->result;
+        } catch (Exception $ex) {
+            logError(
+                'Capture PayPal Commerce payment failure',
+                sprintf(
+                    '<strong>Response</strong><pre>%1$s</pre>',
+                    print_r(json_decode($ex->getMessage(), true), true)
+                )
+            );
 
-			throw $ex;
-		}
-	}
+            throw $ex;
+        }
+    }
 
-	/**
-	 * Create order.
-	 *
-	 * @since 2.9.0
-	 * @see https://developer.paypal.com/docs/api/orders/v2
-	 *
-	 * @param  array  $array
-	 *
-	 * @return string
-	 * @throws Exception
-	 */
-	public function createOrder( $array ) {
-		$this->validateCreateOrderArguments( $array );
+    /**
+     * Create order.
+     *
+     * @since 2.9.0
+     *
+     * @param array $array
+     *
+     * @return string
+     * @throws Exception
+     * @see https://developer.paypal.com/docs/api/orders/v2
+     *
+     */
+    public function createOrder($array)
+    {
+        $this->validateCreateOrderArguments($array);
 
-		$request = new OrdersCreateRequest();
-		$request->payPalPartnerAttributionId( give( 'PAYPAL_COMMERCE_ATTRIBUTION_ID' ) );
-		$request->body = [
-			'intent'              => 'CAPTURE',
-			'payer'               => [
-				'given_name'    => $array['payer']['firstName'],
-				'surname'       => $array['payer']['lastName'],
-				'email_address' => $array['payer']['email'],
-			],
-			'purchase_units'      => [
-				[
-					'reference_id'        => get_post_field( 'post_name', $array['formId'] ),
-					'description'         => $array['formTitle'],
-					'amount'              => [
-						'value'         => give_maybe_sanitize_amount(
-							$array['donationAmount'],
-							[ 'currency' => give_get_currency( $array['formId'] ) ]
-						),
-						'currency_code' => give_get_currency( $array['formId'] ),
-					],
-					'payee'               => [
-						'email_address' => $this->merchantDetails->merchantId,
-						'merchant_id'   => $this->merchantDetails->merchantIdInPayPal,
-					],
-					'payment_instruction' => [
-						'disbursement_mode' => 'INSTANT',
-					],
-				],
-			],
-			'application_context' => [
-				'shipping_preference' => 'NO_SHIPPING',
-				'user_action'         => 'PAY_NOW',
-			],
-		];
+        $request          = new OrdersCreateRequest();
+        $formId           = (int)$array['formId'];
+        $donationCurrency = give_get_currency($formId);
+        $donationAmount   = give_maybe_sanitize_amount(
+            $array['donationAmount'],
+            ['currency' => give_get_currency($formId)]
+        );
+        $request->payPalPartnerAttributionId(give('PAYPAL_COMMERCE_ATTRIBUTION_ID'));
+        $request->body = [
+            'intent'              => 'CAPTURE',
+            'payer'               => [
+                'given_name'    => $array['payer']['firstName'],
+                'surname'       => $array['payer']['lastName'],
+                'email_address' => $array['payer']['email'],
+            ],
+            'purchase_units'      => [
+                [
+                    'description'         => $array['formTitle'],
+                    'amount'              => [
+                        'value'         => $donationAmount,
+                        'currency_code' => $donationCurrency,
+                        'breakdown'     => [
+                            'item_total' => [
+                                'currency_code' => $donationCurrency,
+                                'value'         => $donationAmount,
+                            ]
+                        ]
+                    ],
+                    'payee'               => [
+                        'email_address' => $this->merchantDetails->merchantId,
+                        'merchant_id'   => $this->merchantDetails->merchantIdInPayPal,
+                    ],
+                    'items'               => [
+                        [
+                            'name'        => get_post_field('post_name', $formId),
+                            'unit_amount' => [
+                                'value'         => $donationAmount,
+                                'currency_code' => $donationCurrency
+                            ],
+                            'quantity'    => 1,
+                            'category'    => 'DONATION'
+                        ]
+                    ],
+                    'payment_instruction' => [
+                        'disbursement_mode' => 'INSTANT',
+                    ],
+                ],
+            ],
+            'application_context' => [
+                'shipping_preference' => 'NO_SHIPPING',
+                'user_action'         => 'PAY_NOW',
+            ],
+        ];
 
-		if ( ! empty( $array['payer']['address'] ) ) {
-			$request->body['payer']['address'] = $array['payer']['address'];
-		}
+        if ( ! empty($array['payer']['address'])) {
+            $request->body['payer']['address'] = $array['payer']['address'];
+        }
 
-		try {
-			return $this->paypalClient->getHttpClient()->execute( $request )->result->id;
-		} catch ( Exception $ex ) {
-			logError(
-				'Create PayPal Commerce order failure',
-				sprintf(
-					'<strong>Request</strong><pre>%1$s</pre><br><strong>Response</strong><pre>%2$s</pre>',
-					print_r( $request->body, true ),
-					print_r( json_decode( $ex->getMessage(), true ), true )
-				)
-			);
+        try {
+            return $this->paypalClient->getHttpClient()->execute($request)->result->id;
+        } catch (Exception $ex) {
+            logError(
+                'Create PayPal Commerce order failure',
+                sprintf(
+                    '<strong>Request</strong><pre>%1$s</pre><br><strong>Response</strong><pre>%2$s</pre>',
+                    print_r($request->body, true),
+                    print_r(json_decode($ex->getMessage(), true), true)
+                )
+            );
 
-			throw $ex;
-		}
-	}
+            throw $ex;
+        }
+    }
 
-	/**
-	 * Refunds a processed payment
-	 *
-	 * @since 2.9.0
-	 *
-	 * @param $captureId
-	 *
-	 * @return string The id of the refund
-	 * @throws Exception
-	 */
-	public function refundPayment( $captureId ) {
-		$refund = new CapturesRefundRequest( $captureId );
+    /**
+     * Refunds a processed payment
+     *
+     * @since 2.9.0
+     *
+     * @param $captureId
+     *
+     * @return string The id of the refund
+     * @throws Exception
+     */
+    public function refundPayment($captureId)
+    {
+        $refund = new CapturesRefundRequest($captureId);
 
-		try {
-			return $this->paypalClient->getHttpClient()->execute( $refund )->result->id;
-		} catch ( Exception $exception ) {
-			logError(
-				'Create PayPal Commerce payment refund failure',
-				sprintf(
-					'<strong>Response</strong><pre>%1$s</pre>',
-					print_r( json_decode( $exception->getMessage(), true ), true )
-				)
-			);
+        try {
+            return $this->paypalClient->getHttpClient()->execute($refund)->result->id;
+        } catch (Exception $exception) {
+            logError(
+                'Create PayPal Commerce payment refund failure',
+                sprintf(
+                    '<strong>Response</strong><pre>%1$s</pre>',
+                    print_r(json_decode($exception->getMessage(), true), true)
+                )
+            );
 
-			throw $exception;
-		}
-	}
+            throw $exception;
+        }
+    }
 
-	/**
-	 * Validate argument given to create PayPal order.
-	 *
-	 * @since 2.9.0
-	 *
-	 * @param  array  $array
-	 *
-	 * @throws InvalidArgumentException
-	 */
-	private function validateCreateOrderArguments( $array ) {
-		$required = [ 'formId', 'donationAmount', 'payer' ];
-		$array    = array_filter( $array ); // Remove empty values.
+    /**
+     * Validate argument given to create PayPal order.
+     *
+     * @since 2.9.0
+     *
+     * @param array $array
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateCreateOrderArguments($array)
+    {
+        $required = ['formId', 'donationAmount', 'payer'];
+        $array    = array_filter($array); // Remove empty values.
 
-		if ( array_diff( $required, array_keys( $array ) ) ) {
-			throw new InvalidArgumentException(
-				__(
-					'To create a paypal order, please provide formId, donationAmount and payer',
-					'give'
-				)
-			);
-		}
-	}
+        if (array_diff($required, array_keys($array))) {
+            throw new InvalidArgumentException(
+                __(
+                    'To create a paypal order, please provide formId, donationAmount and payer',
+                    'give'
+                )
+            );
+        }
+    }
 }

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -120,6 +120,7 @@ class PayPalOrder
             ],
             'purchase_units'      => [
                 [
+                    'reference_id'        => get_post_field('post_name', $formId),
                     'description'         => $array['formTitle'],
                     'amount'              => [
                         'value'         => $donationAmount,

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -89,14 +89,15 @@ class PayPalOrder
     /**
      * Create order.
      *
+     * @see https://developer.paypal.com/docs/api/orders/v2
+     *
      * @since 2.9.0
+     * @unreleased Conditionally set transaction as donation or standard transaction in PayPal.
      *
      * @param array $array
      *
      * @return string
      * @throws Exception
-     * @see https://developer.paypal.com/docs/api/orders/v2
-     *
      */
     public function createOrder($array)
     {

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
@@ -10,68 +10,91 @@ class Settings {
 	 */
 	const COUNTRY_KEY = 'paypal_commerce_account_country';
 
-	/**
-	 * wp_options key for the access token
-	 *
-	 * @since 2.9.0
-	 */
-	const ACCESS_TOKEN_KEY = 'temp_give_paypal_commerce_seller_access_token';
+    /**
+     * wp_options key for the access token
+     *
+     * @since 2.9.0
+     */
+    const ACCESS_TOKEN_KEY = 'temp_give_paypal_commerce_seller_access_token';
 
-	/**
-	 * wp_options key for the partner link details
-	 *
-	 * @since 2.9.0
-	 */
-	const PARTNER_LINK_DETAIL_KEY = 'temp_give_paypal_commerce_partner_link';
+    /**
+     * wp_options key for the partner link details
+     *
+     * @since 2.9.0
+     */
+    const PARTNER_LINK_DETAIL_KEY = 'temp_give_paypal_commerce_partner_link';
 
-	/**
-	 * give_settings key for the collect bulling details
-	 *
-	 * @since 2.11.1
-	 */
-	const COLLECT_BILLING_DETAILS_KEY = 'paypal_commerce_collect_billing_details';
+    /**
+     * give_settings key for the collect bulling details
+     *
+     * @since 2.11.1
+     */
+    const COLLECT_BILLING_DETAILS_KEY = 'paypal_commerce_collect_billing_details';
 
-	/**
-	 * Returns the country for the account
-	 *
-	 * @since 2.9.0
-	 *
-	 * @return string|null
-	 */
-	public function getAccountCountry() {
-		return get_option( self::COUNTRY_KEY, give_get_country() );
-	}
+    /**
+     * give_settings key for the collect bulling details
+     *
+     * @unreleased
+     */
+    const TRANSACTION_TYPE = 'paypal_commerce_transaction_type';
 
-	/**
-	 * Returns the account access token
-	 *
-	 * @since 2.9.0
-	 *
-	 * @return array|null
-	 */
-	public function getAccessToken() {
-		return get_option( self::ACCESS_TOKEN_KEY, null );
-	}
+    /**
+     * Returns the country for the account
+     *
+     * @since 2.9.0
+     *
+     * @return string|null
+     */
+    public function getAccountCountry()
+    {
+        return get_option(self::COUNTRY_KEY, give_get_country());
+    }
 
-	/**
-	 * Updates the country account
-	 *
-	 * @param string $country
-	 *
-	 * @return bool
-	 */
-	public function updateAccountCountry( $country ) {
-		return update_option( self::COUNTRY_KEY, $country );
-	}
+    /**
+     * Returns the account access token
+     *
+     * @since 2.9.0
+     *
+     * @return array|null
+     */
+    public function getAccessToken()
+    {
+        return get_option(self::ACCESS_TOKEN_KEY, null);
+    }
 
-	/**
-	 * Updates the account access token
-	 *
-	 * @param $token
-	 *
-	 * @return bool
-	 */
-	public function updateAccessToken( $token ) {
+    /**
+     * Returns the account access token
+     *
+     * @since 2.9.0
+     *
+     * @return array|null
+     */
+    public function getTransactionType()
+    {
+        return get_option(self::TRANSACTION_TYPE, 'donation');
+    }
+
+    /**
+     * Updates the country account
+     *
+     * @param string $country
+     *
+     * @return bool
+     */
+    public function updateAccountCountry($country)
+    {
+        return update_option(self::COUNTRY_KEY, $country);
+    }
+
+    /**
+     * Updates the account access token
+     *
+     * @param $token
+     *
+     * @return bool
+     */
+    public function updateAccessToken($token)
+    {
 		return update_option( self::ACCESS_TOKEN_KEY, $token );
 	}
 
@@ -106,22 +129,32 @@ class Settings {
 		return update_option( self::PARTNER_LINK_DETAIL_KEY, $linkDetails );
 	}
 
-	/**
-	 * Deletes the partner link details
-	 *
-	 * @return bool
-	 */
-	public function deletePartnerLinkDetails() {
-		return delete_option( self::PARTNER_LINK_DETAIL_KEY );
-	}
+    /**
+     * Deletes the partner link details
+     *
+     * @return bool
+     */
+    public function deletePartnerLinkDetails()
+    {
+        return delete_option(self::PARTNER_LINK_DETAIL_KEY);
+    }
 
-	/**
-	 * Deletes the partner link details
-	 *
-	 * @since 2.11.1
-	 * @return bool
-	 */
-	public function canCollectBillingInformation() {
-		return give_is_setting_enabled( give_get_option( self::COLLECT_BILLING_DETAILS_KEY ) );
-	}
+    /**
+     * Deletes the partner link details
+     *
+     * @since 2.11.1
+     * @return bool
+     */
+    public function canCollectBillingInformation()
+    {
+        return give_is_setting_enabled(give_get_option(self::COLLECT_BILLING_DETAILS_KEY));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function isTransactionTypeDonation()
+    {
+        return 'donation' === $this->getTransactionType();
+    }
 }

--- a/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/Settings.php
@@ -71,7 +71,7 @@ class Settings {
      */
     public function getTransactionType()
     {
-        return get_option(self::TRANSACTION_TYPE, 'donation');
+        return give_get_option(self::TRANSACTION_TYPE, 'donation');
     }
 
     /**


### PR DESCRIPTION
Resolves #6083

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I updated the PayPal payment request to submit the order as a Donation.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![Transaction details - PayPal 2021-11-09 at 12 41 44 PM](https://user-images.githubusercontent.com/1784821/140878441-1be8648a-3276-44b4-bc2a-c15f789139e2.jpg)

Note:
- "Order Details" section will be added on the transaction details page. These details also appear on the checkbox modal when paying with smart buttons.
- New entries will be added to "Payment Details" section on the transaction details page.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Create one time donation with smart buttons
- Create one time donation with an advance card field ( I was not able to test because testing cards were not working for me. I am getting authentication error)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

