### PR TITLE
Feature: Add TypedProperties support trait

### DIFF
--- a/src/Framework/Support/TypedProperties/Exceptions/InvalidPropertyType.php
+++ b/src/Framework/Support/TypedProperties/Exceptions/InvalidPropertyType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Give\Framework\Support\TypedProperties\Exceptions;
+
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Support\TypedProperties\TypedProperty;
+
+class InvalidPropertyType extends InvalidArgumentException
+{
+    public function __construct($name, $type, $code = 0, $previous = null)
+    {
+        parent::__construct("Invalid type for property $name, must be type: $type", $code, $previous);
+    }
+
+    public static function fromTypedProperty(TypedProperty $property, $code = 0, $previous = null)
+    {
+        return new static($property->name, $property->type, $code, $previous);
+    }
+}

--- a/src/Framework/Support/TypedProperties/Exceptions/PropertyNotInitialized.php
+++ b/src/Framework/Support/TypedProperties/Exceptions/PropertyNotInitialized.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Give\Framework\Support\TypedProperties\Exceptions;
+
+use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\Support\TypedProperties\TypedProperty;
+
+class PropertyNotInitialized extends Exception
+{
+    /**
+     * @param $propertyName
+     * @param $code
+     * @param $previous
+     */
+    public function __construct($propertyName, $code = 0, $previous = null)
+    {
+        parent::__construct("Typed property $propertyName must not be accessed before initialization", $code, $previous);
+    }
+
+    /**
+     * @param TypedProperty $property
+     *
+     * @return static
+     */
+    public static function fromTypedProperty(TypedProperty $property)
+    {
+        return new static($property->name);
+    }
+}

