### PR TITLE
Refactor: remove  add-on FormData from Data transfer object

### DIFF
--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -83,10 +83,6 @@ class FormData
     /**
      * @var string
      */
-    public $loggedInOnly;
-    /**
-     * @var string
-     */
     public $amount;
     /**
      * @var string
@@ -135,7 +131,6 @@ class FormData
         $self->formMinimum = $request['post_data']['give-form-minimum'];
         $self->formMaximum = $request['post_data']['give-form-maximum'];
         $self->formHash = $request['post_data']['give-form-hash'];
-        $self->loggedInOnly = $request['post_data']['give-logged-in-only'];
         $self->amount = $request['post_data']['give-amount'];
         $self->paymentGateway = $request['post_data']['give-gateway'];
         $self->gatewayNonce = $request['gateway_nonce'];


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I am getting the following error when a donor donates:
```log
[04-Feb-2022 17:08:40 UTC] PHP Notice:  Undefined index: give-logged-in-only in /Users/ravinderkumar/ValetSites/givewp/wp-content/plugins/give/src/PaymentGateways/DataTransferObjects/FormData.php on line 138
```
I find out that this `give-logged-in-only` param add by recurring addon, so I removed it from `FormData` DTO.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

