### PR TITLE
New: Admin can now rearrange the order of funds for donor's choice

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2987,19 +2987,6 @@ const gravatar = require( 'gravatar' );
                     } );
 
                     // Rebuild the dropdown
-                    dropdown.innerHTML = '';
-                    orderedOptions.map( option => {
-                        const newOption = document.createElement('option')
-                        newOption.value = option.value;
-                        newOption.textContent = option.text;
-                        if ( option.selected ) {
-                            newOption.setAttribute('selected', true);
-                        }
-
-                        dropdown.add(newOption)
-                    } );
-
-                    // Rebuild the dropdown
                     GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
 
                     $(this).trigger('chosen:updated')

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2944,39 +2944,125 @@ const gravatar = require( 'gravatar' );
 	 */
 	const GiveMultiSelectOptions = {
 		init: function() {
-			$( '.give-select-chosen[multiple]' ).each( function( i, selectDropdown ) {
-				$( selectDropdown ).chosen().change( function( e, currentOption ) {
-					const $dropdown = $( this );
-					const dropDownId = $dropdown.attr( 'id' );
-					const orderedOptions = [];
+            const selectChosen = document.querySelectorAll('.give-select-chosen[multiple]') ?? [];
 
-					$( `#${ dropDownId }_chosen li.search-choice span` ).each( function( j, element ) {
-						const value = element.textContent;
-						if ( value !== currentOption.deselected ) {
-							orderedOptions.push( { value, selected: true } );
-						}
-					} );
+            Array.from(selectChosen).forEach( dropdown => {
+                const id = dropdown.id + '_chosen';
+                const options = dropdown.options;
+                const orderedOptions = [];
+                const order = dropdown.dataset.order
+                    ? dropdown.dataset.order.split('|')
+                    : [];
 
-					Array.from( e.target.options ).map( option => {
-						const included = orderedOptions.filter( orderedOption => orderedOption.value === option.value ).length;
-						if ( ! included ) {
-							orderedOptions.push( {
-								value: option.value,
-								selected: option.selected,
-							} );
-						}
-					} );
+                if (order.length > 0) {
 
-					// Rebuild the dropdown
-					$dropdown.empty();
-					orderedOptions.map( option => $dropdown.append( $( '<option>', {
-						value: option.value,
-						text: option.value,
-						selected: option.selected,
-					} ) ) );
-				} );
-			} );
+                    order.forEach( (value, i) => {
+                        const items = document.querySelectorAll(`#${id} li.search-choice`) ?? [];
+
+                        items.forEach((item, j) => {
+                            if (i === j) {
+                                const option = Object.values(options).find( option => option.value === value );
+
+                                item.querySelector('span').textContent = option.text;
+
+                                orderedOptions.push( {
+                                    value: option.value,
+                                    text: option.text,
+                                    selected: true
+                                } );
+                            }
+                        })
+                    });
+
+                    // Fill in rest of the options
+                    Object.values(options).map( option => {
+                        const included = orderedOptions.filter( orderedOption => orderedOption.value === option.value ).length;
+                        if ( ! included ) {
+                            orderedOptions.push( {
+                                value: option.value,
+                                text: option.textContent,
+                                selected: option.selected,
+                            } );
+                        }
+                    } );
+
+                    // Rebuild the dropdown
+                    dropdown.innerHTML = '';
+                    orderedOptions.map( option => {
+                        const newOption = document.createElement('option')
+                        newOption.value = option.value;
+                        newOption.textContent = option.text;
+                        if ( option.selected ) {
+                            newOption.setAttribute('selected', true);
+                        }
+
+                        dropdown.add(newOption)
+                    } );
+
+                    // Rebuild the dropdown
+                    GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
+
+                    $(this).trigger('chosen:updated')
+                }
+
+                // Update order on change
+                $( dropdown ).chosen().change( function( e, currentOption ) {
+                    const dropdown = e.target;
+                    const orderedOptions = [];
+
+                    if (currentOption.deselected) {
+                        $(this).trigger('chosen:updated');
+                    }
+
+                    const items = document.querySelectorAll(`#${id} li.search-choice`) ?? [];
+
+                    items.forEach((item) => {
+                        const text = item.querySelector('span').textContent;
+                        const option = Object.values(dropdown.options).find( option => option.textContent === text );
+
+                        if ( option ) {
+                            orderedOptions.push( {
+                                text: option.textContent,
+                                value: option.value,
+                                selected: true
+                            } );
+                        }
+                    });
+
+                    // Fill in rest of the options
+                    Object.values(dropdown.options).map( option => {
+                        const included = orderedOptions.filter( orderedOption => orderedOption.text === option.textContent ).length;
+                        if ( ! included ) {
+                            orderedOptions.push( {
+                                text: option.textContent,
+                                value: option.value,
+                                selected: false
+                            } );
+                        }
+                    } );
+
+                    // Rebuild the dropdown
+                    GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
+                } );
+
+
+
+            });
 		},
+
+        rebuildDropDown: function(dropdown, options) {
+            dropdown.innerHTML = '';
+            options.map( option => {
+                const newOption = document.createElement('option')
+                newOption.value = option.value;
+                newOption.textContent = option.text;
+                if ( option.selected ) {
+                    newOption.setAttribute('selected', true);
+                }
+                dropdown.add(newOption)
+            } );
+
+        }
 	};
 
 	// On DOM Ready.

