### PR TITLE
Fix: check donation validation ajax request correctly

### DIFF
--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1147,43 +1147,36 @@ function give_register_and_login_new_user( $user_data = [] ) {
  * @return  array|bool
  */
 function give_get_donation_form_user( $valid_data = [] ) {
+    // Initialize user.
+    $user      = false;
+    $post_data = give_clean($_POST); // WPCS: input var ok, sanitization ok, CSRF ok.
+    $is_ajax   = ! empty($_POST['give_ajax']) ? $post_data['give_ajax'] : 0; // WPCS: input var ok, sanitization ok, CSRF ok.
 
-	// Initialize user.
-	$user      = false;
-	$is_ajax   = defined( 'DOING_AJAX' ) && DOING_AJAX;
-	$post_data = give_clean( $_POST ); // WPCS: input var ok, sanitization ok, CSRF ok.
+    if ( $is_ajax ) {
+        // Do not create or login the user during the ajax submission (check for errors only).
+        return true;
+    } elseif ( is_user_logged_in() ) {
+        // Set the valid user as the logged in collected data.
+        $user = $valid_data['logged_in_user'];
+    } elseif ( true === $valid_data['need_new_user'] || true === $valid_data['need_user_login'] ) {
+        // New user registration.
+        if ( true === $valid_data['need_new_user'] ) {
+            // Set user.
+            $user = $valid_data['new_user_data'];
 
-	if ( $is_ajax ) {
+            // Register and login new user.
+            $user['user_id'] = give_register_and_login_new_user($user);
+        } elseif ( true === $valid_data['need_user_login'] && ! $is_ajax ) {
+            /**
+             * The login form is now processed in the give_process_donation_login() function.
+             * This is still here for backwards compatibility.
+             * This also allows the old login process to still work if a user removes the checkout login submit button.
+             *
+             * This also ensures that the donor is logged in correctly if they click "Donation" instead of submitting the login form, meaning the donor is logged in during the donation process.
+             */
+            $user = $valid_data['login_user_data'];
 
-		// Do not create or login the user during the ajax submission (check for errors only).
-		return true;
-	} elseif ( is_user_logged_in() ) {
-
-		// Set the valid user as the logged in collected data.
-		$user = $valid_data['logged_in_user'];
-	} elseif ( true === $valid_data['need_new_user'] || true === $valid_data['need_user_login'] ) {
-
-		// New user registration.
-		if ( true === $valid_data['need_new_user'] ) {
-
-			// Set user.
-			$user = $valid_data['new_user_data'];
-
-			// Register and login new user.
-			$user['user_id'] = give_register_and_login_new_user( $user );
-
-		} elseif ( true === $valid_data['need_user_login'] && ! $is_ajax ) {
-
-			/**
-			 * The login form is now processed in the give_process_donation_login() function.
-			 * This is still here for backwards compatibility.
-			 * This also allows the old login process to still work if a user removes the checkout login submit button.
-			 *
-			 * This also ensures that the donor is logged in correctly if they click "Donation" instead of submitting the login form, meaning the donor is logged in during the donation process.
-			 */
-			$user = $valid_data['login_user_data'];
-
-			// Login user.
+            // Login user.
 			give_log_user_in( $user['user_id'], $user['user_login'], $user['user_pass'] );
 		}
 	} // End if().

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1167,7 +1167,7 @@ function give_get_donation_form_user( $valid_data = [] ) {
 
             // Register and login new user.
             $user['user_id'] = give_register_and_login_new_user($user);
-        } elseif ( true === $valid_data['need_user_login'] && ! $is_validateing_donation_form ) {
+        } elseif ( true === $valid_data['need_user_login'] ) {
             /**
              * The login form is now processed in the give_process_donation_login() function.
              * This is still here for backwards compatibility.

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1139,11 +1139,12 @@ function give_register_and_login_new_user( $user_data = [] ) {
 /**
  * Get Donation Form User
  *
+ * @since   1.0
+ * @unreleased Do not run validation check for ajax request expect donation validation ajax request.
+ *
  * @param array $valid_data Valid Data.
  *
  * @access  private
- * @since   1.0
- *
  * @return  array|bool
  */
 function give_get_donation_form_user( $valid_data = [] ) {

--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -1149,11 +1149,11 @@ function give_register_and_login_new_user( $user_data = [] ) {
  */
 function give_get_donation_form_user( $valid_data = [] ) {
     // Initialize user.
-    $user      = false;
-    $post_data = give_clean($_POST); // WPCS: input var ok, sanitization ok, CSRF ok.
-    $is_ajax   = ! empty($_POST['give_ajax']) ? $post_data['give_ajax'] : 0; // WPCS: input var ok, sanitization ok, CSRF ok.
+    $user                                = false;
+    $post_data                           = give_clean($_POST); // WPCS: input var ok, sanitization ok, CSRF ok.
+    $is_validating_donation_form_on_ajax = ! empty($_POST['give_ajax']) ? $post_data['give_ajax'] : 0; // WPCS: input var ok, sanitization ok, CSRF ok.
 
-    if ( $is_ajax ) {
+    if ( $is_validating_donation_form_on_ajax ) {
         // Do not create or login the user during the ajax submission (check for errors only).
         return true;
     } elseif ( is_user_logged_in() ) {
@@ -1167,7 +1167,7 @@ function give_get_donation_form_user( $valid_data = [] ) {
 
             // Register and login new user.
             $user['user_id'] = give_register_and_login_new_user($user);
-        } elseif ( true === $valid_data['need_user_login'] && ! $is_ajax ) {
+        } elseif ( true === $valid_data['need_user_login'] && ! $is_validateing_donation_form ) {
             /**
              * The login form is now processed in the give_process_donation_login() function.
              * This is still here for backwards compatibility.


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
In BitPay addon pull request https://github.com/impress-org/give-bitpay/pull/10, @kjohnson added logic to process donation on ajax request. [`give_get_donation_form_user`](https://github.com/impress-org/givewp/blob/850362bad2d75b02a8d9544e32b80125bfaf42e7/includes/process-donation.php#L1149) does not perform its checks when donation form validation request runs on ajax but its checks do not run for all ajax requests. I update logic to run check on all ajax request except donation validation request as we are doing in [`give_process_form_login`](https://github.com/impress-org/givewp/blob/850362bad2d75b02a8d9544e32b80125bfaf42e7/includes/process-donation.php#L286) function.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request donation processing.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Process one-time donation with BitPay and any other payment gateway.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

