### PR TITLE
New: Limit gateway context and scope

### DIFF
--- a/src/Framework/PaymentGateways/Contracts/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/Contracts/PaymentGateway.php
@@ -9,37 +9,41 @@ use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 /**
  * @unreleased
  */
-abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentGatewayInterface {
-	/**
-	 * @var SubscriptionModuleInterface $subscriptionModule
-	 */
-	public $subscriptionModule;
+abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentGatewayInterface
+{
+    /**
+     * @var SubscriptionModuleInterface $subscriptionModule
+     */
+    public $subscriptionModule;
 
-	/**
-	 * @unreleased
-	 *
-	 * @param  SubscriptionModuleInterface|null  $subscriptionModule
-	 */
-	public function __construct( SubscriptionModuleInterface $subscriptionModule = null ) {
-		$this->subscriptionModule = $subscriptionModule;
-	}
+    /**
+     * @unreleased
+     *
+     * @param  SubscriptionModuleInterface|null  $subscriptionModule
+     */
+    public function __construct(SubscriptionModuleInterface $subscriptionModule = null)
+    {
+        $this->subscriptionModule = $subscriptionModule;
+    }
 
 
-	/**
-	 * @inheritDoc
-	 */
-	public function supportsSubscriptions() {
-		return isset( $this->subscriptionModule );
-	}
+    /**
+     * @inheritDoc
+     */
+    public function supportsSubscriptions()
+    {
+        return isset($this->subscriptionModule);
+    }
 
-	/**
-	 * If a subscription module isn't wanted this method can be overridden by a child class instead.
-	 * Just make sure to override the supportsSubscriptions method as well.
-	 *
-	 * @inheritDoc
-	 */
-	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData ) {
-		$this->subscriptionModule->createSubscription( $paymentData, $subscriptionData );
-	}
+    /**
+     * If a subscription module isn't wanted this method can be overridden by a child class instead.
+     * Just make sure to override the supportsSubscriptions method as well.
+     *
+     * @inheritDoc
+     */
+    public function createSubscription(GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData)
+    {
+        $this->subscriptionModule->createSubscription($paymentData, $subscriptionData);
+    }
 
 }

--- a/src/Framework/PaymentGateways/Contracts/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/Contracts/PaymentGateway.php
@@ -3,6 +3,8 @@
 namespace Give\Framework\PaymentGateways\Contracts;
 
 use Give\Framework\LegacyPaymentGateways\Contracts\LegacyPaymentGatewayInterface;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 
 /**
  * @unreleased
@@ -36,8 +38,8 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
 	 *
 	 * @inheritDoc
 	 */
-	public function handleSubscriptionRequest( $donationId, $subscriptionId, $formData ) {
-		return $this->subscriptionModule->handleSubscriptionRequest( $donationId, $subscriptionId, $formData );
+	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData ) {
+		$this->subscriptionModule->createSubscription( $paymentData, $subscriptionData );
 	}
 
 }

--- a/src/Framework/PaymentGateways/Contracts/PaymentGatewayInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/PaymentGatewayInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Give\Framework\PaymentGateways\Contracts;
 
 use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
@@ -7,72 +8,73 @@ use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 /**
  * @unreleased
  */
-interface PaymentGatewayInterface {
-	/**
-	 * Return a unique identifier for the gateway
-	 *
-	 * @unreleased
-	 *
-	 * @return string
-	 */
-	public static function id();
+interface PaymentGatewayInterface
+{
+    /**
+     * Return a unique identifier for the gateway
+     *
+     * @unreleased
+     *
+     * @return string
+     */
+    public static function id();
 
-	/**
-	 * Return a unique identifier for the gateway
-	 *
-	 * @unreleased
-	 *
-	 * @return string
-	 */
-	public function getId();
+    /**
+     * Return a unique identifier for the gateway
+     *
+     * @unreleased
+     *
+     * @return string
+     */
+    public function getId();
 
-	/**
-	 * Returns a human-readable name for the gateway
-	 *
-	 * @unreleased
-	 *
-	 * @return string - Translated text
-	 */
-	public function getName();
+    /**
+     * Returns a human-readable name for the gateway
+     *
+     * @unreleased
+     *
+     * @return string - Translated text
+     */
+    public function getName();
 
-	/**
-	 * Returns a human-readable label for use when a donor selects a payment method to use
-	 *
-	 * @unreleased
-	 *
-	 * @return string - Translated text
-	 */
-	public function getPaymentMethodLabel();
+    /**
+     * Returns a human-readable label for use when a donor selects a payment method to use
+     *
+     * @unreleased
+     *
+     * @return string - Translated text
+     */
+    public function getPaymentMethodLabel();
 
-	/**
-	 * Determines if subscriptions are supported
-	 *
-	 * @unreleased
-	 *
-	 * @return bool
-	 */
-	public function supportsSubscriptions();
+    /**
+     * Determines if subscriptions are supported
+     *
+     * @unreleased
+     *
+     * @return bool
+     */
+    public function supportsSubscriptions();
 
-	/**
-	 * Create a payment with gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param  GatewayPaymentData  $paymentData
-	 *
-	 * @return void
-	 */
-	public function createPayment( GatewayPaymentData $paymentData );
+    /**
+     * Create a payment with gateway
+     *
+     * @unreleased
+     *
+     * @param  GatewayPaymentData  $paymentData
+     *
+     * @return void
+     */
+    public function createPayment(GatewayPaymentData $paymentData);
 
-	/**
-	 * Create a subscription with gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param  GatewayPaymentData  $paymentData
-	 * @param  GatewaySubscriptionData  $subscriptionData
-	 *
-	 * @return void
-	 */
-	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData );
+    /**
+     * Create a subscription with gateway
+     *
+     * @unreleased
+     *
+     * @param  GatewayPaymentData  $paymentData
+     * @param  GatewaySubscriptionData  $subscriptionData
+     *
+     * @return void
+     */
+    public function createSubscription(GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData);
 }

--- a/src/Framework/PaymentGateways/Contracts/PaymentGatewayInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/PaymentGatewayInterface.php
@@ -1,7 +1,8 @@
 <?php
 namespace Give\Framework\PaymentGateways\Contracts;
 
-use Give\PaymentGateways\DataTransferObjects\FormData;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 
 /**
  * @unreleased
@@ -53,27 +54,25 @@ interface PaymentGatewayInterface {
 	public function supportsSubscriptions();
 
 	/**
-	 * After creating the initial payment, we can continue with the gateway processing for a one-time request
+	 * Create a payment with gateway
 	 *
 	 * @unreleased
 	 *
-	 * @param  int  $donationId
-	 * @param  FormData  $formData
+	 * @param  GatewayPaymentData  $paymentData
 	 *
 	 * @return void
 	 */
-	public function handleOneTimeRequest( $donationId, FormData $formData );
+	public function createPayment( GatewayPaymentData $paymentData );
 
 	/**
-	 * After creating the initial payment, we can continue with the gateway processing for a subscription request
+	 * Create a subscription with gateway
 	 *
 	 * @unreleased
 	 *
-	 * @param  int  $donationId
-	 * @param  int  $subscriptionId
-	 * @param  FormData  $formData
+	 * @param  GatewayPaymentData  $paymentData
+	 * @param  GatewaySubscriptionData  $subscriptionData
 	 *
 	 * @return void
 	 */
-	public function handleSubscriptionRequest( $donationId, $subscriptionId, $formData );
+	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData );
 }

--- a/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
@@ -5,16 +5,17 @@ namespace Give\Framework\PaymentGateways\Contracts;
 use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 
-interface SubscriptionModuleInterface {
-	/**
-	 * Create a subscription with gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param  GatewayPaymentData  $paymentData
-	 * @param  GatewaySubscriptionData  $subscriptionData
-	 *
-	 * @return void
-	 */
-	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData );
+interface SubscriptionModuleInterface
+{
+    /**
+     * Create a subscription with gateway
+     *
+     * @unreleased
+     *
+     * @param  GatewayPaymentData  $paymentData
+     * @param  GatewaySubscriptionData  $subscriptionData
+     *
+     * @return void
+     */
+    public function createSubscription(GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData);
 }

--- a/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
@@ -2,17 +2,19 @@
 
 namespace Give\Framework\PaymentGateways\Contracts;
 
-use Give\PaymentGateways\DataTransferObjects\FormData;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\PaymentGateways\DataTransferObjects\GatewaySubscriptionData;
 
 interface SubscriptionModuleInterface {
 	/**
-	 * Handle gateway subscription request
+	 * Create a subscription with gateway
 	 *
 	 * @unreleased
 	 *
-	 * @param  int  $donationId
-	 * @param  int  $subscriptionId
-	 * @param  FormData  $formData
+	 * @param  GatewayPaymentData  $paymentData
+	 * @param  GatewaySubscriptionData  $subscriptionData
+	 *
+	 * @return void
 	 */
-	public function handleSubscriptionRequest( $donationId, $subscriptionId, $formData );
+	public function createSubscription( GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData );
 }

