### PR TITLE
Fix: Update dependencies to support recent test suite changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "wp-coding-standards/wpcs": "*",
         "phpunit/phpunit": "^5",
         "kjohnson/since-unreleased": "^1.0.0",
-        "wp-cli/wp-cli-bundle": "^2.5"
+        "wp-cli/wp-cli-bundle": "^2.5",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "keywords": [
         "wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "950490e5df21d9bf70b2f3c167d77305",
+    "content-hash": "b02fdd11d488274ec638578a7944e9ec",
     "packages": [
         {
             "name": "composer/installers",
@@ -6036,6 +6036,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -6048,5 +6109,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
## Description

This PR installs the `Yoast/PHPUnit-Polyfills` as a composer (dev) dependency in order to support the recent changes to the WordPress test suite, which is being used as a base for the GiveWP tests.

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

> **Changes to the WordPress Core PHP Test Suite**
>
> **What does this mean for plugins/themes running integration tests based on the WP Core test suite?**
>
> It is a known fact that there are a lot of plugins/themes which use the WordPress Core test framework as a basis for their integration tests.
>
> If your plugin/theme is one of them, these changes will impact you as well.

Source: https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/#impact-plugin-theme-integration-tests

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

https://github.com/impress-org/givewp/actions/runs/1451291808

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

