### PR TITLE
fix Define percentage for actual goal

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1985,7 +1985,7 @@ function give_goal_progress_stats( $form ) {
 	// Define Actual Goal based on the goal format.
 	switch ( $goal_format ) {
 		case 'percentage':
-			$actual     = "{$actual}%";
+			$actual     = "{$progress}%";
 			$total_goal = '';
 			break;
 


### PR DESCRIPTION
Resolves # 6380

## Description

On the Admin Donation Form page, if a user set their goal to display as a percentage, it displayed a dollar amount instead.

## Affects

Admin donation form page

## Visuals

![Screen Shot 2022-04-22 at 4 04 50 PM](https://user-images.githubusercontent.com/75056371/164816855-70b27812-6753-4cd1-8d5f-031c2117c393.png)

## Testing Instructions

1. Edit/Create a form
2. Select Donation Goal under Donation Form Options
3. Enable Donation Goal
4. Set Goal Format to “Percentage Raised” 
5. Set Goal amount 
6. Process a donation 
7. View Donations > All Forms

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

