### PR TITLE
New: Tributes add-on is now supported

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/css/_select-dropdown.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_select-dropdown.scss
@@ -1,3 +1,0 @@
-.give-select {
-    @include give-input;
-}

--- a/src/Views/Form/Templates/Classic/resources/css/_text-input.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_text-input.scss
@@ -23,6 +23,46 @@
     }
 }
 
-.give-input {
+.give-square-cc-fields,
+.give-stripe-cc-field,
+.give-stripe-single-cc-field-wrap,
+form[id*='give-form'] .form-row textarea,
+form[id*='give-form'] .form-row input[type='text'],
+form[id*='give-form'] .form-row input[type='tel'],
+form[id*='give-form'] .form-row input[type='email'],
+form[id*='give-form'] .form-row input[type='password'],
+form[id*='give-form'] .form-row input[type='url'],
+form[id*='give-form'] .form-row textarea.required,
+form[id*='give-form'] .form-row input[type='text'].required,
+form[id*='give-form'] .form-row input[type='tel'].required,
+form[id*='give-form'] .form-row input[type='email'].required,
+form[id*='give-form'] .form-row input[type='password'].required,
+form[id*='give-form'] .form-row input[type='url'].required,
+#give-recurring-form .form-row textarea,
+#give-recurring-form .form-row input[type='text'],
+#give-recurring-form .form-row input[type='tel'],
+#give-recurring-form .form-row input[type='email'],
+#give-recurring-form .form-row input[type='password'],
+#give-recurring-form .form-row input[type='url'],
+form.give-form .form-row textarea,
+form.give-form .form-row input[type='text'],
+form.give-form .form-row input[type='tel'],
+form.give-form .form-row input[type='email'],
+form.give-form .form-row input[type='password'],
+form.give-form .form-row input[type='url'],
+.give-input-field-wrapper {
+    @include give-input
+}
+
+.give-select {
     @include give-input;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='13' height='8' viewBox='0 0 13 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.66016 7.19531C5.90625 7.44141 6.31641 7.44141 6.5625 7.19531L11.8945 1.89062C12.1406 1.61719 12.1406 1.20703 11.8945 0.960938L11.2656 0.332031C11.0195 0.0859375 10.6094 0.0859375 10.3359 0.332031L6.125 4.54297L1.88672 0.332031C1.61328 0.0859375 1.20312 0.0859375 0.957031 0.332031L0.328125 0.960938C0.0820312 1.20703 0.0820312 1.61719 0.328125 1.89062L5.66016 7.19531Z' fill='%23A2A3A2'/%3E%3C/svg%3E"),
+    linear-gradient(to bottom, #fff 0%, #fff 100%);
+    background-repeat: no-repeat, repeat;
+    background-position: right 0.7em top 50%, 0 0;
+    background-size: 0.65em auto, 100%;
 }

--- a/src/Views/Form/Templates/Classic/resources/css/_tributes.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_tributes.scss
@@ -1,0 +1,27 @@
+.give-tributes-dedicate-donation {
+    margin-top: 10px;
+    padding-bottom: 10px;
+
+    .give-tributes-show-wrap {
+        margin-top: 20px;
+    }
+
+    legend,
+    .give-tributes-legend {
+        margin: 0 !important;
+        padding: 10px 0 !important;
+        font-size: 1.1875rem;
+        font-family: inherit;
+        font-weight: 500;
+        line-height: 1.2;
+    }
+
+    .give-tributes-label {
+        display: block;
+        padding: 10px 0;
+    }
+
+    .give_tributes_info_wrap {
+        margin-top: 20px;
+    }
+}

--- a/src/Views/Form/Templates/Classic/resources/css/form.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/form.scss
@@ -29,7 +29,6 @@
 // Common (e.g. reusable components)
 @import 'button';
 @import 'text-input';
-@import 'select-dropdown';
 
 // Specifics
 @import 'header';

--- a/src/Views/Form/Templates/Classic/resources/css/form.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/form.scss
@@ -42,3 +42,4 @@
 // Addons
 @import "currencyswitcher";
 @import "funds";
+@import "tributes";

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -158,7 +158,7 @@ function splitDonationLevelAmountsIntoParts({
 function moveDefaultGatewayDataIntoActiveGatewaySection() {
     addSelectedGatewayDetails(
         createGatewayDetails(
-            document.querySelector('#give_purchase_form_wrap fieldset:not(.give-donation-submit)').innerHTML
+            Array.from(document.querySelectorAll('#give_purchase_form_wrap fieldset:not(.give-donation-submit)')).map(e => e.outerHTML).join('')
         )
     );
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6129

## Description

This PR adds support and styles for the Tribute add-on in the Classic Donation Form.

## Visuals
![image](https://user-images.githubusercontent.com/4222590/143887464-16a83b84-d43c-41d2-900d-4dd06d780f2b.png)


## Testing Instructions

Install and setup tributes add-on
Try every _Tributes Section Location_ where tributes markup can show up in form. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

