### PR TITLE
Fix: complete stripe payment if payment_intent succeeded

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -2,6 +2,8 @@
 
 namespace Give\PaymentGateways\Gateways\Stripe\Traits;
 
+use Give\Framework\PaymentGateways\Commands\PaymentCommand;
+use Give\Framework\PaymentGateways\Commands\PaymentComplete;
 use Give\Framework\PaymentGateways\Commands\PaymentProcessing;
 use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
 use Give\PaymentGateways\Gateways\Stripe\Exceptions\PaymentIntentException;
@@ -12,10 +14,10 @@ trait HandlePaymentIntentStatus
     /**
      * @since 2.19.7 fix param order and only pass donationId
      *
-     * @param  PaymentIntent  $paymentIntent
-     * @param  string  $donationId
+     * @param PaymentIntent $paymentIntent
+     * @param string $donationId
      *
-     * @return PaymentProcessing|RedirectOffsite
+     * @return PaymentCommand|RedirectOffsite
      * @throws PaymentIntentException
      */
     public function handlePaymentIntentStatus(PaymentIntent $paymentIntent, $donationId)
@@ -25,6 +27,7 @@ trait HandlePaymentIntentStatus
                 give_set_payment_transaction_id($donationId, $paymentIntent->id());
                 return new RedirectOffsite($paymentIntent->nextActionRedirectUrl());
             case 'succeeded':
+                return new PaymentComplete($paymentIntent->id());
             case 'processing':
                 return new PaymentProcessing($paymentIntent->id());
             default:

--- a/tests/unit/tests/PaymentGateways/Gateways/Stripe/CreditCardGatewayTest.php
+++ b/tests/unit/tests/PaymentGateways/Gateways/Stripe/CreditCardGatewayTest.php
@@ -40,7 +40,7 @@ class CreditCardGatewayTest extends Give_Unit_Test_Case
         $gateway = new CreditCardGateway();
 
         $this->mock(Give_Stripe_Payment_Intent::class, function() {
-            return new Give_Stripe_Payment_Intent( 'succeeded' );
+            return new Give_Stripe_Payment_Intent( 'processing' );
         });
 
         $this->assertInstanceOf( PaymentProcessing::class, $gateway->createPayment( $this->getMockPaymentData() ) );

--- a/tests/unit/tests/PaymentGateways/Gateways/Stripe/CreditCardGatewayTest.php
+++ b/tests/unit/tests/PaymentGateways/Gateways/Stripe/CreditCardGatewayTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Give\Framework\PaymentGateways\Commands\PaymentComplete;
 use Give\Framework\PaymentGateways\Commands\PaymentProcessing;
 use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
 use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\Gateways\Stripe\CreditCardGateway;
+use Give\ValueObjects\DonorInfo;
 
 /**
  * @since 2.19.0
@@ -19,13 +21,26 @@ class CreditCardGatewayTest extends Give_Unit_Test_Case
     }
 
     /** @test */
-    public function it_creates_a_payment_that_is_processing()
+    public function it_creates_a_payment_that_is_complete()
     {
         $_POST['give_stripe_payment_method'] = 'pm_1234';
         $gateway = new CreditCardGateway();
 
         $this->mock(Give_Stripe_Payment_Intent::class, function() {
            return new Give_Stripe_Payment_Intent( 'succeeded' );
+        });
+
+        $this->assertInstanceOf( PaymentComplete::class, $gateway->createPayment( $this->getMockPaymentData() ) );
+    }
+
+    /** @test */
+    public function it_creates_a_payment_that_is_processing()
+    {
+        $_POST['give_stripe_payment_method'] = 'pm_1234';
+        $gateway = new CreditCardGateway();
+
+        $this->mock(Give_Stripe_Payment_Intent::class, function() {
+            return new Give_Stripe_Payment_Intent( 'succeeded' );
         });
 
         $this->assertInstanceOf( PaymentProcessing::class, $gateway->createPayment( $this->getMockPaymentData() ) );
@@ -50,7 +65,7 @@ class CreditCardGatewayTest extends Give_Unit_Test_Case
         $paymentData->donationId = 0;
         $paymentData->price = '1.00';
         $paymentData->currency = 'USD';
-        $paymentData->donorInfo = new \Give\ValueObjects\DonorInfo();
+        $paymentData->donorInfo = new DonorInfo();
         $paymentData->donorInfo->email = 'tester@test.test';
         return $paymentData;
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6369 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we were updating donation status to `processing` even if payment_intent succeeded.  Even though the donation completes with stripe webhook notification but it is nice to give immediate feedback about payment to the donor. I updated logic to complete donation if payment_intent succeeded.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Confirm these gateways are fully functional

- [x] Stripe Checkout Works (model)
- [x] Stripe Credit Card Works
- [ ] Stripe BECS Works
- [x] Stripe SEPA Works

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

