### PR TITLE
fix: display correct currency for multi-step form donation levels when currency switched

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -205,8 +205,9 @@
 
                     const value = $(this).attr('value');
                     const text = $(this).text();
-                    const symbol = window.give_global_vars.currency_sign;
-                    const position = window.give_global_vars.currency_pos;
+                    const $form = $('form');
+                    const symbol = Give.form.fn.getInfo( 'currency_symbol', $form );
+                    const position = Give.form.fn.getInfo( 'currency_position', $form );
 
                     if (value !== 'custom') {
                         const html =


### PR DESCRIPTION

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves impress-org/give-currency-switcher#299

## Description

When using multi-step forms, the correct currency is shown in the currency switcher dropdown, but the donation level buttons display the site's default currency.

This resolves that by changing the multi-step form template JS to retrieve the currency symbol/position from the form data instead of from the global vars.
(thank you, @ravinderk and @knowler !)
<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
In my testing, this doesn't cause any unexpected problems with auto-switched currencies, but maybe check that just to be sure.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Install GiveWP and the Currency Switcher addon
2. Use USD as global default currency
3. Create a new multi-step form with multiple donation levels
4. Define GBP as your form currency under Currency Switcher
5. Make a test donation. GBP should be displayed as the currency for both the donation amount and the donation levels
6. (thanks, Matheus Martins)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [X] Acceptance criteria satisfied and marked in related issue
-   [X] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [X] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

