### PR TITLE
New: Form Grid block enhancements

### DIFF
--- a/assets/src/css/admin/block-editor.scss
+++ b/assets/src/css/admin/block-editor.scss
@@ -1,4 +1,8 @@
 @import '../frontend/_variables.scss';
+@import '../frontend/mixins';
+@import '../frontend/fonts';
 @import '../frontend/_components.donor.scss';
 @import '../frontend/_grid.scss';
 @import '../frontend/_card.scss';
+@import '../frontend/progress-bar';
+@import '../frontend/forms';

--- a/assets/src/css/admin/give-admin.scss
+++ b/assets/src/css/admin/give-admin.scss
@@ -48,5 +48,6 @@
 @import 'sale-banners';
 @import '_components.admin-header';
 @import '../frontend/progress-bar';
+@import '../frontend/forms';
 
 @import '../../../../src/DonorDashboards/resources/styles/upgradenotice.scss';

--- a/assets/src/css/admin/give-admin.scss
+++ b/assets/src/css/admin/give-admin.scss
@@ -47,7 +47,5 @@
 @import 'upsells';
 @import 'sale-banners';
 @import '_components.admin-header';
-@import '../frontend/progress-bar';
-@import '../frontend/forms';
 
 @import '../../../../src/DonorDashboards/resources/styles/upgradenotice.scss';

--- a/blocks/donation-form-grid/edit/inspector.js
+++ b/blocks/donation-form-grid/edit/inspector.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import {__} from '@wordpress/i18n'
-import {InspectorControls} from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
+import {InspectorControls, store } from '@wordpress/block-editor';
 import {
     PanelBody,
     SelectControl,
@@ -68,6 +69,13 @@ const Inspector = ({attributes, setAttributes}) => {
         return [value];
     };
 
+    const getImageSizes = () => select(store).getSettings().imageSizes.map(({slug, name}) => {
+        return {
+            value: slug,
+            label: name
+        };
+    });
+
     return (
         <InspectorControls key="inspector">
             <PanelBody title={__('Display Appearance', 'give')}>
@@ -125,10 +133,11 @@ const Inspector = ({attributes, setAttributes}) => {
 
                 {showFeaturedImage && (
                     <>
-                        <TextControl
+                        <SelectControl
                             name="imageSize"
                             label={__('Image Size', 'give')}
                             value={imageSize}
+                            options={getImageSizes()}
                             onChange={(value) => saveSetting('imageSize', value)}
                             help={__('Featured image size. Default "medium". Accepts WordPress image sizes.')}
                         />


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

## Description

This PR updates the Image Size option of the Form Grid block, instead of a regular Text Input field where the user had to enter the image size manually, now we have a Select dropdown field with all image size options registered in WordPress. Also, the frontend form styles are imported into the backend styles so that  Donate buttons inside the Form Grid block look nicer.  

## Affects

Form Grid Block

## Visuals

![image](https://user-images.githubusercontent.com/4222590/164428835-edbd3042-6596-4732-b5ac-e9482d6cc4be.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

