### PR TITLE
New: Query Builder now includes insert, update and delete functionality 

### DIFF
--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -16,7 +16,7 @@ use WP_Error;
  * @method static int|bool query(string $query)
  * @method static int|false insert(string $table, array $data, array|string $format)
  * @method static int|false delete(string $table, array $where, array|string $where_format)
- * @method static int|false update(string $table, array $where, array|string $where_format)
+ * @method static int|false update(string $table, array $data, array $where, array|string $format, array|string $where_format)
  * @method static int|false replace(string $table, array $data, array|string $format)
  * @method static null|string get_var(string $query = null, int $x = 0, int $y = 0)
  * @method static array|object|null|void get_row(string $query = null, string $output = OBJECT, int $y = 0)

--- a/src/Framework/QueryBuilder/Concerns/CRUD.php
+++ b/src/Framework/QueryBuilder/Concerns/CRUD.php
@@ -10,6 +10,8 @@ use Give\Framework\Database\DB;
 trait CRUD
 {
     /**
+     * @unreleased
+     *
      * @param  array  $data
      * @param  array|string  $format
      *
@@ -28,6 +30,8 @@ trait CRUD
     }
 
     /**
+     * @unreleased
+     *
      * @param  array  $data
      * @param  null  $format
      *
@@ -48,6 +52,8 @@ trait CRUD
     }
 
     /**
+     * @unreleased
+     *
      * @return false|int
      *
      * @see https://developer.wordpress.org/reference/classes/wpdb/delete/
@@ -64,6 +70,8 @@ trait CRUD
     /**
      * Get results
      *
+     * @unreleased
+     *
      * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
      *
      * @return array|object|null
@@ -76,6 +84,8 @@ trait CRUD
     /**
      * Get row
      *
+     * @unreleased
+     *
      * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
      *
      * @return array|object|null
@@ -86,6 +96,8 @@ trait CRUD
     }
 
     /**
+     * @unreleased
+     *
      * @return string
      */
     private function getTable()
@@ -94,6 +106,8 @@ trait CRUD
     }
 
     /**
+     * @unreleased
+     *
      * @return array[]
      */
     private function getWhere()

--- a/src/Framework/QueryBuilder/Concerns/CRUD.php
+++ b/src/Framework/QueryBuilder/Concerns/CRUD.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Give\Framework\QueryBuilder\Concerns;
+
+use Give\Framework\Database\DB;
+
+/**
+ * @unreleased
+ */
+trait CRUD
+{
+    /**
+     * @param  array  $data
+     * @param  array|string  $format
+     *
+     * @return false|int
+     *
+     * @see https://developer.wordpress.org/reference/classes/wpdb/insert/
+     *
+     */
+    public function insert($data, $format = null)
+    {
+        return DB::insert(
+            $this->getTable(),
+            $data,
+            $format
+        );
+    }
+
+    /**
+     * @param  array  $data
+     * @param  null  $format
+     *
+     * @return false|int
+     *
+     * @see https://developer.wordpress.org/reference/classes/wpdb/update/
+     *
+     */
+    public function update($data, $format = null)
+    {
+        return DB::update(
+            $this->getTable(),
+            $data,
+            $this->getWhere(),
+            $format,
+            null
+        );
+    }
+
+    /**
+     * @return false|int
+     *
+     * @see https://developer.wordpress.org/reference/classes/wpdb/delete/
+     */
+    public function delete()
+    {
+        return DB::delete(
+            $this->getTable(),
+            $this->getWhere(),
+            null
+        );
+    }
+
+    /**
+     * Get results
+     *
+     * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
+     *
+     * @return array|object|null
+     */
+    public function getAll($output = OBJECT)
+    {
+        return DB::get_results($this->getSQL(), $output);
+    }
+
+    /**
+     * Get row
+     *
+     * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
+     *
+     * @return array|object|null
+     */
+    public function get($output = OBJECT)
+    {
+        return DB::get_row($this->getSQL(), $output);
+    }
+
+    /**
+     * @return string
+     */
+    private function getTable()
+    {
+        return $this->froms[ 0 ]->table;
+    }
+
+    /**
+     * @return array[]
+     */
+    private function getWhere()
+    {
+        $wheres = [];
+
+        foreach ($this->wheres as $where) {
+            $wheres[ $where->column ] = $where->value;
+        }
+
+        return $wheres;
+    }
+}

--- a/src/Framework/QueryBuilder/QueryBuilder.php
+++ b/src/Framework/QueryBuilder/QueryBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Give\Framework\QueryBuilder;
 
-use Give\Framework\Database\DB;
+use Give\Framework\QueryBuilder\Concerns\CRUD;
 use Give\Framework\QueryBuilder\Concerns\FromClause;
 use Give\Framework\QueryBuilder\Concerns\GroupByStatement;
 use Give\Framework\QueryBuilder\Concerns\HavingClause;
