### PR TITLE
Fix: Translation strings are now using the same textdomain across all files

### DIFF
--- a/src/DonationSummary/resources/views/summary.php
+++ b/src/DonationSummary/resources/views/summary.php
@@ -18,13 +18,13 @@
             <thead>
             <tr>
                 <th><?php
-                    _e('Donation Summary', 'givewp'); ?></th>
+                    _e('Donation Summary', 'give'); ?></th>
                 <th>
                     <?php
                     if ($this->isMultiStep()): ?>
                         <button type="button" class="back-btn" onclick="GiveDonationSummary.handleNavigateBack(event)">
                             <?php
-                            _e('Edit Donation', 'givewp'); ?>
+                            _e('Edit Donation', 'give'); ?>
                             <?php
                             include plugin_dir_path(__DIR__) . 'images/pencil.svg'; ?>
                         </button>
@@ -40,7 +40,7 @@
             <tr>
                 <td>
                     <div><?php
-                        _e('Payment Amount', 'givewp'); ?></div>
+                        _e('Payment Amount', 'give'); ?></div>
                 </td>
                 <td data-tag="amount"></td>
             </tr>
@@ -50,7 +50,7 @@
             <tr>
                 <td>
                     <div><?php
-                        _e('Giving Frequency', 'givewp'); ?></div>
+                        _e('Giving Frequency', 'give'); ?></div>
                     <?php
                     if ($this->isRecurringEnabled()): ?>
                         <span class="give-donation-summary-help-text js-give-donation-summary-frequency-help-text">


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6247

## Description

This PR resolves the issue where some files were using an incorrect text domain (`givewp`) for translation strings. The issue is resolved by using the correct text domain - `give`.

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

