### PR TITLE
Fix: resolve stalled statement descriptor migration

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Migrations/AddStatementDescriptorToStripeAccounts.php
+++ b/src/PaymentGateways/Gateways/Stripe/Migrations/AddStatementDescriptorToStripeAccounts.php
@@ -29,13 +29,9 @@ class AddStatementDescriptorToStripeAccounts extends Migration
             $statementDescriptor = give_get_option('stripe_statement_descriptor', get_bloginfo('name'));
             foreach ($allStripeAccount as $index => $stripAccount) {
                 if (!isset($stripAccount['statement_descriptor'])) {
-                    $statementDescriptor = trim($statementDescriptor);
-
-                    $unsupportedCharacters = ['<', '>', '"', '\''];
-                    $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
-                    $statementDescriptor = substr($statementDescriptor, 0, 22);
-
-                    $allStripeAccount[$index]['statement_descriptor'] = $statementDescriptor;
+                    $allStripeAccount[$index]['statement_descriptor'] = $this->filterOldStatementDescriptor(
+                        $statementDescriptor
+                    );
                 }
             }
 

--- a/src/PaymentGateways/Gateways/Stripe/Migrations/AddStatementDescriptorToStripeAccounts.php
+++ b/src/PaymentGateways/Gateways/Stripe/Migrations/AddStatementDescriptorToStripeAccounts.php
@@ -31,13 +31,9 @@ class AddStatementDescriptorToStripeAccounts extends Migration
                 if (!isset($stripAccount['statement_descriptor'])) {
                     $statementDescriptor = trim($statementDescriptor);
 
-                    try {
-                        $this->validateStatementDescriptor($statementDescriptor);
-                    } catch (Exception $e) {
-                        $unsupportedCharacters = ['<', '>', '"', '\''];
-                        $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
-                        $statementDescriptor = substr($statementDescriptor, 0, 22);
-                    }
+                    $unsupportedCharacters = ['<', '>', '"', '\''];
+                    $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
+                    $statementDescriptor = substr($statementDescriptor, 0, 22);
 
                     $allStripeAccount[$index]['statement_descriptor'] = $statementDescriptor;
                 }

--- a/src/PaymentGateways/Stripe/Models/AccountDetail.php
+++ b/src/PaymentGateways/Stripe/Models/AccountDetail.php
@@ -157,11 +157,7 @@ class AccountDetail
         $propertyName = 'statement_descriptor';
         if (!array_key_exists($propertyName, $args) || empty($args[$propertyName])) {
             $statementDescriptor = give_get_option('stripe_statement_descriptor', get_bloginfo('name'));
-            $statementDescriptor = trim($statementDescriptor);
-            $unsupportedCharacters = ['<', '>', '"', '\''];
-            $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
-            $statementDescriptor = substr($statementDescriptor, 0, 22);
-            $args[$propertyName] = $statementDescriptor;
+            $args[$propertyName] = $this->filterOldStatementDescriptor($statementDescriptor);
         }
 
         return $args;

--- a/src/PaymentGateways/Stripe/Models/AccountDetail.php
+++ b/src/PaymentGateways/Stripe/Models/AccountDetail.php
@@ -157,13 +157,10 @@ class AccountDetail
         $propertyName = 'statement_descriptor';
         if (!array_key_exists($propertyName, $args) || empty($args[$propertyName])) {
             $statementDescriptor = give_get_option('stripe_statement_descriptor', get_bloginfo('name'));
-            try {
-                $this->validateStatementDescriptor($statementDescriptor);
-            } catch (Exception $e) {
-                $unsupportedCharacters = ['<', '>', '"', '\''];
-                $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
-                $statementDescriptor = substr($statementDescriptor, 0, 22);
-            }
+            $statementDescriptor = trim($statementDescriptor);
+            $unsupportedCharacters = ['<', '>', '"', '\''];
+            $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
+            $statementDescriptor = substr($statementDescriptor, 0, 22);
             $args[$propertyName] = $statementDescriptor;
         }
 

--- a/src/PaymentGateways/Stripe/Traits/HasStripeStatementDescriptorText.php
+++ b/src/PaymentGateways/Stripe/Traits/HasStripeStatementDescriptorText.php
@@ -44,4 +44,21 @@ trait HasStripeStatementDescriptorText
             );
         }
     }
+
+    /**
+     * Return filtered statement descriptor.
+     * This function should be used to filter statement description
+     * which was storing in stripe_statement_descriptor give setting prior to Giver 2.19.
+     *
+     * @param string $text
+     *
+     * @return false|string
+     */
+    protected function filterOldStatementDescriptor($text)
+    {
+        $statementDescriptor = trim($text);
+        $unsupportedCharacters = ['<', '>', '"', '\''];
+        $statementDescriptor = str_replace($unsupportedCharacters, '', $statementDescriptor);
+        return substr($statementDescriptor, 0, 22);
+    }
 }

--- a/src/PaymentGateways/Stripe/Traits/HasStripeStatementDescriptorText.php
+++ b/src/PaymentGateways/Stripe/Traits/HasStripeStatementDescriptorText.php
@@ -50,6 +50,9 @@ trait HasStripeStatementDescriptorText
      * This function should be used to filter statement description
      * which was storing in stripe_statement_descriptor give setting prior to Giver 2.19.
      *
+     * @unreleased
+     * @deprecated
+     *
      * @param string $text
      *
      * @return false|string


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New: Fix:, Changed: or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6270

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This pull request is created to address @kjohnson feedback provided in https://github.com/impress-org/givewp/pull/6269

I find out that we do not need to validate the old statement descriptor instead of that we need to filter it, so I created a function in trait to filter text. I am using old stripe statement descriptor requirements which are backward compatible on stripe. Check filter logic in [`give_stripe_get_statement_descriptor`](https://github.com/impress-org/givewp/pull/6226/files#diff-4e5fad63a0905ce3b8f79970fa6ddc84a16407c5151a035cc4b7e2dd2ccd1444) function.

## Pre-review Checklist

<!-- Complete tasks before requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

