### PR TITLE
Changed:  Form Grid now display excerpts for multi-step forms

### DIFF
--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -450,12 +450,24 @@ class Sequoia extends Template implements Hookable, Scriptable
      *
      * @since 2.7.0
      *
+     * @unreleased Form excerpt has precedence over form description
+     *
      * @param int|null $formId
      *
-     * @return string
+     * @return string|void
      */
     public function getFormExcerpt($formId)
     {
-        return get_the_excerpt($formId);
+        $excerpt = get_the_excerpt($formId);
+        $templateOptions = FormTemplateUtils::getOptions($formId);
+
+        if ( ! empty($excerpt)) {
+            return $excerpt;
+        }
+
+        // Backward compatibility
+        if ( ! empty($templateOptions['introduction']['description']) ) {
+            return $templateOptions['introduction']['description'];
+        }
     }
 }

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -456,10 +456,6 @@ class Sequoia extends Template implements Hookable, Scriptable
      */
     public function getFormExcerpt($formId)
     {
-        $templateOptions = FormTemplateUtils::getOptions($formId);
-
-        return ! empty($templateOptions['introduction']['description']) ?
-            $templateOptions['introduction']['description'] :
-            get_the_excerpt($formId);
+        return get_the_excerpt($formId);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6318

## Description

This PR updates the multi-step template and what is returned from the `Sequoia::getFormExcerpt` function. Before this PR, the default value was the description from Step 1 of the multi-step template, now that's changed to the form excerpt. Description from Step 1 is still used for backward compatibility, but excerpt now has precedence over it. 

## Affects

`Sequoia::getFormExcerpt` 

## Visuals

![image](https://user-images.githubusercontent.com/4222590/159917898-4e1cd65c-85ef-4f0e-a809-b66496148155.png)

## Testing Instructions


1. Create a donation form that use multi-step template
2. Insert some text into the Excerpt field and hit save
3. Create a new WP page and insert Form Grid block
4. Save and preview the page

Text entered into the excerpt field should display as form description 


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

