### PR TITLE
Fix: Payment Amount section is now reflecting the Donation amount when the amount changes

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -47,6 +47,7 @@ domIsReady(() => {
     moveTestModeMessage();
     IS_CURRENCY_SWITCHING_ACTIVE && moveCurrencySwitcherMessageOutsideOfWrapper();
     addFancyBorderWhenChecked();
+    updateDonationSummaryAmountOnChange();
 });
 
 /**
@@ -290,6 +291,13 @@ function updateRecurringDonationFrequency() {
 function updateDonationSummaryAmount() {
     document.querySelector('[data-tag="amount"]').innerHTML = document.querySelector('#give-amount').value;
 }
+
+function updateDonationSummaryAmountOnChange() {
+    document.querySelector('#give-amount').addEventListener('change', function(e){
+        document.querySelector('[data-tag="amount"]').innerHTML = GiveDonationSummary.format_amount(e.target.value, jQuery('.give-form'));
+    } );
+}
+
 
 function attachFeeEvents() {
     const coverFeesCheckbox = document.querySelector('.give_fee_mode_checkbox');

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -47,7 +47,7 @@ domIsReady(() => {
     moveTestModeMessage();
     IS_CURRENCY_SWITCHING_ACTIVE && moveCurrencySwitcherMessageOutsideOfWrapper();
     addFancyBorderWhenChecked();
-    updateDonationSummaryAmountOnChange();
+    IS_DONATION_SUMMARY_ACTIVE && updateDonationSummaryAmountOnChange();
 });
 
 /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6263

## Description

This PR resolves the issue where the Payment Amount section was not updated when the donor manually changes the donation amount. The issue is resolved by adding an event listener to update the Payment Amount section when manually entering a donation amount.

## Affects
Classic Template - Donation summary

## Testing Instructions

1. Create a Donation form that uses the Classic template
2. View Donation form on front-end
3. Manually change the donation amount

The Payment Amount section should display the correct donation amount.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

