### PR TITLE
New: Query Builder now supports having the % wild card in whereLike* functions

### DIFF
--- a/src/Framework/QueryBuilder/Concerns/WhereClause.php
+++ b/src/Framework/QueryBuilder/Concerns/WhereClause.php
@@ -481,11 +481,13 @@ trait WhereClause
             case Operator::LIKE:
             case Operator::NOTLIKE:
                 return DB::prepare(
-                    "%1s %2s %3s '%%%s%%'",
+                    "%1s %2s %3s %s",
                     $where->logicalOperator,
                     $where->column,
                     $where->comparisonOperator,
-                    DB::esc_like($where->value)
+                    strpos($where->value, '%') !== false
+                        ? $where->value
+                        : sprintf('%%%s%%', $where->value )
                 );
 
             // Handle NULL conditions

--- a/tests/unit/tests/Framework/QueryBuilder/WhereTest.php
+++ b/tests/unit/tests/Framework/QueryBuilder/WhereTest.php
@@ -256,6 +256,37 @@ final class WhereTest extends TestCase
         );
     }
 
+    public function testWhereLikeWithWildCardPositionLeft()
+    {
+        $builder = new QueryBuilder();
+
+        $builder
+            ->select('*')
+            ->from(DB::raw('posts'))
+            ->whereLike('post_title', '%Donation');
+
+        $this->assertContains(
+            "SELECT * FROM posts WHERE post_title LIKE '%Donation'",
+            DB::remove_placeholder_escape($builder->getSQL())
+        );
+    }
+
+
+    public function testWhereLikeWithWildCardPositionRight()
+    {
+        $builder = new QueryBuilder();
+
+        $builder
+            ->select('*')
+            ->from(DB::raw('posts'))
+            ->whereLike('post_title', 'Donation%');
+
+        $this->assertContains(
+            "SELECT * FROM posts WHERE post_title LIKE 'Donation%'",
+            DB::remove_placeholder_escape($builder->getSQL())
+        );
+    }
+
 
     public function testWhereNotLike()
     {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6288

## Description

This PR adds support for having an `%` wild card in the Query Builder's `whereLike*` functions on both sides of the `WHERE` condition value which will help us to write more optimized SQL queries. 

Note: This is not a breaking change and all the previous usages of the `whereLike* `functions are working just fine.  

## Affects

Query Builder's `whereLike*` functions


## Testing Instructions

To have a sense of performance impact with this _small_ change:

1. Generate donors by using WP CLI  
`wp give test-donors --count=1000`
3. Now login to MySQL console  
`mysql -u yourusername -p yourpassword` 
4. Run explain command for unoptimized query  
`explain select meta_key from wp_give_donormeta where meta_key like '%donor%'`
5. Now repeat that for the optimized version  
 `explain select meta_key from wp_give_donormeta where meta_key like 'donor%'`

![Screen Capture_select-area_20220309181757](https://user-images.githubusercontent.com/4222590/157496162-1f108628-31a3-4b2e-8880-7145377702e6.png)

[Clarification of the `rows` column in the screenshot. ](https://dev.mysql.com/doc/refman/8.0/en/explain-output.html#explain_rows)
_The rows column indicates the number of rows MySQL believes it must examine to execute the query._ 

The _unoptimized_ query is doing the full-table scan.
The _optimized_ query has to do much less than the _unoptimized_ query, and it is much more performant than the _unoptimized_ query.

**Edit**: it looks like the test data will set only `_give_donor_first_name` and `_give_donor_last_name` columns for donor. 
To have realistic results, we should update the database to look more _organic_.  In order to do that, we can simply run 
```sql
update wp_give_donormeta set meta_key = 'donor_first_name' where meta_key = '_give_donor_first_name' limit 500;
``` 
and then repeat the steps in testing instructions.

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

