### PR TITLE
Fix: legacy history page receipt links 6358

### DIFF
--- a/assets/src/css/frontend/donation-history.scss
+++ b/assets/src/css/frontend/donation-history.scss
@@ -53,7 +53,7 @@
 		td {
 			border: none;
 			padding-top: 0;
-			padding-bottom: 0; 
+			padding-bottom: 0;
 			background-color: rgba(0, 0, 0, 0);
 		}
 

--- a/assets/src/css/frontend/give-frontend.scss
+++ b/assets/src/css/frontend/give-frontend.scss
@@ -49,7 +49,7 @@
 }
 
 .give-grid-ie-utility {
-	margin: 0 -12pxz
+	margin: 0 -12px
 }
 
 @supports (display: grid) {

--- a/assets/src/css/frontend/give-frontend.scss
+++ b/assets/src/css/frontend/give-frontend.scss
@@ -49,7 +49,7 @@
 }
 
 .give-grid-ie-utility {
-	margin: 0 -12px;
+	margin: 0 -12pxz
 }
 
 @supports (display: grid) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -72,7 +72,7 @@ function give_donation_history( $atts, $content = false ) {
 		if ( give_get_receipt_session() || is_user_logged_in() ) {
 			echo sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( give_get_history_page_uri() ),
+				esc_url($_SERVER['HTTP_REFERER'] ),
 				__( '&laquo; Return to All Donations', 'give' )
 			);
 		}

--- a/templates/history-donations.php
+++ b/templates/history-donations.php
@@ -205,7 +205,7 @@ if ( $donations ) : ?>
 									add_query_arg(
 										'donation_id',
 										$post->ID,
-										give_get_history_page_uri()
+                                        $_SERVER['REQUEST_URI']
 									)
 								),
 								$post->post_status,

--- a/templates/history-donations.php
+++ b/templates/history-donations.php
@@ -118,7 +118,7 @@ if ( $donations ) : ?>
 				<tr class="give-donation-row">
 					<?php
 					/**
-					 * Fires in current user donation history table, before the row statrs.
+					 * Fires in current user donation history table, before the row starts.
 					 *
 					 * Allows you to add new <td> elements to the row, before other elements in the row.
 					 *
@@ -198,7 +198,7 @@ if ( $donations ) : ?>
 					<td class="give-donation-details">
 						<?php
 						// Display View Receipt or.
-						if ( 'publish' !== $post->post_status && 'subscription' !== $post->post_status ) :
+						if ( 'publish' !== $post->post_status && 'subscription' !== $post->post_status  ) :
 							echo sprintf(
 								'<span class="give-mobile-title">%4$s</span><a href="%1$s"><span class="give-donation-status %2$s">%3$s</span></a>',
 								esc_url(
@@ -220,8 +220,8 @@ if ( $donations ) : ?>
 									add_query_arg(
 										'donation_id',
 										$post->ID,
-										give_get_history_page_uri()
-									)
+                                        $_SERVER['REQUEST_URI']
+                                    )
 								),
 								__( 'View Receipt &raquo;', 'give' ),
 								esc_html( $table_headings['details'] )


### PR DESCRIPTION
Resolves https://github.com/impress-org/givewp/issues/6358

## Description

This PR updates the View Receipt links on a Legacy Donation History page.

If the Donor Dashboard is enabled it will be assigned as the default Donation History page. When a user views a Legacy Donation History page and clicks a View Receipt link, they are redirected to the Donor Dashboard.

## Affects

- View Receipt links on a Legacy Donation History Page.

## Visuals

![View Receipt Link](https://user-images.githubusercontent.com/75056371/163875106-af060512-009a-47b9-9a4a-4ad204f92d8c.png)
![View Receipt Page](https://user-images.githubusercontent.com/75056371/163875244-0c4f0ac5-6533-40a0-a90b-c816e6c6490a.png)

## Testing Instructions

- Install GiveWP.
- Enable Override Legacy Donation Management Pages in admin Settings -> General.
- Create  a Legacy Donation History page via [donation_history] shortcode.
- Go to the Donations sidebar > Donations and change the status of several donations to pending, processing, refunded, revoked, failed and pre-approved.
- View the Legacy Donation History page.
- Click View Receipt.
- Click Return To All Donations.
-Click pending, processing, refunded, revoked, failed and pre-approved View links.
## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

