### PR TITLE
Fixed Block encountered error while adding class name

### DIFF
--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Give\Helpers\Html;
+
 /**
  * Give_Donation_Form_Block Class.
  *
@@ -117,6 +119,18 @@ class Give_Donation_Form_Block {
 					'id'                  => array(
 						'type' => 'number',
 					),
+					'className' => array(
+						'type' => 'string',
+						'default' => '',
+					),
+					'align' => array(
+						'type' => 'string',
+						'default' => '',
+					),
+					'extUtilities' => array(
+						'type' => 'object',
+						'default' => array(),
+					),
 					'prevId'              => array(
 						'type' => 'number',
 					),
@@ -172,7 +186,17 @@ class Give_Donation_Form_Block {
 		$parameters['display_style']         = $attributes['displayStyle'];
 		$parameters['continue_button_title'] = trim( $attributes['continueButtonTitle'] );
 
-		return give_form_shortcode( $parameters );
+		$class_names = Html::classNames(
+			isset( $attributes['extUtilities'] ) ? $attributes['extUtilities'] : null,
+			! empty( $attributes['align'] ) ? 'align' . $attributes['align'] : null,
+			isset( $attributes['className'] ) ? $attributes['className'] : null
+		);
+
+		$content = '<div class="' . $class_names . '">';
+		$content .= give_form_shortcode( $parameters );
+		$content .= '</div>';
+
+		return $content;
 	}
 
 	/**

--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -123,10 +123,6 @@ class Give_Donation_Form_Block {
 						'type' => 'string',
 						'default' => '',
 					),
-					'align' => array(
-						'type' => 'string',
-						'default' => '',
-					),
 					'extUtilities' => array(
 						'type' => 'object',
 						'default' => array(),
@@ -188,15 +184,14 @@ class Give_Donation_Form_Block {
 
 		$class_names = Html::classNames(
 			isset( $attributes['extUtilities'] ) ? $attributes['extUtilities'] : null,
-			! empty( $attributes['align'] ) ? 'align' . $attributes['align'] : null,
 			isset( $attributes['className'] ) ? $attributes['className'] : null
 		);
 
-		$content = '<div class="' . $class_names . '">';
-		$content .= give_form_shortcode( $parameters );
-		$content .= '</div>';
+		add_filter( 'give_form_wrap_classes', function() use ( $class_names ) {
+			return $class_names;
+		});
 
-		return $content;
+		return give_form_shortcode( $parameters );
 	}
 
 	/**

--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -182,9 +182,9 @@ class Give_Donation_Form_Block {
 			isset( $attributes['className'] ) ? $attributes['className'] : null
 		);
 
-		add_filter( 'give_form_wrap_classes', function() use ( $class_names ) {
-			return $class_names;
-		});
+		add_filter( 'give_form_wrap_classes', function( $classes ) use ( $class_names ) {
+			return Html::classNames( $classes, $class_names );
+		} );
 
 		return give_form_shortcode( $parameters );
 	}

--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -123,10 +123,6 @@ class Give_Donation_Form_Block {
 						'type' => 'string',
 						'default' => '',
 					),
-					'extUtilities' => array(
-						'type' => 'object',
-						'default' => array(),
-					),
 					'prevId'              => array(
 						'type' => 'number',
 					),
@@ -183,7 +179,6 @@ class Give_Donation_Form_Block {
 		$parameters['continue_button_title'] = trim( $attributes['continueButtonTitle'] );
 
 		$class_names = Html::classNames(
-			isset( $attributes['extUtilities'] ) ? $attributes['extUtilities'] : null,
 			isset( $attributes['className'] ) ? $attributes['className'] : null
 		);
 


### PR DESCRIPTION
After inserting the block if you try to add any class name its broke.

Fix: Added some attributes to register_block_type

```
'className' => array(
'type' => 'string',
'default' => '',
),
'align' => array(
'type' => 'string',
'default' => '',
),
'extUtilities' => array(
'type' => 'object',
'default' => array(),
),
```
ServerSideRender requires the same attributes to render the block. By default, the class name field is empty ( Advanced Inspectors ) so it doesn't display any error but if you try to add any class name you will see the error.
