### PR TITLE
feature: Check visibility before validating required.

### DIFF
--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Actions;
+
+use ArrayObject;
+use Give\Framework\FieldsAPI\Conditions\BasicCondition;
+use Give\Framework\FieldsAPI\Conditions\Condition;
+use Give\Framework\FieldsAPI\Field;
+use Give\ValueObjects\Money;
+
+/**
+ * @unreleased
+ */
+class DetermineVisibilityForRequest
+{
+    /** @var bool */
+    const IS_VISIBLE = true;
+
+    /** @var Field */
+    private $field;
+
+    /** @var ArrayObject */
+    protected $postData;
+
+    /**
+     * @unreleased
+     * @param Field $field
+     * @param array $postData
+     */
+    public function __construct(Field $field, array $postData )
+    {
+        $this->field = $field;
+        $this->postData = new ArrayObject( $postData );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __invoke()
+    {
+        if( ! $this->fieldHasVisibilityConditions() ) {
+            return self::IS_VISIBLE;
+        }
+
+        $conditions = $this->field->getVisibilityConditions();
+        return array_reduce( $conditions, [$this, 'reduceVisibility'], self::IS_VISIBLE );
+    }
+
+    protected function fieldHasVisibilityConditions()
+    {
+        return method_exists( $this->field, 'hasVisibilityConditions' )
+            && $this->field->hasVisibilityConditions();
+    }
+
+    protected function reduceVisibility( $visibility, Condition $condition )
+    {
+        $result = $this->compareConditionWithOperator( $condition );
+
+        return 'and' === $condition->boolean
+            ? $visibility && $result
+            : $visibility || $result;
+    }
+
+    protected function compareConditionWithOperator( Condition $condition )
+    {
+        if( is_a( $condition, BasicCondition::class ) ) {
+            return $this->compareBasicConditionWithOperator( $condition );
+        }
+
+        // @TODO Implement nested conditions.
+        return self::IS_VISIBLE;
+    }
+
+    protected function compareBasicConditionWithOperator( BasicCondition $condition )
+    {
+        $conditionValue = $condition->value;
+        $comparisonValue = $this->postData[ $condition->field ];
+
+        if( 'give-amount' === $condition->field ) {
+            $conditionValue = $this->normalizeMinorAmount( $conditionValue );
+            $comparisonValue = $this->normalizeMinorAmount( $comparisonValue );
+        }
+
+        switch( $condition->operator ) {
+            case '=':
+                return $comparisonValue === $conditionValue;
+            case '!=':
+                return $comparisonValue !== $conditionValue;
+            case '>':
+                return $comparisonValue > $conditionValue;
+            case '>=':
+                return $comparisonValue >= $conditionValue;
+            case '<':
+                return $comparisonValue < $conditionValue;
+            case '<=':
+                return $comparisonValue <= $conditionValue;
+        }
+    }
+
+    /**
+     * @param $amount
+     * @return int
+     */
+    protected function normalizeMinorAmount( $amount )
+    {
+        $currency = give_get_currency($this->postData[ 'give-form-id' ]);
+        $allCurrencyData = give_get_currencies('all');
+        $currencyData = $allCurrencyData[ $currency ];
+
+        $amount = str_replace( $currencyData['setting']['thousands_separator'], '', $amount );
+        $amount = str_replace( $currencyData['setting']['decimal_separator'], '.', $amount );
+
+        return Money::of( $amount, $currency )->getMinorAmount();
+    }
+}

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -127,11 +127,10 @@ class DetermineVisibilityForRequest
     protected function normalizeMinorAmount($amount)
     {
         $currency = give_get_currency($this->postData['give-form-id']);
-        $allCurrencyData = give_get_currencies('all');
-        $currencyData = $allCurrencyData[$currency];
+        $settings = give_get_currencies('all')[$currency]['setting'];
 
         $amount = str_replace(
-            [$currencyData['setting']['thousands_separator'], $currencyData['setting']['decimal_separator']],
+            [$settings['thousands_separator'], $settings['decimal_separator']],
             ['', '.'],
             $amount
         );

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -130,8 +130,11 @@ class DetermineVisibilityForRequest
         $allCurrencyData = give_get_currencies('all');
         $currencyData = $allCurrencyData[$currency];
 
-        $amount = str_replace($currencyData['setting']['thousands_separator'], '', $amount);
-        $amount = str_replace($currencyData['setting']['decimal_separator'], '.', $amount);
+        $amount = str_replace(
+            [$currencyData['setting']['thousands_separator'], $currencyData['setting']['decimal_separator']],
+            ['', '.'],
+            $amount
+        );
 
         return Money::of($amount, $currency)->getMinorAmount();
     }

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -46,12 +46,22 @@ class DetermineVisibilityForRequest
         return array_reduce( $conditions, [$this, 'reduceVisibility'], self::IS_VISIBLE );
     }
 
