### PR TITLE
Fix: prevent fatal error when goal set to empty string or null

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -647,7 +647,7 @@ class Give_Donate_Form {
 			}
 		}
 
-		return apply_filters( 'give_get_set_goal', $this->goal, $this->ID );
+		return apply_filters( 'give_get_set_goal', $this->goal ?: 0, $this->ID );
 
 	}
 

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -623,6 +623,7 @@ class Give_Donate_Form {
 	 * Retrieve the goal
 	 *
 	 * @since  1.0
+     * @unreleased Set default goal value to zero to prevent fatal error on PHP8.0.
 	 * @access public
 	 *
 	 * @return float  Goal.

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1255,7 +1255,7 @@ function give_admin_form_goal_stats( $form_id ) {
 
 	$html             = '';
 	$goal_stats       = give_goal_progress_stats( $form_id );
-	$percent_complete = round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100;
+	$percent_complete = $goal_stats['raw_goal'] ? round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100 : 0;
 
 	$html .= sprintf(
 		'<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1245,6 +1245,8 @@ function give_set_form_closed_status( $form_id ) {
 /**
  * Show Form Goal Stats in Admin ( Listing and Detail page )
  *
+ * @unreleased Prevent divide by zero issue in goal percentage calculation logic.
+ *
  * @param int $form_id Form ID.
  *
  * @since 2.1.0

--- a/tests/unit/legacy/tests-donate-form-class.php
+++ b/tests/unit/legacy/tests-donate-form-class.php
@@ -100,7 +100,7 @@ class Tests_Donate_Form_Class extends Give_Unit_Test_Case {
 	 */
 	public function test_get_goal() {
 		$simple_form = new Give_Donate_Form( $this->_simple_form->ID );
-		$this->assertEquals( '', $simple_form->get_goal() );
+		$this->assertEquals( 0, $simple_form->get_goal() );
 		give_update_meta( $simple_form->ID, '_give_set_goal', give_sanitize_amount_for_db( 5000 ) );
 
 		// Enable Goal.


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6044

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Although it is not possible to enable a goal without a non-zero goal if somehow that happens then the admin should be able to edit the goal set on the donation form screen to fix the issue. I update the default goal amount to `0`.
This pull request also fixes divided by zero issue in `give_admin_form_goal_stats` function. 

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
|You should not be able to reproduce the issue when following the [steps given in the issue](https://github.com/impress-org/givewp/issues/6044#issuecomment-1041898391).

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

