### PR TITLE
Fix: Dismiss Free Addon modal on plain permalinks

### DIFF
--- a/src/Promotions/FreeAddonModal/Controllers/EnqueueModal.php
+++ b/src/Promotions/FreeAddonModal/Controllers/EnqueueModal.php
@@ -21,6 +21,8 @@ class EnqueueModal
         return [
             'siteUrl' => site_url(),
             'siteName' => get_bloginfo('name'),
+            'apiRoot' => esc_url_raw(rest_url('/give/v1/promotions/free-addon-modal/complete')),
+            'nonce' => wp_create_nonce('wp_rest'),
         ];
     }
 }

--- a/src/Promotions/sharedResources/hooks/useFreeAddonSubscription.js
+++ b/src/Promotions/sharedResources/hooks/useFreeAddonSubscription.js
@@ -8,13 +8,13 @@ import {useState, useCallback} from 'react';
  * @returns {boolean} Whether the request was successful.
  */
 async function markSubscriptionComplete(reason) {
-    const response = await fetch('/wp-json/give/v1/promotions/free-addon-modal/complete', {
+    const response = await fetch(giveFreeAddonModal.apiRoot, {
         method: 'POST',
         credentials: 'same-origin',
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json',
-            'X-WP-Nonce': wpApiSettings.nonce,
+            'X-WP-Nonce': giveFreeAddonModal.nonce,
         },
         body: JSON.stringify({reason}),
     });


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6259 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
When using plain permalink structure, the Free Addon modal would have to be dismissed every time a user opened an admin page. This was happening because the API request that fires after the modal is dismissed was not being sent to the correct URL. The `wpApiSettings`  global only exists when permalinks are not plain, so this PR sets a nonce and API URL whenever the modal would show and fetches based on that.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
N/A

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Go to the admin area
2. Go to Settings -> Permalinks
3. Set the permalink setting to 'Plain Permalinks' and update the settings
4. Install GiveWP
5. If you haven't already dismissed the Free Addon modal, it will show up on any admin page
6. If you have dismissed it, you can make it display again by going to the `wp_options` table in your database (using a tool like PHPMyAdmin or Adminer) and deleting the `give_free_addon_modal_displayed` option.
7. Scroll to the bottom of the Free Addon modal and click "No thanks!"
8. Refresh the page
9. Notice the modal still displays, even though it should be hidden after dismissing it.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [X] Acceptance criteria satisfied and marked in related issue
-   [X] Relevant `@unreleased` tags included in DocBlocks
-   [X] Includes unit and/or end-to-end tests
-   [X] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

