### PR TITLE
Updated currency symbol for LKR

### DIFF
--- a/includes/currencies-list.php
+++ b/includes/currencies-list.php
@@ -1152,7 +1152,7 @@ return array(
 	),
 	'LKR' => array(
 		'admin_label' => sprintf( __( 'Sri Lankan rupee (%1$s)', 'give' ), '&#xdbb;&#xdd4;' ),
-		'symbol'      => '&#xdbb;&#xdd4;',
+		'symbol'      => 'Rs',
 		'setting'     => array(
 			'currency_position'   => 'before',
 			'thousands_separator' => ',',


### PR DESCRIPTION
LKR has three currency symbols, all three are accepted. The plugin has been using the currency symbol which is used only used by a part of Sri Lanka. I've now changed to Rs which can be understood and accepted by anyone instead of just a specific of people in the country.

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

