### PR TITLE
Tributes display styles are updated

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/css/_radio.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_radio.scss
@@ -47,6 +47,6 @@
     }
 }
 
-:is(.form-row, .give-tributes-dedicate-donation) input[type='radio'] {
+:is(.form-row, .give-tributes-dedicate-donation) input[type='radio']:not(.give-tribute-type-button) {
     @include give-radio;
 }

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -322,6 +322,14 @@ class Sequoia extends Template implements Hookable, Scriptable
 			";
         }
 
+        if (Utils::isPluginActive('give-tributes/give-tributes.php')) {
+            $dynamicCss .= "
+				.give-tributes-type-button-list input[type='radio']:checked + label.give-tribute-type-button {
+				    color: {$primaryColor} !important;
+				}
+			";
+        }
+
         if ($isGoogleFontEnabled) {
             $dynamicCss .= "body, button, input, select{font-family: 'Montserrat', sans-serif;}";
         }

--- a/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
@@ -82,11 +82,6 @@
         }
     }
 
-    // Match style of payment level buttons.
-    input[type='radio']:checked + label.give-tribute-type-button {
-        color: #28C77B !important;
-    }
-
     // Adjust layout to avoid overlapping text.
     .give-tributes-type-button-list {
         margin-top: 20px;

--- a/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
@@ -43,7 +43,7 @@
         position: absolute !important;
     }
 
-    input[type='radio'] + label {
+    input[type='radio'] + label:not(.give-tribute-type-button) {
         padding: 0 10px 0 28px;
         width: 100%;
         color: #696969;
@@ -82,7 +82,32 @@
         }
     }
 
-    input[type='radio']:checked + label::after {
+    // Match style of payment level buttons.
+    input[type='radio']:checked + label.give-tribute-type-button {
+        color: #28C77B !important;
+    }
+
+    // Adjust layout to avoid overlapping text.
+    .give-tributes-type-button-list {
+        margin-top: 20px;
+        margin-bottom: 70px;
+    }
+
+    .give-tribute-type-button {
+        // Match style of payment level buttons.
+        font-size: 20px;
+        padding-left: 20px;
+        padding-right: 20px;
+
+        // Support overflow for multiple buttons or long text labels
+        display: flex;
+        flex-wrap: wrap;
+        & li {
+            height: 60px;
+        }
+    }
+
+    input[type='radio']:checked + label:not(.give-tribute-type-button)::after {
         transform: scale3d(1, 1, 1);
     }
 
@@ -114,4 +139,8 @@ html[dir='rtl'] {
             }
         }
     }
+}
+
+.give-section.choose-amount .give-tributes-dedicate-donation {
+    margin: 24px 30px 0 30px;
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related to impress-org/give-tributes#303

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the style in GiveWP that relate to the Tributes add-on.

Specifically, updating the selected state when using buttons (instead of radios) caused some layout/overlap issues.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Multi-Step Form

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/10858303/153660616-f8528d4b-47f3-49d0-9f4c-3489b6fd8725.png) | ![Screenshot 2022-02-11 at 11-20-06 Donation Form with Tributes – WordPress](https://user-images.githubusercontent.com/10858303/153658824-bad0efe9-da06-45d2-b761-41917587a028.png) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

With the Tributes add-on installed and active:

- Create a donation form
- Add multiple tribute options, ie "In honor of"
- Update the tributes display style to "buttons"

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

