### PR TITLE
Feature: add traits for stripe api requests

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Exceptions/StripeApiRequestException.php
+++ b/src/PaymentGateways/Gateways/Stripe/Exceptions/StripeApiRequestException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Exceptions;
+
+use Give\Framework\Exceptions\Primitives\Exception;
+
+/**
+ * @unreleased
+ */
+class StripeApiRequestException extends Exception
+{
+
+}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
@@ -16,11 +16,12 @@ trait CreateCharge
      * @unreleased
      *
      * @param array $stripeChargeRequestArgs
+     * @param array $options
      *
      * @return Charge
      * @throws StripeApiRequestException
      */
-    public function createCharge($stripeChargeRequestArgs)
+    public function createCharge($stripeChargeRequestArgs, $options = [])
     {
         give_stripe_set_app_info();
 
@@ -34,7 +35,10 @@ trait CreateCharge
 
             return Charge::create(
                 $stripeChargeRequestArgs,
-                give_stripe_get_connected_account_options()
+                wp_parse_args(
+                    $options,
+                    give_stripe_get_connected_account_options()
+                )
             );
         } catch (Exception $e) {
             throw new StripeApiRequestException(

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
@@ -2,8 +2,9 @@
 
 namespace Give\PaymentGateways\Gateways\Stripe\Traits\StripeApi;
 
+use Exception;
+use Give\PaymentGateways\Gateways\Stripe\Exceptions\StripeApiRequestException;
 use Give\PaymentGateways\Stripe\ApplicationFee;
-use GiveStripe\PaymentMethods\Exceptions\StripeApiException;
 use Stripe\Charge;
 
 /**
@@ -17,17 +18,15 @@ trait CreateCharge
      * @param array $stripeChargeRequestArgs
      *
      * @return Charge
-     * @throws StripeApiException
+     * @throws StripeApiRequestException
      */
     public function createCharge($donationId, $stripeChargeRequestArgs)
     {
-        // Set App Info to Stripe.
         give_stripe_set_app_info();
 
         try {
             // Charge application fee, only if the Stripe premium add-on is not active.
             if (ApplicationFee::canAddfee()) {
-                // Set Application Fee Amount.
                 $stripeChargeRequestArgs['application_fee_amount'] = give_stripe_get_application_fee_amount(
                     $stripeChargeRequestArgs['amount']
                 );
@@ -37,12 +36,12 @@ trait CreateCharge
                 $stripeChargeRequestArgs,
                 give_stripe_get_connected_account_options()
             );
-        } catch (\Exception $e) {
-            throw new StripeApiException(
+        } catch (Exception $e) {
+            throw new StripeApiRequestException(
                 sprintf(
-                /* translators: %s Exception Error Message */
-                    __('Unable to create a successful charge. Details: %s', 'give'),
-                    $e
+                /* translators: 1: Exception Error Message */
+                    esc_html__('Unable to create a successful charge. Details: %1$s', 'give'),
+                    $e->getMessage()
                 )
             );
         }

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Traits\StripeApi;
+
+use Give\PaymentGateways\Stripe\ApplicationFee;
+use GiveStripe\PaymentMethods\Exceptions\StripeApiException;
+use Stripe\Charge;
+
+/**
+ * @unreleased
+ */
+trait CreateCharge
+{
+    /**
+     * @unreleased
+     *
+     * @param array $stripeChargeRequestArgs
+     *
+     * @return Charge
+     * @throws StripeApiException
+     */
+    public function createCharge($donationId, $stripeChargeRequestArgs)
+    {
+        // Set App Info to Stripe.
+        give_stripe_set_app_info();
+
+        try {
+            // Charge application fee, only if the Stripe premium add-on is not active.
+            if (ApplicationFee::canAddfee()) {
+                // Set Application Fee Amount.
+                $stripeChargeRequestArgs['application_fee_amount'] = give_stripe_get_application_fee_amount(
+                    $stripeChargeRequestArgs['amount']
+                );
+            }
+
+            return Charge::create(
+                $stripeChargeRequestArgs,
+                give_stripe_get_connected_account_options()
+            );
+        } catch (\Exception $e) {
+            throw new StripeApiException(
+                sprintf(
+                /* translators: %s Exception Error Message */
+                    __('Unable to create a successful charge. Details: %s', 'give'),
+                    $e
+                )
+            );
+        }
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateCharge.php
@@ -20,7 +20,7 @@ trait CreateCharge
      * @return Charge
      * @throws StripeApiRequestException
      */
-    public function createCharge($donationId, $stripeChargeRequestArgs)
+    public function createCharge($stripeChargeRequestArgs)
     {
         give_stripe_set_app_info();
 

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Traits\StripeApi;
+
+use Exception;
+use Give\PaymentGateways\Gateways\Stripe\Exceptions\StripeApiRequestException;
+use Give\PaymentGateways\Stripe\ApplicationFee;
+use Stripe\Source;
+
+/**
+ * @unreleased
+ */
+class CreateSource
+{
+    /**
+     * @unreleased
+     *
+     * @param array $stripeSourceRequestArgs
+     * @param int $formId
+     *
+     * @return Source
+     * @throws StripeApiRequestException
+     */
+    public function createCharge($stripeSourceRequestArgs, $formId = 0)
+    {
+        give_stripe_set_app_info($formId);
+
+        try {
+            // Charge application fee, only if the Stripe premium add-on is not active.
+            if (ApplicationFee::canAddfee()) {
+                $stripeSourceRequestArgs['application_fee_amount'] = give_stripe_get_application_fee_amount(
+                    $stripeSourceRequestArgs['amount']
+                );
+            }
+
+            return Source::create(
+                $stripeSourceRequestArgs,
+                give_stripe_get_connected_account_options()
+            );
+        } catch (Exception $e) {
+            throw new StripeApiRequestException(
+                sprintf(
+                /* translators: 1: Exception Error Message */
+                    esc_html__('Unable to create a successful source. Details: %1$s', 'give'),
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
@@ -10,7 +10,7 @@ use Stripe\Source;
 /**
  * @unreleased
  */
-class CreateSource
+trait CreateSource
 {
     /**
      * @unreleased

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
@@ -16,14 +16,13 @@ class CreateSource
      * @unreleased
      *
      * @param array $stripeSourceRequestArgs
-     * @param int $formId
      *
      * @return Source
      * @throws StripeApiRequestException
      */
-    public function createCharge($stripeSourceRequestArgs, $formId = 0)
+    public function createCharge($stripeSourceRequestArgs)
     {
-        give_stripe_set_app_info($formId);
+        give_stripe_set_app_info();
 
         try {
             // Charge application fee, only if the Stripe premium add-on is not active.

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
@@ -21,7 +21,7 @@ trait CreateSource
      * @return Source
      * @throws StripeApiRequestException
      */
-    public function createCharge($stripeSourceRequestArgs, $options = [])
+    public function createSource($stripeSourceRequestArgs, $options = [])
     {
         give_stripe_set_app_info();
 

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/CreateSource.php
@@ -16,11 +16,12 @@ class CreateSource
      * @unreleased
      *
      * @param array $stripeSourceRequestArgs
+     * @param array $options
      *
      * @return Source
      * @throws StripeApiRequestException
      */
-    public function createCharge($stripeSourceRequestArgs)
+    public function createCharge($stripeSourceRequestArgs, $options = [])
     {
         give_stripe_set_app_info();
 
@@ -34,7 +35,10 @@ class CreateSource
 
             return Source::create(
                 $stripeSourceRequestArgs,
-                give_stripe_get_connected_account_options()
+                wp_parse_args(
+                    $options,
+                    give_stripe_get_connected_account_options()
+                )
             );
         } catch (Exception $e) {
             throw new StripeApiRequestException(

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveSource.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveSource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Traits\StripeApi;
+
+use Exception;
+use Give\PaymentGateways\Gateways\Stripe\Exceptions\StripeApiRequestException;
+use Stripe\Source;
+
+/**
+ * @unreleased
+ */
+trait RetrieveSource
+{
+    /**
+     * @unreleased
+     * @return Source
+     * @throws StripeApiRequestException
+     */
+    public function getSourceDetails($sourceId, $options = [])
+    {
+        // Set Application Info.
+        give_stripe_set_app_info();
+
+        try {
+            // Retrieve Source Object.
+            return Source::retrieve(
+                $sourceId,
+                wp_parse_args(
+                    $options,
+                    give_stripe_get_connected_account_options()
+                )
+            );
+        } catch (Exception $e) {
+            // Something went wrong outside of Stripe.
+            throw new StripeApiRequestException(
+                sprintf(
+                /* translators: %s Exception Message Body */
+                    esc_html__('Unable to retrieve source. Details: %s', 'give'),
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Traits\StripeApi;
+
+use Exception;
+use Give\PaymentGateways\Gateways\Stripe\Exceptions\StripeApiRequestException;
+use Stripe\Token as StripeToken;
+
+/**
+ * @unreleased
+ */
+trait RetrieveToken
+{
+    /**
+     * This function will be used to fetch token details for given stripe token id.
+     *
+     * @unreleased
+     *
+     * @param array $args Additional arguments.
+     * @param string $tokenId Stripe Token ID.
+     *
+     * @return array
+     * @throws StripeApiRequestException
+     */
+    protected function getTokenDetails($tokenId, $args = [])
+    {
+        // Set Application Info.
+        give_stripe_set_app_info();
+
+        try {
+            $requestArgs = wp_parse_args(
+                $args,
+                give_stripe_get_connected_account_options()
+            );
+
+            // Retrieve Token Object.
+            return StripeToken::retrieve($tokenId, $requestArgs)
+                ->toArray();
+        } catch (Exception $e) {
+            throw new StripeApiRequestException(
+                sprintf(
+                /* translators: %s Exception Message Body */
+                    __('Unable to retrieve token. Details: %s', 'give'),
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
@@ -24,7 +24,6 @@ trait RetrieveToken
      */
     protected function getTokenDetails($tokenId, $args = [])
     {
-        // Set Application Info.
         give_stripe_set_app_info();
 
         try {
@@ -33,14 +32,13 @@ trait RetrieveToken
                 give_stripe_get_connected_account_options()
             );
 
-            // Retrieve Token Object.
             return StripeToken::retrieve($tokenId, $requestArgs)
                 ->toArray();
         } catch (Exception $e) {
             throw new StripeApiRequestException(
                 sprintf(
-                /* translators: %s Exception Message Body */
-                    __('Unable to retrieve token. Details: %s', 'give'),
+                /* translators: 1: Exception Message Body */
+                    esc_html__('Unable to retrieve token. Details: %1$s', 'give'),
                     $e->getMessage()
                 )
             );

--- a/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/StripeApi/RetrieveToken.php
@@ -16,24 +16,24 @@ trait RetrieveToken
      *
      * @unreleased
      *
-     * @param array $args Additional arguments.
      * @param string $tokenId Stripe Token ID.
+     * @param array $options
      *
      * @return array
      * @throws StripeApiRequestException
      */
-    protected function getTokenDetails($tokenId, $args = [])
+    protected function getTokenDetails($tokenId, $options = [])
     {
         give_stripe_set_app_info();
 
         try {
-            $requestArgs = wp_parse_args(
-                $args,
-                give_stripe_get_connected_account_options()
-            );
-
-            return StripeToken::retrieve($tokenId, $requestArgs)
-                ->toArray();
+            return StripeToken::retrieve(
+                $tokenId,
+                wp_parse_args(
+                    $options,
+                    give_stripe_get_connected_account_options()
+                )
+            )->toArray();
         } catch (Exception $e) {
             throw new StripeApiRequestException(
                 sprintf(


### PR DESCRIPTION
Blocker https://github.com/impress-org/give-stripe/pull/495

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

While working on https://github.com/impress-org/give-stripe/pull/495, I find out that these traits can be added to Give Core which can be used by add-ons like recurring donation, stripe pro.


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You can test them with https://github.com/impress-org/give-stripe/pull/495 pull request.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

