### PR TITLE
Fix: Close form modal on a form grid by clicking on the background

### DIFF
--- a/assets/src/js/plugins/form-template/parent-page.js
+++ b/assets/src/js/plugins/form-template/parent-page.js
@@ -70,6 +70,17 @@ jQuery( function() {
 		} );
 	} );
 
+    /*
+     * Close form modal by clicking on the background
+     * @unreleased
+     */
+    document.addEventListener('click', function(e){
+        if (e.target.matches('.modal-inner-wrap') || e.target.matches('.give-embed-form-wrapper.modal')) {
+           e.target.querySelector('.js-give-embed-form-modal-closer').click();
+        }
+    });
+
+
 	/**
 	 * Close embed form modal when press "esc" key.
 	 */


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6316

## Description

This PR resolves the issue where closing the donation form modal by clicking on the background was not possible. This functionality already worked for the legacy template, but it didn't work for the classic and multi-step template.  The issue is resolved by adding an event listener on the modal background which will close the modal after the user clicks on the background. 

## Affects

Donation form modal

## Visuals

![Screen Capture_select-area_20220324122112](https://user-images.githubusercontent.com/4222590/159906334-921b7cae-e68a-4876-b901-c6eb6c1ed66a.gif)

## Testing Instructions

1. Add donation form for each template
2. Create a page and insert donation form grid block
3. Save and preview the page
4. Open each form and try to close it by clicking on the modal background (anywhere outside the modal content)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

