### PR TITLE
Fix: Add default empty state for email recipient repeater

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -584,7 +584,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					</th>
 					<td class="give-forminp give-forminp-<?php echo sanitize_title( $value['type'] ); ?>">
 						<?php if ( $value['repeat'] ) : ?>
-							<?php foreach ( $option_value as $index => $field_value ) : ?>
+							<?php foreach ( $option_value ?: [ '' ] as $index => $field_value ) : ?>
 								<p>
 									<input
 											name="<?php echo esc_attr( $value['id'] ); ?>[]"


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4411

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a default empty state to the email recipients repeater.

The _add recipient_ button requires an existing input element to be cloned, so removing all email recipients breaks the repeater. The newly added default empty state always renders at least one (empty) input element which can be used to add an initial email recipient.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

In the settings of an admin email:

- Remove all email recipients
- Save the settings
- Reload the page
- Add an initial recipient
- Add a new recipient 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

