### PR TITLE
Fix: set only pending PayPal Standard donation set to processing

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -106,7 +106,10 @@ class PayPalStandard extends PaymentGateway
     {
         $donationId = (int)$queryParams['donation-id'];
         $payment = new Give_Payment($donationId);
-        $payment->update_status('processing');
+
+        if( 'pending' === $payment->status ) {
+            $payment->update_status('processing');
+        }
 
         return new RedirectResponse(Call::invoke(GenerateDonationReceiptPageUrl::class, $donationId));
     }

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -93,6 +93,7 @@ class PayPalStandard extends PaymentGateway
      * Handle payment redirect after successful payment on PayPal standard.
      *
      * @since 2.19.0
+     * @unreleased Only pending PayPal Standard donation set to processing.
      *
      * @param array $queryParams Query params in gateway route. {
      *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6294 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
We noticed a race condition between donor redirect from PayPal Standard and PayPal Ipn cause donation status issue. Because of this completed donations are set to pending. I update the logic to prevent this issue. From now only pending PayPal Standard donations will be set to processing

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
PayPal standard donations will have correct donation status and this race condition will never occur.

[give.zip](https://github.com/impress-org/givewp/files/8221167/give.zip)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

