### PR TITLE
New: Query Builder's attachMeta now supports fetching multiple instances of the same meta key

### DIFF
--- a/src/Framework/QueryBuilder/Concerns/GroupByStatement.php
+++ b/src/Framework/QueryBuilder/Concerns/GroupByStatement.php
@@ -20,15 +20,17 @@ trait GroupByStatement
      */
     public function groupBy($tableColumn)
     {
-        $this->groupByColumns[] = DB::prepare( '%1s', $tableColumn);
+        if (!in_array($tableColumn, $this->groupByColumns, true)) {
+            $this->groupByColumns[] = DB::prepare('%1s', $tableColumn);
+        }
 
         return $this;
     }
 
     protected function getGroupBySQL()
     {
-        return ! empty($this->groupByColumns)
-            ? ['GROUP BY ' . implode(',', array_unique($this->groupByColumns))]
+        return !empty($this->groupByColumns)
+            ? ['GROUP BY ' . implode(',', $this->groupByColumns)]
             : [];
     }
 }

--- a/src/Framework/QueryBuilder/Concerns/GroupByStatement.php
+++ b/src/Framework/QueryBuilder/Concerns/GroupByStatement.php
@@ -28,7 +28,7 @@ trait GroupByStatement
     protected function getGroupBySQL()
     {
         return ! empty($this->groupByColumns)
-            ? ['GROUP BY ' . implode(',', $this->groupByColumns)]
+            ? ['GROUP BY ' . implode(',', array_unique($this->groupByColumns))]
             : [];
     }
 }

--- a/src/Framework/QueryBuilder/Concerns/MetaQuery.php
+++ b/src/Framework/QueryBuilder/Concerns/MetaQuery.php
@@ -108,11 +108,15 @@ trait MetaQuery
             // Set dynamic alias
             $tableAlias = sprintf('%s_%s_%d', ($table instanceof RawSQL) ? $table->sql : $table, 'attach_meta', $i);
 
