### PR TITLE
Fix: cast bill_times to an integer in subscription class

### DIFF
--- a/give.php
+++ b/give.php
@@ -5,7 +5,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.19.2
+ * Version: 2.19.3
  * Requires at least: 4.9
  * Requires PHP: 5.6
  * Text Domain: give
@@ -289,7 +289,7 @@ final class Give
     {
         // Plugin version.
         if ( ! defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.19.2');
+            define('GIVE_VERSION', '2.19.3');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 4.9
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 2.19.2
+Stable tag: 2.19.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,11 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.19.3: March 4th, 2022 =
+* Fix: PayPal Standard donations above 1000 dollars are now working again
+* Fix: PayPal IPN URL is now working again
+* Fix: Stripe subscriptions with no end were being canceled upon the next renewal when using GiveWP Recurring 1.15.0. This resolves that issue. Please update!
+
 = 2.19.2: March 2nd, 2022 =
 * Fix: Resolved issue with connecting to Stripe with API Keys
 

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -139,7 +139,7 @@ class Give_Subscription {
 	/**
      * Setup the subscription object.
      *
-     * @unreleased - cast bill_times to integer
+     * @since 2.19.3 - cast bill_times to integer
      *
      * @param  int  $id_or_object
      *

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -137,12 +137,14 @@ class Give_Subscription {
 	}
 
 	/**
-	 * Setup the subscription object.
-	 *
-	 * @param int $id_or_object
-	 *
-	 * @return Give_Subscription|bool
-	 */
+     * Setup the subscription object.
+     *
+     * @unreleased - cast bill_times to integer
+     *
+     * @param  int  $id_or_object
+     *
+     * @return Give_Subscription|bool
+     */
 	private function setup_subscription( $id_or_object = 0 ) {
 
 		if ( empty( $id_or_object ) ) {
@@ -163,18 +165,22 @@ class Give_Subscription {
 		}
 
 		foreach ( $sub as $key => $value ) {
+            // Backwards compatibility:
+            // Ensure product_id get sent to new form_id.
+            if ('product_id' === $key) {
+                $this->form_id = $value;
+            }
 
-			// Backwards compatibility:
-			// Ensure product_id get sent to new form_id.
-			if ( 'product_id' === $key ) {
-				$this->form_id = $value;
-			}
-			if ( 'customer_id' === $key ) {
-				$this->donor_id = $value;
-			}
+            if ('customer_id' === $key) {
+                $this->donor_id = $value;
+            }
 
-			$this->$key = $value;
-		}
+            if ('bill_times' === $key) {
+                $value = (int)$value;
+            }
+
+            $this->$key = $value;
+        }
 
 		$this->donor   = new Give_Donor( $this->donor_id );
 		$this->gateway = give_get_payment_gateway( $this->parent_payment_id );

--- a/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Actions/CreatePayPalStandardPaymentURL.php
@@ -40,7 +40,7 @@ class CreatePayPalStandardPaymentURL
 
             // Donation information.
             'invoice' => $paymentData->purchaseKey,
-            'amount' => $paymentData->amount,
+            'amount' => $paymentData->price,
             'item_name' => stripslashes($itemName),
             'currency_code' => give_get_currency($paymentData->donationId),
 
@@ -107,7 +107,7 @@ class CreatePayPalStandardPaymentURL
                 $paymentData->donationId,
                 $paymentData->legacyPaymentData
             ],
-            '' // TODO: add plugin version: @since 2.19.0
+            '2.19.0'
         );
     }
 }

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -2,6 +2,7 @@
 
 namespace Give\PaymentGateways\Gateways\PayPalStandard\Controllers;
 
+use Give\Log\Log;
 use Give\PaymentGateways\Gateways\PayPalStandard\PayPalStandard;
 use Give\PaymentGateways\Gateways\PayPalStandard\Webhooks\WebhookRegister;
 use Give\PaymentGateways\Gateways\PayPalStandard\Webhooks\WebhookValidator;
@@ -28,14 +29,15 @@ class PayPalStandardWebhook
      * Handle PayPal ipn
      *
      * @since 2.19.0
+     * @unreleased Respond with 200 http status to ipn.
      */
     public function handle()
     {
         $eventData = file_get_contents('php://input');
         $eventData = wp_parse_args($eventData);
 
-        if ( ! $this->webhookValidator->verifyEventSignature($eventData)) {
-            wp_die('Forbidden', 404);
+        if (!$this->webhookValidator->verifyEventSignature($eventData)) {
+            exit();
         }
 
         $donationId = isset($eventData['custom']) ? absint($eventData['custom']) : 0;
@@ -43,8 +45,15 @@ class PayPalStandardWebhook
 
         // ipn verification can be disabled in GiveWP (<=2.15.0).
         // This check will prevent anonymous requests from editing donation, if ipn verification disabled.
-        if ( ! $this->verifyDonationId($donationId)) {
-            wp_die('Forbidden', 404);
+        if (!$this->verifyDonationId($donationId)) {
+            Log::error(
+                'PayPal Standard IPN Error',
+                [
+                    'Message' => 'Donation id (from IPN) does not exist.',
+                    'Event Data' => $eventData
+                ]
+            );
+            exit();
         }
 
         $this->recordIpn($eventData, $donationId);
@@ -62,10 +71,11 @@ class PayPalStandardWebhook
     }
 
     /**
-     * @param array $eventData
+     * @since 2.19.0
+     *
      * @param int $donationId
      *
-     * @since 2.19.0
+     * @param array $eventData
      */
     private function recordIpn(array $eventData, $donationId)
     {

--- a/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Controllers/PayPalStandardWebhook.php
@@ -29,7 +29,7 @@ class PayPalStandardWebhook
      * Handle PayPal ipn
      *
      * @since 2.19.0
-     * @unreleased Respond with 200 http status to ipn.
+     * @since 2.19.3 Respond with 200 http status to ipn.
      */
     public function handle()
     {

--- a/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
@@ -14,7 +14,7 @@ class WebhookValidator
 {
     /**
      * @since 2.19.0
-     * @unreleased Update log message.
+     * @since 2.19.3 Update log message.
      *
      * @param array $eventData PayPal ipn body data.
      *

--- a/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Webhooks/WebhookValidator.php
@@ -14,6 +14,7 @@ class WebhookValidator
 {
     /**
      * @since 2.19.0
+     * @unreleased Update log message.
      *
      * @param array $eventData PayPal ipn body data.
      *
@@ -56,9 +57,12 @@ class WebhookValidator
         }
 
         if ('VERIFIED' !== $apiResponse['body']) {
-            Log::error(
+            Log::warning(
                 'PayPal Standard IPN Error',
-                ['IPN Data' => $apiResponse]
+                [
+                    'Message' => 'This is not a verified IPN.',
+                    'IPN Data' => $apiResponse
+                ]
             );
 
             return false;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

When creating the Subscription object, the bill_times column was being assigned as a string from the database.  Throughout the codebase we will typically cast the value to an integer.  There was an edge case where this did not happen and caused a type conditional to return true when it should have returned false - resulting in completing Stripe subscriptions.

To fix this upstream, bill_times will be set as an integer from `setup_subscription()` in `Give_Subscription`

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `Give_Subscription`


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Follow testing steps from this canny report.

https://feedback.givewp.com/bug-reports/p/stripe-renewal-payments-are-cancelling-the-subscription-at-stripe

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