--- a/src/Framework/Support/TypedProperties/Exceptions/PropertyReadOnly.php
+++ b/src/Framework/Support/TypedProperties/Exceptions/PropertyReadOnly.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Give\Framework\Support\TypedProperties\Exceptions;
+
+use Give\Framework\Exceptions\Primitives\Exception;
+
+class PropertyReadOnly extends Exception
+{
+    /**
+     * @param string         $propertyName
+     * @param string         $className
+     * @param int            $code
+     * @param Exception|null $previous
+     */
+    public function __construct($propertyName, $className, $code = 0, $previous = null)
+    {
+        parent::__construct(
+            sprintf(
+                'Property "%s" of class "%s" is read-only.',
+                $propertyName,
+                $className
+            ),
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Framework/Support/TypedProperties/TypedProperties.php
+++ b/src/Framework/Support/TypedProperties/TypedProperties.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Give\Framework\Support\TypedProperties;
+
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Support\TypedProperties\Exceptions\InvalidPropertyType;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyNotInitialized;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyReadOnly;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyWriteOnly;
+
+trait TypedProperties
+{
+    /**
+     * Values may be set as
+     *      "key" => "type"
+     *      "key:readonly"
+     *      "key" => ["type", "default"]
+     *      "key" => ["type:readonly", "default"]
+     *
+     * @var TypedProperty[]|array The properties that are allowed to be set.
+     */
+    protected $properties = [];
+
+    /**
+     * @var bool Whether the properties have been initialized.
+     */
+    private $propertiesInitialized = false;
+
+    /**
+     * Gets the value of a property after property checks.
+     *
+     * @unreleased
+     *
+     * @param $name
+     *
+     * @return mixed
+     * @throws PropertyNotInitialized
+     */
+    public function __get($name)
+    {
+        $this->initializeProperties();
+
+        $property = $this->getProperty($name);
+
+        // Use a getter if one exists.
+        if (method_exists($this, 'get' . ucfirst($name))) {
+            return $this->{'get' . ucfirst($name)}($property);
+        }
+
+        return $property->getValue();
+    }
+
+    /**
+     * Sets the value of a property after property checks.
+     *
+     * @param $name
+     * @param $value
+     *
+     * @return void
+     * @throws PropertyReadOnly
+     */
+    public function __set($name, $value)
+    {
+        $this->initializeProperties();
+
+        $property = $this->getProperty($name);
+
+        // Use a setter if one exists.
+        if (method_exists($this, 'set' . ucfirst($name))) {
+            if (!$property->acceptsValue($value)) {
+                throw InvalidPropertyType::fromTypedProperty($property);
+            }
+            $this->{'set' . ucfirst($name)}($value, $property);
+        } else {
+            $property->setValue($value);
+        }
+    }
+
+    /**
+     * Checks whether the property has been set or not.
+     *
+     * @unreleased
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        $this->initializeProperties();
+
+        return $this->getProperty($name)->hasBeenSet();
+    }
+
+    /**
+     * Provide a callable to loop through all the property values.
+     *
+     * @param callable $callback
+     *
+     * @return void
+     */
+    public function mapProperties($callback)
+    {
+        foreach ($this->properties as $name => $property) {
+            $callback($property->getValue(), $name);
+        }
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param $name
+     *
+     * @return TypedProperty
+     */
+    protected function getProperty($name)
+    {
+        if (!isset($this->properties[$name])) {
+            throw new InvalidArgumentException("Property '$name' is not valid.");
+        }
+
+        return $this->properties[$name];
+    }
+
+    /**
+     * Initializes the object properties by taking the shorthand notation and turning each property into a TypedProperty
+     * to be used when accessing the object.
+     *
+     * @unreleased
+     *
+     * @return void
+     */
+    private function initializeProperties()
+    {
+        if ($this->propertiesInitialized) {
+            return;
+        }
+
+        $properties = [];
+        foreach ($this->properties as $name => $details) {
+            list($name, $accessRule) = array_pad(explode(':', $name), 2, null);
+            list($type, $default) = is_array($details) ? $details : [$details, null];
+
+            if ($accessRule !== null && $accessRule !== 'readonly') {
+                throw new InvalidArgumentException("Invalid access rule '$accessRule' for property '$name'.");
+            }
+
+            if ($default !== null && gettype($default) !== $type) {
+                throw new InvalidArgumentException("Default value for property '$name' is not of type '$type'.");
+            }
+
+            $hasDefault = is_array($details) && isset($details[1]);
+            $properties[$name] = new TypedProperty(
+                $name,
+                $type,
+                $default,
+                $hasDefault,
+                $accessRule === 'readonly',
+                static::class
+            );
+        }
+
+        $this->properties = $properties;
+        $this->propertiesInitialized = true;
+    }
+}

--- a/src/Framework/Support/TypedProperties/TypedProperty.php
+++ b/src/Framework/Support/TypedProperties/TypedProperty.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Give\Framework\Support\TypedProperties;
+
+use Give\Framework\Support\TypedProperties\Exceptions\InvalidPropertyType;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyNotInitialized;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyReadOnly;
+use Give\Framework\Support\TypedProperties\Exceptions\PropertyWriteOnly;
+
+class TypedProperty
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @var mixed
+     */
+    protected $default;
+
+    /**
+     * @var bool
+     */
+    protected $isReadOnly = false;
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var bool
+     */
+    private $isInitialized = false;
+
+    /**
+     * @unreleased
+     *
+     * @param string $name
+     * @param string $type
+     * @param mixed  $default
+     * @param bool   $applyDefault
+     * @param bool   $readOnly
+     *
+     * @throws PropertyReadOnly
+     */
+    public function __construct($name, $type, $default, $applyDefault, $readOnly, $class)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->default = $default;
+        $this->isReadOnly = $readOnly;
+        $this->class = $class;
+
+        if ($applyDefault) {
+            $this->setValue($default);
+        }
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        if (!$this->isInitialized) {
+            throw PropertyNotInitialized::fromTypedProperty($this);
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param mixed $value
+     *
+     * @return void
+     */
+    public function setValue($value)
+    {
+        if (!$this->acceptsValue($value)) {
+            throw new InvalidPropertyType($this->name, $this->type);
+        }
+
+        if (!$this->isWriteable()) {
+            throw new PropertyReadOnly($this->name, $this->class);
+        }
+
+        $this->isInitialized = true;
+        $this->value = $value;
+    }
+
+    /**
+     * Returns whether the property is writable. This is based on whether the property is read-only and the property
+     * value hasn't been written to, yet.
+     *
+     * @unreleased
+     *
+     * @return bool
+     */
+    public function isWriteable()
+    {
+        return !$this->isReadOnly || !$this->isInitialized;
+    }
+
+    /**
+     * Checks whether a given value is of the correct type.
+     *
+     * @unreleased
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function acceptsValue($value)
+    {
+        if ($this->type === 'mixed') {
+            return true;
+        }
+
+        return $this->type === gettype($value);
+    }
+
+    /**
+     * Mimics the isset() behavior for a property. Here's the definition from the PHP docs:
+     * "Determine if a variable is considered set, this means if a variable is declared and is different than null."
+     *
+     * @return bool
+     */
+    public function hasBeenSet()
+    {
+        return $this->isInitialized && $this->value !== null;
+    }
+}

--- a/src/Framework/Support/TypedProperties/readme.md
+++ b/src/Framework/Support/TypedProperties/readme.md
@@ -1,0 +1,113 @@
+# Typed Properties Trait
+
+In certain projects you just find yourself locked into older versions of PHP. You stand on your toes, gazing over the
+project fence into other yards, thinking, "it must be nice." PHP is a great language and is evolving, but older versions
+simply have terribly type hinting. Especially in classes, typed properties weren't introduced into PHP 7.4.
+
+This little trait is for those that want the powers of typed properties but can't support PHP 7.4.
+
+## How it works
+
+The philosophy of this trait is to provide a way to declare typed properties in such a way that works as closely as
+possible to real typed properties in PHP 7.4 and beyond. It introduces a couple extra features, but only as a superset
+of how typed properties ultimately work.
+
+Here's an example:
+
+```php
+use GiveWP\Framework\Support\TypedProperties\TypedProperties;
+
+class User {
+    use TypedProperties;
+
+    protected $properties = [
+        'firstName' => 'string',
+        'lastName' => 'string',
+        'fullName' => 'string:readonly',
+        'email' => ['string', 'foo@example.com'],
+        'birthday' => DateTime::class,
+        'password' => 'string:readonly',
+    ];
+
+    public function __construct($firstName, $lastName, $birthday, $password) {
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->birthday = new DateTime($birthday);
+        $this->password = $password;
+    }
+
+    public function getFullName() {
+        return $this->firstName . ' ' . $this->lastName;
+    }
+
+    public function passwordMatches($password) {
+        return $this->password === $password;
+    }
+}
+
+$bill = new User('Bill', 'Murray', '1950-09-21', 'password');
+$bill->fullName; // Bill Murray
+$bill->email; // foo@example.com
+$bill->passwordMatches('password'); // true
+```
+
+First, let's break down the `$properties` array into its options. The first item is the property name, the second is its
+type and optional attributes:
+
+```php
+$properties = [
+    'name' => 'type',
+    'name' => 'type:readonly',
+    'name' => ['type', 'defaultValue'],
+];
+```
+
+Note:
+
+- The `type` may be any [PHP type](https://www.php.net/manual/en/language.types.php)
+- If a colon us used after the type you may specify whether the property is read-only
+- If used as an array, the second item is the default value
+
+## Usage Details
+
+There are a few nuances to be aware of, so please review the following.
+
+### Getters and Setters
+By making a function with the prefix of `get` or `set`, followed by the property name, you can simulate computed
+properties. Note that the underlying property value is not set unless you do so in your setter.
+
+If you want to get or set the value of a property, the `TypedProperty` is passed to the setter as the second argument
+(after the value), and the first argument for the getter.
+
+```php
+public function getName(TypedProperty $property) {
+    return ucfirst($property->getValue());
+}
+
+public function setName($value, TypedProperty $property) {
+    $property->setValue(strtolower($value));
+}
+```
+
+### Looping through properties
+
+A limit of traits is that you cannot implement interfaces. As such, iterable interfaces are not automatically supported.
+The implementing class can, of course, implement `Iterator` interface to support iteration. In the meantime, you can use
+the `mapProperties` method to loop through the properties:
+
+```php
+$user = new User('Bill', 'Murray', '1950-09-21', 'password');
+$user->mapProperties(function($name, $value) {
+    // do something with $name and $value
+});
+```
+
+### Force writing property values
+You can't.
+
+"Wait, what?"
+
+No, really. You can't. The point of this trait is to act as close to typed properties in PHP 7.4+ as possible. You can't
+force values for typed properties then, so you can't here, either. This may seem like a strange limitation, but it's in
+place to help guide towards proper structure. Breaking out of types kind of defeats the purpose of types. You can always
+set the type to `mixed` if you need flexibility.


### PR DESCRIPTION
## Description

Please see the readme.md file provided in the PR for full details of what this is and how to use it.

To emphasize it, I'm really trying to be as close to how typed properties work in PHP 7.4+ as possible. As such, there are a number of conscious limitations, such as forcing a value. I also stuck with how things like `isset()` are defined. A few things simply aren't possible as a trait, but I tried to document those limitations. This could be made a bit more strict if it was a parent class, but it's important to me that this is a trait, as to broaden its usability.

The point of this PR is just to raise the conversation as to how helpful something like this may be.

## Affects

Nothing uses this, so nothing is affected.

## Testing Instructions

Create a class that uses the trait and test it out!

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

