### PR TITLE
Fix: react javascript warning on add-on page

### DIFF
--- a/src/Promotions/InPluginUpsells/resources/js/components/FreeAddOnTab.js
+++ b/src/Promotions/InPluginUpsells/resources/js/components/FreeAddOnTab.js
@@ -35,15 +35,15 @@ export const FreeAddOnTab = () => {
                         </h3>
                     </div>
                     <div className={styles.description}>
-                        {reports.description.map((text) => (
-                            <p dangerouslySetInnerHTML={{__html: transformStrong(text)}}></p>
+                        {reports.description.map((text, index) => (
+                            <p dangerouslySetInnerHTML={{__html: transformStrong(text)}} key={index}></p>
                         ))}
                     </div>
                 </div>
                 <aside className={styles.includes}>
                     <h4>{reports.highlights.heading}</h4>
-                    {reports.highlights.items.map(({icon, text}) => (
-                        <div className={styles.nameAndFlag}>
+                    {reports.highlights.items.map(({icon, text}, index) => (
+                        <div className={styles.nameAndFlag} key={index}>
                             <img className={styles.icon} src={icon} alt="Icon" />
                             <strong>{text}</strong>
                         </div>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6367

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we are not adding the `key` attribute to the` jsx` tag which is required when you print in the loop. I added it to resolve the issue.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Run npm run dev before starting testing.


You should not able to reproduce the issue as mentioned in the issue description.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

