### PR TITLE
Add new option to adjust whether modal links open in a new window or self

### DIFF
--- a/assets/src/js/admin/plugin-deactivation-survey.js
+++ b/assets/src/js/admin/plugin-deactivation-survey.js
@@ -41,6 +41,7 @@ class GiveDeactivationSurvey {
 					confirmBtnTitle: give_vars.submit_and_deactivate,
 					link: window.deactivationLink,
 					link_text: give_vars.skip_and_deactivate,
+					link_self: true,
 				},
 
 				successConfirm: function() {
@@ -65,7 +66,8 @@ class GiveDeactivationSurvey {
 						continueFlag = false;
 					}
 
-					/* If a radio button is assosciated with additional field
+					/**
+                     * If a radio button is associated with additional field
 					 * and if that field is empty, then throw error.
 					 */
 					let userReasonField = '';

--- a/assets/src/js/plugins/modal.js
+++ b/assets/src/js/plugins/modal.js
@@ -64,7 +64,7 @@ class GiveModal {
 				<div class="give-modal__controls">
 
 					${ ( 'form' === this.config.type ) ? '<div class="spinner"></div>' : '' }
-					${ ( 'form' === this.config.type && 'undefined' !== this.config.modalContent.link ) ? `<a class="give-modal--additional-link" href="${ this.config.modalContent.link }" target="_blank">${ this.config.modalContent.link_text }</a>` : '' }
+					${ ( 'form' === this.config.type && 'undefined' !== this.config.modalContent.link ) ? `<a class="give-modal--additional-link" href="${ this.config.modalContent.link }" target="${ ( 'undefined' !== this.config.modalContent.link_self && this.config.modalContent.link_self ) ? '_self' : '_blank' }">${ this.config.modalContent.link_text }</a>` : '' }
 
 					<button class="give-button give-popup-close-button${ this.config.classes.cancelBtn ? ` ${ this.config.classes.cancelBtn }` : ' give-button--secondary' }">
 						${ this.config.modalContent.cancelBtnTitle ? this.config.modalContent.cancelBtnTitle : ( 'confirm' === this.config.type ? Give.fn.getGlobalVar( 'cancel' ) : Give.fn.getGlobalVar( 'close' ) ) }


### PR DESCRIPTION


<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6190 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new config option to our modal config. Sometimes you don't want links to open in a new window, as is the case with the plugin deactivation survey.

By default, links will open in a new window. This is because this is likely the preferred behavior for modals, and we don't want to adversely effect other modals currently using the link config option.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Give modal config.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Try creating a modal or using the deactivation modal. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

