### PR TITLE
Fix: Only validate email settings that are not empty

### DIFF
--- a/src/Email/GlobalSettingValidator.php
+++ b/src/Email/GlobalSettingValidator.php
@@ -28,14 +28,18 @@ class GlobalSettingValidator
 
     /**
      * @since 2.17.1
+     * @unreleased Only filter value as unique array if set. Some settings do not need to be set, ie donation-receipt_recipient.
      */
     public function validateSetting($value)
     {
-        // Same unique email address for email recipients.
-        $recipientEmails = array_unique(array_filter($value));
+        if( ! empty( $value ) ) {
+            // Same unique email address for email recipients.
+            $recipientEmails = array_unique(array_filter($value));
 
-        // Set default email recipient to admin email.
-        return $recipientEmails ?: [get_bloginfo('admin_email')];
+            // Set default email recipient to admin email.
+            $value = $recipientEmails ?: [get_bloginfo('admin_email')];
+        }
+        return $value;
     }
 
     /**

--- a/tests/unit/tests/Email/GlobalSettingValidatorTest.php
+++ b/tests/unit/tests/Email/GlobalSettingValidatorTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Give\Email\GlobalSettingValidator;
+
+final class GlobalSettingValidatorTest extends Give_Unit_Test_Case
+{
+    /** @test */
+    public function it_does_not_validate_empty_values()
+    {
+        $hook = "give_admin_settings_sanitize_option_donation-receipt_recipient";
+        add_filter($hook, [ new GlobalSettingValidator, 'validateSetting']);
+        $value = apply_filters( $hook, null );
+
+        $this->assertEquals( null, $value );
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6159

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR restores a missing check so that email settings are only validated (formatted as an array) if the value is set. Some email settings, such as `donation-receipt_recipient` should not be set and filtering an unset setting will force the incorrect default value.

## Regression

See https://github.com/impress-org/givewp/commit/26943820f7614fd3cd58a14bb99e6d092b554165#diff-68527fe96f367d826d44f3bf1c8cb7e978284b45bf3e4c0a684d026bcac7e6ef


Original implementation:
```php
if ( ! empty( $_POST[ "{$email_type}_recipient" ] ) ) {
  $recipientEmails = array_unique(array_filter($_POST["{$email_type}_recipient"]));
  $_POST["{$email_type}_recipient"] = $recipientEmails ?: [get_bloginfo('admin_email')];
}
```

Regression:
```php
public function validateSetting($value) {
  // Same unique email address for email recipients.
  $recipientEmails = array_unique(array_filter($value));

  // Set default email recipient to admin email.
  return $recipientEmails ?: [get_bloginfo('admin_email')];
}
```

## Additional Information

For customers that are already having issues due to improperly updated donor email recipient settings, the following utility plugin will correct the issue by removing the settings that should not have been set in the first place (as they are not customizable settings).

```php
<?php

/**
 * Plugin Name: GiveWP - [Utility] Fix improperly updated donor email recipients.
 */

/**
 * Donor email recipient settings should not be set. They default to `{donor_email}` and are not customizable.
 * Due to a regression in saving email settings, these settings were improperly updated.
 */
add_action( 'init', function() {

  $donorEmailRecipientSettings = [ 'donation-receipt_recipient', 'offline-donation-instruction_recipient', 'donor-register_recipient', 'donor-note_recipient', 'email-access_recipient' ];
  
  foreach( $donorEmailRecipientSettings as $setting_name ) {
    give_delete_option( $setting_name );
  }
});
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Saving donor email settings should not update the recipient setting and should not cause an Array to String conversion error on the settings page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

