### PR TITLE
fix: get correct donation form stripe account to process donation

### DIFF
--- a/give.php
+++ b/give.php
@@ -5,7 +5,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.19.1
+ * Version: 2.19.2
  * Requires at least: 4.9
  * Requires PHP: 5.6
  * Text Domain: give
@@ -289,7 +289,7 @@ final class Give
     {
         // Plugin version.
         if ( ! defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.19.1');
+            define('GIVE_VERSION', '2.19.2');
         }
 
         // Plugin Root File.

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -415,19 +415,36 @@ function give_stripe_is_zero_decimal_currency() {
  * @since 2.5.0
  * @since 2.19.0 Previously stripe accounts have single global statement descriptor.
  *             Now each stripe account will have their own statement descriptor.
+ * @unreleased give_stripe_get_connected_account_options function returns empty string as account id for stripe account connected with api keys.
+ *             For this return an exception throws. Internal logic update to get donation form stripe account on basis of account type
  *
- * @param array $data List of posted variable while submitting donation.
+ * @param array $donation_data List of posted variable while submitting donation.
  *
  * @return mixed
  * @throws InvalidPropertyName
  */
-function give_stripe_get_statement_descriptor($data = [])
+function give_stripe_get_statement_descriptor($donation_data = [])
 {
+    $form_id = 0;
+
+    if ($donation_data && $donation_data['post_data']['give-form-id']) {
+        $form_id = (int)$donation_data['post_data']['give-form-id'];
+    } elseif (!empty($_POST['give-form-id'])) {
+        $form_id = absint($_POST['give-form-id']);
+    }
+
+    /*
+     * Stripe account connected with api keys does not have account id.
+     * We can use account slug to retrieve account data .
+     */
+    $defaultAccount = give_stripe_get_default_account($form_id);
+    $stripAccountId = $defaultAccount['account_id'] ?: $defaultAccount['account_slug'];
+
     $stripeAccountFormPayment = give(Settings::class)
-        ->getStripeAccountById(give_stripe_get_connected_account_options()['stripe_account']);
+        ->getStripeAccountById($stripAccountId);
     $text = $stripeAccountFormPayment->statementDescriptor;
 
-    return apply_filters('give_stripe_statement_descriptor', $text, $data);
+    return apply_filters('give_stripe_statement_descriptor', $text, $donation_data);
 }
 
 /**

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -415,7 +415,7 @@ function give_stripe_is_zero_decimal_currency() {
  * @since 2.5.0
  * @since 2.19.0 Previously stripe accounts have single global statement descriptor.
  *             Now each stripe account will have their own statement descriptor.
- * @unreleased give_stripe_get_connected_account_options function returns empty string as account id for stripe account connected with api keys.
+ * @since 2.19.2 give_stripe_get_connected_account_options function returns empty string as account id for stripe account connected with api keys.
  *             For this return an exception throws. Internal logic update to get donation form stripe account on basis of account type
  *
  * @param array $donation_data List of posted variable while submitting donation.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 4.9
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 2.19.1
+Stable tag: 2.19.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.19.2: March 2nd, 2022 =
+* Fix: Resolved issue with connecting to Stripe with API Keys
+
 = 2.19.1: February 25th, 2022 =
 * Fix: Added backwards compatibility for Stripe statement descriptors that do not yet meet the new requirements.
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6278

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that `give_stripe_get_connected_account_options()` function return empty string for donation form Stripe account which connected with API keys. [This type of account does not have an account id](https://github.com/impress-org/give-stripe/blob/6da468cbc3885f62d0b7fd4da98071d83933764c/src/Settings/DataTransferObjects/AddStripeAccountApiKeysDto.php#L79). I updated logic to handle this case. If the stripe account does not have an account id then we can use an account slug to get account details.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
The donor should be able to donate with a connected stripe account and stripe API key account.

Testing Give File: [give.zip](https://github.com/impress-org/givewp/files/8172239/give.zip)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