@@ -21,6 +21,7 @@ use Give\Framework\QueryBuilder\Concerns\WhereClause;
  */
 class QueryBuilder
 {
+    use CRUD;
     use FromClause;
     use GroupByStatement;
     use HavingClause;
@@ -52,35 +53,11 @@ class QueryBuilder
             $this->getUnionSQL()
         );
 
-        // Trim triple doubles spaces added by DB::prepare
+        // Trim double spaces added by DB::prepare
         return str_replace(
             ['   ', '  '],
             ' ',
             implode(' ', $sql)
         );
-    }
-
-    /**
-     * Get results
-     *
-     * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
-     *
-     * @return array|object|null
-     */
-    public function getAll($output = OBJECT)
-    {
-        return DB::get_results($this->getSQL(), $output);
-    }
-
-    /**
-     * Get row
-     *
-     * @param  string ARRAY_A|ARRAY_N|OBJECT|OBJECT_K $output
-     *
-     * @return array|object|null
-     */
-    public function get($output = OBJECT)
-    {
-        return DB::get_row($this->getSQL(), $output);
     }
 }

--- a/src/Framework/QueryBuilder/README.md
+++ b/src/Framework/QueryBuilder/README.md
@@ -36,6 +36,12 @@ Query Builder helper class is used to write SQL queries
   - [attachMeta](#attachmeta)
   - [configureMetaTable](#configuremetatable)
 
+- [CRUD](#crud)
+  - [Insert](#insert)
+  - [Update](#update)
+  - [Delete](#delete)
+  - [Get](#get)
+
 
 ## DB
 
@@ -671,3 +677,58 @@ WHERE post_type = 'give_payment'
   AND donationMeta.custom_meta_value = '1'
 ```
 
+## CRUD
+
+### Insert
+
+The QueryBuilder also provides `QueryBuilder::insert` method that may be used to insert records into the database table.
+
+```php
+DB::table('posts')
+    ->insert([
+        'post_title'   => 'Post Title',
+        'post_author'  => 1,
+        'post_content' => 'Post Content'
+    ]);
+```
+
+
+### Update
+
+In addition to inserting records into the database, the QueryBuilder can also update existing records using the `QueryBuilder::update` method.
+
+```php
+DB::table('posts')
+    ->where('post_author', 1)
+    ->update([
+        'post_title'   => 'Post Title 2',
+        'post_content' => 'Post Content 2'
+    ]);
+```
+
+### Delete
+
+The `QueryBuilder::delete` method may be used to delete records from the table.
+
+```php
+DB::table('posts')
+    ->where('post_author', 1)
+    ->delete();
+```
+
+
+### Get
+
+#### Available methods - get / getAll
+
+Get single row
+
+```php
+$post = DB::table('posts')->where('post_author', 1)->get();
+```
+
+Get all rows
+
+```php
+$posts = DB::table('posts')->where('post_status', 'published')->getAll();
+```

--- a/tests/unit/tests/Framework/QueryBuilder/CRUDTest.php
+++ b/tests/unit/tests/Framework/QueryBuilder/CRUDTest.php
@@ -1,12 +1,22 @@
 <?php
 
+namespace unit\tests\Framework\QueryBuilder;
+
 use Give\Framework\Database\DB;
+use Give\Framework\QueryBuilder\Concerns\CRUD;
 use PHPUnit\Framework\TestCase;
 
-final class CRUD_Test extends TestCase
+/**
+ * @unreleased
+ *
+ * @covers CRUD
+ */
+final class CRUDTest extends TestCase
 {
     /**
      * Truncate posts table to avoid duplicate records
+     *
+     * @unreleased
      *
      * @return void
      */
@@ -19,12 +29,16 @@ final class CRUD_Test extends TestCase
         DB::query("TRUNCATE TABLE $posts");
     }
 
-
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
     public function testInsertShouldAddRowToDatabase()
     {
         $data = [
-            'post_title'   => 'Query Builder CRUD test',
-            'post_type'    => 'crud_test',
+            'post_title' => 'Query Builder CRUD test',
+            'post_type' => 'crud_test',
             'post_content' => 'Hello World!',
         ];
 
@@ -42,12 +56,16 @@ final class CRUD_Test extends TestCase
         $this->assertEquals($data['post_content'], $post->post_content);
     }
 
-
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
     public function testUpdateShouldUpdateRowValuesInDatabase()
     {
         $data = [
-            'post_title'   => 'Query Builder CRUD test',
-            'post_type'    => 'crud_test',
+            'post_title' => 'Query Builder CRUD test',
+            'post_type' => 'crud_test',
             'post_content' => 'Hello World!',
         ];
 
@@ -62,11 +80,11 @@ final class CRUD_Test extends TestCase
         ];
 
         DB::table('posts')
-          ->where('ID', $id)
-          ->update($updated);
+            ->where('ID', $id)
+            ->update($updated);
 
         $post = DB::table('posts')
-            ->select( 'ID', 'post_title', 'post_type', 'post_content')
+            ->select('ID', 'post_title', 'post_type', 'post_content')
             ->where('ID', $id)
             ->get();
 
@@ -76,12 +94,16 @@ final class CRUD_Test extends TestCase
         $this->assertEquals($updated['post_content'], $post->post_content);
     }
 
-
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
     public function testDeleteShouldDeleteRowInDatabase()
     {
         $data = [
-            'post_title'   => 'Query Builder CRUD test',
-            'post_type'    => 'crud_test',
+            'post_title' => 'Query Builder CRUD test',
+            'post_type' => 'crud_test',
             'post_content' => 'Hello World!',
         ];
 
@@ -104,7 +126,6 @@ final class CRUD_Test extends TestCase
             ->get();
 
         $this->assertNull($post);
-
     }
 
 }

--- a/tests/unit/tests/Framework/QueryBuilder/CRUD_Test.php
+++ b/tests/unit/tests/Framework/QueryBuilder/CRUD_Test.php
@@ -1,0 +1,110 @@
+<?php
+
+use Give\Framework\Database\DB;
+use PHPUnit\Framework\TestCase;
+
+final class CRUD_Test extends TestCase
+{
+    /**
+     * Truncate posts table to avoid duplicate records
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $posts = DB::prefix('posts');
+
+        DB::query("TRUNCATE TABLE $posts");
+    }
+
+
+    public function testInsertShouldAddRowToDatabase()
+    {
+        $data = [
+            'post_title'   => 'Query Builder CRUD test',
+            'post_type'    => 'crud_test',
+            'post_content' => 'Hello World!',
+        ];
+
+        DB::table('posts')->insert($data);
+
+        $id = DB::last_insert_id();
+
+        $post = DB::table('posts')
+            ->select('post_title', 'post_type', 'post_content')
+            ->where('ID', $id)
+            ->get();
+
+        $this->assertEquals($data['post_title'], $post->post_title);
+        $this->assertEquals($data['post_type'], $post->post_type);
+        $this->assertEquals($data['post_content'], $post->post_content);
+    }
+
+
+    public function testUpdateShouldUpdateRowValuesInDatabase()
+    {
+        $data = [
+            'post_title'   => 'Query Builder CRUD test',
+            'post_type'    => 'crud_test',
+            'post_content' => 'Hello World!',
+        ];
+
+        DB::table('posts')->insert($data);
+
+        $id = DB::last_insert_id();
+
+        $updated = [
+            'post_title'   => 'Query Builder CRUD test - UPDATED',
+            'post_type'    => 'crud_test-updated',
+            'post_content' => 'Hello World! - UPDATED',
+        ];
+
+        DB::table('posts')
+          ->where('ID', $id)
+          ->update($updated);
+
+        $post = DB::table('posts')
+            ->select( 'ID', 'post_title', 'post_type', 'post_content')
+            ->where('ID', $id)
+            ->get();
+
+        $this->assertEquals($id, $post->ID);
+        $this->assertEquals($updated['post_title'], $post->post_title);
+        $this->assertEquals($updated['post_type'], $post->post_type);
+        $this->assertEquals($updated['post_content'], $post->post_content);
+    }
+
+
+    public function testDeleteShouldDeleteRowInDatabase()
+    {
+        $data = [
+            'post_title'   => 'Query Builder CRUD test',
+            'post_type'    => 'crud_test',
+            'post_content' => 'Hello World!',
+        ];
+
+        DB::table('posts')->insert($data);
+
+        $id = DB::last_insert_id();
+
+        $post = DB::table('posts')
+            ->where('ID', $id)
+            ->get();
+
+        $this->assertNotNull($post);
+
+        DB::table('posts')
+            ->where('ID', $id)
+            ->delete();
+
+        $post = DB::table('posts')
+            ->where('ID', $id)
+            ->get();
+
+        $this->assertNull($post);
+
+    }
+
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6205

## Description

To have a more consistent API, Query Builder now includes `insert`, `update`, and `delete` functionality. 

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Testing Instructions

### Insert

```php
DB::table('posts')
    ->insert([
        'post_title'   => 'Post Title',
        'post_author'  => 1,
        'post_content' => 'Post Content'
    ]);
```

### Update

```php
DB::table('posts')
    ->where('post_author', 1)
    ->update([
        'post_title'   => 'Post Title 2',
        'post_content' => 'Post Content 2'
    ]);
```

### Delete

```php
DB::table('posts')
    ->where('post_author', 1)
    ->delete();
```

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

