### PR TITLE
Refactor: remove cardInfo from PaymentGatewayLog

### DIFF
--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -4,6 +4,7 @@ namespace Give\Framework\PaymentGateways\Log;
 
 use Give\Log\Log;
 use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\ValueObjects\CardInfo;
 
 /**
  * @unreleased remove cardInfo from log
@@ -23,6 +24,10 @@ class PaymentGatewayLog extends Log
         foreach ($arguments[1] as $argument) {
             if ($argument instanceof GatewayPaymentData) {
                 unset($argument->cardInfo, $argument->legacyPaymentData['card_info']);
+            }
+
+            if ($argument instanceof CardInfo) {
+                unset($argument);
             }
         }
 

--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -3,8 +3,10 @@
 namespace Give\Framework\PaymentGateways\Log;
 
 use Give\Log\Log;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 
 /**
+ * @unreleased remove cardInfo from log
  * @since 2.18.0
  */
 class PaymentGatewayLog extends Log
@@ -16,6 +18,13 @@ class PaymentGatewayLog extends Log
     {
         $arguments[1]['category'] = 'Payment Gateway';
         $arguments[1]['source'] = 'Payment Gateway';
+
+
+        foreach ($arguments[1] as $argument) {
+            if ($argument instanceof GatewayPaymentData) {
+                unset($argument->cardInfo, $argument->legacyPaymentData['card_info']);
+            }
+        }
 
         parent::__callStatic($name, $arguments);
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6310

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Donor `CardInfo` was getting logged when an a payment gateway error was thrown. This PR ensures that whenever someone is logging data with `PaymentGatewayLog` the instances of `CardInfo` are removed.

## Testing

- Option 1: Within a gateway, log the `PaymentGatewayLog` with the entire `$gatewayPaymentData` as a property and make sure the `CardInfo` is not in there when donating with that gateway.
- Option 2: throw a gateway exception in a gateway and make sure the `CardInfo` is not in there when donating with that gateway.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

