### PR TITLE
Condition operators are now decoded in case of values stored encoded

### DIFF
--- a/src/Framework/FieldsAPI/Conditions/BasicCondition.php
+++ b/src/Framework/FieldsAPI/Conditions/BasicCondition.php
@@ -41,6 +41,13 @@ class BasicCondition extends Condition
      */
     public function __construct($field, $operator, $value, $boolean = 'and')
     {
+        /**
+         * Decode (maybe) the operator in case the operator is stored as an encoded setting value.
+         * @link https://github.com/impress-org/give-form-field-manager/issues/376
+         * @unreleased
+         */
+        $operator = html_entity_decode( $operator );
+
         if ($this->invalidOperator($operator)) {
             throw new InvalidArgumentException(
                 "Invalid operator: $operator. Must be one of: " . implode(', ', static::OPERATORS)

--- a/tests/unit/tests/Framework/FieldsAPI/Conditions/BasicConditionTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Conditions/BasicConditionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace unit\tests\Framework\FieldsAPI\Conditions;
+
+use Give\Framework\FieldsAPI\Conditions\BasicCondition;
+use Give_Unit_Test_Case;
+
+class BasicConditionTest extends Give_Unit_Test_Case {
+
+    public function testConditionAcceptsEncodedOperator() {
+        $condition = new BasicCondition('foo', '&lt;', 'bar');
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/give-form-field-manager/issues/376

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a line to decode the operator before validation, in case the operator value is coming from the database and encoded as an HTML entity.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Using GiveWP 2.17.1
- Using FFM 2.0.1
- Set an FFM field's visibility to Less Than or Less Than Or Equals
- Form **should** load and **should not** throw the following error:
`Fatal error: Uncaught Give\Framework\Exceptions\Primitives\InvalidArgumentException: Invalid operator: &lt;=. Must be one of: =, !=, >, >=, <, <= in give/src/Framework/FieldsAPI/Conditions/BasicCondition.php on line 45`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

