### PR TITLE
Fix: show new donation form listing page on `Donations` menu item

### DIFF
--- a/includes/admin/class-blank-slate.php
+++ b/includes/admin/class-blank-slate.php
@@ -9,6 +9,8 @@
  * @since       1.8.13
  */
 
+use Give\DonationForms\DonationFormsAdminPage;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -279,7 +281,7 @@ class Give_Blank_Slate {
 				'heading'  => __( 'No donations found.', 'give' ),
 				'message'  => __( 'When your first donation arrives, a record of the donation will appear here.', 'give' ),
 				'cta_text' => __( 'View All Forms', 'give' ),
-				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
+				'cta_link' => DonationFormsAdminPage::getUrl(),
 				'help'     => sprintf(
 					/* translators: 1: Opening anchor tag. 2: Closing anchor tag. */
 					__( 'Need help? Learn more about %1$sDonations%2$s.', 'give' ),
@@ -295,7 +297,7 @@ class Give_Blank_Slate {
 				'heading'  => __( 'No donors found.', 'give' ),
 				'message'  => __( 'When your first donation arrives, the donor will appear here.', 'give' ),
 				'cta_text' => __( 'View All Forms', 'give' ),
-				'cta_link' => admin_url( 'edit.php?post_type=give_forms' ),
+				'cta_link' => DonationFormsAdminPage::getUrl(),
 				'help'     => sprintf(
 					/* translators: 1: Opening anchor tag. 2: Closing anchor tag. */
 					__( 'Need help? Learn more about %1$sDonors%2$s.', 'give' ),

--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -9,9 +9,9 @@
  * @since       1.0
  */
 
-// Exit if accessed directly.
 use Give\DonationForms\DonationFormsAdminPage;
 
+// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -10,6 +10,8 @@
  */
 
 // Exit if accessed directly.
+use Give\DonationForms\DonationFormsAdminPage;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -40,7 +42,7 @@ function give_dashboard_at_a_glance_widget( $items ) {
 		if ( current_user_can( 'edit_give_forms', get_current_user_id() ) ) {
 			$text = sprintf(
 				'<a class="give-forms-count" href="%1$s">%2$s</a>',
-				admin_url( 'edit.php?post_type=give_forms' ),
+				DonationFormsAdminPage::getUrl(),
 				$text
 			);
 		} else {

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -483,6 +483,14 @@ function give_show_upgrade_notices( $give_updates ) {
 			'callback' => 'give_v270_store_stripe_account_for_donation_callback',
 		]
 	);
+
+    $give_updates->register(
+        [
+            'id'       => 'v270_store_stripe_account_for_donation-234',
+            'version'  => '2.7.0',
+            'callback' => 'give_v270_store_stripe_account_for_donation_callback',
+        ]
+    );
 }
 
 add_action( 'give_register_updates', 'give_show_upgrade_notices' );

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -483,14 +483,6 @@ function give_show_upgrade_notices( $give_updates ) {
 			'callback' => 'give_v270_store_stripe_account_for_donation_callback',
 		]
 	);
-
-    $give_updates->register(
-        [
-            'id'       => 'v270_store_stripe_account_for_donation-234',
-            'version'  => '2.7.0',
-            'callback' => 'give_v270_store_stripe_account_for_donation_callback',
-        ]
-    );
 }
 
 add_action( 'give_register_updates', 'give_show_upgrade_notices' );

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -29,7 +29,7 @@ class DonationFormsAdminPage
     /**
      * @unreleased
      */
-    public function highlightAllFormsMenuItem($menu)
+    public function highlightAllFormsMenuItem()
     {
         global $submenu;
         $pages = [

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -89,4 +89,13 @@ class DonationFormsAdminPage
     {
         return isset($_GET['page']) && $_GET['page'] === 'give-forms';
     }
+
+    /**
+     * @unreleased
+     * @return string
+     */
+    public static function getUrl()
+    {
+        return add_query_arg(['page' => 'give-forms'], admin_url('edit.php?post_type=give_forms'));
+    }
 }

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -22,6 +22,9 @@ class DonationFormsAdminPage
             'edit_give_forms',
             'give-forms',
             [$this, 'render'],
+            // Do not change the submenu position unless you have a strong reason.
+            // We use this position value to access this menu data in $submenu to add a custom class.
+            // Check DonationFormsAdminPage::highlightAllFormsMenuItem
             0
         );
     }
@@ -38,6 +41,7 @@ class DonationFormsAdminPage
         ];
 
         if (in_array($_SERVER['REQUEST_URI'], $pages)) {
+            // Add class to highlight 'All Forms' submenu.
             $submenu['edit.php?post_type=give_forms'][0][4] = add_cssclass(
                 'current',
                 isset($submenu['edit.php?post_type=give_forms'][0][4]) ? $submenu['edit.php?post_type=give_forms'][0][4] : ''

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -22,8 +22,27 @@ class DonationFormsAdminPage
             'edit_give_forms',
             'give-forms',
             [$this, 'render'],
-            1
+            0
         );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function highlightAllFormsMenuItem($menu)
+    {
+        global $submenu;
+        $pages = [
+            '/wp-admin/admin.php?page=give-forms', // Donation main menu page.
+            '/wp-admin/edit.php?post_type=give_forms' // Legacy donation form listing page.
+        ];
+
+        if (in_array($_SERVER['REQUEST_URI'], $pages)) {
+            $submenu['edit.php?post_type=give_forms'][0][4] = add_cssclass(
+                'current',
+                isset($submenu['edit.php?post_type=give_forms'][0][4]) ? $submenu['edit.php?post_type=give_forms'][0][4] : ''
+            );
+        }
     }
 
     /**
@@ -31,7 +50,7 @@ class DonationFormsAdminPage
      */
     public function loadScripts()
     {
-        $data =  [
+        $data = [
             'apiRoot' => esc_url_raw(rest_url('give-api/v2/admin/forms')),
             'apiNonce' => wp_create_nonce('wp_rest'),
         ];

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -25,6 +25,7 @@ class ServiceProvider implements ServiceProviderInterface
     public function boot()
     {
         Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'register');
+        Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'highlightAllFormsMenuItem');
 
         if (DonationFormsAdminPage::isShowing()) {
             Hooks::addAction('admin_enqueue_scripts', DonationFormsAdminPage::class, 'loadScripts');

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -62,7 +62,7 @@ class Page
             'manage_give_settings',
             'give-setup',
             [$this, 'render_page'],
-            0
+            2
         );
     }
 

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -8,6 +8,8 @@
 
 namespace Give\Onboarding\Setup;
 
+use Give\DonationForms\DonationFormsAdminPage;
+
 defined('ABSPATH') || exit;
 
 /**
@@ -31,7 +33,7 @@ class Page
         if (wp_verify_nonce($_GET['_wpnonce'], 'dismiss_setup_page')) {
             give_update_option('setup_page_enabled', self::DISABLED);
 
-            wp_redirect(add_query_arg(['post_type' => 'give_forms'], admin_url('edit.php')));
+            wp_redirect(DonationFormsAdminPage::getUrl());
             exit;
         }
     }
@@ -73,7 +75,7 @@ class Page
      */
     public function enqueue_scripts()
     {
-        if ( ! isset($_GET['page']) || 'give-setup' !== $_GET['page']) {
+        if (!isset($_GET['page']) || 'give-setup' !== $_GET['page']) {
             return;
         }
 

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -62,7 +62,7 @@ class Page
             'manage_give_settings',
             'give-setup',
             [$this, 'render_page'],
-            $position = 0
+            0
         );
     }
 

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -9,6 +9,7 @@ use Give\Onboarding\FormRepository;
 use Give\Onboarding\Helpers\FormatList;
 use Give\Onboarding\Helpers\LocationList;
 use Give\Onboarding\LocaleCollection;
+use Give\Onboarding\SettingsRepository;
 use Give\Onboarding\SettingsRepositoryFactory;
 use Give\Onboarding\Setup\Page as SetupPage;
 
@@ -41,6 +42,7 @@ class Page
     /**
      * @param FormRepository $formRepository
      * @param SettingsRepositoryFactory $settingsRepositoryFactory
+     * @param LocaleCollection $localeCollection
      */
     public function __construct(
         FormRepository $formRepository,

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -4,6 +4,7 @@ namespace Give\Onboarding\Wizard;
 
 defined('ABSPATH') || exit;
 
+use Give\DonationForms\DonationFormsAdminPage;
 use Give\Helpers\EnqueueScript;
 use Give\Onboarding\FormRepository;
 use Give\Onboarding\Helpers\FormatList;
@@ -143,7 +144,7 @@ class Page
             'apiNonce' => wp_create_nonce('wp_rest'),
             'setupUrl' => SetupPage::getSetupPageEnabledOrDisabled() === SetupPage::ENABLED ?
                 admin_url('edit.php?post_type=give_forms&page=give-setup') :
-                admin_url('edit.php?post_type=give_forms'),
+                DonationFormsAdminPage::getUrl(),
             'formPreviewUrl' => admin_url('?page=give-form-preview'),
             'localeCurrency' => $this->localeCollection->pluck('currency_code'),
             'currencies' => FormatList::fromKeyValue(give_get_currencies_list()),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6362 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This pull request adds logic to show the new donation form listing page when the admin clicks on the `Donations` menu item.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
I also updated  are places that are linked to the legacy form listing page:
-  `Dismiss Setup Page` link on the setup page.
- CTA button link on the donor, donation, and form listing blank slate display.
- In the `At a Glance` dashboard widget

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Admin should see a new form listing page when clicking on the `Donations` menu item. Also, check the places I mentioned in the `Affects` section.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

