### PR TITLE
Fix: do not show free add-on as unlicensed on system info page

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -5,6 +5,7 @@
 
 use Give\Framework\Migrations\MigrationsRunner;
 use Give\Helpers\Table;
+use Give\License\PremiumAddonsListManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -794,18 +795,29 @@ $give_updates = Give_Updates::get_instance();
 			<td><?php echo wp_kses( $plugin_name, wp_kses_allowed_html( 'post' ) ); ?></td>
 			<td class="help">&nbsp;</td>
 			<td>
-				<?php
-				if ( isset( $plugin_data['License'] ) && true === $plugin_data['License'] ) {
-					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark> ' . __( 'Licensed', 'give' );
-				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-no-alt"></span></mark> ' . __( 'Unlicensed', 'give' );
-				}
+                <?php
+                if (!give(PremiumAddonsListManager::class)->isPremiumAddons($plugin_data['PluginURI'])) {
+                    echo '<mark class="error"><span class="dashicons dashicons-heart"></span></mark> ' . __(
+                            'Free addon',
+                            'give'
+                        );
+                } elseif (isset($plugin_data['License']) && true === $plugin_data['License']) {
+                    echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark> ' . __(
+                            'Licensed',
+                            'give'
+                        );
+                } else {
+                    echo '<mark class="error"><span class="dashicons dashicons-no-alt"></span></mark> ' . __(
+                            'Unlicensed',
+                            'give'
+                        );
+                }
 
-				echo ' &ndash; '
-					 . sprintf( _x( 'by %s', 'by author', 'give' ), wp_kses( $author_name, wp_kses_allowed_html( 'post' ) ) )
-					 . ' &ndash; '
-					 . esc_html( $plugin_data['Version'] );
-				?>
+                echo ' &ndash; '
+                    . sprintf(_x('by %s', 'by author', 'give'), wp_kses($author_name, wp_kses_allowed_html('post')))
+                    . ' &ndash; '
+                    . esc_html($plugin_data['Version']);
+                ?>
 			</td>
 		</tr>
 		<?php


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6256 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I fixed `Active GiveWP Add-ons` listing logic. Free addon mark as ` Free addon` in listing.

![GiveWP Tools ‹ GiveWP Playground — WordPress 2022-02-23 at 4 39 19 PM](https://user-images.githubusercontent.com/1784821/155308081-344a0f30-783d-4522-ae41-5afeb2e80bbf.jpg)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] Install free plugin https://wordpress.org/plugins/give-pixel-tracking/
- [ ] Review `Active GiveWP Add-ons` on system info page `Donations -> Tools -> System Info`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

