### PR TITLE
Fix: Migration Runner is not attempting to re-run failed migrations on each page load anymore

### DIFF
--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -132,8 +132,6 @@ class MigrationsRunner
                         ),
                     ]
                 );
-
-                break;
             }
 
             try {
@@ -150,6 +148,11 @@ class MigrationsRunner
 
             // Commit transaction if successful
             $wpdb->query('COMMIT');
+
+            // Stop Migration Runner if migration has failed
+            if ($migrationLog->getStatus() === MigrationLogStatus::FAILED) {
+                break;
+            }
         }
     }
 

--- a/src/Framework/Migrations/MigrationsRunner.php
+++ b/src/Framework/Migrations/MigrationsRunner.php
@@ -146,13 +146,13 @@ class MigrationsRunner
                 );
             }
 
-            // Commit transaction if successful
-            $wpdb->query('COMMIT');
-
             // Stop Migration Runner if migration has failed
             if ($migrationLog->getStatus() === MigrationLogStatus::FAILED) {
                 break;
             }
+
+            // Commit transaction if successful
+            $wpdb->query('COMMIT');
         }
     }
 


### PR DESCRIPTION
Resolves #6274 

## Description
This PR resolves the issue where Migration Runner was attempting to re-run failed migrations on each page load.  

The problem was that we were stoping Migration Runner before we stored information about the failed migration. That information is important because it is used by Migration Runner to determine if there are migrations to run. Since this data was missing, the Migration Runner was attempting to re-run failed migration on each page load. 

## Affects
Migration Runner

## Testing Instructions

1. Download [TestMigrationRunner.zip](https://github.com/impress-org/givewp/files/8159953/TestMigrationRunner.zip) and paste it into `src/` directory. 
2. Add `Give\TestMigrationRunner\ServiceProvider::class` to ServiceProviders list.
3. Navigate to `Tools > Data > Database updates` and check the migrations list - you should now see two new migrations, MigrationOne and MigrationTwo
4. Refresh the page a few times and monitor the `error_log` file. When migration runs, it should add a new row into the `error_log` file.

Migration Runner should stop running migrations if there are failed migrations.

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

