### PR TITLE
Fix: improve Paypal ipn webhook handling

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
@@ -107,7 +107,7 @@ class CreatePayPalStandardPaymentURL
                 $paymentData->donationId,
                 $paymentData->legacyPaymentData
             ],
-            '' // TODO: add plugin version: @since 2.19.0
+            '2.19.0'
         );
     }
 }

--- a/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
@@ -40,7 +40,7 @@ class CreatePayPalStandardPaymentURL
 
             // Donation information.
             'invoice' => $paymentData->purchaseKey,
-            'amount' => $paymentData->amount,
+            'amount' => $paymentData->price,
             'item_name' => stripslashes($itemName),
             'currency_code' => give_get_currency($paymentData->donationId),
 

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -46,7 +46,7 @@ class PayPalStandardWebhook
         // ipn verification can be disabled in GiveWP (<=2.15.0).
         // This check will prevent anonymous requests from editing donation, if ipn verification disabled.
         if (!$this->verifyDonationId($donationId)) {
-            Log::info(
+            Log::error(
                 'PayPal Standard IPN Error',
                 [
                     'Message' => 'Donation id (from IPN) does not exist.',

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -2,6 +2,7 @@
 
 namespace Give\PaymentGateways\Gateways\PayPalStandard\Controllers;
 
+use Give\Log\Log;
 use Give\PaymentGateways\Gateways\PayPalStandard\PayPalStandard;
 use Give\PaymentGateways\Gateways\PayPalStandard\Webhooks\WebhookRegister;
 use Give\PaymentGateways\Gateways\PayPalStandard\Webhooks\WebhookValidator;
@@ -34,8 +35,8 @@ class PayPalStandardWebhook
         $eventData = file_get_contents('php://input');
         $eventData = wp_parse_args($eventData);
 
-        if ( ! $this->webhookValidator->verifyEventSignature($eventData)) {
-            wp_die('Forbidden', 403);
+        if (!$this->webhookValidator->verifyEventSignature($eventData)) {
+            exit();
         }
 
         $donationId = isset($eventData['custom']) ? absint($eventData['custom']) : 0;
@@ -43,8 +44,15 @@ class PayPalStandardWebhook
 
         // ipn verification can be disabled in GiveWP (<=2.15.0).
         // This check will prevent anonymous requests from editing donation, if ipn verification disabled.
-        if ( ! $this->verifyDonationId($donationId)) {
-            wp_die('Forbidden', 403);
+        if (!$this->verifyDonationId($donationId)) {
+            Log::info(
+                'PayPal Standard IPN Error',
+                [
+                    'Message' => 'Donation id (from IPN) does not exist.',
+                    'Event Data' => $eventData
+                ]
+            );
+            exit();
         }
 
         $this->recordIpn($eventData, $donationId);
@@ -62,10 +70,11 @@ class PayPalStandardWebhook
     }
 
     /**
-     * @param array $eventData
+     * @since 2.19.0
+     *
      * @param int $donationId
      *
-     * @since 2.19.0
+     * @param array $eventData
      */
     private function recordIpn(array $eventData, $donationId)
     {

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -29,6 +29,7 @@ class PayPalStandardWebhook
      * Handle PayPal ipn
      *
      * @since 2.19.0
+     * @unreleased Respond with 200 http status to ipn.
      */
     public function handle()
     {

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -35,7 +35,7 @@ class PayPalStandardWebhook
         $eventData = wp_parse_args($eventData);
 
         if ( ! $this->webhookValidator->verifyEventSignature($eventData)) {
-            wp_die('Forbidden', 404);
+            wp_die('Forbidden', 403);
         }
 
         $donationId = isset($eventData['custom']) ? absint($eventData['custom']) : 0;
@@ -44,7 +44,7 @@ class PayPalStandardWebhook
         // ipn verification can be disabled in GiveWP (<=2.15.0).
         // This check will prevent anonymous requests from editing donation, if ipn verification disabled.
         if ( ! $this->verifyDonationId($donationId)) {
-            wp_die('Forbidden', 404);
+            wp_die('Forbidden', 403);
         }
 
         $this->recordIpn($eventData, $donationId);

--- a/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
@@ -57,7 +57,7 @@ class WebhookValidator
         }
 
         if ('VERIFIED' !== $apiResponse['body']) {
-            Log::error(
+            Log::warning(
                 'PayPal Standard IPN Error',
                 [
                     'Message' => 'This is not a verified IPN.',

--- a/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
@@ -57,7 +57,7 @@ class WebhookValidator
 
         if ('VERIFIED' !== $apiResponse['body']) {
             Log::error(
-                'PayPal Standard IPN Error',
+                'PayPal Standard IPN Verification Error',
                 ['IPN Data' => $apiResponse]
             );
 

--- a/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
@@ -14,6 +14,7 @@ class WebhookValidator
 {
     /**
      * @since 2.19.0
+     * @unreleased Update log message.
      *
      * @param array $eventData PayPal ipn body data.
      *
@@ -57,8 +58,11 @@ class WebhookValidator
 
         if ('VERIFIED' !== $apiResponse['body']) {
             Log::error(
-                'PayPal Standard IPN Verification Error',
-                ['IPN Data' => $apiResponse]
+                'PayPal Standard IPN Error',
+                [
+                    'Message' => 'This is not a verified IPN.',
+                    'IPN Data' => $apiResponse
+                ]
             );
 
             return false;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6280 https://github.com/impress-org/givewp/issues/6281

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I updated the webhook handler to respond with `200` HTTP status to unsuccessful PayPal IPN. I log will be added upon failure. Donors will also be able to donate the amount in thousands.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
Log Entry on PayPal Standard IPN Error:
![GiveWP Tools ‹ GiveWP Playground — WordPress 2022-03-03 at 11 35 57 PM](https://user-images.githubusercontent.com/1784821/156625058-da8c2be9-1fad-4b8e-92e6-dbbf2855d33b.jpg)



## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- Visit `{home-url}/?give-listener=IPN` and `{home-url}/?give-listener=give-gateway&give-gateway-id=paypal&give-gateway-method=handleIpnNotification` in browser.
    - A log will be created because we will be not able to verify IPN.
    - You will respond with `200` HTTP status.
- Send IPN from Paypal Iopn simulator to above URLs
    - A log will be created.
     - You will respond with `200` HTTP status and Paypal will inform you that handshake was successful.

Test GiveWP Zip File: [give.zip](https://github.com/impress-org/givewp/files/8180120/give.zip)

## Pre-review Checklist
<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