+    /**
+     * @unreleased
+     * @return bool
+     */
     protected function fieldHasVisibilityConditions()
     {
         return method_exists( $this->field, 'hasVisibilityConditions' )
             && $this->field->hasVisibilityConditions();
     }
 
+    /**
+     * @unreleased
+     * @param bool $visibility
+     * @param Condition $condition
+     * @return bool
+     */
     protected function reduceVisibility( $visibility, Condition $condition )
     {
         $result = $this->compareConditionWithOperator( $condition );
@@ -61,6 +71,11 @@ class DetermineVisibilityForRequest
             : $visibility || $result;
     }
 
+    /**
+     * @unreleased
+     * @param Condition $condition
+     * @return bool
+     */
     protected function compareConditionWithOperator( Condition $condition )
     {
         if( is_a( $condition, BasicCondition::class ) ) {
@@ -71,6 +86,11 @@ class DetermineVisibilityForRequest
         return self::IS_VISIBLE;
     }
 
+    /**
+     * @unreleased
+     * @param BasicCondition $condition
+     * @return bool
+     */
     protected function compareBasicConditionWithOperator( BasicCondition $condition )
     {
         $conditionValue = $condition->value;
@@ -100,6 +120,7 @@ class DetermineVisibilityForRequest
     }
 
     /**
+     * @unreleased
      * @param $amount
      * @return int
      */

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -27,10 +27,10 @@ class DetermineVisibilityForRequest
      * @param Field $field
      * @param array $postData
      */
-    public function __construct(Field $field, array $postData )
+    public function __construct(Field $field, array $postData)
     {
         $this->field = $field;
-        $this->postData = new ArrayObject( $postData );
+        $this->postData = new ArrayObject($postData);
     }
 
     /**
@@ -38,12 +38,12 @@ class DetermineVisibilityForRequest
      */
     public function __invoke()
     {
-        if( ! $this->fieldHasVisibilityConditions() ) {
+        if (!$this->fieldHasVisibilityConditions()) {
             return self::IS_VISIBLE;
         }
 
         $conditions = $this->field->getVisibilityConditions();
-        return array_reduce( $conditions, [$this, 'reduceVisibility'], self::IS_VISIBLE );
+        return array_reduce($conditions, [$this, 'reduceVisibility'], self::IS_VISIBLE);
     }
 
     /**
@@ -52,7 +52,7 @@ class DetermineVisibilityForRequest
      */
     protected function fieldHasVisibilityConditions()
     {
-        return method_exists( $this->field, 'hasVisibilityConditions' )
+        return method_exists($this->field, 'hasVisibilityConditions')
             && $this->field->hasVisibilityConditions();
     }
 
@@ -62,9 +62,9 @@ class DetermineVisibilityForRequest
      * @param Condition $condition
      * @return bool
      */
-    protected function reduceVisibility( $visibility, Condition $condition )
+    protected function reduceVisibility($visibility, Condition $condition)
     {
-        $result = $this->compareConditionWithOperator( $condition );
+        $result = $this->compareConditionWithOperator($condition);
 
         return 'and' === $condition->boolean
             ? $visibility && $result
@@ -76,10 +76,10 @@ class DetermineVisibilityForRequest
      * @param Condition $condition
      * @return bool
      */
-    protected function compareConditionWithOperator( Condition $condition )
+    protected function compareConditionWithOperator(Condition $condition)
     {
-        if( is_a( $condition, BasicCondition::class ) ) {
-            return $this->compareBasicConditionWithOperator( $condition );
+        if (is_a($condition, BasicCondition::class)) {
+            return $this->compareBasicConditionWithOperator($condition);
         }
 
         // @TODO Implement nested conditions.
@@ -91,17 +91,17 @@ class DetermineVisibilityForRequest
      * @param BasicCondition $condition
      * @return bool
      */
-    protected function compareBasicConditionWithOperator( BasicCondition $condition )
+    protected function compareBasicConditionWithOperator(BasicCondition $condition)
     {
         $conditionValue = $condition->value;
-        $comparisonValue = $this->postData[ $condition->field ];
+        $comparisonValue = $this->postData[$condition->field];
 
-        if( 'give-amount' === $condition->field ) {
-            $conditionValue = $this->normalizeMinorAmount( $conditionValue );
-            $comparisonValue = $this->normalizeMinorAmount( $comparisonValue );
+        if ('give-amount' === $condition->field) {
+            $conditionValue = $this->normalizeMinorAmount($conditionValue);
+            $comparisonValue = $this->normalizeMinorAmount($comparisonValue);
         }
 
-        switch( $condition->operator ) {
+        switch ($condition->operator) {
             case '=':
                 return $comparisonValue === $conditionValue;
             case '!=':
@@ -124,15 +124,15 @@ class DetermineVisibilityForRequest
      * @param $amount
      * @return int
      */
-    protected function normalizeMinorAmount( $amount )
+    protected function normalizeMinorAmount($amount)
     {
-        $currency = give_get_currency($this->postData[ 'give-form-id' ]);
+        $currency = give_get_currency($this->postData['give-form-id']);
         $allCurrencyData = give_get_currencies('all');
-        $currencyData = $allCurrencyData[ $currency ];
+        $currencyData = $allCurrencyData[$currency];
 
-        $amount = str_replace( $currencyData['setting']['thousands_separator'], '', $amount );
-        $amount = str_replace( $currencyData['setting']['decimal_separator'], '.', $amount );
+        $amount = str_replace($currencyData['setting']['thousands_separator'], '', $amount);
+        $amount = str_replace($currencyData['setting']['decimal_separator'], '.', $amount);
 
-        return Money::of( $amount, $currency )->getMinorAmount();
+        return Money::of($amount, $currency)->getMinorAmount();
     }
 }

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -94,6 +94,8 @@ class DetermineVisibilityForRequest
                 return $comparisonValue < $conditionValue;
             case '<=':
                 return $comparisonValue <= $conditionValue;
+            default:
+                return false;
         }
     }
 

--- a/tests/unit/tests/Form/LegacyConsumer/Actions/DetermineVisibilityForRequestTest.php
+++ b/tests/unit/tests/Form/LegacyConsumer/Actions/DetermineVisibilityForRequestTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Give\Form\LegacyConsumer\Actions\DetermineVisibilityForRequest;
+use Give\Framework\FieldsAPI\Text;
+
+final class DetermineVisibilityForRequestTest extends Give_Unit_Test_Case
+{
+    public function testItDeterminesAFieldIsVisibleComparedToString()
+    {
+        $form = Give_Helper_Form::create_simple_form();
+        $requestData = new ArrayObject([
+            'give-form-id' => $form->ID,
+            'give-amount' => '10.00',
+            'my_field' => 'test',
+            'my_other_field' => 'test'
+        ]);
+
+        $field = new Text( 'my_field' );
+        $field->showIf('my_other_field', '=', 'test');
+
+        $action = new DetermineVisibilityForRequest( $field, $requestData );
+
+        $this->assertTrue( $action->__invoke() );
+    }
+
+    public function testItDeterminesAFieldIsNotVisibleComparedToString()
+    {
+        $form = Give_Helper_Form::create_simple_form();
+        $requestData = new ArrayObject([
+            'give-form-id' => $form->ID,
+            'give-amount' => '10.00',
+            'my_field' => 'test',
+            'my_other_field' => 'nottest'
+        ]);
+
+        $field = new Text( 'my_field' );
+        $field->showIf('my_other_field', '<', 'test');
+
+        $action = new DetermineVisibilityForRequest( $field, $requestData );
+
+        $this->assertFalse( $action->__invoke() );
+    }
+
+    public function testItDeterminesAFieldIsVisibleComparedToGiveAmount()
+    {
+        $form = Give_Helper_Form::create_simple_form();
+        $requestData = new ArrayObject([
+            'give-form-id' => $form->ID,
+            'give-amount' => '10.00',
+            'my_field' => 'test',
+        ]);
+
+        $field = new Text( 'my_field' );
+        $field->showIf('give-amount', '>=', '100');
+
+        $action = new DetermineVisibilityForRequest( $field, $requestData );
+
+        $this->assertTrue( $action->__invoke() );
+    }
+
+    public function testItDeterminesAFieldIsNotVisibleComparedToGiveAmount()
+    {
+        $form = Give_Helper_Form::create_simple_form();
+        $requestData = new ArrayObject([
+            'give-form-id' => $form->ID,
+            'give-amount' => '10.00',
+            'my_field' => 'test',
+        ]);
+
+        $field = new Text( 'my_field' );
+        $field->showIf('give-amount', '<', '100');
+
+        $action = new DetermineVisibilityForRequest( $field, $requestData );
+
+        $this->assertFalse( $action->__invoke() );
+    }
+}

--- a/tests/unit/tests/Form/LegacyConsumer/Actions/DetermineVisibilityForRequestTest.php
+++ b/tests/unit/tests/Form/LegacyConsumer/Actions/DetermineVisibilityForRequestTest.php
@@ -8,12 +8,12 @@ final class DetermineVisibilityForRequestTest extends Give_Unit_Test_Case
     public function testItDeterminesAFieldIsVisibleComparedToString()
     {
         $form = Give_Helper_Form::create_simple_form();
-        $requestData = new ArrayObject([
+        $requestData = [
             'give-form-id' => $form->ID,
             'give-amount' => '10.00',
             'my_field' => 'test',
             'my_other_field' => 'test'
-        ]);
+        ];
 
         $field = new Text( 'my_field' );
         $field->showIf('my_other_field', '=', 'test');
@@ -26,15 +26,15 @@ final class DetermineVisibilityForRequestTest extends Give_Unit_Test_Case
     public function testItDeterminesAFieldIsNotVisibleComparedToString()
     {
         $form = Give_Helper_Form::create_simple_form();
-        $requestData = new ArrayObject([
+        $requestData = [
             'give-form-id' => $form->ID,
             'give-amount' => '10.00',
             'my_field' => 'test',
             'my_other_field' => 'nottest'
-        ]);
+        ];
 
         $field = new Text( 'my_field' );
-        $field->showIf('my_other_field', '<', 'test');
+        $field->showIf('my_other_field', '=', 'test');
 
         $action = new DetermineVisibilityForRequest( $field, $requestData );
 
@@ -44,14 +44,14 @@ final class DetermineVisibilityForRequestTest extends Give_Unit_Test_Case
     public function testItDeterminesAFieldIsVisibleComparedToGiveAmount()
     {
         $form = Give_Helper_Form::create_simple_form();
-        $requestData = new ArrayObject([
+        $requestData = [
             'give-form-id' => $form->ID,
             'give-amount' => '10.00',
             'my_field' => 'test',
-        ]);
+        ];
 
         $field = new Text( 'my_field' );
-        $field->showIf('give-amount', '>=', '100');
+        $field->showIf('give-amount', '<', '100');
 
         $action = new DetermineVisibilityForRequest( $field, $requestData );
 
@@ -61,14 +61,14 @@ final class DetermineVisibilityForRequestTest extends Give_Unit_Test_Case
     public function testItDeterminesAFieldIsNotVisibleComparedToGiveAmount()
     {
         $form = Give_Helper_Form::create_simple_form();
-        $requestData = new ArrayObject([
+        $requestData = [
             'give-form-id' => $form->ID,
             'give-amount' => '10.00',
             'my_field' => 'test',
-        ]);
+        ];
 
         $field = new Text( 'my_field' );
-        $field->showIf('give-amount', '<', '100');
+        $field->showIf('give-amount', '>=', '100');
 
         $action = new DetermineVisibilityForRequest( $field, $requestData );
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves impress-org/give-form-field-manager#389

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements a visibility check on fields before validating each field as required. This is in addition to the client-side validation that was previously solely responsible for considering visibility for required validation.

The issue in impress-org/give-form-field-manager#389 manifested as an issue with checkboxes because an unchecked checkbox does not submit with the form.

Additionally, this PR updates the required check to check for empty values. Previously it just checked that the value was seet in the `$_POST` array, but that would allow empty values to pass validation on the server.

## Acceptance Criteria

- [x] Required checkbox **fails** validation if no value is selected and the field is visible.
- [x] Required checkbox **passes** validation if no value is selected and the field is **not** visible.
- [x] Required radio **fails** validation if no value is selected and the field is visible.
- [x] Required radio **passes** validation if no value is selected and the field is **not** visible.
- [x] Required textbox **fails** validation<sup>1</sup> if no value is provided and the field is visible.
- [x] Required textbox **passes** validation if no value is provided and the field is **not** visible.

<sup>1</sup> Previously, required validation for textboxes was only checked by the browser (HTML5 validation), but the server did not validate correctly because an empty value was passed, so the field was not checked (an empty string passes an isset check). This wasn't noticeable before because the HTML5 validation didn't allow the form to submit, but the server side validation is required because HTML5 validation can be bypassed.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

