### PR TITLE
Refactor: simplify human readable date logic to prevent php warnings

### DIFF
--- a/src/DonationForms/Endpoints/ListForms.php
+++ b/src/DonationForms/Endpoints/ListForms.php
@@ -87,7 +87,7 @@ class ListForms extends Endpoint
                 'donations' => give()->donationFormsRepository->getFormDonationsCount($form->id),
                 'amount'    => $this->getFormAmount($form),
                 'revenue'   => $this->formatAmount($form->revenue),
-                'datetime'  => $this->getDateTime($form->createdAt, $form->createdAtGmt),
+                'datetime'  => $this->getDateTime($form->createdAt),
                 'shortcode' => sprintf('[give_form id="%d"]', $form->id),
                 'permalink' => html_entity_decode(get_permalink($form->id)),
                 'edit'      => html_entity_decode(get_edit_post_link($form->id))
@@ -140,41 +140,27 @@ class ListForms extends Endpoint
     }
 
     /**
-     * @param  string  $date
+     * @param  string  $date Date in mysql format.
      *
      * @return string
      */
-    private function getDateTime($date, $dateGmt = false)
+    private function getDateTime($date)
     {
-        if((int)$dateGmt)
-        {
-            $timezone = get_option('timezone_string');
-            $timezone = $timezone ?: get_option('gmt_offset');
-            if($timezone = timezone_open($timezone))
-            {
-                $date  = date_create($dateGmt, $timezone);
-            }
-            else
-            {
-                $date  = date_create($date);
-            }
-        }
-        else
-        {
-            $date  = date_create($date);
-        }
-        $timestamp = $date->getTimestamp();
-        $time      = date_i18n(get_option('time_format'), $timestamp);
+        $dateTimestamp = strtotime( $date );
+        $currentTimestamp  = current_time('timestamp' );
+        $todayTimestamp  = strtotime( 'today', $currentTimestamp );
+        $yesterdayTimestamp  = strtotime( 'yesterday', $currentTimestamp );
+        $time      = date_i18n(get_option('time_format'), $dateTimestamp);
 
-        if ($timestamp >= strtotime('today')) {
+        if ($dateTimestamp >= $todayTimestamp) {
             return __('Today', 'give') . ' ' . __('at', 'give') . ' ' . $time;
         }
 
-        if ($timestamp >= strtotime('yesterday')) {
+        if ( $dateTimestamp < $todayTimestamp && $dateTimestamp >= $yesterdayTimestamp) {
             return __('Yesterday', 'give') . ' ' . __('at', 'give') . ' ' . $time;
         }
 
-        return date_i18n(get_option('date_format'), $timestamp);
+        return date_i18n(get_option('date_format'), $dateTimestamp);
     }
 
     /**

--- a/src/DonationForms/Endpoints/ListForms.php
+++ b/src/DonationForms/Endpoints/ListForms.php
@@ -148,18 +148,27 @@ class ListForms extends Endpoint
      */
     private function getDateTime($date)
     {
-        $dateTimestamp = strtotime( $date );
-        $currentTimestamp  = current_time('timestamp' );
-        $todayTimestamp  = strtotime( 'today', $currentTimestamp );
-        $yesterdayTimestamp  = strtotime( 'yesterday', $currentTimestamp );
-        $time      = date_i18n(get_option('time_format'), $dateTimestamp);
+        $dateTimestamp = strtotime($date);
+        $currentTimestamp = current_time('timestamp');
+        $todayTimestamp = strtotime('today', $currentTimestamp);
+        $yesterdayTimestamp = strtotime('yesterday', $currentTimestamp);
 
         if ($dateTimestamp >= $todayTimestamp) {
-            return __('Today', 'give') . ' ' . __('at', 'give') . ' ' . $time;
+            return sprintf(
+                '%1$s %2$s %3$s',
+                esc_html__('Today', 'give'),
+                esc_html__('at', 'give'),
+                date_i18n(get_option('time_format'), $dateTimestamp)
+            );
         }
 
-        if ( $dateTimestamp < $todayTimestamp && $dateTimestamp >= $yesterdayTimestamp) {
-            return __('Yesterday', 'give') . ' ' . __('at', 'give') . ' ' . $time;
+        if ($dateTimestamp < $todayTimestamp && $dateTimestamp >= $yesterdayTimestamp) {
+            return sprintf(
+                '%1$s %2$s %3$s',
+                esc_html__('Yesterday', 'give'),
+                esc_html__('at', 'give'),
+                date_i18n(get_option('time_format'), $dateTimestamp)
+            );
         }
 
         return date_i18n(get_option('date_format'), $dateTimestamp);

--- a/src/DonationForms/Endpoints/ListForms.php
+++ b/src/DonationForms/Endpoints/ListForms.php
@@ -140,6 +140,8 @@ class ListForms extends Endpoint
     }
 
     /**
+     * Returns human readable date.
+     *
      * @param  string  $date Date in mysql format.
      *
      * @return string


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
On local site I was getting PHP warnings:
```
[23-Feb-2022 11:42:10 UTC] PHP Warning:  timezone_open(): Unknown or bad timezone (0) in /Users/ravinderkumar/ValetSites/givewp/wp-content/plugins/give/src/DonationForms/Endpoints/ListForms.php on line 153
[23-Feb-2022 11:42:10 UTC] PHP Stack trace:
[23-Feb-2022 11:42:10 UTC] PHP   1. {main}() /Users/ravinderkumar/.composer/vendor/laravel/valet/server.php:0
[23-Feb-2022 11:42:10 UTC] PHP   2. require() /Users/ravinderkumar/.composer/vendor/laravel/valet/server.php:234
[23-Feb-2022 11:42:10 UTC] PHP   3. require() /Users/ravinderkumar/ValetSites/givewp/index.php:17
[23-Feb-2022 11:42:10 UTC] PHP   4. wp($query_vars = *uninitialized*) /Users/ravinderkumar/ValetSites/givewp/wp-blog-header.php:16
[23-Feb-2022 11:42:10 UTC] PHP   5. WP->main($query_args = '') /Users/ravinderkumar/ValetSites/givewp/wp-includes/functions.php:1310
[23-Feb-2022 11:42:10 UTC] PHP   6. WP->parse_request($extra_query_vars = '') /Users/ravinderkumar/ValetSites/givewp/wp-includes/class-wp.php:758
[23-Feb-2022 11:42:10 UTC] PHP   7. do_action_ref_array($hook_name = 'parse_request', $args = [0 => class WP { public $public_query_vars = [...]; public $private_query_vars = [...]; public $extra_query_vars = [...]; public $query_vars = [...]; public $query_string = NULL; public $request = 'wp-json/give-api/v2/admin/forms'; public $matched_rule = '^wp-json/(.*)?'; public $matched_query = 'rest_route=/give-api%2Fv2%2Fadmin%2Fforms'; public $did_permalink = FALSE }]) /Users/ravinderkumar/ValetSites/givewp/wp-includes/class-wp.php:396
[23-Feb-2022 11:42:10 UTC] PHP   8. WP_Hook->do_action($args = [0 => class WP { public $public_query_vars = [...]; public $private_query_vars = [...]; public $extra_query_vars = [...]; public $query_vars = [...]; public $query_string = NULL; public $request = 'wp-json/give-api/v2/admin/forms'; public $matched_rule = '^wp-json/(.*)?'; public $matched_query = 'rest_route=/give-api%2Fv2%2Fadmin%2Fforms'; public $did_permalink = FALSE }]) /Users/ravinderkumar/ValetSites/givewp/wp-includes/plugin.php:522
[23-Feb-2022 11:42:10 UTC] PHP   9. WP_Hook->apply_filters($value = '', $args = [0 => class WP { public $public_query_vars = [...]; public $private_query_vars = [...]; public $extra_query_vars = [...]; public $query_vars = [...]; public $query_string = NULL; public $request = 'wp-json/give-api/v2/admin/forms'; public $matched_rule = '^wp-json/(.*)?'; public $matched_query = 'rest_route=/give-api%2Fv2%2Fadmin%2Fforms'; public $did_permalink = FALSE }]) /Users/ravinderkumar/ValetSites/givewp/wp-includes/class-wp-hook.php:331
[23-Feb-2022 11:42:10 UTC] PHP  10. rest_api_loaded(class WP { public $public_query_vars = [0 => 'm', 1 => 'p', 2 => 'posts', 3 => 'w', 4 => 'cat', 5 => 'withcomments', 6 => 'withoutcomments', 7 => 's', 8 => 'search', 9 => 'exact', 10 => 'sentence', 11 => 'calendar', 12 => 'page', 13 => 'paged', 14 => 'more', 15 => 'tb', 16 => 'pb', 17 => 'author', 18 => 'order', 19 => 'orderby', 20 => 'year', 21 => 'monthnum', 22 => 'day', 23 => 'hour', 24 => 'minute', 25 => 'second', 26 => 'name', 27 => 'category_name', 28 => 'tag', 29 => 'feed', 30 => 'author_name', 31 => 'pagename', 32 => 'page_id', 33 => 'error', 34 => 'attachment', 35 => 'attachment_id', 36 => 'subpost', 37 => 'subpost_id', 38 => 'preview', 39 => 'robots', 40 => 'favicon', 41 => 'taxonomy', 42 => 'term', 43 => 'cpage', 44 => 'post_type', 45 => 'embed', 46 => 'post_format', 47 => 'give_forms', 48 => 'rest_route', 49 => 'sitemap', 50 => 'sitemap-subtype', 51 => 'sitemap-stylesheet', 52 => 'give-api', 53 => 'token', 54 => 'key', 55 => 'query', 56 => 'type', 57 => 'form', 58 => 'number', 59 => 'date', 60 => 'startdate', 61 => 'enddate', 62 => 'donor', 63 => 'format', 64 => 'id', 65 => 'purchasekey', 66 => 'email', 67 => 'give-embed', 68 => 'give-generate-donor-dashboard-page', 69 => 'give-generated-donor-dashboard-page', 70 => 'give_form_id', 71 => 'url_prefix', 72 => 'file']; public $private_query_vars = [0 => 'offset', 1 => 'posts_per_page', 2 => 'posts_per_archive_page', 3 => 'showposts', 4 => 'nopaging', 5 => 'post_type', 6 => 'post_status', 7 => 'category__in', 8 => 'category__not_in', 9 => 'category__and', 10 => 'tag__in', 11 => 'tag__not_in', 12 => 'tag__and', 13 => 'tag_slug__in', 14 => 'tag_slug__and', 15 => 'tag_id', 16 => 'post_mime_type', 17 => 'perm', 18 => 'comments_per_page', 19 => 'post__in', 20 => 'post__not_in', 21 => 'post_parent', 22 => 'post_parent__in', 23 => 'post_parent__not_in', 24 => 'title', 25 => 'fields']; public $extra_query_vars = []; public $query_vars = ['search' => '', 'page' => '1', 'rest_route' => '/give-api/v2/admin/forms']; public $query_string = NULL; public $request = 'wp-json/give-api/v2/admin/forms'; public $matched_rule = '^wp-json/(.*)?'; public $matched_query = 'rest_route=/give-api%2Fv2%2Fadmin%2Fforms'; public $did_permalink = FALSE }) /Users/ravinderkumar/ValetSites/givewp/wp-includes/class-wp-hook.php:307
[23-Feb-2022 11:42:10 UTC] PHP  11. WP_REST_Server->serve_request($path = '/give-api/v2/admin/forms') /Users/ravinderkumar/ValetSites/givewp/wp-includes/rest-api.php:386
[23-Feb-2022 11:42:10 UTC] PHP  12. WP_REST_Server->dispatch($request = class WP_REST_Request { protected $method = 'GET'; protected $params = ['URL' => [...], 'GET' => [...], 'POST' => [...], 'FILES' => [...], 'JSON' => NULL, 'defaults' => [...]]; protected $headers = ['cookie' => [...], 'accept_language' => [...], 'accept_encoding' => [...], 'referer' => [...], 'sec_fetch_dest' => [...], 'sec_fetch_mode' => [...], 'sec_fetch_site' => [...], 'sec_gpc' => [...], 'accept' => [...], 'content_type' => [...], 'user_agent' => [...], 'x_wp_nonce' => [...], 'host' => [...], 'content_length' => [...]]; protected $body = ''; protected $route = '/give-api/v2/admin/forms'; protected $attributes = ['methods' => [...], 'accept_json' => FALSE, 'accept_raw' => FALSE, 'show_in_index' => TRUE, 'args' => [...], 'callback' => [...], 'permission_callback' => [...]]; protected $parsed_json = TRUE; protected $parsed_body = FALSE }) /Users/ravinderkumar/ValetSites/givewp/wp-includes/rest-api/class-wp-rest-server.php:414
[23-Feb-2022 11:42:10 UTC] PHP  13. WP_REST_Server->respond_to_request($request = class WP_REST_Request { protected $method = 'GET'; protected $params = ['URL' => [...], 'GET' => [...], 'POST' => [...], 'FILES' => [...], 'JSON' => NULL, 'defaults' => [...]]; protected $headers = ['cookie' => [...], 'accept_language' => [...], 'accept_encoding' => [...], 'referer' => [...], 'sec_fetch_dest' => [...], 'sec_fetch_mode' => [...], 'sec_fetch_site' => [...], 'sec_gpc' => [...], 'accept' => [...], 'content_type' => [...], 'user_agent' => [...], 'x_wp_nonce' => [...], 'host' => [...], 'content_length' => [...]]; protected $body = ''; protected $route = '/give-api/v2/admin/forms'; protected $attributes = ['methods' => [...], 'accept_json' => FALSE, 'accept_raw' => FALSE, 'show_in_index' => TRUE, 'args' => [...], 'callback' => [...], 'permission_callback' => [...]]; protected $parsed_json = TRUE; protected $parsed_body = FALSE }, $route = '/give-api/v2/admin/forms', $handler = ['methods' => ['GET' => TRUE], 'accept_json' => FALSE, 'accept_raw' => FALSE, 'show_in_index' => TRUE, 'args' => ['page' => [...], 'perPage' => [...], 'status' => [...], 'search' => [...]], 'callback' => [0 => class Give\DonationForms\Endpoints\ListForms { ... }, 1 => 'handleRequest'], 'permission_callback' => [0 => class Give\DonationForms\Endpoints\ListForms { ... }, 1 => 'permissionsCheck']], $response = NULL) /Users/ravinderkumar/ValetSites/givewp/wp-includes/rest-api/class-wp-rest-server.php:988
[23-Feb-2022 11:42:10 UTC] PHP  14. Give\DonationForms\Endpoints\ListForms->handleRequest($request = class WP_REST_Request { protected $method = 'GET'; protected $params = ['URL' => [...], 'GET' => [...], 'POST' => [...], 'FILES' => [...], 'JSON' => NULL, 'defaults' => [...]]; protected $headers = ['cookie' => [...], 'accept_language' => [...], 'accept_encoding' => [...], 'referer' => [...], 'sec_fetch_dest' => [...], 'sec_fetch_mode' => [...], 'sec_fetch_site' => [...], 'sec_gpc' => [...], 'accept' => [...], 'content_type' => [...], 'user_agent' => [...], 'x_wp_nonce' => [...], 'host' => [...], 'content_length' => [...]]; protected $body = ''; protected $route = '/give-api/v2/admin/forms'; protected $attributes = ['methods' => [...], 'accept_json' => FALSE, 'accept_raw' => FALSE, 'show_in_index' => TRUE, 'args' => [...], 'callback' => [...], 'permission_callback' => [...]]; protected $parsed_json = TRUE; protected $parsed_body = FALSE }) /Users/ravinderkumar/ValetSites/givewp/wp-includes/rest-api/class-wp-rest-server.php:1141
[23-Feb-2022 11:42:10 UTC] PHP  15. Give\DonationForms\Endpoints\ListForms->getDateTime($date = '2022-02-09 07:14:43', $dateGmt = '2022-02-09 07:14:43') /Users/ravinderkumar/ValetSites/givewp/wp-content/plugins/give/src/DonationForms/Endpoints/ListForms.php:90
[23-Feb-2022 11:42:10 UTC] PHP  16. timezone_open($timezone = '0') /Users/ravinderkumar/ValetSites/givewp/wp-content/plugins/give/src/DonationForms/Endpoints/ListForms.php:153

```


To fix the issue, I simplify human-readable date logic. The second param has been removed from `getDateTime` function.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] You should not see PHP warnings in `debug.log` on the form listing page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

