### PR TITLE
Fix: Update stripe meta data count

### DIFF
--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1140,8 +1140,8 @@ function give_stripe_prepare_metadata( $donation_id, $donation_data = [] ) {
 	$args = array_merge( $args, give_stripe_get_custom_ffm_fields( $form_id, $donation_id ) );
 
 	// Limit metadata passed to Stripe as maximum of 20 metadata is only allowed.
-	if ( count( $args ) > 20 ) {
-		$args = array_slice( $args, 0, 19, false );
+	if ( count( $args ) > 50 ) {
+		$args = array_slice( $args, 0, 49, false );
 		$args = array_merge(
 			$args,
 			[


### PR DESCRIPTION
## Description

The maximum number of [Stripe metadata](https://stripe.com/docs/api/metadata) fields as been increased from 20 to 50.

## Affects

Affect should be limited. More metadata fields will be pushed into Stripe. Otherwise, behavior unchanged. 

I cannot find any documentation if old Stripe api versions support more metadata fields.

## Visuals

NA

## Testing Instructions

Add more than 20 metadata field to a [Stripe payment](https://github.com/impress-org/givewp-snippet-library/blob/master/gateway-customizations/stripe-pass-custom-meta-for-payments.php) using a metadata hook. Create test payments, verify more than 20, but not more than 50, metadata key/value pairs are pushed into stripe.

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

