### PR TITLE
Hot Fix: Classic template displays payment fields when there is only one active gateway

### DIFF
--- a/give.php
+++ b/give.php
@@ -5,7 +5,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.18.0
+ * Version: 2.18.1
  * Requires at least: 4.9
  * Requires PHP: 5.6
  * Text Domain: give
@@ -282,7 +282,7 @@ final class Give
     {
         // Plugin version.
         if ( ! defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.18.0');
+            define('GIVE_VERSION', '2.18.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 4.9
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 2.18.0
+Stable tag: 2.18.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.18.1: February 2nd, 2022 =
+* Fix: On Classic template the payment fields didn't show up when there was only one active gateway, and now they do!
+
 = 2.18.0: January 19th, 2022 =
 * New: Shiny new Classic Form Template! Check it out!
 * New: New Gateway API under the hood for integrating with payment gateways. Developer docs to come!

--- a/src/Views/Form/Templates/Classic/resources/css/_payment-details.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_payment-details.scss
@@ -162,11 +162,58 @@ $gatewayFontSize: 1rem;
     }
 }
 
-.give-gateway-details {
+#give_cc_fields, .give_gateway_details {
     display: grid;
     grid-auto-flow: row;
     grid-template-columns: repeat(12, 1fr);
     row-gap: 1rem;
+    column-gap: 1rem;
+
+    > * {
+        grid-column: span 12;
+    }
+
+    > .give-ffm-form-row-half,
+    > .give-ffm-form-row-one-third,
+    > .give-ffm-form-row-two-third,
+    > .form-row-wide {
+        width: revert;
+        padding: revert;
+        float: revert;
+    }
+
+    > .give-ffm-form-row-one-third {
+        grid-column: span 4;
+    }
+
+    > .give-ffm-form-row-half {
+        grid-column: span 6;
+    }
+
+    > .give-ffm-form-row-two-third {
+        grid-column: span 8;
+    }
+
+    > .form-row-wide {
+        grid-column: span 12;
+    }
+
+    @media screen and (min-width: $desktopMinWidth) {
+        > .form-row-responsive {
+            &.form-row-one-third {
+                grid-column: span 4;
+            }
+            &.form-row-half {
+                grid-column: span 6;
+            }
+            &.form-row-two-thirds {
+                grid-column: span 8;
+            }
+        }
+    }
+}
+
+.give-gateway-details {
     inline-size: 100%;
     border-block-start-width: 0;
     border-inline: 0.0625rem solid #ddd;

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -61,7 +61,11 @@ function moveTestModeMessage() {
     const testModeMessage = document.querySelector('#give_error_test_mode');
 
     if (testModeMessage) {
-        document.querySelector('.give-payment-mode-label').after(testModeMessage);
+        if (hasSingleGateway()) {
+            document.querySelector('#give_secure_site_wrapper').before(testModeMessage);
+        } else {
+            document.querySelector('.give-payment-mode-label').after(testModeMessage);
+        }
     }
 }
 
@@ -237,6 +241,10 @@ function addTooltipToLevel(node) {
 }
 
 function moveDefaultGatewayDataIntoActiveGatewaySection() {
+    if (hasSingleGateway()) {
+        return;
+    }
+
     addSelectedGatewayDetails(createGatewayDetails());
 
     document
@@ -490,4 +498,8 @@ function setStripeElementStyles() {
         fontFamily: window.getComputedStyle(document.body).fontFamily,
         fontWeight: 400,
     });
+}
+
+function hasSingleGateway() {
+    return document.getElementById('give-gateway-radio-list').children.length === 1;
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6202 

## Description

The Classic template, up to this point, moved the default payment fields into the payment gateway selection area when the form renders. The problem with this is that the gateway selection area has a `display: none` applied to it when rendered on the server. An option was to simply remove this for Classic, but it looks odd to be prompted as to how to pay when there's only one payment option.

This patch makes moving the fields around conditional, and moves the test notice into view as well. It also brings over the CSS necessary to style things properly when in the new area.


## Affects

Classic template

## Visuals

### Before
![image](https://user-images.githubusercontent.com/2024145/152054663-fa1b4685-6c22-45e0-a6ff-5f2f0957bd2b.png)

### After
![image](https://user-images.githubusercontent.com/2024145/152054720-c01c6169-671d-4890-9dcd-136e5ea879a8.png)


## Testing Instructions

See the Issue for instructions on reproducing the issue. It should look _and work_ fine with this PR in place. Be sure to also test multiple gateways, to avoid regression issues.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

