### PR TITLE
fix: add default value and update placeholder amount to be 10000

### DIFF
--- a/includes/admin/forms/class-metabox-form-data.php
+++ b/includes/admin/forms/class-metabox-form-data.php
@@ -471,8 +471,9 @@ class Give_MetaBox_Form_Data {
 								'id'            => $prefix . 'set_goal',
 								'type'          => 'text_small',
 								'data_type'     => 'price',
-								'attributes'    => [
-									'placeholder' => $price_placeholder,
+                                'default'       => give_format_decimal( [ 'amount' => '10000.00' ] ),
+                                'attributes'    => [
+									'placeholder' => give_format_decimal( [ 'amount' => '10000.00' ] ),
 									'class'       => 'give-money-field',
 								],
 								'wrapper_class' => 'give-hidden',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6145 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the default goal amount and the placeholder text to be a more realistic number of `10,000`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Default goal amount for donation forms

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="934" alt="2021-12-09_21-06-05" src="https://user-images.githubusercontent.com/1571635/145520349-fcd37c16-139d-472b-a7b6-8f8fb0ac85a2.png">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a new donation form
2. Enable a goal and see the default goal amount

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

