### PR TITLE
Fix: convert amount value to string before comparison with expected string value

### DIFF
--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -81,7 +81,7 @@ document.addEventListener('readystatechange', (event) => {
                             ? Give.fn.unFormatCurrency(
                                   input.value,
                                   Give.form.fn.getInfo('decimal_separator', donationForm)
-                              )
+                              ).toString()
                             : input.value;
 
                     const comparisonResult = compareWithOperator(operator, inputValue, value);

--- a/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
+++ b/src/Form/LegacyConsumer/resources/js/conditinal-fields.js
@@ -66,7 +66,8 @@ document.addEventListener('readystatechange', (event) => {
             const fieldName = fieldWrapper.getAttribute('data-field-name');
             const visibilityCondition = visibilityConditions[0]; // Currently we support only one visibility condition.
             let visible = false;
-            const {operator, value} = visibilityCondition;
+            const {operator} = visibilityCondition;
+            let {value} = visibilityCondition;
 
             const inputs = donationForm.querySelectorAll(`[name="${watchedFieldName}"]`);
             let hasFieldController = !!inputs.length;
@@ -74,15 +75,17 @@ document.addEventListener('readystatechange', (event) => {
             if (hasFieldController) {
                 inputs.forEach((input) => {
                     const fieldType = input.getAttribute('type');
+                    let inputValue = input.value;
 
                     // Make an exception for the amount field and parse the value
-                    const inputValue =
-                        input.name === 'give-amount'
-                            ? Give.fn.unFormatCurrency(
-                                  input.value,
-                                  Give.form.fn.getInfo('decimal_separator', donationForm)
-                              ).toString()
-                            : input.value;
+                    if (input.name === 'give-amount') {
+                        inputValue = Give.fn.unFormatCurrency(
+                            input.value,
+                            Give.form.fn.getInfo('decimal_separator', donationForm)
+                        );
+
+                        value = Math.abs(parseFloat(value));
+                    }
 
                     const comparisonResult = compareWithOperator(operator, inputValue, value);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6267

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we are comparing the donation amount numeric value to the expected donation amount string value. I converted the donation amount's actual value to a numeric type to prevent issues.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
It will only affect FFM custom field visibility on basis of donation amount field.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] FFM custom field appears correctly when the donation amount matches to expect amount ( currency: USD)
- [ ] FFM custom field appears correctly when the donation amount matches to expect amount ( currency: EUR)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

