### PR TITLE
Fix: access Paypal Standard logo from correct location

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
@@ -54,6 +54,7 @@ class PayPalStandardBillingFields
      * Return paypal logo.
      *
      * @since 2.19.0
+     * @unreleased Use correct logo path.
      *
      * @return string
      */

--- a/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
@@ -60,7 +60,7 @@ class PayPalStandardBillingFields
     private function getLogo()
     {
         return file_get_contents(
-            GIVE_PLUGIN_DIR . '/src/PaymentGateways/PayPalStandard/resources/templates/paypal-standard-logo.svg'
+            GIVE_PLUGIN_DIR . 'src/PaymentGateways/Gateways/PayPalStandard/resources/templates/paypal-standard-logo.svg'
         );
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6292 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I updated PayPal standard's logo location path to access it correctly. 

![image](https://user-images.githubusercontent.com/1784821/157606259-879e5072-4ea8-4316-a654-dcc24ab1e8e6.png)


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Multi-Step form template's donor information for PayPal Standard payment.  

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You will see PayPal Standard logo in a multi-step form template.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

