### PR TITLE
Add $args parameter for legacy form field markup.

### DIFF
--- a/src/Framework/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayRegisterAdapter.php
+++ b/src/Framework/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayRegisterAdapter.php
@@ -23,9 +23,9 @@ class LegacyPaymentGatewayRegisterAdapter {
 		$registeredGatewayId = $registeredGateway->getId();
 
 		add_action( "give_{$registeredGatewayId}_cc_form",
-			static function ( $formId ) use ( $registeredGateway, $legacyPaymentGatewayAdapter ) {
-				echo $legacyPaymentGatewayAdapter->getLegacyFormFieldMarkup( $formId, $registeredGateway );
-			} );
+			static function ( $formId, $args ) use ( $registeredGateway, $legacyPaymentGatewayAdapter ) {
+				echo $legacyPaymentGatewayAdapter->getLegacyFormFieldMarkup( $formId, $args, $registeredGateway );
+			}, 10, 2 );
 
 		add_action( "give_gateway_{$registeredGatewayId}",
 			static function ( $legacyDonationData ) use ( $registeredGateway, $legacyPaymentGatewayAdapter ) {

--- a/src/Framework/LegacyPaymentGateways/Contracts/LegacyPaymentGatewayInterface.php
+++ b/src/Framework/LegacyPaymentGateways/Contracts/LegacyPaymentGatewayInterface.php
@@ -13,5 +13,5 @@ interface LegacyPaymentGatewayInterface {
 	 *
 	 * @return string|bool
 	 */
-	public function getLegacyFormFieldMarkup( $formId );
+	public function getLegacyFormFieldMarkup( $formId, $args );
 }

--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -20,15 +20,17 @@ class LegacyPaymentGatewayAdapter
      * Get legacy form field markup to display gateway specific payment fields
      *
      * @since 2.18.0
+     * @unreleased Added missing $args parameter for ID prefixing and general backwards compatibility.
      *
-     * @param  int  $formId
-     * @param  PaymentGatewayInterface  $registeredGateway
+     * @param int $formId
+     * @param array $args
+     * @param PaymentGatewayInterface  $registeredGateway
      *
      * @return string|bool
      */
-    public function getLegacyFormFieldMarkup($formId, $registeredGateway)
+    public function getLegacyFormFieldMarkup($formId, $args, $registeredGateway)
     {
-        return $registeredGateway->getLegacyFormFieldMarkup($formId);
+        return $registeredGateway->getLegacyFormFieldMarkup($formId, $args);
     }
 
     /**

--- a/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
+++ b/src/PaymentGateways/Gateways/TestGateway/TestGateway.php
@@ -49,7 +49,7 @@ class TestGateway extends PaymentGateway
     /**
      * @inheritDoc
      */
-    public function getLegacyFormFieldMarkup($formId)
+    public function getLegacyFormFieldMarkup($formId, $args)
     {
         if (FormUtils::isLegacyForm($formId)) {
             return false;

--- a/src/PaymentGateways/Gateways/TestGateway/TestGatewayOffsite.php
+++ b/src/PaymentGateways/Gateways/TestGateway/TestGatewayOffsite.php
@@ -59,7 +59,7 @@ class TestGatewayOffsite extends OffSitePaymentGateway
     /**
      * @inheritDoc
      */
-    public function getLegacyFormFieldMarkup($formId)
+    public function getLegacyFormFieldMarkup($formId, $args)
     {
         if (FormUtils::isLegacyForm($formId)) {
             return false;

--- a/tests/unit/tests/PaymentGateways/PaymentGatewaysRegisterTest.php
+++ b/tests/unit/tests/PaymentGateways/PaymentGatewaysRegisterTest.php
@@ -136,7 +136,7 @@ class MockStripe extends PaymentGateway
         return 'Credit Card';
     }
 
-    public function getLegacyFormFieldMarkup($formId)
+    public function getLegacyFormFieldMarkup($formId, $args)
     {
         // TODO: Implement getLegacyFormFieldMarkup() method.
     }
@@ -181,7 +181,7 @@ class MockPaypal extends PaymentGateway
         return 'PayPal';
     }
 
-    public function getLegacyFormFieldMarkup($formId)
+    public function getLegacyFormFieldMarkup($formId, $args)
     {
         // TODO: Implement getLegacyFormFieldMarkup() method.
     }
@@ -226,7 +226,7 @@ class MockPaypalOffsite extends PaymentGateway implements OffsiteGatewayInterfac
         return 'PayPal';
     }
 
-    public function getLegacyFormFieldMarkup($formId)
+    public function getLegacyFormFieldMarkup($formId, $args)
     {
         // TODO: Implement getLegacyFormFieldMarkup() method.
     }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The `give_{$gateway}_cc_form` action passes three parameters: `$formId`, `$args`, and `$echo`.

In the first iteration of the `LegacyPaymentGatewayAdapter` only the `$formId` is being passed along to the gateway.

While migrating the Stripe gateway I realized that the `$args` parameter is necessary for rendering the legacy form field markup. In the case of Stripe, the `$args['id_prefix']` is used to target input fields for mounting the Stripe Elements.

Additionally, there are backwards compatibility considerations. At least for Stripe, the `$args` parameter is passed along to action hooks within the rendering of the HTML.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

