### PR TITLE
Fix: Make Give admin notices display inline with Donation Forms admin page header

### DIFF
--- a/src/DonationForms/resources/components/AdminDonationFormsPage.module.scss
+++ b/src/DonationForms/resources/components/AdminDonationFormsPage.module.scss
@@ -6,6 +6,10 @@
     padding-block: 1em;
     padding-inline: 1.5em;
     border-bottom: 0.0625rem solid #dbdbdb;
+
+    & > img, & > svg {
+        flex-shrink: 0;
+    }
 }
 
 .pageTitle {

--- a/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
+++ b/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
@@ -38,6 +38,7 @@ export default function AdminDonationFormsPage() {
                 <a href="post-new.php?post_type=give_forms" className={styles.addFormButton}>
                     {__('Add Form', 'give')}
                 </a>
+                <hr className="wp-header-end" style={{display: 'none'}}/>
             </div>
             <div className={styles.searchContainer}>
                 <input

--- a/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
+++ b/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
@@ -32,15 +32,15 @@ export default function AdminDonationFormsPage() {
 
     return (
         <article>
-            <div className={styles.pageHeader}>
+            <header className={styles.pageHeader}>
                 <GiveIcon size={'1.875rem'}/>
                 <h1 className={styles.pageTitle}>{__('Donation Forms', 'give')}</h1>
                 <a href="post-new.php?post_type=give_forms" className={styles.addFormButton}>
                     {__('Add Form', 'give')}
                 </a>
-                <hr className="wp-header-end" style={{display: 'none'}}/>
-            </div>
-            <div className={styles.searchContainer}>
+                <div className={"wp-header-end"} style={{display: 'none'}}/>
+            </header>
+            <section role={"search"} className={styles.searchContainer}>
                 <input
                     type="search"
                     aria-label={__('Search donation forms', 'give')}
@@ -55,7 +55,7 @@ export default function AdminDonationFormsPage() {
                         </option>
                     ))}
                 </select>
-            </div>
+            </section>
             <div className={styles.pageContent}>
                 <DonationFormsTable statusFilter={statusFilter} search={debouncedSearch} />
             </div>

--- a/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
+++ b/src/DonationForms/resources/components/AdminDonationFormsPage.tsx
@@ -38,7 +38,6 @@ export default function AdminDonationFormsPage() {
                 <a href="post-new.php?post_type=give_forms" className={styles.addFormButton}>
                     {__('Add Form', 'give')}
                 </a>
-                <div className={"wp-header-end"} style={{display: 'none'}}/>
             </header>
             <section role={"search"} className={styles.searchContainer}>
                 <input
@@ -56,6 +55,8 @@ export default function AdminDonationFormsPage() {
                     ))}
                 </select>
             </section>
+            <div className={"wp-header-end"} style={{display: 'none'}}>
+            </div>
             <div className={styles.pageContent}>
                 <DonationFormsTable statusFilter={statusFilter} search={debouncedSearch} />
             </div>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
On the Donation Forms admin page, notices were displaying above the contents of the rest of the page, which looked messy. The JS that moves the admin notices places it after the element with the `wp-header-end` class, so I included a hidden element with that class in the header. It seemed cleaner than applying that class to an existing element and negating its styling with CSS.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
N/A

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
Before:
![image](https://user-images.githubusercontent.com/7819986/157746012-43446f05-5dfd-4826-b23b-fa57b5a15df7.png)

After:
![image](https://user-images.githubusercontent.com/7819986/157745932-9aebaa70-744b-4827-8da7-d4d5cfc38169.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Install GiveWP
2. Navigate to the donation forms page (Donations -> All Forms)
3. If there are Give notices visible, verify that they display in the header consistently with other Give admin pages
4. If there are no Give notices visible, you can trigger one by installing Gift Aid and setting the currency to something other than "Pounds Sterling (£)" in Donations -> Settings -> General -> Currency (as seen above)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [X] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [X] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