--- a/src/Framework/PaymentGateways/PaymentGatewayRegister.php
+++ b/src/Framework/PaymentGateways/PaymentGatewayRegister.php
@@ -18,7 +18,7 @@ class PaymentGatewayRegister extends PaymentGatewaysIterator
     protected $gateways = [];
 
     /**
-     * * Get Gateways
+     * Get Gateways
      *
      * @unreleased
      *
@@ -115,6 +115,7 @@ class PaymentGatewayRegister extends PaymentGatewaysIterator
      * @unreleased
      *
      * @param  string  $gatewayClass
+     * @param  string  $gatewayId
      *
      * @return void
      */

--- a/src/Framework/PaymentGateways/PaymentGatewayRegister.php
+++ b/src/Framework/PaymentGateways/PaymentGatewayRegister.php
@@ -13,120 +13,130 @@ use Give\Framework\PaymentGateways\Exceptions\OverflowException;
 /**
  * @unreleased
  */
-class PaymentGatewayRegister extends PaymentGatewaysIterator {
-	protected $gateways = [];
+class PaymentGatewayRegister extends PaymentGatewaysIterator
+{
+    protected $gateways = [];
 
-	/**
-	 * * Get Gateways
-	 *
-	 * @unreleased
-	 *
-	 * @return array
-	 */
-	public function getPaymentGateways() {
-		return $this->gateways;
-	}
+    /**
+     * * Get Gateways
+     *
+     * @unreleased
+     *
+     * @return array
+     */
+    public function getPaymentGateways()
+    {
+        return $this->gateways;
+    }
 
-	/**
-	 * Get Gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param  string  $id
-	 *
-	 * @return string
-	 */
-	public function getPaymentGateway( $id ) {
-		if ( ! isset( $this->gateways[ $id ] ) ) {
-			throw new InvalidArgumentException( "No migration exists with the ID {$id}" );
-		}
+    /**
+     * Get Gateway
+     *
+     * @unreleased
+     *
+     * @param  string  $id
+     *
+     * @return string
+     */
+    public function getPaymentGateway($id)
+    {
+        if (!isset($this->gateways[$id])) {
+            throw new InvalidArgumentException("No migration exists with the ID {$id}");
+        }
 
-		return $this->gateways[ $id ];
-	}
+        return $this->gateways[$id];
+    }
 
-	/**
-	 * @unreleased
-	 *
-	 * @param string $id
-	 *
-	 * @return bool
-	 */
-	public function hasPaymentGateway( $id ) {
-		return isset( $this->gateways[ $id ] );
-	}
+    /**
+     * @unreleased
+     *
+     * @param  string  $id
+     *
+     * @return bool
+     */
+    public function hasPaymentGateway($id)
+    {
+        return isset($this->gateways[$id]);
+    }
 
-	/**
-	 * Register Gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param  string  $gatewayClass
-	 *
-	 * @throws OverflowException|InvalidArgumentException|Exception
-	 */
-	public function registerGateway( $gatewayClass ) {
-		if ( ! is_subclass_of( $gatewayClass, PaymentGateway::class ) ) {
-			throw new InvalidArgumentException( sprintf(
-				'%1$s must extend %2$s',
-				$gatewayClass,
-				PaymentGateway::class
-			) );
-		}
+    /**
+     * Register Gateway
+     *
+     * @unreleased
+     *
+     * @param  string  $gatewayClass
+     *
+     * @throws OverflowException|InvalidArgumentException|Exception
+     */
+    public function registerGateway($gatewayClass)
+    {
+        if (!is_subclass_of($gatewayClass, PaymentGateway::class)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '%1$s must extend %2$s',
+                    $gatewayClass,
+                    PaymentGateway::class
+                )
+            );
+        }
 
-		$gatewayId = $gatewayClass::id();
+        $gatewayId = $gatewayClass::id();
 
-		if ( isset( $this->gateways[ $gatewayId ] ) ) {
-			throw new OverflowException( "Cannot register a gateway with an id that already exists: $gatewayId" );
-		}
+        if (isset($this->gateways[$gatewayId])) {
+            throw new OverflowException("Cannot register a gateway with an id that already exists: $gatewayId");
+        }
 
-		$this->gateways[ $gatewayId ] = $gatewayClass;
+        $this->gateways[$gatewayId] = $gatewayClass;
 
-		$this->registerGatewayWithServiceContainer( $gatewayClass, $gatewayId );
+        $this->registerGatewayWithServiceContainer($gatewayClass, $gatewayId);
 
-		$this->afterGatewayRegister( $gatewayClass );
-	}
+        $this->afterGatewayRegister($gatewayClass);
+    }
 
-	/**
-	 * Unregister Gateway
-	 *
-	 * @unreleased
-	 *
-	 * @param $gatewayId
-	 */
-	public function unregisterGateway( $gatewayId ) {
-		if ( isset( $this->gateways[ $gatewayId ] ) ) {
-			unset( $this->gateways[ $gatewayId ] );
-		}
-	}
+    /**
+     * Unregister Gateway
+     *
+     * @unreleased
+     *
+     * @param $gatewayId
+     */
+    public function unregisterGateway($gatewayId)
+    {
+        if (isset($this->gateways[$gatewayId])) {
+            unset($this->gateways[$gatewayId]);
+        }
+    }
 
-	/**
-	 *
-	 * Register Gateway with Service Container as Singleton
-	 * with option of adding Subscription Module through filter "give_gateway_{$gatewayId}_subscription_module"
-	 *
-	 * @unreleased
-	 *
-	 * @param  string  $gatewayClass
-	 *
-	 * @return void
-	 */
-	private function registerGatewayWithServiceContainer( $gatewayClass, $gatewayId ) {
-		give()->singleton( $gatewayClass, function ( Container $container ) use ( $gatewayClass, $gatewayId ) {
-			$subscriptionModule = apply_filters( "give_gateway_{$gatewayId}_subscription_module", null );
+    /**
+     *
+     * Register Gateway with Service Container as Singleton
+     * with option of adding Subscription Module through filter "give_gateway_{$gatewayId}_subscription_module"
+     *
+     * @unreleased
+     *
+     * @param  string  $gatewayClass
+     *
+     * @return void
+     */
+    private function registerGatewayWithServiceContainer($gatewayClass, $gatewayId)
+    {
+        give()->singleton($gatewayClass, function (Container $container) use ($gatewayClass, $gatewayId) {
+            $subscriptionModule = apply_filters("give_gateway_{$gatewayId}_subscription_module", null);
 
-			return new $gatewayClass( $subscriptionModule ? $container->make( $subscriptionModule ) : null );
-		} );
-	}
+            return new $gatewayClass($subscriptionModule ? $container->make($subscriptionModule) : null);
+        });
+    }
 
-	/**
-	 * After gateway is registered, connect to legacy payment gateway adapter
-	 *
-	 * @param  string  $gatewayClass
-	 */
-	private function afterGatewayRegister( $gatewayClass ) {
-		/** @var LegacyPaymentGatewayRegisterAdapter $legacyPaymentGatewayRegisterAdapter */
-		$legacyPaymentGatewayRegisterAdapter = give( LegacyPaymentGatewayRegisterAdapter::class );
+    /**
+     * After gateway is registered, connect to legacy payment gateway adapter
+     *
+     * @param  string  $gatewayClass
+     */
+    private function afterGatewayRegister($gatewayClass)
+    {
+        /** @var LegacyPaymentGatewayRegisterAdapter $legacyPaymentGatewayRegisterAdapter */
+        $legacyPaymentGatewayRegisterAdapter = give(LegacyPaymentGatewayRegisterAdapter::class);
 
-		$legacyPaymentGatewayRegisterAdapter->connectGatewayToLegacyPaymentGatewayAdapter( $gatewayClass );
-	}
+        $legacyPaymentGatewayRegisterAdapter->connectGatewayToLegacyPaymentGatewayAdapter($gatewayClass);
+    }
 }

