### PR TITLE
Fix: set correct path for icomoon fonts

### DIFF
--- a/assets/src/css/frontend/fonts.scss
+++ b/assets/src/css/frontend/fonts.scss
@@ -9,10 +9,10 @@
 */
 @font-face {
   font-family: 'give-icomoon';
-  src: url('../../fonts/icomoon.eot?kdnr3d');
-  src: url('../../fonts/icomoon.eot?kdnr3d#iefix') format('embedded-opentype'),
-  url('../../fonts/icomoon.woff?kdnr3d') format('woff'),
-  url('../../fonts/icomoon.svg?kdnr3d#icomoon') format('svg');
+  src: url('../fonts/icomoon.eot?kdnr3d');
+  src: url('../fonts/icomoon.eot?kdnr3d#iefix') format('embedded-opentype'),
+  url('../fonts/icomoon.woff?kdnr3d') format('woff'),
+  url('../fonts/icomoon.svg?kdnr3d#icomoon') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6100

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

When we switched to Laravel Mix, we needed to change how assets were referenced in CSS to reflect their `dist` path. Not everything was updated. This PR fixes the issue for the icomoon fonts which are used in the legacy form template.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The legacy form template.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Test the legacy form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
