### PR TITLE
Feature: log failed license api request information

### DIFF
--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -33,7 +33,7 @@ function give_upload_addon_handler() {
 
 	// Bailout if user does not has permission.
 	if ( ! current_user_can( 'upload_plugins' ) ) {
-		wp_send_json_error( [ 'errorMsg' => __( 'Sorry, you are not allowed to upload add-ons on this site.', 'give' ) ] );
+		wp_send_json_error( [ 'errorMsg' => __( 'The current user does not have permission to upload plugins on this site.', 'give' ) ] );
 	}
 
 	$access_type = get_filesystem_method();
@@ -42,7 +42,7 @@ function give_upload_addon_handler() {
 		wp_send_json_error(
 			[
 				'errorMsg' => sprintf(
-					__( 'Sorry, you can not upload plugins because GiveWP does not have direct access to the file system. Please <a href="%1$s" target="_blank">click here</a> to upload the add-on.', 'give' ),
+					__( 'In order to upload add-ons here, GiveWP needs direct access to the file system. Please <a href="%1$s" target="_blank">visit the main plugin page</a> to manually upload the add-on.', 'give' ),
 					admin_url( 'plugin-install.php?tab=upload' )
 				),
 			]
@@ -52,7 +52,7 @@ function give_upload_addon_handler() {
 	$file_type = wp_check_filetype( $_FILES['file']['name'], [ 'zip' => 'application/zip' ] );
 
 	if ( empty( $file_type['ext'] ) ) {
-		wp_send_json_error( [ 'errorMsg' => __( 'Only zip file type allowed to upload. Please upload a valid add-on file.', 'give' ) ] );
+		wp_send_json_error( [ 'errorMsg' => __( 'Uploaded add-ons must be (unzipped) ZIP files. Upload a valid add-on ZIP.', 'give' ) ] );
 	}
 
 	$give_addons_list   = give_get_plugins();
@@ -93,7 +93,7 @@ function give_upload_addon_handler() {
 		/* any problems and we exit */
 		wp_send_json_error(
 			[
-				'errorMsg' => __( 'File system does not load correctly.', 'give' ),
+				'errorMsg' => __( 'The file system did not load correctly. This is usually a permissions issue on your server, and not something that GiveWP has control over. Try uploading the ZIP like a regular plugin.', 'give' ),
 			]
 		);
 	}
@@ -163,7 +163,7 @@ function give_get_license_info_handler() {
 	if ( ! $license_key ) {
 		wp_send_json_error(
 			[
-				'errorMsg' => __( 'Sorry, you entered an invalid key.', 'give' ),
+				'errorMsg' => __( 'You entered an invalid key. Confirm your license key on your GiveWP dashboard and try again.', 'give' ),
 			]
 		);
 
@@ -212,7 +212,7 @@ function give_get_license_info_handler() {
 		wp_send_json_error(
 			[
 				'errorMsg' => sprintf(
-					__( 'Sorry, this license was unable to activate because the license status returned as <code>%2$s</code>. Please visit your <a href="%1$s" target="_blank">license dashboard</a> to check the details and access priority support.', 'give' ),
+					__( 'The license failed to activate, due to a status of <code>%2$s</code>. Check the logs at Donations > Tools > Logs for more detail, and <a href="%1$s" target="_blank">reach out to the Customer Success team.</a>', 'give' ),
 					Give_License::get_account_url(),
 					$check_license_res['license']
 				),
@@ -228,7 +228,7 @@ function give_get_license_info_handler() {
 		wp_send_json_error(
 			[
 				'errorMsg' => sprintf(
-					__( 'Sorry, we are unable to activate this license because this key does not belong to this add-on. Please visit your <a href="%1$s" target="_blank">license dashboard</a> to check the details and access priority support.', 'give' ),
+					__( 'This license key does not belong to this add-on. <a href="%1$s" target="_blank">Reach out to the Customer Success team</a> if you continue to have issues.', 'give' ),
 					Give_License::get_account_url()
 				),
 			]
@@ -257,7 +257,7 @@ function give_get_license_info_handler() {
 	if ( ! $is_reactivating_license && ! $activate_license_res['success'] ) {
 
 		$response['errorMsg'] = sprintf(
-			__( 'Sorry, this license was unable to activate because the license status returned as <code>%2$s</code>. Please visit your <a href="%1$s" target="_blank">license dashboard</a> to check the details and access priority support.', 'give' ),
+			__( 'The license failed to activate, due to a status of <code>%2$s</code>. Check the logs at Donations > Tools > Logs for more detail, and <a href="%1$s" target="_blank">reach out to the Customer Success team.</a>', 'give' ),
 			Give_License::get_account_url(),
 			$check_license_res['license']
 		);
@@ -293,7 +293,7 @@ function give_get_license_info_handler() {
 	if ( $is_reactivating_license && ! $activate_license_res['success'] ) {
 
 		$response['errorMsg'] = sprintf(
-			__( 'Sorry, this license was unable to activate because the license status returned as <code>%2$s</code>. Please visit your <a href="%1$s" target="_blank">license dashboard</a> to check the details and access priority support.', 'give' ),
+			__( 'The license failed to activate, due to a status of <code>%2$s</code>. Check the logs at Donations > Tools > Logs for more detail, and <a href="%1$s" target="_blank">reach out to the Customer Success team.</a>', 'give' ),
 			Give_License::get_account_url(),
 			$check_license_res['license']
 		);
@@ -374,7 +374,7 @@ function give_deactivate_license_handler() {
 	if ( empty( $give_licenses[ $license ] ) ) {
 		wp_send_json_error(
 			[
-				'errorMsg' => __( 'We are unable to deactivate invalid license', 'give' ),
+				'errorMsg' => __( 'License is invalid, so it can\'t be deactivated.', 'give' ),
 			]
 		);
 	}

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -52,7 +52,7 @@ function give_upload_addon_handler() {
 	$file_type = wp_check_filetype( $_FILES['file']['name'], [ 'zip' => 'application/zip' ] );
 
 	if ( empty( $file_type['ext'] ) ) {
-		wp_send_json_error( [ 'errorMsg' => __( 'Uploaded add-ons must be (unzipped) ZIP files. Upload a valid add-on ZIP.', 'give' ) ] );
+		wp_send_json_error( [ 'errorMsg' => __( 'Uploaded add-ons must be (zipped) ZIP files. Upload a valid add-on ZIP.', 'give' ) ] );
 	}
 
 	$give_addons_list   = give_get_plugins();

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -10,185 +10,188 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+use Give\Log\Log;
+
+if ( ! defined('ABSPATH') ) {
+    exit;
 }
 
-if ( ! class_exists( 'Give_License' ) ) :
+if ( ! class_exists('Give_License') ) :
 
-	/**
-	 * Give_License Class
-	 *
-	 * This class simplifies the process of adding license information
-	 * to new Give add-ons.
-	 *
-	 * @since 1.0
-	 */
-	class Give_License {
+    /**
+     * Give_License Class
+     *
+     * This class simplifies the process of adding license information
+     * to new Give add-ons.
+     *
+     * @since 1.0
+     */
+    class Give_License
+    {
 
-		/**
-		 * File
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $file;
+        /**
+         * File
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $file;
 
-		/**
-		 * License
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $license;
+        /**
+         * License
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $license;
 
-		/**
-		 * Item name
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $item_name;
+        /**
+         * Item name
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $item_name;
 
-		/**
-		 * Item ID
-		 *
-		 * @access private
-		 * @since  2.2.4
-		 *
-		 * @var    int
-		 */
-		private $item_id;
+        /**
+         * Item ID
+         *
+         * @access private
+         * @since  2.2.4
+         *
+         * @var    int
+         */
+        private $item_id;
 
-		/**
-		 * License Information object.
-		 *
-		 * @access private
-		 * @since  1.7
-		 *
-		 * @var    object
-		 */
-		private $license_data;
+        /**
+         * License Information object.
+         *
+         * @access private
+         * @since  1.7
+         *
+         * @var    object
+         */
+        private $license_data;
 
-		/**
-		 * Item shortname
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $item_shortname;
+        /**
+         * Item shortname
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $item_shortname;
 
-		/**
-		 * Version
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $version;
+        /**
+         * Version
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $version;
 
-		/**
-		 * Author
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private $author;
+        /**
+         * Author
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private $author;
 
-		/**
-		 * Plugin directory name
-		 *
-		 * @access private
-		 * @since  2.5.0
-		 *
-		 * @var    string
-		 */
-		private $plugin_dirname;
+        /**
+         * Plugin directory name
+         *
+         * @access private
+         * @since  2.5.0
+         *
+         * @var    string
+         */
+        private $plugin_dirname;
 
-		/**
-		 * Website URL
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private static $site_url = 'https://givewp.com/';
+        /**
+         * Website URL
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private static $site_url = 'https://givewp.com/';
 
-		/**
-		 * API URL
-		 *
-		 * @access private
-		 * @since  1.0
-		 *
-		 * @var    string
-		 */
-		private static $api_url = 'https://givewp.com/edd-sl-api/';
+        /**
+         * API URL
+         *
+         * @access private
+         * @since  1.0
+         *
+         * @var    string
+         */
+        private static $api_url = 'https://givewp.com/edd-sl-api/';
 
-		/**
-		 * array of licensed addons
-		 *
-		 * @since  2.1.4
-		 * @access private
-		 *
-		 * @var    array
-		 */
-		private static $licensed_addons = [];
+        /**
+         * array of licensed addons
+         *
+         * @since  2.1.4
+         * @access private
+         *
+         * @var    array
+         */
+        private static $licensed_addons = [];
 
-		/**
-		 * Account URL
-		 *
-		 * @access private
-		 * @since  1.7
-		 *
-		 * @var null|string
-		 */
-		private static $account_url = 'http://docs.givewp.com/settings-account';
+        /**
+         * Account URL
+         *
+         * @access private
+         * @since  1.7
+         *
+         * @var null|string
+         */
+        private static $account_url = 'http://docs.givewp.com/settings-account';
 
-		/**
-		 * Downloads URL
-		 *
-		 * @access private
-		 * @since  2.5.0
-		 *
-		 * @var null|string
-		 */
-		private static $downloads_url = 'http://docs.givewp.com/settings-downloads';
+        /**
+         * Downloads URL
+         *
+         * @access private
+         * @since  2.5.0
+         *
+         * @var null|string
+         */
+        private static $downloads_url = 'http://docs.givewp.com/settings-downloads';
 
-		/**
-		 * Checkout URL
-		 *
-		 * @access private
-		 * @since  1.7
-		 *
-		 * @var null|string
-		 */
-		private static $checkout_url = 'https://givewp.com/checkout/';
+        /**
+         * Checkout URL
+         *
+         * @access private
+         * @since  1.7
+         *
+         * @var null|string
+         */
+        private static $checkout_url = 'https://givewp.com/checkout/';
 
-		/**
-		 * Class Constructor
-		 *
-		 * Set up the Give License Class.
-		 *
-		 * @access public
-		 *
-		 * @param string $_file
-		 * @param string $_item_name
-		 * @param string $_version
-		 * @param string $_author
-		 * @param string $_optname
-		 * @param string $_api_url
+        /**
+         * Class Constructor
+         *
+         * Set up the Give License Class.
+         *
+         * @access public
+         *
+         * @param string $_file
+         * @param string $_item_name
+         * @param string $_version
+         * @param string $_author
+         * @param string $_optname
+         * @param string $_api_url
 		 * @param string $_checkout_url
 		 * @param string $_account_url
 		 * @param int    $_item_id
@@ -277,118 +280,140 @@ if ( ! class_exists( 'Give_License' ) ) :
 
 		/**
 		 * Get license information.
-		 *
-		 * @param string $edd_action
-		 * @param bool   $response_in_array
-		 *
-		 * @return mixed
-		 * @deprecated 2.5.0 Use self::request_license_api instead.
-		 *
-		 * @since      1.8.9
-		 * @access     public
-		 */
-		public function get_license_info( $edd_action = '', $response_in_array = false ) {
+         *
+         * @param string $edd_action
+         * @param bool $response_in_array
+         *
+         * @return mixed
+         * @deprecated 2.5.0 Use self::request_license_api instead.
+         *
+         * @since      1.8.9
+         * @access     public
+         */
+        public function get_license_info($edd_action = '', $response_in_array = false)
+        {
+            if ( empty($edd_action) ) {
+                return false;
+            }
 
-			if ( empty( $edd_action ) ) {
-				return false;
-			}
+            give_doing_it_wrong(__FUNCTION__, 'Use self::request_license_api instead from GiveWP 2.5.0');
 
-			give_doing_it_wrong( __FUNCTION__, 'Use self::request_license_api instead from GiveWP 2.5.0' );
+            // Data to send to the API.
+            $api_params = [
+                'edd_action' => $edd_action, // never change from "edd_" to "give_"!
+                'license'    => $this->license,
+                'item_name'  => urlencode($this->item_name),
+            ];
 
-			// Data to send to the API.
-			$api_params = [
-				'edd_action' => $edd_action, // never change from "edd_" to "give_"!
-				'license'    => $this->license,
-				'item_name'  => urlencode( $this->item_name ),
-			];
+            return self::request_license_api($api_params, $response_in_array);
+        }
 
-			return self::request_license_api( $api_params, $response_in_array );
-		}
-
-		/**
-		 * Return licensed addons info
-		 *
-		 * Note: note only for internal logic
-		 *
-		 * @return array
-		 * @since 2.1.4
-		 */
-		static function get_licensed_addons() {
-			return self::$licensed_addons;
-		}
+        /**
+         * Return licensed addons info
+         *
+         * Note: note only for internal logic
+         *
+         * @since 2.1.4
+         * @return array
+         */
+        static function get_licensed_addons()
+        {
+            return self::$licensed_addons;
+        }
 
 
-		/**
-		 * Check if license key attached to subscription
-		 *
-		 * @param string $license_key
-		 *
-		 * @return array
-		 * @since 2.5.0
-		 */
-		static function is_subscription( $license_key = '' ) {
-			// Check if current license is part of subscription or not.
-			$subscriptions = get_option( 'give_subscriptions' );
-			$subscription  = [];
+        /**
+         * Check if license key attached to subscription
+         *
+         * @since 2.5.0
+         *
+         * @param string $license_key
+         *
+         * @return array
+         */
+        static function is_subscription($license_key = '')
+        {
+            // Check if current license is part of subscription or not.
+            $subscriptions = get_option('give_subscriptions');
+            $subscription  = [];
 
-			if ( $subscriptions ) {
-				foreach ( $subscriptions as $subs ) {
-					if ( in_array( $license_key, $subs['licenses'] ) ) {
-						$subscription = $subs;
-						break;
-					}
-				}
-			}
+            if ( $subscriptions ) {
+                foreach ($subscriptions as $subs) {
+                    if ( in_array($license_key, $subs['licenses']) ) {
+                        $subscription = $subs;
+                        break;
+                    }
+                }
+            }
 
-			return $subscription;
-		}
+            return $subscription;
+        }
 
-		/**
-		 * Get license information.
-		 *
-		 * @param array $api_params
-		 * @param bool  $response_in_array
-		 *
-		 * @return array|WP_Error
-		 * @since  1.8.9
-		 * @access public
-		 */
-		public static function request_license_api( $api_params = [], $response_in_array = false ) {
-			// Bailout.
-			if ( empty( $api_params['edd_action'] ) ) {
-				return new WP_Error( 'give-invalid-edd-action', __( 'Valid edd_action not defined', 'give' ) );
-			}
+        /**
+         * Get license information.
+         *
+         * @since  1.8.9
+         * @access public
+         *
+         * @param bool $response_in_array
+         *
+         * @param array $api_params
+         *
+         * @return array|WP_Error
+         */
+        public static function request_license_api($api_params = [], $response_in_array = false)
+        {
+            // Bailout.
+            if ( empty($api_params['edd_action']) ) {
+                return new WP_Error('give-invalid-edd-action', __('Valid edd_action not defined', 'give'));
+            }
 
-			// Data to send to the API.
-			$default_api_params = [
-				// 'edd_action' => $edd_action, never change from "edd_" to "give_"!
-				// 'license'    => $this->license,
-				// 'item_name'  => urlencode( $this->item_name ),
-				'url' => home_url(),
-			];
+            // Data to send to the API.
+            $default_api_params = [
+                // 'edd_action' => $edd_action, never change from "edd_" to "give_"!
+                // 'license'    => $this->license,
+                // 'item_name'  => urlencode( $this->item_name ),
+                'url' => home_url(),
+            ];
 
-			$api_params = wp_parse_args( $api_params, $default_api_params );
+            $api_params = wp_parse_args($api_params, $default_api_params);
 
-			// Call the API.
-			$response = wp_remote_post(
-				self::$api_url,
-				apply_filters(
-					'give_request_license_api_args',
-					[
-						'timeout'   => 15,
-						'sslverify' => false,
-						'body'      => $api_params,
-					]
-				)
-			);
+            // Call the API.
+            $response = wp_remote_post(
+                self::$api_url,
+                apply_filters(
+                    'give_request_license_api_args',
+                    [
+                        'timeout'   => 15,
+                        'sslverify' => false,
+                        'body'      => $api_params,
+                    ]
+                )
+            );
 
-			// Make sure there are no errors.
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
+            $statusCode = wp_remote_retrieve_response_code($response);
+            $body       = json_decode(wp_remote_retrieve_body($response), $response_in_array);
 
-			return json_decode( wp_remote_retrieve_body( $response ), $response_in_array );
-		}
+            if ( 200 !== $statusCode ) {
+                Log::http(
+                    'License Api request failed',
+                    [
+                        'category'    => 'License',
+                        'api url'     => self::$api_url,
+                        'request'     => $api_params,
+                        'status code' => $statusCode,
+                        'response'    => $response
+                    ]
+                );
+            }
+
+            // Make sure there are no errors.
+            if ( is_wp_error($response) ) {
+                return $response;
+            }
+
+            return $body;
+        }
 
 		/**
 		 * Get license by plugin dirname

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -353,7 +353,7 @@ if ( ! class_exists('Give_License') ) :
          * Get license information.
          *
          * @since  1.8.9
-         * @access public
+         * @unreleased log failed license api request information
          *
          * @param bool $response_in_array
          *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6107

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
As mentioned in the issue description, we were not logging license api failed request information. I added logging logic in `Give_License:: request_license_api `. a log will be added to the system if the response status code is not `200`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://user-images.githubusercontent.com/1784821/141989588-b3de905a-be86-46b1-89d3-b7399e3342ff.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Test this pull request by activating the add-on license.

**Note: To test this pull request you have to mimic the response code ( other than `200` ) in `Give_License:: request_license_api ` function.**

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

