### PR TITLE
Fix: fatal Stripe gateway errors from missing handlePaymentIntentStatus args

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.19.6
+ * Version: 2.19.7
  * Requires at least: 5.0
  * Requires PHP: 5.6
  * Text Domain: give
@@ -303,7 +303,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.19.6');
+            define('GIVE_VERSION', '2.19.7');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 2.19.6
+Stable tag: 2.19.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -250,6 +250,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.19.7: April 4th, 2022 =
+* Fix: Resolved a regression in 2.19.6 that broke the Stripe Checkout gateway — please update immediately
+
 = 2.19.6: March 31st, 2022 =
 * Change: Click in the background when viewing a form in the Form Grid now closes the form
 * Fix: Significant improvements to making GiveWP translatable, especially the Donor Dashboard and other JavaScript

--- a/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
@@ -33,6 +33,7 @@ class BECSGateway extends PaymentGateway
 
     /**
      * @inheritDoc
+     * @unreleased fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException
@@ -51,7 +52,8 @@ class BECSGateway extends PaymentGateway
                 $donationSummary,
                 $stripeCustomer,
                 $paymentMethod
-            )
+            ),
+            $paymentData->donationId
         );
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
@@ -33,7 +33,7 @@ class BECSGateway extends PaymentGateway
 
     /**
      * @inheritDoc
-     * @unreleased fix handlePaymentIntentStatus not receiving extra param
+     * @since 2.19.7 fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException

--- a/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
@@ -69,6 +69,7 @@ class CheckoutGateway extends PaymentGateway
     }
 
     /**
+     * @unreleased fix argument order of CreateCheckoutSession
      * @since 2.19.0
      *
      * @return RedirectOffsite
@@ -77,7 +78,7 @@ class CheckoutGateway extends PaymentGateway
     {
         $donationSummary = Call::invoke(Actions\SaveDonationSummary::class, $paymentData);
         $stripeCustomer = Call::invoke(Actions\GetOrCreateStripeCustomer::class, $paymentData);
-        $session = Call::invoke( Actions\CreateCheckoutSession::class, $donationSummary, $stripeCustomer, $paymentData );
+        $session = Call::invoke(Actions\CreateCheckoutSession::class, $paymentData, $donationSummary, $stripeCustomer);
 
         return new RedirectOffsite(
             $this->getRedirectUrl( $session->id(), give_get_payment_form_id( $paymentData->donationId ) )

--- a/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
@@ -8,13 +8,10 @@ use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
 use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Helpers\Call;
-use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Gateways\Stripe;
 use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
+use Give\PaymentGateways\Exceptions\InvalidPropertyName;
 use Give\PaymentGateways\Gateways\Stripe\Exceptions\CheckoutException;
-use Give\PaymentGateways\Gateways\Stripe\Helpers\CheckoutHelper;
-use Give\PaymentGateways\Gateways\Stripe\ValueObjects\CheckoutSession;
-use Give\PaymentGateways\Gateways\Stripe\ValueObjects\PaymentIntent;
 
 /**
  * @since 2.19.0
@@ -24,31 +21,13 @@ class CheckoutGateway extends PaymentGateway
     use Traits\CheckoutInstructions;
     use Traits\CheckoutModal;
     use Traits\CheckoutRedirect;
-    use Traits\HandlePaymentIntentStatus;
 
     /**
-     * @inheritDoc
-     * @since 2.19.0
-     * @return GatewayCommand
-     * @throws PaymentGatewayException
-     */
-    public function createPayment( GatewayPaymentData $paymentData )
-    {
-        switch (give_stripe_get_checkout_type()) {
-            case 'modal':
-                return $this->createPaymentModal($paymentData);
-            case 'redirect':
-                return $this->createPaymentRedirect($paymentData);
-            default:
-                throw new CheckoutException('Invalid Checkout Error');
-        }
-    }
-
-    /**
+     * @unreleased fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return PaymentProcessing|RedirectOffsite
      * @throws Exceptions\PaymentIntentException
-     * @throws \Give\PaymentGateways\Exceptions\InvalidPropertyName
+     * @throws InvalidPropertyName
      */
     protected function createPaymentModal( GatewayPaymentData $paymentData )
     {
@@ -64,8 +43,29 @@ class CheckoutGateway extends PaymentGateway
                 $donationSummary,
                 $stripeCustomer,
                 $paymentMethod
-            )
+            ),
+            $paymentData->donationId
         );
+    }
+
+    use Traits\HandlePaymentIntentStatus;
+
+    /**
+     * @inheritDoc
+     * @since 2.19.0
+     * @return GatewayCommand
+     * @throws PaymentGatewayException
+     */
+    public function createPayment(GatewayPaymentData $paymentData)
+    {
+        switch (give_stripe_get_checkout_type()) {
+            case 'modal':
+                return $this->createPaymentModal($paymentData);
+            case 'redirect':
+                return $this->createPaymentRedirect($paymentData);
+            default:
+                throw new CheckoutException('Invalid Checkout Error');
+        }
     }
 
     /**
@@ -73,10 +73,10 @@ class CheckoutGateway extends PaymentGateway
      *
      * @return RedirectOffsite
      */