--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -2947,49 +2947,12 @@ const gravatar = require( 'gravatar' );
             const selectChosen = document.querySelectorAll('.give-select-chosen[multiple]') ?? [];
 
             Array.from(selectChosen).forEach( dropdown => {
-                const id = dropdown.id + '_chosen';
-                const options = dropdown.options;
-                const orderedOptions = [];
                 const order = dropdown.dataset.order
                     ? dropdown.dataset.order.split('|')
                     : [];
 
                 if (order.length > 0) {
-
-                    order.forEach( (value, i) => {
-                        const items = document.querySelectorAll(`#${id} li.search-choice`) ?? [];
-
-                        items.forEach((item, j) => {
-                            if (i === j) {
-                                const option = Object.values(options).find( option => option.value === value );
-
-                                item.querySelector('span').textContent = option.text;
-
-                                orderedOptions.push( {
-                                    value: option.value,
-                                    text: option.text,
-                                    selected: true
-                                } );
-                            }
-                        })
-                    });
-
-                    // Fill in rest of the options
-                    Object.values(options).map( option => {
-                        const included = orderedOptions.filter( orderedOption => orderedOption.value === option.value ).length;
-                        if ( ! included ) {
-                            orderedOptions.push( {
-                                value: option.value,
-                                text: option.textContent,
-                                selected: option.selected,
-                            } );
-                        }
-                    } );
-
-                    // Rebuild the dropdown
-                    GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
-
-                    $(this).trigger('chosen:updated')
+                    GiveMultiSelectOptions.reorderItems(dropdown, order);
                 }
 
                 // Update order on change
@@ -3001,7 +2964,7 @@ const gravatar = require( 'gravatar' );
                         $(this).trigger('chosen:updated');
                     }
 
-                    const items = document.querySelectorAll(`#${id} li.search-choice`) ?? [];
+                    const items = document.querySelectorAll(`#${dropdown.id}_chosen li.search-choice`) ?? [];
 
                     items.forEach((item) => {
                         const text = item.querySelector('span').textContent;
@@ -3032,10 +2995,48 @@ const gravatar = require( 'gravatar' );
                     GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
                 } );
 
-
-
             });
 		},
+
+        reorderItems: function(dropdown, order) {
+            const options = dropdown.options;
+            const orderedOptions = [];
+
+            order.forEach( (value, i) => {
+                const items = document.querySelectorAll(`#${dropdown.id}_chosen li.search-choice`) ?? [];
+
+                items.forEach((item, j) => {
+                    if (i === j) {
+                        const option = Object.values(options).find( option => option.value === value );
+
+                        item.querySelector('span').textContent = option.text;
+
+                        orderedOptions.push( {
+                            value: option.value,
+                            text: option.text,
+                            selected: true
+                        } );
+                    }
+                })
+            });
+
+            // Fill in rest of the options
+            Object.values(options).map( option => {
+                const included = orderedOptions.filter( orderedOption => orderedOption.value === option.value ).length;
+                if ( ! included ) {
+                    orderedOptions.push( {
+                        value: option.value,
+                        text: option.textContent,
+                        selected: option.selected,
+                    } );
+                }
+            } );
+
+            // Rebuild the dropdown
+            GiveMultiSelectOptions.rebuildDropDown(dropdown, orderedOptions);
+
+            $(this).trigger('chosen:updated')
+        },
 
         rebuildDropDown: function(dropdown, options) {
             dropdown.innerHTML = '';
@@ -3044,7 +3045,7 @@ const gravatar = require( 'gravatar' );
                 newOption.value = option.value;
                 newOption.textContent = option.text;
                 if ( option.selected ) {
-                    newOption.setAttribute('selected', true);
+                    newOption.setAttribute('selected', 'true');
                 }
                 dropdown.add(newOption)
             } );

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -356,6 +356,7 @@ function give_chosen_input( $field ) {
 				name="<?php echo $fieldName; ?>"
 				id="<?php echo esc_attr( $field['id'] ); ?>"
 			<?php echo "{$type} {$allow_new_values} {$placeholder}"; ?>
+            <?php echo give_get_attribute_str( $field ); ?>
 		>
 			<?php
 			foreach ( $choices as $key => $name ) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/give-funds/issues/112

When merging this PR, the https://github.com/impress-org/give-funds/pull/114 should be merged also.

## Description

This PR adds support for admins to rearrange the order of funds on the Edit Form screen.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/154315031-c5927f04-733c-4a65-8a82-be58e850009d.png)

## Affects

`multiselect` field type

## Testing Instructions
In order to test this, you should be on the [feature/reorder-funds-112](https://github.com/impress-org/give-funds/tree/feature/reorder-funds-112) branch for Funds add-on.

1. Add 3 or more funds
2. Add a donation form
3. Navigate to the `Fund Options` tab and select `Donor's choice`
4. Select all funds in reverse order, or whatever order you like, and hit `Save`
5. The order of the selected funds should be persistent
6. Now preview the Donation Form on the frontend and check the order of funds in the dropdown.
7. The order should match the order on the `Edit Form` screen

With these changes, title prefixes are affected, and they should be tested as well.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

