### PR TITLE
Fix: remove Babel polyfill enqueue and setting

### DIFF
--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -122,17 +122,6 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 							],
 						],
 						[
-							'name'    => __( 'Babel Polyfill Script', 'give' ),
-							'desc'    => __( 'This controls loading the Babel polyfill, which provides backwards compatibility for older browsers such as IE 11. The polyfill may be disabled to avoid conflicts with other themes or plugins that load the same script.', 'give' ),
-							'id'      => 'babel_polyfill_script',
-							'type'    => 'radio_inline',
-							'default' => 'enabled',
-							'options' => [
-								'enabled'  => __( 'Enabled', 'give' ),
-								'disabled' => __( 'Disabled', 'give' ),
-							],
-						],
-						[
 							'name'          => __( 'Setup Page', 'give' ),
 							/* translators: %s: about page URL */
 							'desc'          => sprintf(

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -447,20 +447,6 @@ class Give_Scripts {
 	 * @since 2.1.0
 	 */
 	public function public_enqueue_scripts() {
-
-		// Call Babel Polyfill with common handle so that it is compatible with plugins and themes.
-		if ( ! wp_script_is( 'babel-polyfill', 'enqueued' )
-			 && give_is_setting_enabled( give_get_option( 'babel_polyfill_script', 'enabled' ) )
-		) {
-			wp_enqueue_script(
-				'babel-polyfill',
-				GIVE_PLUGIN_URL . 'assets/dist/js/babel-polyfill.js',
-				[ 'jquery' ],
-				GIVE_VERSION,
-				false
-			);
-		}
-
 		wp_enqueue_script( 'give' );
 
 		$this->public_localize_scripts();

--- a/src/DonorDashboards/RequestHandler.php
+++ b/src/DonorDashboards/RequestHandler.php
@@ -113,7 +113,7 @@ class RequestHandler
     private function getListOfScriptsToDequeue($scripts)
     {
         $list = [];
-        $skip = ['babel-polyfill'];
+        $skip = [];
         $themeDir = get_template_directory_uri();
 
         /* @var _WP_Dependency $data */

--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -66,7 +66,7 @@ class LoadTemplate
         $this->setUpTemplate();
 
         // Exit is template is not valid.
-        if ( ! ($this->template instanceof Template)) {
+        if (! ($this->template instanceof Template)) {
             return;
         }
 
@@ -246,7 +246,7 @@ class LoadTemplate
     private function getListOfScriptsToDequeue($scripts)
     {
         $list = [];
-        $skip = ['babel-polyfill'];
+        $skip = [];
         $themeDir = get_template_directory_uri();
 
         /* @var _WP_Dependency $data */


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6077

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We removed Babel polyfill when we switched to Laravel Mix initially by happenstance. We decided that we did not need it anymore and that users could add it themselves via a snippet if they needed it. We forgot to remove the enqueue and the admin setting for it. This pull request removes the enqueue and the admin setting.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Admin settings.
- Every place that loads the frontend JS.
- Every addon that wants the polyfill.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Load the a Give form and check the page’s console for errors (or the Network tab in devtools).

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [x] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