--- a/src/Framework/PaymentGateways/PaymentGatewayRegister.php
+++ b/src/Framework/PaymentGateways/PaymentGatewayRegister.php
@@ -40,8 +40,8 @@ class PaymentGatewayRegister extends PaymentGatewaysIterator
      */
     public function getPaymentGateway($id)
     {
-        if (!isset($this->gateways[$id])) {
-            throw new InvalidArgumentException("No migration exists with the ID {$id}");
+        if (!$this->hasPaymentGateway($id)) {
+            throw new InvalidArgumentException("No gateway exists with the ID {$id}");
         }
 
         return $this->gateways[$id];
@@ -82,7 +82,7 @@ class PaymentGatewayRegister extends PaymentGatewaysIterator
 
         $gatewayId = $gatewayClass::id();
 
-        if (isset($this->gateways[$gatewayId])) {
+        if ($this->hasPaymentGateway($gatewayId)) {
             throw new OverflowException("Cannot register a gateway with an id that already exists: $gatewayId");
         }
 

--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -15,114 +15,122 @@ use Give\PaymentGateways\DataTransferObjects\SubscriptionData;
  * Class LegacyPaymentGatewayAdapter
  * @unreleased
  */
-class LegacyPaymentGatewayAdapter {
+class LegacyPaymentGatewayAdapter
+{
 
-	/**
-	 * Get legacy form field markup to display gateway specific payment fields
-	 *
-	 * @unreleased
-	 *
-	 * @param  int  $formId
-	 * @param  PaymentGatewayInterface  $registeredGateway
-	 *
-	 * @return string|bool
-	 */
-	public function getLegacyFormFieldMarkup( $formId, $registeredGateway ) {
-		return $registeredGateway->getLegacyFormFieldMarkup( $formId );
-	}
+    /**
+     * Get legacy form field markup to display gateway specific payment fields
+     *
+     * @unreleased
+     *
+     * @param  int  $formId
+     * @param  PaymentGatewayInterface  $registeredGateway
+     *
+     * @return string|bool
+     */
+    public function getLegacyFormFieldMarkup($formId, $registeredGateway)
+    {
+        return $registeredGateway->getLegacyFormFieldMarkup($formId);
+    }
 
-	/**
-	 * First we create a payment, then move on to the gateway processing
-	 *
-	 * @unreleased
-	 *
-	 * @param  array  $request  Donation Data
-	 * @param  PaymentGatewayInterface  $registeredGateway
-	 *
-	 */
-	public function handleBeforeGateway( $request, $registeredGateway ) {
-		$formData = FormData::fromRequest( $request );
+    /**
+     * First we create a payment, then move on to the gateway processing
+     *
+     * @unreleased
+     *
+     * @param  array  $request  Donation Data
+     * @param  PaymentGatewayInterface  $registeredGateway
+     *
+     */
+    public function handleBeforeGateway($request, $registeredGateway)
+    {
+        $formData = FormData::fromRequest($request);
 
-		$this->validateGatewayNonce( $formData->gatewayNonce );
+        $this->validateGatewayNonce($formData->gatewayNonce);
 
-		$donationId = $this->createPayment( $formData->toPaymentData() );
+        $donationId = $this->createPayment($formData->toPaymentData());
 
-		$gatewayPaymentData = GatewayPaymentData::fromArray( [
-			'amount' => $formData->amount,
-			'currency' => $formData->currency,
-			'date' => $formData->date,
-			'price' => $formData->price,
-			'priceId' => $formData->priceId,
-			'gatewayId' => $formData->paymentGateway,
-			'paymentId' => $donationId,
-			'purchaseKey' => $formData->purchaseKey,
-			'donorInfo' => $formData->donorInfo,
-			'cardInfo' => $formData->cardInfo,
-			'billingAddress' => $formData->billingAddress,
-		] );
+        $gatewayPaymentData = GatewayPaymentData::fromArray([
+            'amount' => $formData->amount,
+            'currency' => $formData->currency,
+            'date' => $formData->date,
+            'price' => $formData->price,
+            'priceId' => $formData->priceId,
+            'gatewayId' => $formData->paymentGateway,
+            'paymentId' => $donationId,
+            'purchaseKey' => $formData->purchaseKey,
+            'donorInfo' => $formData->donorInfo,
+            'cardInfo' => $formData->cardInfo,
+            'billingAddress' => $formData->billingAddress,
+        ]);
 
-		if ( function_exists( 'Give_Recurring' ) && Give_Recurring()->is_recurring( $formData->formId ) ) {
-			$subscriptionData = SubscriptionData::fromRequest( $request );
-			$subscriptionId = $this->createSubscription( $donationId, $formData, $subscriptionData );
+        if (function_exists('Give_Recurring') && Give_Recurring()->is_recurring($formData->formId)) {
+            $subscriptionData = SubscriptionData::fromRequest($request);
+            $subscriptionId = $this->createSubscription($donationId, $formData, $subscriptionData);
 
-			$gatewaySubscriptionData = GatewaySubscriptionData::fromArray( [
-				'period' => $subscriptionData->period,
-				'times' => $subscriptionData->times,
-				'frequency' => $subscriptionData->frequency,
-				'subscriptionId' => $subscriptionId,
-			] );
+            $gatewaySubscriptionData = GatewaySubscriptionData::fromArray([
+                'period' => $subscriptionData->period,
+                'times' => $subscriptionData->times,
+                'frequency' => $subscriptionData->frequency,
+                'subscriptionId' => $subscriptionId,
+            ]);
 
-			$registeredGateway->createSubscription( $gatewayPaymentData, $gatewaySubscriptionData );
-		}
+            $registeredGateway->createSubscription($gatewayPaymentData, $gatewaySubscriptionData);
+        }
 
-		$registeredGateway->createPayment( $gatewayPaymentData );
-	}
+        $registeredGateway->createPayment($gatewayPaymentData);
+    }
 
-	/**
-	 * Create the payment
-	 *
-	 * @unreleased
-	 *
-	 * @param  GiveInsertPaymentData  $giveInsertPaymentData
-	 *
-	 * @return int
-	 */
-	private function createPayment( GiveInsertPaymentData $giveInsertPaymentData ) {
-		/** @var CreatePaymentAction $createPaymentAction */
-		$createPaymentAction = give( CreatePaymentAction::class );
+    /**
+     * Create the payment
+     *
+     * @unreleased
+     *
+     * @param  GiveInsertPaymentData  $giveInsertPaymentData
+     *
+     * @return int
+     */
+    private function createPayment(GiveInsertPaymentData $giveInsertPaymentData)
+    {
+        /** @var CreatePaymentAction $createPaymentAction */
+        $createPaymentAction = give(CreatePaymentAction::class);
 
-		return $createPaymentAction( $giveInsertPaymentData );
-	}
+        return $createPaymentAction($giveInsertPaymentData);
+    }
 
-	/**
-	 * Create the payment
-	 *
-	 * @unreleased
-	 *
-	 * @param  int  $donationId
-	 * @param  FormData  $formData
-	 * @param  SubscriptionData  $subscriptionData
-	 *
-	 * @return int
-	 */
-	private function createSubscription( $donationId, FormData $formData, SubscriptionData $subscriptionData ) {
-		/** @var CreateSubscriptionAction $createSubscriptionAction */
-		$createSubscriptionAction = give( CreateSubscriptionAction::class );
+    /**
+     * Create the payment
+     *
+     * @unreleased
+     *
+     * @param  int  $donationId
+     * @param  FormData  $formData
+     * @param  SubscriptionData  $subscriptionData
+     *
+     * @return int
+     */
+    private function createSubscription($donationId, FormData $formData, SubscriptionData $subscriptionData)
+    {
+        /** @var CreateSubscriptionAction $createSubscriptionAction */
+        $createSubscriptionAction = give(CreateSubscriptionAction::class);
 
-		return $createSubscriptionAction( $donationId, $formData, $subscriptionData );
-	}
+        return $createSubscriptionAction($donationId, $formData, $subscriptionData);
+    }
 
-	/**
-	 * Validate Gateway Nonce
-	 *
-	 * @unreleased
-	 *
-	 * @param  string  $gatewayNonce
-	 */
-	private function validateGatewayNonce( $gatewayNonce ) {
-		if ( ! wp_verify_nonce( $gatewayNonce, 'give-gateway' ) ) {
-			wp_die( esc_html__( 'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.',
-				'give' ), esc_html__( 'Error', 'give' ), [ 'response' => 403 ] );
-		}
-	}
+    /**
+     * Validate Gateway Nonce
+     *
+     * @unreleased
+     *
+     * @param  string  $gatewayNonce
+     */
+    private function validateGatewayNonce($gatewayNonce)
+    {
+        if (!wp_verify_nonce($gatewayNonce, 'give-gateway')) {
+            wp_die(esc_html__(
+                'We\'re unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance.',
+                'give'
+            ), esc_html__('Error', 'give'), ['response' => 403]);
+        }
+    }
 }

--- a/src/PaymentGateways/Actions/CreatePaymentAction.php
+++ b/src/PaymentGateways/Actions/CreatePaymentAction.php
@@ -9,24 +9,26 @@ use Give\PaymentGateways\DataTransferObjects\GiveInsertPaymentData;
  * Class CreatePaymentAction
  * @unreleased
  */
-class CreatePaymentAction {
-	/**
-	 * @unreleased
-	 *
-	 * @param  GiveInsertPaymentData  $giveInsertPaymentData
-	 *
-	 * @return bool|int
-	 */
-	public function __invoke( GiveInsertPaymentData $giveInsertPaymentData ) {
-		// Record the pending payment
-		$payment = give_insert_payment( $giveInsertPaymentData->toArray() );
+class CreatePaymentAction
+{
+    /**
+     * @unreleased
+     *
+     * @param  GiveInsertPaymentData  $giveInsertPaymentData
+     *
+     * @return bool|int
+     */
+    public function __invoke(GiveInsertPaymentData $giveInsertPaymentData)
+    {
+        // Record the pending payment
+        $payment = give_insert_payment($giveInsertPaymentData->toArray());
 
-		// If errors are present, send the user back to the donation page, so they can be corrected
-		if ( ! $payment ) {
-			Log::error( esc_html__( 'Payment Error', 'give' ), $giveInsertPaymentData->toArray() );
-			give_send_back_to_checkout( '?payment-mode=' . $giveInsertPaymentData->paymentGateway );
-		}
+        // If errors are present, send the user back to the donation page, so they can be corrected
+        if (!$payment) {
+            Log::error(esc_html__('Payment Error', 'give'), $giveInsertPaymentData->toArray());
+            give_send_back_to_checkout('?payment-mode=' . $giveInsertPaymentData->paymentGateway);
+        }
 
-		return $payment;
-	}
+        return $payment;
+    }
 }

--- a/src/PaymentGateways/Actions/CreatePaymentAction.php
+++ b/src/PaymentGateways/Actions/CreatePaymentAction.php
@@ -3,7 +3,7 @@
 namespace Give\PaymentGateways\Actions;
 
 use Give\Log\Log;
-use Give\PaymentGateways\DataTransferObjects\FormData;
+use Give\PaymentGateways\DataTransferObjects\GiveInsertPaymentData;
 
 /**
  * Class CreatePaymentAction
@@ -13,18 +13,18 @@ class CreatePaymentAction {
 	/**
 	 * @unreleased
 	 *
-	 * @param  FormData  $formData
+	 * @param  GiveInsertPaymentData  $giveInsertPaymentData
 	 *
 	 * @return bool|int
 	 */
-	public function __invoke( FormData $formData ) {
+	public function __invoke( GiveInsertPaymentData $giveInsertPaymentData ) {
 		// Record the pending payment
-		$payment = give_insert_payment( $formData->toPaymentArray() );
+		$payment = give_insert_payment( $giveInsertPaymentData->toArray() );
 
 		// If errors are present, send the user back to the donation page, so they can be corrected
-		if (! $payment ) {
-			Log::error( esc_html__( 'Payment Error', 'give' ), $formData->toPaymentArray() );
-			give_send_back_to_checkout( '?payment-mode=' . $formData->paymentGateway );
+		if ( ! $payment ) {
+			Log::error( esc_html__( 'Payment Error', 'give' ), $giveInsertPaymentData->toArray() );
+			give_send_back_to_checkout( '?payment-mode=' . $giveInsertPaymentData->paymentGateway );
 		}
 
 		return $payment;

--- a/src/PaymentGateways/Actions/CreateSubscriptionAction.php
+++ b/src/PaymentGateways/Actions/CreateSubscriptionAction.php
@@ -13,117 +13,126 @@ use Give_Donor;
  * Class CreateSubscriptionAction
  * @unreleased
  */
-class CreateSubscriptionAction {
-	/**
-	 * Processes the recurring donation form and sends sets up the subscription data for hand-off to the gateway.
-	 *
-	 * @unreleased
-	 *
-	 * @param  int  $donationId
-	 * @param  FormData  $formData
-	 * @param  SubscriptionData  $subscriptionData
-	 *
-	 * @return int
-	 */
-	public function __invoke( $donationId, FormData $formData, SubscriptionData $subscriptionData ) {
-		$donor = $this->getOrCreateDonor( $formData->donorInfo );
+class CreateSubscriptionAction
+{
+    /**
+     * Processes the recurring donation form and sends sets up the subscription data for hand-off to the gateway.
+     *
+     * @unreleased
+     *
+     * @param  int  $donationId
+     * @param  FormData  $formData
+     * @param  SubscriptionData  $subscriptionData
+     *
+     * @return int
+     */
+    public function __invoke($donationId, FormData $formData, SubscriptionData $subscriptionData)
+    {
+        $donor = $this->getOrCreateDonor($formData->donorInfo);
 
-		$subscriptionArgs = $this->getSubscriptionData( $formData, $subscriptionData );
+        $subscriptionArgs = $this->getSubscriptionData($formData, $subscriptionData);
 
-		return $this->createSubscription( $donationId, $donor->id, $subscriptionArgs );
-	}
+        return $this->createSubscription($donationId, $donor->id, $subscriptionArgs);
+    }
 
-	/**
-	 * @param  FormData  $formData
-	 * @param  SubscriptionData  $subscriptionData
-	 *
-	 * @return SubscriptionArgs
-	 */
-	private function getSubscriptionData( FormData $formData, SubscriptionData $subscriptionData ) {
-		$subscriptionArgs = SubscriptionArgs::fromRequest( [
-			'period' => $subscriptionData->period,
-			'times' => ! empty( $subscriptionData->times ) ? (int) $subscriptionData->times : 0,
-			'frequency' => ! empty( $subscriptionData->frequency ) ? (int) $subscriptionData->frequency : 1,
-			'formTitle' => $formData->formTitle,
-			'formId' => $formData->formId,
-			'priceId' => $formData->priceId,
-			'price' => $formData->price,
-			'status' => 'pending'
-		] );
+    /**
+     * @param  FormData  $formData
+     * @param  SubscriptionData  $subscriptionData
+     *
+     * @return SubscriptionArgs
+     */
+    private function getSubscriptionData(FormData $formData, SubscriptionData $subscriptionData)
+    {
+        $subscriptionArgs = SubscriptionArgs::fromRequest([
+            'period' => $subscriptionData->period,
+            'times' => !empty($subscriptionData->times) ? (int)$subscriptionData->times : 0,
+            'frequency' => !empty($subscriptionData->frequency) ? (int)$subscriptionData->frequency : 1,
+            'formTitle' => $formData->formTitle,
+            'formId' => $formData->formId,
+            'priceId' => $formData->priceId,
+            'price' => $formData->price,
+            'status' => 'pending'
+        ]);
 
-		apply_filters( 'give_recurring_subscription_pre_gateway_args', $subscriptionArgs->toArray() );
+        apply_filters('give_recurring_subscription_pre_gateway_args', $subscriptionArgs->toArray());
 
-		return $subscriptionArgs;
-	}
+        return $subscriptionArgs;
+    }
 
-	/**
-	 * Get or create donor
-	 *
-	 * @unreleased
-	 *
-	 * @param  DonorInfo  $donorInfo
-	 *
-	 * @return Give_Donor
-	 */
-	private function getOrCreateDonor( DonorInfo $donorInfo ) {
-		$subscriber = empty( $donorInfo->wpUserId ) ?
-			new Give_Donor( $donorInfo->email ) :
-			new Give_Donor( $donorInfo->wpUserId, true );
+    /**
+     * Get or create donor
+     *
+     * @unreleased
+     *
+     * @param  DonorInfo  $donorInfo
+     *
+     * @return Give_Donor
+     */
+    private function getOrCreateDonor(DonorInfo $donorInfo)
+    {
+        $subscriber = empty($donorInfo->wpUserId) ?
+            new Give_Donor($donorInfo->email) :
+            new Give_Donor($donorInfo->wpUserId, true);
 
-		if ( empty( $subscriber->id ) ) {
-			$name = sprintf(
-				'%s %s',
-				( ! empty( $donorInfo->firstName ) ? trim( $donorInfo->firstName ) : '' ),
-				( ! empty( $donorInfo->lastName ) ? trim( $donorInfo->lastName ) : '' )
-			);
+        if (empty($subscriber->id)) {
+            $name = sprintf(
+                '%s %s',
+                (!empty($donorInfo->firstName) ? trim($donorInfo->firstName) : ''),
+                (!empty($donorInfo->lastName) ? trim($donorInfo->lastName) : '')
+            );
 
-			$subscriber_data = [
-				'name' => trim( $name ),
-				'email' => $donorInfo->email,
-				'user_id' => $donorInfo->wpUserId,
-			];
+            $subscriber_data = [
+                'name' => trim($name),
+                'email' => $donorInfo->email,
+                'user_id' => $donorInfo->wpUserId,
+            ];
 
-			$subscriber->create( $subscriber_data );
-		}
+            $subscriber->create($subscriber_data);
+        }
 
-		return $subscriber;
-	}
+        return $subscriber;
+    }
 
-	/**
-	 * Records subscription donations in the database and creates a give_payment record.
-	 *
-	 * @unreleased
-	 *
-	 * @param  int  $donationId
-	 * @param  int  $donorId
-	 * @param  SubscriptionArgs  $subscriptionArgs
-	 *
-	 * @return int
-	 */
-	private function createSubscription($donationId, $donorId, $subscriptionArgs ) {
+    /**
+     * Records subscription donations in the database and creates a give_payment record.
+     *
+     * @unreleased
+     *
+     * @param  int  $donationId
+     * @param  int  $donorId
+     * @param  SubscriptionArgs  $subscriptionArgs
+     *
+     * @return int
+     */
+    private function createSubscription($donationId, $donorId, $subscriptionArgs)
+    {
+        // Set subscription_payment.
+        give_update_meta($donationId, '_give_subscription_payment', true);
 
-		// Set subscription_payment.
-		give_update_meta( $donationId, '_give_subscription_payment', true );
+        // Now create the subscription record.
+        $subscriber = new Subscriber($donorId);
 
-		// Now create the subscription record.
-		$subscriber = new Subscriber( $donorId );
+        $args = [
+            'form_id' => $subscriptionArgs->formId,
+            'parent_payment_id' => $donationId,
+            'status' => $subscriptionArgs->status,
+            'period' => $subscriptionArgs->periodInterval,
+            'frequency' => $subscriptionArgs->frequencyIntervalCount,
+            'initial_amount' => $subscriptionArgs->initialAmount,
+            'recurring_amount' => $subscriptionArgs->recurringAmount,
+            'recurring_fee_amount' => $subscriptionArgs->recurringFeeAmount,
+            'bill_times' => $subscriptionArgs->billTimes,
+            'expiration' => $subscriber->get_new_expiration(
+                $subscriptionArgs->formId,
+                $subscriptionArgs->priceId,
+                $subscriptionArgs->frequencyIntervalCount,
+                $subscriptionArgs->periodInterval
+            ),
+            'profile_id' => $subscriptionArgs->profileId,
+            'transaction_id' => $subscriptionArgs->transactionId,
+            'user_id' => $donorId,
+        ];
 
-		$args = [
-			'form_id'              => $subscriptionArgs->formId,
-			'parent_payment_id'    => $donationId,
-			'status'               => $subscriptionArgs->status,
-			'period'               => $subscriptionArgs->periodInterval,
-			'frequency'            => $subscriptionArgs->frequencyIntervalCount,
-			'initial_amount'       => $subscriptionArgs->initialAmount,
-			'recurring_amount'     => $subscriptionArgs->recurringAmount,
-			'recurring_fee_amount' => $subscriptionArgs->recurringFeeAmount,
-			'bill_times'           => $subscriptionArgs->billTimes,
-			'expiration'           => $subscriber->get_new_expiration( $subscriptionArgs->formId, $subscriptionArgs->priceId, $subscriptionArgs->frequencyIntervalCount, $subscriptionArgs->periodInterval ),
-			'profile_id'           => $subscriptionArgs->profileId,
-			'transaction_id'       => $subscriptionArgs->transactionId,
-			'user_id'              => $donorId,
-		];
-
-		return $subscriber->add_subscription( $args )->id;
-	}
+        return $subscriber->add_subscription($args)->id;
+    }
 }

--- a/src/PaymentGateways/Actions/RegisterPaymentGateways.php
+++ b/src/PaymentGateways/Actions/RegisterPaymentGateways.php
@@ -7,61 +7,65 @@ use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 
-class RegisterPaymentGateways {
-	/**
-	 * Array of PaymentGateway classes to be bootstrapped
-	 *
-	 * @var string[]
-	 */
-	public $gateways = [
-		TestGateway::class
-	];
+class RegisterPaymentGateways
+{
+    /**
+     * Array of PaymentGateway classes to be bootstrapped
+     *
+     * @var string[]
+     */
+    public $gateways = [
+        TestGateway::class
+    ];
 
-	/**
-	 * Registers all the payment gateways with GiveWP
-	 *
-	 * @unreleased
-	 *
-	 * @param array $gateways
-	 *
-	 * @return array
-	 *
-	 * @throws InvalidArgumentException|Exception
-	 *
-	 */
-	public function __invoke( array $gateways ) {
-		/** @var PaymentGatewayRegister $paymentGatewayRegister */
-		$paymentGatewayRegister = give( PaymentGatewayRegister::class );
+    /**
+     * Registers all the payment gateways with GiveWP
+     *
+     * @unreleased
+     *
+     * @param  array  $gateways
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException|Exception
+     *
+     */
+    public function __invoke(array $gateways)
+    {
+        /** @var PaymentGatewayRegister $paymentGatewayRegister */
+        $paymentGatewayRegister = give(PaymentGatewayRegister::class);
 
-		foreach ( $this->gateways as $gateway ) {
-			$paymentGatewayRegister->registerGateway( $gateway );
-		}
+        foreach ($this->gateways as $gateway) {
+            $paymentGatewayRegister->registerGateway($gateway);
+        }
 
-		$this->register3rdPartyPaymentGateways( $paymentGatewayRegister );
-		$this->unregister3rdPartyPaymentGateways( $paymentGatewayRegister );
+        $this->register3rdPartyPaymentGateways($paymentGatewayRegister);
+        $this->unregister3rdPartyPaymentGateways($paymentGatewayRegister);
 
-		return $gateways;
-	}
+        return $gateways;
+    }
 
-	/**
-	 * Register 3rd party payment gateways
-	 *
-	 * @unreleased
-	 *
-	 * @param  PaymentGatewayRegister  $paymentGatewayRegister
-	 */
-	private function register3rdPartyPaymentGateways( PaymentGatewayRegister $paymentGatewayRegister ) {
-		do_action( 'give_register_payment_gateway', $paymentGatewayRegister );
-	}
+    /**
+     * Register 3rd party payment gateways
+     *
+     * @unreleased
+     *
+     * @param  PaymentGatewayRegister  $paymentGatewayRegister
+     */
+    private function register3rdPartyPaymentGateways(PaymentGatewayRegister $paymentGatewayRegister)
+    {
+        do_action('give_register_payment_gateway', $paymentGatewayRegister);
+    }
 
-	/**
-	 * Unregister 3rd party payment gateways
-	 *
-	 * @unreleased
-	 *
-	 * @param  PaymentGatewayRegister  $paymentGatewayRegister
-	 */
-	private function unregister3rdPartyPaymentGateways( PaymentGatewayRegister $paymentGatewayRegister ) {
-		do_action( 'give_unregister_payment_gateway', $paymentGatewayRegister );
-	}
+    /**
+     * Unregister 3rd party payment gateways
+     *
+     * @unreleased
+     *
+     * @param  PaymentGatewayRegister  $paymentGatewayRegister
+     */
+    private function unregister3rdPartyPaymentGateways(PaymentGatewayRegister $paymentGatewayRegister)
+    {
+        do_action('give_unregister_payment_gateway', $paymentGatewayRegister);
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -164,7 +164,6 @@ class FormData
     public function toPaymentData()
     {
         return GiveInsertPaymentData::fromArray([
-            'userInfo' => '',
             'price' => $this->price,
             'formTitle' => $this->formTitle,
             'formId' => $this->formId,
@@ -173,7 +172,7 @@ class FormData
             'donorEmail' => $this->donorInfo->email,
             'purchase_key' => $this->purchaseKey,
             'currency' => $this->currency,
-            'user_info' => $this->userInfo,
+            'userInfo' => $this->userInfo,
         ]);
     }
 }

--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -144,11 +144,11 @@ class FormData {
 			'number'   => $request['card_info']['card_number'],
 		] );
 		$self->billingAddress = Address::fromArray( [
-			'line1'      => $request['card_info']['card_address'],
-			'line2'      => $request['card_info']['card_address_2'],
-			'city'       => $request['card_info']['card_city'],
-			'state'      => $request['card_info']['card_state'],
-			'country'    => $request['card_info']['card_country'],
+			'line1' => $request['card_info']['card_address'],
+			'line2' => $request['card_info']['card_address_2'],
+			'city' => $request['card_info']['card_city'],
+			'state' => $request['card_info']['card_state'],
+			'country' => $request['card_info']['card_country'],
 			'postalCode' => $request['card_info']['card_zip'],
 		] );
 
@@ -156,22 +156,21 @@ class FormData {
 	}
 
 	/**
-	 * This is used to expose data for use with give_insert_payment
 	 *
-	 * @return array
+	 * @return GiveInsertPaymentData
 	 */
-	public function toPaymentArray() {
-		return [
-			'price'           => $this->price,
-			'give_form_title' => $this->formTitle,
-			'give_form_id'    => $this->formId,
-			'give_price_id'   => $this->priceId,
-			'date'            => $this->date,
-			'user_email'      => $this->donorInfo->email,
-			'purchase_key'    => $this->purchaseKey,
-			'currency'        => $this->currency,
-			'user_info'       => $this->userInfo,
-			'status'          => 'pending',
-		];
+	public function toPaymentData() {
+		return GiveInsertPaymentData::fromArray( [
+			'userInfo' => '',
+			'price' => $this->price,
+			'formTitle' => $this->formTitle,
+			'formId' => $this->formId,
+			'priceId' => $this->priceId,
+			'date' => $this->date,
+			'donorEmail' => $this->donorInfo->email,
+			'purchase_key' => $this->purchaseKey,
+			'currency' => $this->currency,
+			'user_info' => $this->userInfo,
+		] );
 	}
 }

--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -161,7 +161,7 @@ class FormData
      *
      * @return GiveInsertPaymentData
      */
-    public function toPaymentData()
+    public function toGiveInsertPaymentData()
     {
         return GiveInsertPaymentData::fromArray([
             'price' => $this->price,
@@ -173,6 +173,27 @@ class FormData
             'purchase_key' => $this->purchaseKey,
             'currency' => $this->currency,
             'userInfo' => $this->userInfo,
+        ]);
+    }
+
+    /**
+     * @param  int  $donationId
+     * @return GatewayPaymentData
+     */
+    public function toGatewayPaymentData($donationId)
+    {
+        return GatewayPaymentData::fromArray([
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            'date' => $this->date,
+            'price' => $this->price,
+            'priceId' => $this->priceId,
+            'gatewayId' => $this->paymentGateway,
+            'paymentId' => $donationId,
+            'purchaseKey' => $this->purchaseKey,
+            'donorInfo' => $this->donorInfo,
+            'cardInfo' => $this->cardInfo,
+            'billingAddress' => $this->billingAddress,
         ]);
     }
 }

--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -10,167 +10,170 @@ use Give\ValueObjects\DonorInfo;
  * Class FormData
  * @unreleased
  */
-class FormData {
-	/**
-	 * @var float
-	 */
-	public $price;
-	/**
-	 * @var string
-	 */
-	public $formTitle;
-	/**
-	 * @var string
-	 */
-	public $date;
-	/**
-	 * @var string
-	 */
-	public $purchaseKey;
-	/**
-	 * @var string
-	 */
-	public $currency;
-	/**
-	 * @var array
-	 */
-	public $userInfo;
-	/**
-	 * @var string
-	 */
-	public $paymentGateway;
-	/**
-	 * @var string
-	 */
-	public $gatewayNonce;
-	/**
-	 * @var array
-	 */
-	public $postData;
-	/**
-	 * @var CardInfo
-	 */
-	public $cardInfo;
-	/**
-	 * @var int
-	 */
-	public $formId;
-	/**
-	 * @var string
-	 */
-	public $priceId;
-	/**
-	 * @var string
-	 */
-	public $formIdPrefix;
-	/**
-	 * @var string
-	 */
-	public $currentUrl;
-	/**
-	 * @var string
-	 */
-	public $formMinimum;
-	/**
-	 * @var string
-	 */
-	public $formMaximum;
-	/**
-	 * @var string
-	 */
-	public $formHash;
-	/**
-	 * @var string
-	 */
-	public $loggedInOnly;
-	/**
-	 * @var string
-	 */
-	public $amount;
-	/**
-	 * @var string
-	 */
-	public $userId;
-	/**
-	 * @var Address
-	 */
-	public $billingAddress;
-	/**
-	 * @var DonorInfo
-	 */
-	public $donorInfo;
+class FormData
+{
+    /**
+     * @var float
+     */
+    public $price;
+    /**
+     * @var string
+     */
+    public $formTitle;
+    /**
+     * @var string
+     */
+    public $date;
+    /**
+     * @var string
+     */
+    public $purchaseKey;
+    /**
+     * @var string
+     */
+    public $currency;
+    /**
+     * @var array
+     */
+    public $userInfo;
+    /**
+     * @var string
+     */
+    public $paymentGateway;
+    /**
+     * @var string
+     */
+    public $gatewayNonce;
+    /**
+     * @var array
+     */
+    public $postData;
+    /**
+     * @var CardInfo
+     */
+    public $cardInfo;
+    /**
+     * @var int
+     */
+    public $formId;
+    /**
+     * @var string
+     */
+    public $priceId;
+    /**
+     * @var string
+     */
+    public $formIdPrefix;
+    /**
+     * @var string
+     */
+    public $currentUrl;
+    /**
+     * @var string
+     */
+    public $formMinimum;
+    /**
+     * @var string
+     */
+    public $formMaximum;
+    /**
+     * @var string
+     */
+    public $formHash;
+    /**
+     * @var string
+     */
+    public $loggedInOnly;
+    /**
+     * @var string
+     */
+    public $amount;
+    /**
+     * @var string
+     */
+    public $userId;
+    /**
+     * @var Address
+     */
+    public $billingAddress;
+    /**
+     * @var DonorInfo
+     */
+    public $donorInfo;
 
-	/**
-	 * Convert data from request into DTO
-	 *
-	 * @unreleased
-	 *
-	 * @return self
-	 */
-	public static function fromRequest( array $request ) {
-		$self = new static();
+    /**
+     * Convert data from request into DTO
+     *
+     * @unreleased
+     *
+     * @return self
+     */
+    public static function fromRequest(array $request)
+    {
+        $self = new static();
 
-		$self->price = $request['price'];
-		$self->date = $request['date'];
-		$self->purchaseKey = $request['purchase_key'];
-		$self->currency = give_get_currency( $request['post_data']['give-form-id'], $request );
-		$self->userInfo = $request['user_info'];
-		$self->postData = $request['post_data'];
-		$self->formTitle = $request['post_data']['give-form-title'];
-		$self->formId = (int) $request['post_data']['give-form-id'];
-		$self->priceId = isset( $request['post_data']['give-price-id'] ) ? $request['post_data']['give-price-id'] : '';
-		$self->formIdPrefix = $request['post_data']['give-form-id-prefix'];
-		$self->currentUrl = $request['post_data']['give-current-url'];
-		$self->formMinimum = $request['post_data']['give-form-minimum'];
-		$self->formMaximum = $request['post_data']['give-form-maximum'];
-		$self->formHash = $request['post_data']['give-form-hash'];
-		$self->loggedInOnly = $request['post_data']['give-logged-in-only'];
-		$self->amount = $request['post_data']['give-amount'];
-		$self->paymentGateway = $request['post_data']['give-gateway'];
-		$self->gatewayNonce = $request['gateway_nonce'];
-		$self->donorInfo = DonorInfo::fromArray( [
-			'wpUserId' => $request['user_info']['id'],
-			'firstName' => $request['user_info']['first_name'],
-			'lastName' => $request['user_info']['last_name'],
-			'email' => $request['user_info']['email'],
-			'honorific' => ! empty( $request['user_info']['title'] ) ? $request['user_info']['title'] : '',
-			'address' => $request['user_info']['address']
-		] );
-		$self->cardInfo = CardInfo::fromArray( [
-			'name' => $request['card_info']['card_name'],
-			'cvc' => $request['card_info']['card_cvc'],
-			'expMonth' => $request['card_info']['card_exp_month'],
-			'expYear'  => $request['card_info']['card_exp_year'],
-			'number'   => $request['card_info']['card_number'],
-		] );
-		$self->billingAddress = Address::fromArray( [
-			'line1' => $request['card_info']['card_address'],
-			'line2' => $request['card_info']['card_address_2'],
-			'city' => $request['card_info']['card_city'],
-			'state' => $request['card_info']['card_state'],
-			'country' => $request['card_info']['card_country'],
-			'postalCode' => $request['card_info']['card_zip'],
-		] );
+        $self->price = $request['price'];
+        $self->date = $request['date'];
+        $self->purchaseKey = $request['purchase_key'];
+        $self->currency = give_get_currency($request['post_data']['give-form-id'], $request);
+        $self->userInfo = $request['user_info'];
+        $self->postData = $request['post_data'];
+        $self->formTitle = $request['post_data']['give-form-title'];
+        $self->formId = (int)$request['post_data']['give-form-id'];
+        $self->priceId = isset($request['post_data']['give-price-id']) ? $request['post_data']['give-price-id'] : '';
+        $self->formIdPrefix = $request['post_data']['give-form-id-prefix'];
+        $self->currentUrl = $request['post_data']['give-current-url'];
+        $self->formMinimum = $request['post_data']['give-form-minimum'];
+        $self->formMaximum = $request['post_data']['give-form-maximum'];
+        $self->formHash = $request['post_data']['give-form-hash'];
+        $self->loggedInOnly = $request['post_data']['give-logged-in-only'];
+        $self->amount = $request['post_data']['give-amount'];
+        $self->paymentGateway = $request['post_data']['give-gateway'];
+        $self->gatewayNonce = $request['gateway_nonce'];
+        $self->donorInfo = DonorInfo::fromArray([
+            'wpUserId' => $request['user_info']['id'],
+            'firstName' => $request['user_info']['first_name'],
+            'lastName' => $request['user_info']['last_name'],
+            'email' => $request['user_info']['email'],
+            'honorific' => !empty($request['user_info']['title']) ? $request['user_info']['title'] : '',
+            'address' => $request['user_info']['address']
+        ]);
+        $self->cardInfo = CardInfo::fromArray([
+            'name' => $request['card_info']['card_name'],
+            'cvc' => $request['card_info']['card_cvc'],
+            'expMonth' => $request['card_info']['card_exp_month'],
+            'expYear' => $request['card_info']['card_exp_year'],
+            'number' => $request['card_info']['card_number'],
+        ]);
+        $self->billingAddress = Address::fromArray([
+            'line1' => $request['card_info']['card_address'],
+            'line2' => $request['card_info']['card_address_2'],
+            'city' => $request['card_info']['card_city'],
+            'state' => $request['card_info']['card_state'],
+            'country' => $request['card_info']['card_country'],
+            'postalCode' => $request['card_info']['card_zip'],
+        ]);
 
-		return $self;
-	}
+        return $self;
+    }
 
-	/**
-	 *
-	 * @return GiveInsertPaymentData
-	 */
-	public function toPaymentData() {
-		return GiveInsertPaymentData::fromArray( [
-			'userInfo' => '',
-			'price' => $this->price,
-			'formTitle' => $this->formTitle,
-			'formId' => $this->formId,
-			'priceId' => $this->priceId,
-			'date' => $this->date,
-			'donorEmail' => $this->donorInfo->email,
-			'purchase_key' => $this->purchaseKey,
-			'currency' => $this->currency,
-			'user_info' => $this->userInfo,
-		] );
-	}
+    /**
+     *
+     * @return GiveInsertPaymentData
+     */
+    public function toPaymentData()
+    {
+        return GiveInsertPaymentData::fromArray([
+            'userInfo' => '',
+            'price' => $this->price,
+            'formTitle' => $this->formTitle,
+            'formId' => $this->formId,
+            'priceId' => $this->priceId,
+            'date' => $this->date,
+            'donorEmail' => $this->donorInfo->email,
+            'purchase_key' => $this->purchaseKey,
+            'currency' => $this->currency,
+            'user_info' => $this->userInfo,
+        ]);
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
@@ -23,61 +23,62 @@ class GatewayPaymentData {
 	 * @var float
 	 */
 	public $price;
-	/**
-	 * @var string
-	 */
-	public $priceId;
-	/**
-	 * @var string
-	 */
-	public $date;
-	/**
-	 * @var string
-	 */
-	public $purchaseKey;
-	/**
-	 * @var string
-	 */
-	public $currency;
-	/**
-	 * @var DonorInfo
-	 */
-	public $donorInfo;
-	/**
-	 * @var CardInfo
-	 */
-	public $cardInfo;
-	/**
-	 * @var string
-	 */
-	public $amount;
-	/**
-	 * @var Address
-	 */
-	public $billingAddress;
+    /**
+     * @var string
+     */
+    public $priceId;
+    /**
+     * @var string
+     */
+    public $date;
+    /**
+     * @var string
+     */
+    public $purchaseKey;
+    /**
+     * @var string
+     */
+    public $currency;
+    /**
+     * @var DonorInfo
+     */
+    public $donorInfo;
+    /**
+     * @var CardInfo
+     */
+    public $cardInfo;
+    /**
+     * @var string
+     */
+    public $amount;
+    /**
+     * @var Address
+     */
+    public $billingAddress;
 
-	/**
-	 * Convert data from array into DTO
-	 *
-	 * @unreleased
-	 *
-	 * @return self
-	 */
-	public static function fromArray( array $array ) {
-		$self = new static();
+    /**
+     * Convert data from array into DTO
+     *
+     * @unreleased
+     *
+     * @return self
+     */
+    public static function fromArray(array $array)
+    {
+        $self = new static();
 
-		$self->price = $array['price'];
-		$self->priceId = $array['priceId'];
-		$self->currency = $array['currency'];
-		$self->amount = $array['amount'];
-		$self->date = $array['date'];
-		$self->gatewayId = $array['gatewayId'];
-		$self->paymentId = $array['paymentId'];
-		$self->purchaseKey = $array['purchaseKey'];
-		$self->donorInfo = $array['donorInfo'];
-		$self->cardInfo = $array['cardInfo'];
-		$self->billingAddress = $array['billingAddress'];
+        $self->price = $array['price'];
+        $self->priceId = $array['priceId'];
+        $self->currency = $array['currency'];
+        $self->amount = $array['amount'];
+        $self->date = $array['date'];
+        $self->gatewayId = $array['gatewayId'];
+        $self->paymentId = $array['paymentId'];
+        $self->purchaseKey = $array['purchaseKey'];
+        $self->donorInfo = $array['donorInfo'];
+        $self->cardInfo = $array['cardInfo'];
+        $self->billingAddress = $array['billingAddress'];
 
-		return $self;
-	}
+        return $self;
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Give\PaymentGateways\DataTransferObjects;
+
+use Give\ValueObjects\Address;
+use Give\ValueObjects\CardInfo;
+use Give\ValueObjects\DonorInfo;
+
+/**
+ * Class GatewayPaymentData
+ * @unreleased
+ */
+class GatewayPaymentData {
+	/**
+	 * @var string
+	 */
+	public $gatewayId;
+	/**
+	 * @var string
+	 */
+	public $paymentId;
+	/**
+	 * @var float
+	 */
+	public $price;
+	/**
+	 * @var string
+	 */
+	public $priceId;
+	/**
+	 * @var string
+	 */
+	public $date;
+	/**
+	 * @var string
+	 */
+	public $purchaseKey;
+	/**
+	 * @var string
+	 */
+	public $currency;
+	/**
+	 * @var DonorInfo
+	 */
+	public $donorInfo;
+	/**
+	 * @var CardInfo
+	 */
+	public $cardInfo;
+	/**
+	 * @var string
+	 */
+	public $amount;
+	/**
+	 * @var Address
+	 */
+	public $billingAddress;
+
+	/**
+	 * Convert data from array into DTO
+	 *
+	 * @unreleased
+	 *
+	 * @return self
+	 */
+	public static function fromArray( array $array ) {
+		$self = new static();
+
+		$self->price = $array['price'];
+		$self->priceId = $array['priceId'];
+		$self->currency = $array['currency'];
+		$self->amount = $array['amount'];
+		$self->date = $array['date'];
+		$self->gatewayId = $array['gatewayId'];
+		$self->paymentId = $array['paymentId'];
+		$self->purchaseKey = $array['purchaseKey'];
+		$self->donorInfo = $array['donorInfo'];
+		$self->cardInfo = $array['cardInfo'];
+		$self->billingAddress = $array['billingAddress'];
+
+		return $self;
+	}
+}

--- a/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
@@ -10,19 +10,20 @@ use Give\ValueObjects\DonorInfo;
  * Class GatewayPaymentData
  * @unreleased
  */
-class GatewayPaymentData {
-	/**
-	 * @var string
-	 */
-	public $gatewayId;
-	/**
-	 * @var string
-	 */
-	public $paymentId;
-	/**
-	 * @var float
-	 */
-	public $price;
+class GatewayPaymentData
+{
+    /**
+     * @var string
+     */
+    public $gatewayId;
+    /**
+     * @var string
+     */
+    public $paymentId;
+    /**
+     * @var float
+     */
+    public $price;
     /**
      * @var string
      */

--- a/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewayPaymentData.php
@@ -45,7 +45,7 @@ class GatewayPaymentData
      */
     public $donorInfo;
     /**
-     * @var CardInfo
+     * @var CardInfo|null
      */
     public $cardInfo;
     /**
@@ -53,7 +53,7 @@ class GatewayPaymentData
      */
     public $amount;
     /**
-     * @var Address
+     * @var Address|null
      */
     public $billingAddress;
 

--- a/src/PaymentGateways/DataTransferObjects/GatewaySubscriptionData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewaySubscriptionData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Give\PaymentGateways\DataTransferObjects;
+
+/**
+ * Class GatewaySubscriptionData
+ * @unreleased
+ */
+class GatewaySubscriptionData {
+	/**
+	 * @var string
+	 */
+	public $period;
+
+	/**
+	 * @var string
+	 */
+	public $times;
+
+	/**
+	 * @var string
+	 */
+	public $frequency;
+	/**
+	 * @var int
+	 */
+	public $subscriptionId;
+
+	/**
+	 * Convert data from array into DTO
+	 *
+	 * @unreleased
+	 *
+	 * @return self
+	 */
+	public static function fromArray( array $array ) {
+		$self = new static();
+
+		$self->period = $array['period'];
+		$self->times = $array['times'];
+		$self->frequency = $array['frequency'];
+		$self->subscriptionId = $array['subscriptionId'];
+
+		return $self;
+	}
+}

--- a/src/PaymentGateways/DataTransferObjects/GatewaySubscriptionData.php
+++ b/src/PaymentGateways/DataTransferObjects/GatewaySubscriptionData.php
@@ -6,41 +6,43 @@ namespace Give\PaymentGateways\DataTransferObjects;
  * Class GatewaySubscriptionData
  * @unreleased
  */
-class GatewaySubscriptionData {
-	/**
-	 * @var string
-	 */
-	public $period;
+class GatewaySubscriptionData
+{
+    /**
+     * @var string
+     */
+    public $period;
 
-	/**
-	 * @var string
-	 */
-	public $times;
+    /**
+     * @var string
+     */
+    public $times;
 
-	/**
-	 * @var string
-	 */
-	public $frequency;
-	/**
-	 * @var int
-	 */
-	public $subscriptionId;
+    /**
+     * @var string
+     */
+    public $frequency;
+    /**
+     * @var int
+     */
+    public $subscriptionId;
 
-	/**
-	 * Convert data from array into DTO
-	 *
-	 * @unreleased
-	 *
-	 * @return self
-	 */
-	public static function fromArray( array $array ) {
-		$self = new static();
+    /**
+     * Convert data from array into DTO
+     *
+     * @unreleased
+     *
+     * @return self
+     */
+    public static function fromArray(array $array)
+    {
+        $self = new static();
 
-		$self->period = $array['period'];
-		$self->times = $array['times'];
-		$self->frequency = $array['frequency'];
-		$self->subscriptionId = $array['subscriptionId'];
+        $self->period = $array['period'];
+        $self->times = $array['times'];
+        $self->frequency = $array['frequency'];
+        $self->subscriptionId = $array['subscriptionId'];
 
-		return $self;
-	}
+        return $self;
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
@@ -9,92 +9,94 @@ namespace Give\PaymentGateways\DataTransferObjects;
  *
  * @unreleased
  */
-class GiveInsertPaymentData {
-	/**
-	 * @var float
-	 */
-	public $price;
-	/**
-	 * @var string
-	 */
-	public $priceId;
-	/**
-	 * @var string
-	 */
-	public $date;
-	/**
-	 * @var string
-	 */
-	public $purchaseKey;
-	/**
-	 * @var string
-	 */
-	public $currency;
-	/**
-	 * @var string
-	 */
-	public $amount;
-	/**
-	 * @var string
-	 */
-	public $formTitle;
-	/**
-	 * @var int
-	 */
-	public $formId;
-	/**
-	 * @var array
-	 */
-	public $userInfo;
-	/**
-	 * @var string
-	 */
-	public $donorEmail;
-	/**
-	 * @var string
-	 */
-	public $paymentGateway;
+class GiveInsertPaymentData
+{
+    /**
+     * @var float
+     */
+    public $price;
+    /**
+     * @var string
+     */
+    public $priceId;
+    /**
+     * @var string
+     */
+    public $date;
+    /**
+     * @var string
+     */
+    public $purchaseKey;
+    /**
+     * @var string
+     */
+    public $currency;
+    /**
+     * @var string
+     */
+    public $amount;
+    /**
+     * @var string
+     */
+    public $formTitle;
+    /**
+     * @var int
+     */
+    public $formId;
+    /**
+     * @var array
+     */
+    public $userInfo;
+    /**
+     * @var string
+     */
+    public $donorEmail;
+    /**
+     * @var string
+     */
+    public $paymentGateway;
 
-	/**
-	 * Convert data from array into DTO
-	 *
-	 * @unreleased
-	 *
-	 * @return self
-	 */
-	public static function fromArray( array $array ) {
-		$self = new static();
+    /**
+     * Convert data from array into DTO
+     *
+     * @unreleased
+     *
+     * @return self
+     */
+    public static function fromArray(array $array)
+    {
+        $self = new static();
 
-		$self->price = $array['price'];
-		$self->priceId = $array['priceId'];
-		$self->formTitle = $array['formTitle'];
-		$self->formId = $array['formId'];
-		$self->currency = $array['currency'];
-		$self->date = $array['date'];
-		$self->purchaseKey = $array['purchaseKey'];
-		$self->donorEmail = $array['donorEmail'];
-		$self->userInfo = $array['userInfo'];
-		$self->paymentGateway = $array['paymentGateway'];
+        $self->price = $array['price'];
+        $self->priceId = $array['priceId'];
+        $self->formTitle = $array['formTitle'];
+        $self->formId = $array['formId'];
+        $self->currency = $array['currency'];
+        $self->date = $array['date'];
+        $self->purchaseKey = $array['purchaseKey'];
+        $self->donorEmail = $array['donorEmail'];
+        $self->userInfo = $array['userInfo'];
+        $self->paymentGateway = $array['paymentGateway'];
 
-		return $self;
-	}
+        return $self;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function toArray()
-	{
-		return [
-			'price'           => $this->price,
-			'give_form_title' => $this->formTitle,
-			'give_form_id'    => $this->formId,
-			'give_price_id'   => $this->priceId,
-			'date'            => $this->date,
-			'user_email'      => $this->donorEmail,
-			'purchase_key'    => $this->purchaseKey,
-			'currency'        => $this->currency,
-			'user_info'       => $this->userInfo,
-			'status'          => 'pending',
-		];
-	}
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'price' => $this->price,
+            'give_form_title' => $this->formTitle,
+            'give_form_id' => $this->formId,
+            'give_price_id' => $this->priceId,
+            'date' => $this->date,
+            'user_email' => $this->donorEmail,
+            'purchase_key' => $this->purchaseKey,
+            'currency' => $this->currency,
+            'user_info' => $this->userInfo,
+            'status' => 'pending',
+        ];
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Give\PaymentGateways\DataTransferObjects;
+
+/**
+ * Class GiveInsertPaymentData
+ *
+ * This is used to expose data for use with give_insert_payment
+ *
+ * @unreleased
+ */
+class GiveInsertPaymentData {
+	/**
+	 * @var float
+	 */
+	public $price;
+	/**
+	 * @var string
+	 */
+	public $priceId;
+	/**
+	 * @var string
+	 */
+	public $date;
+	/**
+	 * @var string
+	 */
+	public $purchaseKey;
+	/**
+	 * @var string
+	 */
+	public $currency;
+	/**
+	 * @var string
+	 */
+	public $amount;
+	/**
+	 * @var string
+	 */
+	public $formTitle;
+	/**
+	 * @var int
+	 */
+	public $formId;
+	/**
+	 * @var array
+	 */
+	public $userInfo;
+	/**
+	 * @var string
+	 */
+	public $donorEmail;
+	/**
+	 * @var string
+	 */
+	public $paymentGateway;
+
+	/**
+	 * Convert data from array into DTO
+	 *
+	 * @unreleased
+	 *
+	 * @return self
+	 */
+	public static function fromArray( array $array ) {
+		$self = new static();
+
+		$self->price = $array['price'];
+		$self->priceId = $array['priceId'];
+		$self->formTitle = $array['formTitle'];
+		$self->formId = $array['formId'];
+		$self->currency = $array['currency'];
+		$self->date = $array['date'];
+		$self->purchaseKey = $array['purchaseKey'];
+		$self->donorEmail = $array['donorEmail'];
+		$self->userInfo = $array['userInfo'];
+		$self->paymentGateway = $array['paymentGateway'];
+
+		return $self;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return [
+			'price'           => $this->price,
+			'give_form_title' => $this->formTitle,
+			'give_form_id'    => $this->formId,
+			'give_price_id'   => $this->priceId,
+			'date'            => $this->date,
+			'user_email'      => $this->donorEmail,
+			'purchase_key'    => $this->purchaseKey,
+			'currency'        => $this->currency,
+			'user_info'       => $this->userInfo,
+			'status'          => 'pending',
+		];
+	}
+}

--- a/src/PaymentGateways/DataTransferObjects/SubscriptionData.php
+++ b/src/PaymentGateways/DataTransferObjects/SubscriptionData.php
@@ -6,36 +6,38 @@ namespace Give\PaymentGateways\DataTransferObjects;
  * Class SubscriptionData
  * @unreleased
  */
-class SubscriptionData {
-	/**
-	 * @var string
-	 */
-	public $period;
+class SubscriptionData
+{
+    /**
+     * @var string
+     */
+    public $period;
 
-	/**
-	 * @var string
-	 */
-	public $times;
+    /**
+     * @var string
+     */
+    public $times;
 
-	/**
-	 * @var string
-	 */
-	public $frequency;
+    /**
+     * @var string
+     */
+    public $frequency;
 
-	/**
-	 * Convert data from request into DTO
-	 *
-	 * @unreleased
-	 *
-	 * @return self
-	 */
-	public static function fromRequest( array $request ) {
-		$self = new static();
+    /**
+     * Convert data from request into DTO
+     *
+     * @unreleased
+     *
+     * @return self
+     */
+    public static function fromRequest(array $request)
+    {
+        $self = new static();
 
-		$self->period = $request['period'];
-		$self->times = $request['times'];
-		$self->frequency = $request['frequency'];
+        $self->period = $request['period'];
+        $self->times = $request['times'];
+        $self->frequency = $request['frequency'];
 
-		return $self;
-	}
+        return $self;
+    }
 }

--- a/src/PaymentGateways/DataTransferObjects/SubscriptionData.php
+++ b/src/PaymentGateways/DataTransferObjects/SubscriptionData.php
@@ -40,4 +40,18 @@ class SubscriptionData
 
         return $self;
     }
+
+    /**
+     * @param  int  $subscriptionId
+     * @return GatewaySubscriptionData
+     */
+    public function toGatewaySubscriptionData($subscriptionId)
+    {
+        return GatewaySubscriptionData::fromArray([
+            'period' => $this->period,
+            'times' => $this->times,
+            'frequency' => $this->frequency,
+            'subscriptionId' => $subscriptionId,
+        ]);
+    }
 }

--- a/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
+++ b/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
@@ -4,7 +4,7 @@ namespace Give\PaymentGateways\Gateways\TestGateway;
 
 use Give\Framework\PaymentGateways\Contracts\PaymentGateway;
 use Give\Helpers\Form\Utils as FormUtils;
-use Give\PaymentGateways\DataTransferObjects\FormData;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\Gateways\TestGateway\Actions\PublishPaymentAndSendToSuccessPage;
 use Give\PaymentGateways\Gateways\TestGateway\Views\LegacyFormFieldMarkup;
 
@@ -59,10 +59,10 @@ class TestGateway extends PaymentGateway {
 	/**
 	 * @inheritDoc
 	 */
-	public function handleOneTimeRequest( $donationId, FormData $formData ) {
+	public function createPayment( GatewayPaymentData $gatewayData ) {
 		/** @var PublishPaymentAndSendToSuccessPage $action */
 		$action = give( PublishPaymentAndSendToSuccessPage::class );
 
-		return $action( $donationId );
+		return $action( $gatewayData->paymentId );
 	}
 }

--- a/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
+++ b/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
@@ -59,10 +59,11 @@ class TestGateway extends PaymentGateway {
 	/**
 	 * @inheritDoc
 	 */
-	public function createPayment( GatewayPaymentData $gatewayData ) {
-		/** @var PublishPaymentAndSendToSuccessPage $action */
-		$action = give( PublishPaymentAndSendToSuccessPage::class );
+	public function createPayment(GatewayPaymentData $paymentData)
+    {
+        /** @var PublishPaymentAndSendToSuccessPage $action */
+        $action = give(PublishPaymentAndSendToSuccessPage::class);
 
-		return $action( $gatewayData->paymentId );
-	}
+        return $action($paymentData->paymentId);
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

One of the main goals of payment flow 2.0 is to simplify the responsibility of payment gateways.  Currently, the gateways are too aware of GiveWP and are being given all data from the form submission. This makes the gateways somewhat of a _free-for-all_ and unclear to what is actually required for the gateway.  Instead they should only receive data required to process payments.

This PR limits the scope and context of gateways by using common gateway terms for methods with single gateway specific DTOs as params.  All references of _Form_ and _Request_ have been removed from the gateway interface.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

**New DTOs for gateways**
- `GatewayPaymentData`
- `GatewaySubscriptionData`

**PaymentGatewayInterface Scope and Context Limiting**

Replace `handleOneTimeRequest()` and `handleSubscriptionRequest()` with:

- `createPayment(GatewayPaymentData $paymentData)`
- `createSubscription(GatewayPaymentData $paymentData, GatewaySubscriptionData $subscriptionData)`

![Screen Shot 2021-11-09 at 4 22 56 PM](https://user-images.githubusercontent.com/10138447/141006950-853a85a4-23e3-446e-a4ce-9ae982075c47.png)


## Testing Instructions

- Donate using the _Test Gateway_


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