-    protected function createPaymentRedirect( GatewayPaymentData $paymentData )
+    protected function createPaymentRedirect(GatewayPaymentData $paymentData)
     {
-        $donationSummary = Call::invoke( Actions\SaveDonationSummary::class, $paymentData );
-        $stripeCustomer = Call::invoke( Actions\GetOrCreateStripeCustomer::class, $paymentData );
+        $donationSummary = Call::invoke(Actions\SaveDonationSummary::class, $paymentData);
+        $stripeCustomer = Call::invoke(Actions\GetOrCreateStripeCustomer::class, $paymentData);
         $session = Call::invoke( Actions\CreateCheckoutSession::class, $donationSummary, $stripeCustomer, $paymentData );
 
         return new RedirectOffsite(

--- a/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CheckoutGateway.php
@@ -23,7 +23,7 @@ class CheckoutGateway extends PaymentGateway
     use Traits\CheckoutRedirect;
 
     /**
-     * @unreleased fix handlePaymentIntentStatus not receiving extra param
+     * @since 2.19.7 fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return PaymentProcessing|RedirectOffsite
      * @throws Exceptions\PaymentIntentException
@@ -69,7 +69,7 @@ class CheckoutGateway extends PaymentGateway
     }
 
     /**
-     * @unreleased fix argument order of CreateCheckoutSession
+     * @since 2.19.7 fix argument order of CreateCheckoutSession
      * @since 2.19.0
      *
      * @return RedirectOffsite

--- a/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
@@ -40,6 +40,7 @@ class CreditCardGateway extends PaymentGateway
 
     /**
      * @inheritDoc
+     * @unreleased fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException
@@ -53,13 +54,13 @@ class CreditCardGateway extends PaymentGateway
         $createIntentAction = new Actions\CreatePaymentIntent([]);
 
         return $this->handlePaymentIntentStatus(
-            $paymentData,
             $createIntentAction(
                 $paymentData,
                 $donationSummary,
                 $stripeCustomer,
                 $paymentMethod
-            )
+            ),
+            $paymentData->donationId
         );
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
@@ -40,7 +40,7 @@ class CreditCardGateway extends PaymentGateway
 
     /**
      * @inheritDoc
-     * @unreleased fix handlePaymentIntentStatus not receiving extra param
+     * @since 2.19.7 fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException

--- a/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
@@ -33,7 +33,7 @@ class SEPAGateway extends PaymentGateway
 
     /**
      * @inheritDoc
-     * @unreleased fix handlePaymentIntentStatus not receiving extra param
+     * @since 2.19.7 fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException

--- a/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
@@ -33,6 +33,7 @@ class SEPAGateway extends PaymentGateway
 
     /**
      * @inheritDoc
+     * @unreleased fix handlePaymentIntentStatus not receiving extra param
      * @since 2.19.0
      * @return GatewayCommand
      * @throws PaymentGatewayException
@@ -51,7 +52,8 @@ class SEPAGateway extends PaymentGateway
                 $donationSummary,
                 $stripeCustomer,
                 $paymentMethod
-            )
+            ),
+            $paymentData->donationId
         );
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -4,24 +4,25 @@ namespace Give\PaymentGateways\Gateways\Stripe\Traits;
 
 use Give\Framework\PaymentGateways\Commands\PaymentProcessing;
 use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
-use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\Gateways\Stripe\Exceptions\PaymentIntentException;
 use Give\PaymentGateways\Gateways\Stripe\ValueObjects\PaymentIntent;
 
 trait HandlePaymentIntentStatus
 {
     /**
-     * @param GatewayPaymentData $paymentData
-     * @param PaymentIntent $paymentIntent
+     * @unreleased fix param order and only pass donationId
+     *
+     * @param  PaymentIntent  $paymentIntent
+     * @param  string  $donationId
      *
      * @return PaymentProcessing|RedirectOffsite
      * @throws PaymentIntentException
      */
-    public function handlePaymentIntentStatus(GatewayPaymentData $paymentData, PaymentIntent $paymentIntent)
+    public function handlePaymentIntentStatus(PaymentIntent $paymentIntent, $donationId)
     {
         switch ($paymentIntent->status()) {
             case 'requires_action':
-                give_set_payment_transaction_id($paymentData->donationId, $paymentIntent->id());
+                give_set_payment_transaction_id($donationId, $paymentIntent->id());
                 return new RedirectOffsite($paymentIntent->nextActionRedirectUrl());
             case 'succeeded':
             case 'processing':

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -10,7 +10,7 @@ use Give\PaymentGateways\Gateways\Stripe\ValueObjects\PaymentIntent;
 trait HandlePaymentIntentStatus
 {
     /**
-     * @unreleased fix param order and only pass donationId
+     * @since 2.19.7 fix param order and only pass donationId
      *
      * @param  PaymentIntent  $paymentIntent
      * @param  string  $donationId

--- a/src/PaymentGateways/PayPalCommerce/Migrations/RemoveLogWithCardInfo.php
+++ b/src/PaymentGateways/PayPalCommerce/Migrations/RemoveLogWithCardInfo.php
@@ -6,7 +6,7 @@ use Give\Framework\Database\DB;
 use Give\Framework\Migrations\Contracts\Migration;
 
 /**
- * @unreleased
+ * @since 2.19.7
  */
 class RemoveLogWithCardInfo extends Migration
 {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6346 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

During a recent hotfix #6330 the method used throughout all Stripe gateways `handlePaymentIntentStatus()` was changed to add an additional argument.  The problem was only 1 instance was updated instead of all 4.  This PR reduces that additional `GatewayPaymentData` argument to a simple `donationId` passed as the second param - while updating _all_ the instances of that method.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- All Stripe Gateways have been affected by this PR

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Test all Stripe gateways

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

**Confirm these gateways are fully functional**

-   [ ] Stripe Checkout Works
-   [ ] Stripe Credit Card Works
-   [ ] Stripe BECS Works
-   [ ] Stripe SEPA Works


