### PR TITLE
Fix: load required file with legacy service provider to process plugin uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -10,20 +10,18 @@
  */
 
 // Exit if accessed directly.
+use Give\ServiceProviders\LegacyServiceProvider;
+
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-// Load Give file.
-include_once( 'give.php' );
-
 /**
- * Initialize the main Give class, which includes loading the code necessary to process the uninstall.
- * This is included manually because the plugins_loaded hook does not run on uninstall.
- *
- * @since 2.7.4
+ * Initiate LegacyServiceProvider which includes loading logic of the code necessary to process the uninstall.
+ * @unreleased
  */
-give()->init();
+$legacyServiceProvider = new LegacyServiceProvider();
+$legacyServiceProvider->register();
 
 // Prevent checking for plugin updates
 remove_filter( 'pre_set_site_transient_update_plugins', 'give_check_addon_updates', 999 );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6157

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that [`LegacyServiceProvider`](https://github.com/impress-org/givewp/blob/2a7f671f6d499ffc52bc7a462b511d8625ea169f/src/ServiceProviders/LegacyServiceProvider.php#L1) class has logic to include required files for plugin uninstallation. By using this class we can prevent frequent PHPUnit test failures.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects `uninstall.php`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You can test these changes with https://github.com/impress-org/givewp/pull/6154 pull request.
 - [ ] Run PHPUnit tests
 - [ ] Uninstall plugin manually and review if whether or not plugin data was removed.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

