### PR TITLE
Refactor: use generics for the ModelQueryBuilder

### DIFF
--- a/src/Donations/Models/Donation.php
+++ b/src/Donations/Models/Donation.php
@@ -149,7 +149,7 @@ class Donation extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donor>
      */
     public function donor()
     {
@@ -159,7 +159,7 @@ class Donation extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Subscription>
      */
     public function subscription()
     {
@@ -203,7 +203,7 @@ class Donation extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donation>
      */
     public static function query()
     {

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -459,14 +459,13 @@ class DonationRepository
     }
 
     /**
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donation>
      */
     public function prepareQuery()
     {
-        $builder = new ModelQueryBuilder();
+        $builder = new ModelQueryBuilder(Donation::class);
 
         return $builder->from('posts')
-            ->setModel(Donation::class)
             ->select(
                 ['ID', 'id'],
                 ['post_date', 'createdAt'],

--- a/src/Donors/Models/Donor.php
+++ b/src/Donors/Models/Donor.php
@@ -138,7 +138,7 @@ class Donor extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donation>
      */
     public function donations()
     {
@@ -148,7 +148,7 @@ class Donor extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Subscription>
      */
     public function subscriptions()
     {
@@ -178,7 +178,7 @@ class Donor extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donor>
      */
     public static function query()
     {

--- a/src/Donors/Repositories/DonorRepository.php
+++ b/src/Donors/Repositories/DonorRepository.php
@@ -346,14 +346,13 @@ class DonorRepository
     }
 
     /**
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donor>
      */
     public function prepareQuery()
     {
-        $builder = new ModelQueryBuilder();
+        $builder = new ModelQueryBuilder(Donor::class);
 
         return $builder->from('give_donors')
-            ->setModel(Donor::class)
             ->select(
                 'id',
                 ['user_id', 'userId'],

--- a/src/Framework/Models/Contracts/ModelCrud.php
+++ b/src/Framework/Models/Contracts/ModelCrud.php
@@ -3,7 +3,7 @@
 namespace Give\Framework\Models\Contracts;
 
 use Give\Framework\Models\Model;
-use Give\Framework\QueryBuilder\QueryBuilder;
+use Give\Framework\Models\ModelQueryBuilder;
 
 /**
  * @unreleased
@@ -43,7 +43,7 @@ interface ModelCrud
     /**
      * @unreleased
      *
-     * @return QueryBuilder
+     * @return ModelQueryBuilder
      */
     public static function query();
 

--- a/src/Framework/Models/ModelQueryBuilder.php
+++ b/src/Framework/Models/ModelQueryBuilder.php
@@ -2,44 +2,51 @@
 
 namespace Give\Framework\Models;
 
-use Give\Donations\Models\Donation;
-use Give\Donors\Models\Donor;
 use Give\Framework\Database\DB;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\Models\Contracts\ModelCrud;
 use Give\Framework\QueryBuilder\QueryBuilder;
-use Give\Subscriptions\Models\Subscription;
 
 /**
  * @unreleased
+ *
+ * @template M
  */
 class ModelQueryBuilder extends QueryBuilder
 {
     /**
-     * @var string
+     * @var class-string<M>
      */
     protected $model;
+
+    /**
+     * @param class-string<M> $modelClass
+     */
+    public function __construct($modelClass)
+    {
+        if (!is_subclass_of($modelClass, Model::class)) {
+            throw new InvalidArgumentException("$modelClass must be an instance of " . Model::class);
+        }
+
+        $this->model = $modelClass;
+    }
 
     /**
      * Get row
      *
      * @unreleased
      *
-     * @return object|Model|Donation|Donor|Subscription|null
+     * @return M|null
      */
     public function get($output = OBJECT)
     {
         $row = DB::get_row($this->getSQL(), OBJECT);
 
-        if (!$row){
+        if (!$row) {
             return null;
         }
 
-        if (isset($this->model)) {
-            return $this->getRowAsModel($row);
-        }
-
-        return $row;
+        return $this->getRowAsModel($row);
     }
 
     /**
@@ -47,7 +54,7 @@ class ModelQueryBuilder extends QueryBuilder
      *
      * @unreleased
      *
-     * @return array|Donation[]|Donor[]|Model[]|Subscription[]|object|null
+     * @return M[]|null
      */
     public function getAll($output = OBJECT)
     {
@@ -64,15 +71,14 @@ class ModelQueryBuilder extends QueryBuilder
         return $results;
     }
 
-
     /**
      * Get row as model
      *
      * @unreleased
      *
-     * @param  object|null  $row
+     * @param object|null $row
      *
-     * @return Model|Donation|Subscription|Donor|null
+     * @return M|null
      */
     protected function getRowAsModel($row)
     {
@@ -85,15 +91,14 @@ class ModelQueryBuilder extends QueryBuilder
         return $model::fromQueryBuilderObject($row);
     }
 
-
     /**
      * Get results as models
      *
      * @unreleased
      *
-     * @param  object[]  $results
+     * @param object[] $results
      *
-     * @return Model[]|Donation[]|Subscription[]|Donor[]|null
+     * @return M[]|null
      */
     protected function getAllAsModel($results)
     {
@@ -107,22 +112,5 @@ class ModelQueryBuilder extends QueryBuilder
         return array_map(static function ($object) use ($model) {
             return $model::fromQueryBuilderObject($object);
         }, $results);
-    }
-
-     /**
-     * Set the model to be used for returning formatted query
-     *
-     * @param  string  $model
-     * @return $this
-     */
-    public function setModel($model)
-    {
-        if (!is_subclass_of($model, Model::class)) {
-            throw new InvalidArgumentException("$model must be an instance of " . Model::class);
-        }
-
-        $this->model = $model;
-
-        return $this;
     }
 }

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -81,7 +81,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donor>
      */
     public function donor()
     {
@@ -91,7 +91,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Donation>
      */
     public function donations()
     {
@@ -147,7 +147,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Subscription>
      */
     public static function query()
     {

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -317,14 +317,13 @@ class SubscriptionRepository
     /**
      * @unreleased
      *
-     * @return ModelQueryBuilder
+     * @return ModelQueryBuilder<Subscription>
      */
     public function prepareQuery()
     {
-        $builder = new ModelQueryBuilder();
+        $builder = new ModelQueryBuilder(Subscription::class);
 
         return $builder->from('give_subscriptions')
-            ->setModel(Subscription::class)
             ->select(
                 ['id', 'id'],
                 ['created', 'createdAt'],

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -325,17 +325,17 @@ class SubscriptionRepository
 
         return $builder->from('give_subscriptions')
             ->select(
-                ['id', 'id'],
+                'id',
                 ['created', 'createdAt'],
                 ['expiration', 'expiresAt'],
                 ['customer_id', 'donorId'],
-                ['period', 'period'],
+                'period',
                 ['frequency', 'frequency'],
                 ['bill_times', 'installments'],
                 ['transaction_id', 'transactionId'],
                 ['recurring_amount', 'amount'],
                 ['recurring_fee_amount', 'feeAmount'],
-                ['status', 'status'],
+                'status',
                 ['profile_id', 'gatewaySubscriptionId'],
                 ['product_id', 'donationFormId']
             );


### PR DESCRIPTION
## Description

The existing `ModelQueryBuilder` required a return union type with every single type of Model, which then meant the IDE would autocomplete _every_ method and property for a given model, as it didn't know which one it is.

Using generics, we can inform the instance which Model class it represents. PHP doesn't actually have generics, but PhpStorm recently added support for inferring generics from docblocks. As you can see, this cleans things up quite a bit.

As a note, the `prepareQuery` return type is needed, for example `@return ModelQueryBuilder<Donation>`. The reason is PhpStorm doesn't _yet_ support [inferring the type from the `class-string<>` parameter](https://youtrack.jetbrains.com/issue/WI-65811).

## Affects

Existing model repositories

## Testing Instructions

Just make the repositories still work and that autocomplete works better in PhpStorm.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