-            $columnName = ($concat)
-                ? "GROUP_CONCAT(DISTINCT {$tableAlias}.{$metaTable->valueColumnName})"
-                : "{$tableAlias}.{$metaTable->valueColumnName}";
-
-            $this->select([$columnName, $columnAlias ?: $column]);
+            if ($concat) {
+                $this->selectRaw(
+                    "CONCAT('[',GROUP_CONCAT(DISTINCT CONCAT('\"',%1s,'\"')),']') AS %2s",
+                    $tableAlias . '.' . $metaTable->valueColumnName,
+                    $columnAlias ?: $column
+                );
+            } else {
+                $this->select(["{$tableAlias}.{$metaTable->valueColumnName}", $columnAlias ?: $column]);
+            }
 
             $this->join(
                 function (JoinQueryBuilder $builder) use ($table, $foreignKey, $primaryKey, $tableAlias, $column, $metaTable) {

--- a/src/Framework/QueryBuilder/Concerns/MetaQuery.php
+++ b/src/Framework/QueryBuilder/Concerns/MetaQuery.php
@@ -29,9 +29,9 @@ trait MetaQuery
     private $defaultMetaValueColumn = 'meta_value';
 
     /**
-     * @param  string|RawSQL  $table
-     * @param  string  $metaKeyColumn
-     * @param  string  $metaValueColumn
+     * @param string|RawSQL $table
+     * @param string $metaKeyColumn
+     * @param string $metaValueColumn
      *
      * @return $this
      */
@@ -47,7 +47,7 @@ trait MetaQuery
     }
 
     /**
-     * @param  string|RawSQL  $table
+     * @param string|RawSQL $table
      *
      * @return MetaTable
      */
@@ -71,27 +71,48 @@ trait MetaQuery
     /**
      * Select meta columns
      *
-     * @param  string|RawSQL  $table
-     * @param  string  $foreignKey
-     * @param  string  $primaryKey
-     * @param  array  $columns
+     * @param string|RawSQL $table
+     * @param string $foreignKey
+     * @param string $primaryKey
+     * @param array $columns
      *
      * @return $this
      */
     public function attachMeta($table, $foreignKey, $primaryKey, ...$columns)
     {
+        $groupConcat = false;
         $metaTable = $this->getMetaTable($table);
 
-        foreach ($columns as $i => $entry) {
-            if (is_array($entry)) {
-                list ($column, $columnAlias) = $entry;
+        // Check if we have meta columns that dev wants to group concat
+        foreach ($columns as $definition) {
+            if (is_array($definition)) {
+                list (, , $concat) = array_pad($definition, 3, false);
+                if ($concat) {
+                    $groupConcat = true;
+                    // Include foreign key so that dev doesn't have to
+                    // he will be confused why he needs this if we don't do it for him, and we also want to prevent errors if sql_mode is only_full_group_by
+                    $this->groupBy($foreignKey);
+                    break;
+                }
+            }
+        }
+
+        foreach ($columns as $i => $definition) {
+            if (is_array($definition)) {
+                list ($column, $columnAlias, $concat) = array_pad($definition, 3, false);
             } else {
-                $column = $entry;
-                $columnAlias = null;
+                $column = $definition;
+                $columnAlias = $concat = false;
             }
 
             // Set dynamic alias
             $tableAlias = sprintf('%s_%s_%d', ($table instanceof RawSQL) ? $table->sql : $table, 'attach_meta', $i);
+
+            $columnName = ($concat)
+                ? "GROUP_CONCAT(DISTINCT {$tableAlias}.{$metaTable->valueColumnName})"
+                : "{$tableAlias}.{$metaTable->valueColumnName}";
+
+            $this->select([$columnName, $columnAlias ?: $column]);
 
             $this->join(
                 function (JoinQueryBuilder $builder) use ($table, $foreignKey, $primaryKey, $tableAlias, $column, $metaTable) {
@@ -102,7 +123,11 @@ trait MetaQuery
                 }
             );
 
-            $this->select(["{$tableAlias}.{$metaTable->valueColumnName}", $columnAlias ? : $column]);
+            // If this is non-aggregate column - we have to include it in the GROUP BY statement
+            // otherwise the query will fail on servers that have sql_mode flag set to only_full_group_by
+            if ($groupConcat && !$concat) {
+                $this->groupBy($columnAlias ?: $column);
+            }
         }
 
         return $this;

--- a/src/Framework/QueryBuilder/README.md
+++ b/src/Framework/QueryBuilder/README.md
@@ -669,7 +669,7 @@ GROUP BY id
 
 Returned result:
 
-Instances with the same key, in this case `additional_email`, will be concatenated and separated by a comma.
+Instances with the same key, in this case `additional_email`, will be concatenated into JSON array string.
 
 ```php
 Array
@@ -679,7 +679,7 @@ Array
             [id] => 1
             [email] => bill@flywheel.local
             [name] => Bill Murray
-            [additionalEmails] => email1@lywheel.local,email2@lywheel.local
+            [additionalEmails] => ["email1@lywheel.local","email2@lywheel.local"]
         )
 
     [1] => stdClass Object
@@ -687,7 +687,7 @@ Array
             [id] => 2
             [email] => jon@flywheel.local
             [name] => Jon Waldstein
-            [additionalEmails] => email3@lywheel.local,email4@lywheel.local,email5@lywheel.local
+            [additionalEmails] => ["email3@lywheel.local","email4@lywheel.local","email5@lywheel.local"]
         )
 
     [2] => stdClass Object

--- a/src/Framework/QueryBuilder/README.md
+++ b/src/Framework/QueryBuilder/README.md
@@ -638,6 +638,69 @@ stdClass Object
 )
 ```
 
+#### Fetch multiple instances of the same meta key
+
+Sometimes we need to fetch multiple instances of the same meta key. This is possible by setting the third parameter to `true`, example `['additional_email', 'additionalEmails', true]`
+
+```php
+DB::table('give_donors')
+  ->select(
+      'id',
+      'email',
+      'name'
+  )
+  ->attachMeta(
+      'give_donormeta',
+      'id',
+      'donor_id',
+  	  ['additional_email', 'additionalEmails', true]
+  );
+
+```
+
+Generated SQL:
+
+```sql
+SELECT id, email, name, GROUP_CONCAT(DISTINCT give_donormeta_attach_meta_0.meta_value) AS additionalEmails
+FROM wp_give_donors
+    LEFT JOIN wp_give_donormeta give_donormeta_attach_meta_0 ON id = give_donormeta_attach_meta_0.donor_id AND give_donormeta_attach_meta_0.meta_key = 'additional_email'
+GROUP BY id
+```
+
+Returned result:
+
+Instances with the same key, in this case `additional_email`, will be concatenated and separated by a comma.
+
+```php
+Array
+(
+    [0] => stdClass Object
+        (
+            [id] => 1
+            [email] => bill@flywheel.local
+            [name] => Bill Murray
+            [additionalEmails] => email1@lywheel.local,email2@lywheel.local
+        )
+
+    [1] => stdClass Object
+        (
+            [id] => 2
+            [email] => jon@flywheel.local
+            [name] => Jon Waldstein
+            [additionalEmails] => email3@lywheel.local,email4@lywheel.local,email5@lywheel.local
+        )
+
+    [2] => stdClass Object
+        (
+            [id] => 3
+            [email] => ante@flywheel.local
+            [name] => Ante laca
+            [additionalEmails] =>
+        )
+
+)
+```
+
 ### configureMetaTable
 
 By default, `QueryBuilder::attachMeta` will use `meta_key`, and `meta_value` as meta table column names, but that sometimes might not be the case.

--- a/tests/unit/tests/Framework/QueryBuilder/AttachMetaTest.php
+++ b/tests/unit/tests/Framework/QueryBuilder/AttachMetaTest.php
@@ -4,8 +4,16 @@ use Give\Framework\Database\DB;
 use Give\Framework\QueryBuilder\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @since 2.19.0
+ *
+ * @covers AttachMeta
+ */
 final class AttachMetaTest extends TestCase
 {
+    /**
+     * @since 2.19.0
+     */
     public function testAttachMeta()
     {
         $builder = new QueryBuilder();
@@ -35,7 +43,36 @@ final class AttachMetaTest extends TestCase
         );
     }
 
+    /**
+     * @unreleased
+     */
+    public function testAttachMetaGroupConcatQuery()
+    {
+        $builder = new QueryBuilder();
 
+        $builder
+            ->from(DB::raw('wp_give_donors'))
+            ->select(
+                'id',
+                'email',
+                'name'
+            )
+            ->attachMeta(
+                DB::raw('wp_give_donormeta'),
+                'id',
+                'donor_id',
+                ['additional_email', 'additionalEmails', true]
+            );
+
+        $this->assertContains(
+            "SELECT id, email, name, GROUP_CONCAT(DISTINCT wp_give_donormeta_attach_meta_0.meta_value) AS additionalEmails FROM wp_give_donors LEFT JOIN wp_give_donormeta wp_give_donormeta_attach_meta_0 ON id = wp_give_donormeta_attach_meta_0.donor_id AND wp_give_donormeta_attach_meta_0.meta_key = 'additional_email' GROUP BY id",
+            $builder->getSQL()
+        );
+    }
+
+    /**
+     * @since 2.19.0
+     */
     public function testConfigureMeta()
     {
         $builder = new QueryBuilder();

--- a/tests/unit/tests/Framework/QueryBuilder/AttachMetaTest.php
+++ b/tests/unit/tests/Framework/QueryBuilder/AttachMetaTest.php
@@ -65,7 +65,7 @@ final class AttachMetaTest extends TestCase
             );
 
         $this->assertContains(
-            "SELECT id, email, name, GROUP_CONCAT(DISTINCT wp_give_donormeta_attach_meta_0.meta_value) AS additionalEmails FROM wp_give_donors LEFT JOIN wp_give_donormeta wp_give_donormeta_attach_meta_0 ON id = wp_give_donormeta_attach_meta_0.donor_id AND wp_give_donormeta_attach_meta_0.meta_key = 'additional_email' GROUP BY id",
+            "SELECT id, email, name, CONCAT('[',GROUP_CONCAT(DISTINCT CONCAT('\"',wp_give_donormeta_attach_meta_0.meta_value,'\"')),']') AS additionalEmails FROM wp_give_donors LEFT JOIN wp_give_donormeta wp_give_donormeta_attach_meta_0 ON id = wp_give_donormeta_attach_meta_0.donor_id AND wp_give_donormeta_attach_meta_0.meta_key = 'additional_email' GROUP BY id",
             $builder->getSQL()
         );
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6272 

## Description

This PR adds additional functionality to the Query Builder's `attachMeta` function. Now is possible to fetch multiple instances of the same meta key using `attachMeta` and by setting the third parameter of the meta column definition to `true`. 
Fetching all instances is accomplished by using the MySQL `GROUP_CONCAT` aggregate function. All instances of the same meta key will be concatenated into JSON array string. For example, `additionalEmails` value would be `["email1","email2","email3"]`

## Testing Instructions

```php
DB::table('give_donors')
  ->select(
      'id',
      ['user_id', 'userId'],
      'email',
      'name',
      ['purchase_value', 'purchaseValue'],
      ['purchase_count', 'purchaseCount'],
      ['payment_ids', 'paymentIds'],
      ['date_created', 'createdAt'],
      'token',
      ['verify_key', 'verifyKey'],
      ['verify_throttle', 'verifyThrottle']
  )
  ->attachMeta(
      'give_donormeta',
      'id',
      'donor_id',
      ['_give_donor_first_name', 'firstName'],
      ['_give_donor_last_name', 'lastName'],
      ['additional_email', 'additionalEmails', true]
  );
```

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

