### PR TITLE
Fix: don't strip table prefixes in Query Builder

### DIFF
--- a/src/DonationForms/resources/components/DonationFormsTable.tsx
+++ b/src/DonationForms/resources/components/DonationFormsTable.tsx
@@ -113,7 +113,7 @@ export default function DonationFormsTable({statusFilter: status, search}: Donat
                     setPage={setPage}
                 />
             </div>
-            {initialLoad ? (
+            {( initialLoad && !error ) ? (
                 <div className={styles.initialLoad}>
                     <div className={cx(styles.tableGroup)}>
                         <Spinner size={'large'} />
@@ -253,7 +253,7 @@ export default function DonationFormsTable({statusFilter: status, search}: Donat
                         {isEmpty && (
                             <div className={styles.statusMessage}>{__('No donation forms found.', 'give')}</div>
                         )}
-                        {error && !isValidating && (
+                        {error && (
                             <>
                                 <div className={styles.statusMessage}>
                                     {__('There was a problem retrieving the donation forms.', 'give')}

--- a/src/DonationForms/resources/components/DonationFormsTableRows.tsx
+++ b/src/DonationForms/resources/components/DonationFormsTableRows.tsx
@@ -60,6 +60,10 @@ export default function DonationFormsTableRows({listParams, mutateForm, status})
         setDeleted([]);
     }
 
+    if(!data?.forms) {
+        return false;
+    }
+
     const trash = data ? data.trash : false;
 
     return data.forms.map((form) => (

--- a/src/Framework/QueryBuilder/Concerns/TablePrefix.php
+++ b/src/Framework/QueryBuilder/Concerns/TablePrefix.php
@@ -28,11 +28,20 @@ trait TablePrefix
             return $table->sql;
         }
 
-        $table = preg_replace(
-            sprintf('/^%s/', preg_quote($wpdb->prefix)),
-            '',
-            $table
-        );
+        $prefixRegex = sprintf('/^%s/', preg_quote($wpdb->prefix));
+        //remove the first instance of the table prefix
+        error_log('prefix: ' . $prefixRegex);
+        error_log('before: ' . $table);
+        if(strpos($table, $prefixRegex) === 0)
+        {
+            $table = preg_replace(
+                $prefixRegex,
+                '',
+                $table,
+                1
+            );
+        }
+        error_log('after: ' . $table);
 
         if (array_key_exists($table, $sharedTables)) {
             return $sharedTables[ $table ];

--- a/src/Framework/QueryBuilder/Concerns/TablePrefix.php
+++ b/src/Framework/QueryBuilder/Concerns/TablePrefix.php
@@ -28,21 +28,6 @@ trait TablePrefix
             return $table->sql;
         }
 
-        $prefixRegex = sprintf('/^%s/', preg_quote($wpdb->prefix));
-        //remove the first instance of the table prefix
-        error_log('prefix: ' . $prefixRegex);
-        error_log('before: ' . $table);
-        if(strpos($table, $prefixRegex) === 0)
-        {
-            $table = preg_replace(
-                $prefixRegex,
-                '',
-                $table,
-                1
-            );
-        }
-        error_log('after: ' . $table);
-
         if (array_key_exists($table, $sharedTables)) {
             return $sharedTables[ $table ];
         }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6282 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
When Give's database is prefixed with give_, the Donation Forms page doesn't load, infinitely displaying the loading message.

After some digging, it appears this was happening because of a Query Builder issue. The call to `attach_meta()` in the Donation Forms repository was stripping all of the instances of the prefix from the table name before prefixing it, so `give_give_formmeta` became `give_formmeta`. After some discussion, it was determined the best solution was to keep Query Builder from stripping the prefix altogether.
 
Before, Query Builder methods would either accept the prefixed or unprefixed table name. After this PR, Query Builder methods will only work with unprefixed table names. The raw SQL methods (i.e. `joinRaw', `selectRaw`) will still use the full prefixed table names.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This will affect any other places where the Give Core version of Query Builder is currently being used.

Since the Donation Forms page was showing the loading spinner/message even after the initial API request failed, I've also tightened up error handling on that page. The `There was a problem retrieving the donation forms` error message now displays if the initial load fails, and will not wait until SWR is done retrying the request to display.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Install GiveWP
2. Change your database prefix for your WP install to `give_`.
**Note**: This plugin allows you to do that very easily from the WP admin: https://wordpress.org/plugins/brozzme-db-prefix-change/
As always, BACK UP! before doing any procedure that deals with your database. (Thanks, @rickalday!)
3. In the admin area, navigate to the Donation Forms page (Donations -> All Forms) and make sure the page displays correctly
4. Change your database prefix to something other than `give_`.
5. Repeat step 3

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [X] Acceptance criteria satisfied and marked in related issue
-   [X] Relevant `@unreleased` tags included in DocBlocks
-   [X] Includes unit and/or end-to-end tests
-   [X] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

