### PR TITLE
New: Adds SendWP integration to email settings admin page.

### DIFF
--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -332,7 +332,7 @@ add_action( 'wp_ajax_give_sendwp_remote_install', 'give_sendwp_remote_install_ha
  */
 function give_sendwp_disconnect () {
 
-	if ( ! current_user_can( 'manage_shop_settings' ) ) {
+	if ( ! current_user_can( 'manage_give_settings' ) ) {
 		wp_send_json_error( array(
 			'error' => __( 'You do not have permission to do this.', 'give' )
 		) );

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -249,3 +249,99 @@ function give_add_ons_feed( $feed_type = '', $echo = true ) {
 
 	return $cache;
 }
+
+/**
+ * Handle installation and connection for SendWP via ajax
+ *
+ * @since 2.9.15
+ */
+function give_sendwp_remote_install_handler () {
+
+	if ( ! current_user_can( 'manage_give_settings' ) ) {
+		wp_send_json_error( array(
+			'error' => __( 'You do not have permission to do this.', 'give' )
+		) );
+	}
+
+	include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+	include_once ABSPATH . 'wp-admin/includes/file.php';
+	include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+	$plugins = get_plugins();
+
+	if( ! array_key_exists( 'sendwp/sendwp.php', $plugins ) ) {
+
+		/*
+		* Use the WordPress Plugins API to get the plugin download link.
+		*/
+		$api = plugins_api( 'plugin_information', array(
+			'slug' => 'sendwp',
+		) );
+
+		if ( is_wp_error( $api ) ) {
+			wp_send_json_error( array(
+				'error' => $api->get_error_message(),
+				'debug' => $api
+			) );
+		}
+
+		/*
+		* Use the AJAX Upgrader skin to quietly install the plugin.
+		*/
+		$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
+		$install = $upgrader->install( $api->download_link );
+		if ( is_wp_error( $install ) ) {
+			wp_send_json_error( array(
+				'error' => $install->get_error_message(),
+				'debug' => $api
+			) );
+		}
+
+		$activated = activate_plugin( $upgrader->plugin_info() );
+
+	} else {
+
+		$activated = activate_plugin( 'sendwp/sendwp.php' );
+
+	}
+
+	/*
+	* Final check to see if SendWP is available.
+	*/
+	if( ! function_exists('sendwp_get_server_url') ) {
+		wp_send_json_error( array(
+			'error' => __( 'Something went wrong. SendWP was not installed correctly.', 'give' )
+		) );
+	}
+
+	wp_send_json_success( array(
+		'partner_id'      => 51154,
+		'register_url'    => sendwp_get_server_url() . '_/signup',
+		'client_name'     => sendwp_get_client_name(),
+        'client_url'      => sendwp_get_client_url(),
+		'client_secret'   => sendwp_get_client_secret(),
+		'client_redirect' => admin_url( '/edit.php?post_type=give_forms&page=give-settings&tab=emails&section=email-settings' ),
+	) );
+}
+add_action( 'wp_ajax_give_sendwp_remote_install', 'give_sendwp_remote_install_handler' );
+
+/**
+ * Handle deactivation of SendWP via ajax
+ *
+ * @since 2.9.15
+ */
+function give_sendwp_disconnect () {
+
+	if ( ! current_user_can( 'manage_shop_settings' ) ) {
+		wp_send_json_error( array(
+			'error' => __( 'You do not have permission to do this.', 'give' )
+		) );
+	}
+
+	sendwp_disconnect_client();
+
+	deactivate_plugins( 'sendwp/sendwp.php' );
+
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_give_sendwp_disconnect', 'give_sendwp_disconnect' );

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -36,6 +36,148 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 			$this->enable_save = ! ( Give_Admin_Settings::is_setting_page( 'emails', 'donor-email' ) || Give_Admin_Settings::is_setting_page( 'emails', 'admin-email' ) );
 
 			add_action( 'give_admin_field_email_notification', array( $this, 'email_notification_setting' ) );
+            add_action( 'give_admin_field_give_sendwp_button', [ $this, '_render_give_sendwp_button' ], 10, 3 );
+		}
+
+        /**
+		 * Render give_currency_code_preview field type
+		 *
+		 * @since  2.3.0
+		 * @access public
+		 *
+		 * @param array $field Field Attributes array.
+		 *
+		 * @return void
+		 */
+		public function _render_give_sendwp_button( $field, $value ) {
+            // Connection status partial label based on the state of the SendWP email sending setting (Tools -> SendWP)
+            $connected  = '<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">';
+            $connected .= __( 'Access your SendWP account', 'give' );
+            $connected .= '</a>.';
+
+            $disconnected = sprintf(
+                __( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="' . admin_url( '/tools.php?page=sendwp' ) . '">Click here</a> to enable it.</em>', 'give' )
+            );
+
+            // Checks if SendWP is connected
+            $client_connected = function_exists( 'sendwp_client_connected' ) && sendwp_client_connected() ? true : false;
+
+            // Checks if email sending is enabled in SendWP
+            $forwarding_enabled = function_exists( 'sendwp_forwarding_enabled' ) && sendwp_forwarding_enabled() ? true : false;
+
+            // Output the appropriate button and label based on connection status
+            if( $client_connected ) :
+                ?>
+                <tr valign="top" <?php echo ! empty( $field['wrapper_class'] ) ? 'class="' . $field['wrapper_class'] . '"' : ''; ?>>
+                    <th scope="row" class="titledesc">
+                        <label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['name'] ); ?></label>
+                    </th>
+                    <td class="give-forminp">
+                        <p><?php _e( 'SendWP plugin activated.', 'give' ); ?> <?php echo $forwarding_enabled ? $connected : $disconnected ; ?></p>
+
+                        <br style="margin-bottom: 0.5rem;"/>
+
+                        <button id="give-sendwp-disconnect" class="button"><?php _e( 'Disconnect SendWP', 'give' ); ?></button>
+                    </td>
+                </tr>
+                <?php
+            else :
+                ?>
+                <tr valign="top" <?php echo ! empty( $field['wrapper_class'] ) ? 'class="' . $field['wrapper_class'] . '"' : ''; ?>>
+                    <th scope="row" class="titledesc">
+                        <label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['name'] ); ?></label>
+                    </th>
+                    <td class="give-forminp">
+                        <div class="give-field-description">
+                            <?php _e( 'We recommend SendWP to ensure quick and reliable delivery of all emails sent from your site, such as donation receipts, recurring donation renewal reminders, password resets, and more.', 'give' ); ?> <?php printf( __( '%sLearn more%s', 'give' ), '<a href="https://sendwp.com/" target="_blank" rel="noopener noreferrer">', '</a>' ); ?>
+                        </div>
+
+                        <br style="margin-bottom: 0.5rem;"/>
+
+                        <button type="button" id="give-sendwp-connect" class="button button-primary"><?php esc_html_e( 'Connect with SendWP', 'give' ); ?>
+                    </button>
+                    </td>
+                </tr>
+
+                <script>
+                    jQuery('#give-sendwp-connect').on('click', function(e) {
+
+                        e.preventDefault();
+                        jQuery(this).html( give_vars.wait + ' <span class="give-loading"></span>' );
+                        document.body.style.cursor = 'wait';
+                        give_sendwp_remote_install();
+
+                    });
+
+                    jQuery('#give-sendwp-disconnect').on('click', function(e) {
+                        e.preventDefault();
+                        jQuery(this).html( give_vars.wait + ' <span class="give-loading dark"></span>' );
+                        document.body.style.cursor = 'wait';
+                        give_sendwp_disconnect();
+
+                    });
+
+                    function give_sendwp_remote_install() {
+                        var data = {
+                            'action': 'give_sendwp_remote_install',
+                        };
+
+                        // since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+                        jQuery.post(ajaxurl, data, function( response ) {
+
+                            if( ! response.success ) {
+
+                                if( confirm( response.data.error ) ) {
+                                    location.reload();
+                                    return;
+                                }
+                            }
+
+                            give_sendwp_register_client(
+                                response.data.register_url,
+                                response.data.client_name,
+                                response.data.client_secret,
+                                response.data.client_redirect,
+                                response.data.partner_id
+                            );
+                        });
+                    }
+
+                    function give_sendwp_disconnect() {
+                        var data = {
+                            'action': 'give_sendwp_disconnect',
+                        };
+
+                        jQuery.post(ajaxurl, data, function( response ) {
+                            location.reload();
+                        });
+                    }
+
+                    function give_sendwp_register_client(register_url, client_name, client_secret, client_redirect, partner_id) {
+
+                        var form = document.createElement("form");
+                        form.setAttribute("method", 'POST');
+                        form.setAttribute("action", register_url);
+
+                        function give_sendwp_append_form_input(name, value) {
+                            var input = document.createElement("input");
+                            input.setAttribute("type", "hidden");
+                            input.setAttribute("name", name);
+                            input.setAttribute("value", value);
+                            form.appendChild(input);
+                        }
+
+                        give_sendwp_append_form_input('client_name', client_name);
+                        give_sendwp_append_form_input('client_secret', client_secret);
+                        give_sendwp_append_form_input('client_redirect', client_redirect);
+                        give_sendwp_append_form_input('partner_id', partner_id);
+
+                        document.body.appendChild(form);
+                        form.submit();
+                    }
+                </script>
+                <?php
+            endif;
 		}
 
 		/**
@@ -83,6 +225,12 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 							'desc'    => esc_html__( 'Email address from which all GiveWP emails are sent from. This will act as the "from" and "reply-to" email address.', 'give' ),
 							'default' => get_bloginfo( 'admin_email' ),
 							'type'    => 'text',
+						),
+                        array(
+							'id'      => 'sendwp',
+							'name'    => esc_html__( 'SendWP', 'give' ),
+							'desc'    => esc_html__( 'We recommend SendWP to ensure quick and reliable delivery of all emails sent from your store, such as donation receipts, recurring donation renewal reminders, password resets, and more.', 'give' ),
+							'type'    => 'give_sendwp_button',
 						),
 						array(
 							'name'  => esc_html__( 'Donation Notification Settings Docs Link', 'give' ),

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
                     jQuery('#give-sendwp-connect').on('click', function(e) {
 
                         e.preventDefault();
-                        jQuery(this).html( give_vars.wait + ' <span class="give-loading"></span>' );
+                        jQuery(this).html( 'Connecting <span class="give-loading"></span>' );
                         document.body.style.cursor = 'wait';
                         give_sendwp_remote_install();
 
@@ -111,7 +111,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 
                     jQuery('#give-sendwp-disconnect').on('click', function(e) {
                         e.preventDefault();
-                        jQuery(this).html( give_vars.wait + ' <span class="give-loading dark"></span>' );
+                        jQuery(this).html( 'Disconnecting <span class="give-loading dark"></span>' );
                         document.body.style.cursor = 'wait';
                         give_sendwp_disconnect();
 

--- a/includes/admin/settings/class-settings-general.php
+++ b/includes/admin/settings/class-settings-general.php
@@ -564,6 +564,8 @@ if ( ! class_exists( 'Give_Settings_General' ) ) :
 			<?php
 		}
 
+
+
 		/**
 		 * Render give_unlock_all_settings field type
 		 *


### PR DESCRIPTION
Resolves #6229 

## Description

This PR adds the ability to automatically download the SendWP plugin, register and attempt to activate the plugin. It includes a description of what SendWP is, when Give recommends it, and why you should use it.

## Affects

GiveWP Email Settings page

## Visuals

<img width="1552" alt="Screen Shot 2022-02-12 at 1 25 42 PM" src="https://user-images.githubusercontent.com/3329081/153723650-3dea5e13-04ef-41f4-a22f-25ea5b45d845.png">
<img width="1552" alt="Screen Shot 2022-02-12 at 1 28 51 PM" src="https://user-images.githubusercontent.com/3329081/153723652-bace5b5d-7576-43a5-bcc8-4722336129a0.png">


## Testing Instructions

- This can only be tested from a publicly available URL (not local) as the process of connecting & disconnecting requires redirects back to the site.

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

