### PR TITLE
Fix: Paypal Standard donations are set to complete

### DIFF
--- a/includes/gateways/paypal/paypal-standard.php
+++ b/includes/gateways/paypal/paypal-standard.php
@@ -145,6 +145,7 @@ function give_get_paypal_page_style()
  * Shows "Donation Processing" message for PayPal payments that are still pending on site return
  *
  * @since      1.0
+ * @unreleased Get donation id from donor session.
  *
  * @param $content
  *

--- a/includes/gateways/paypal/paypal-standard.php
+++ b/includes/gateways/paypal/paypal-standard.php
@@ -152,16 +152,8 @@ function give_get_paypal_page_style()
  */
 function give_paypal_success_page_content($content)
 {
-    if ( ! isset($_GET['payment-id']) && ! give_get_purchase_session()) {
-        return $content;
-    }
-
-    $payment_id = isset($_GET['payment-id']) ? absint($_GET['payment-id']) : false;
-
-    if ( ! $payment_id) {
-        $session = give_get_purchase_session();
-        $payment_id = give_get_donation_id_by_key($session['purchase_key']);
-    }
+    $session = give_get_purchase_session();
+    $payment_id = give_get_donation_id_by_key($session['purchase_key']);
 
     $payment = get_post($payment_id);
     if ($payment && 'pending' === $payment->post_status) {

--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -3,8 +3,11 @@
 namespace Give\Framework\PaymentGateways\Log;
 
 use Give\Log\Log;
+use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\ValueObjects\CardInfo;
 
 /**
+ * @unreleased remove cardInfo from log
  * @since 2.18.0
  */
 class PaymentGatewayLog extends Log
@@ -16,6 +19,17 @@ class PaymentGatewayLog extends Log
     {
         $arguments[1]['category'] = 'Payment Gateway';
         $arguments[1]['source'] = 'Payment Gateway';
+
+
+        foreach ($arguments[1] as $argument) {
+            if ($argument instanceof GatewayPaymentData) {
+                unset($argument->cardInfo, $argument->legacyPaymentData['card_info']);
+            }
+
+            if ($argument instanceof CardInfo) {
+                unset($argument);
+            }
+        }
 
         parent::__callStatic($name, $arguments);
     }

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -108,13 +108,11 @@ class PayPalStandard extends PaymentGateway
     public function handleSuccessPaymentReturn($queryParams)
     {
         $donationId = (int)$queryParams['donation-id'];
-        $payment = new Give_Payment($donationId);
 
-        if( 'pending' === $payment->status ) {
-            $payment->update_status('processing');
-        }
-
-        return new RedirectResponse(Call::invoke(GenerateDonationReceiptPageUrl::class, $donationId));
+        return new RedirectResponse(add_query_arg(
+            [ 'payment-confirmation' => $this->getId() ],
+            Call::invoke(GenerateDonationReceiptPageUrl::class, $donationId)
+        ));
     }
 
     /**

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -96,6 +96,8 @@ class PayPalStandard extends PaymentGateway
      *
      * @since 2.19.0
      * @since 2.19.4 Only pending PayPal Standard donation set to processing.
+     * @unreleased 1. Do not set donation to "processing"
+     *             2. Add "payment-confirmation" param to receipt page url
      *
      * @param  array  $queryParams  Query params in gateway route. {
      *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6294

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that Paypal standard donations remain `processing` because of race condition conflict between PayPal payment redirect after completing payment and  Paypal ipn notification.

I find out that in old logic
- We keep donations to pending mode till we get ipn from Paypal.
- Donor sees receipt after [9 seconds](https://github.com/impress-org/givewp/blob/a3e29a5f385757b96d73f4f1c4231afa39d4ce8b/templates/payment-processing.php#L21) (legacy template)/ [5 seconds](https://github.com/impress-org/givewp/blob/a3e29a5f385757b96d73f4f1c4231afa39d4ce8b/src/Views/Form/defaultFormDonationProcessing.php#L21) (classic & multi step form template) if PayPal ipn did not receive.

I updated the logic to reflect that with the new payment gateway api logic.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects Paypal standard donation flow for a one-time donations.


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should see the loader for 5 seconds in multi-step form or class form template and redirection notice for the legacy template if ipn did not receive by the website before PayPal payment redirect.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

