### PR TITLE
Fix: use `type=button` for buttons in donation summary

### DIFF
--- a/src/DonationSummary/resources/views/summary.php
+++ b/src/DonationSummary/resources/views/summary.php
@@ -20,7 +20,7 @@
                 <th><?php
                     _e('Donation Summary', 'givewp'); ?></th>
                 <th>
-                    <button class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">
+                    <button type="button" class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">
                         <?php
                         _e('Edit Donation', 'givewp'); ?>
                         <?php
@@ -57,7 +57,7 @@
                             /* translators: 1: <button> open tag 2: close tag. */
                             echo sprintf(
                                 __('Consider making this donation %srecurring%s', 'give'),
-                                '<button class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">',
+                                '<button type="button" class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">',
                                 '</button>'
                             );
                             ?>


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I noticed while developing the Classic template that when I pressed these buttons the browser would focus the wrong input. It took me a while, but I realized it was because the form was submitting and it was focuing a required field that I had left empty. The default value of the `type` attribute for a `<button>` element is `submit` and when in a `<form>` element context, pressing a button will cause it to submit the form. We should set the `type` to `button` to avoid this.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Donation summary

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

- No visual change.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Use a donation form with the summary and change that the form doesn’t submit when pressing one of the edit buttons in the donation summary.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

- [ ] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@since` tags included in DocBlocks
- [ ] Changes logged to the `Unreleased` section of `CHANGELOG.md`
- [ ] Includes unit and/or end-to-end tests
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
