### PR TITLE
Prevent PHP notice on donation form edit screen

### DIFF
--- a/src/Views/Form/Templates/Classic/Classic.php
+++ b/src/Views/Form/Templates/Classic/Classic.php
@@ -234,7 +234,7 @@ class Classic extends Template implements Hookable, Scriptable
         $hasGoal = $form->has_goal();
 
         echo $this->loadFile('views/header.php', [
-            'title'                => $this->options[ 'visual_appearance' ][ 'main_heading' ] ?? $form->post_title,
+            'title'                => isset($this->options['visual_appearance']['main_heading']) ? $this->options['visual_appearance']['main_heading'] : $form->post_title,
             'description'          => $this->options[ 'visual_appearance' ][ 'description' ],
             'isSecureBadgeEnabled' => $this->options[ 'visual_appearance' ][ 'secure_badge' ] === 'enabled',
             'secureBadgeContent'   => $this->options[ 'visual_appearance' ][ 'secure_badge_text' ],

--- a/src/Views/Form/Templates/Classic/Classic.php
+++ b/src/Views/Form/Templates/Classic/Classic.php
@@ -225,6 +225,8 @@ class Classic extends Template implements Hookable, Scriptable
     /**
      * Render donation form header
      *
+     * @unreleased use trinary operator instead of Coalesce operator to make code php 5.6 compatible.
+     *
      * @param  int  $formId
      * @param  array  $args
      * @param  Give_Donate_Form  $form


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6194

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we were using `Coalesce operator` in a trinary condition which is not compatible with PHP 5.6. I updated the code to make it compatible with PHP 5.6


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should not able to reproduce the issue when following the steps given in the issue description.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

