### PR TITLE
Fix: do not log sensitive information

### DIFF
--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -24,6 +24,21 @@ class PaymentGatewayLog extends Log
         foreach ($arguments[1] as $argument) {
             if ($argument instanceof GatewayPaymentData) {
                 unset($argument->cardInfo, $argument->legacyPaymentData['card_info']);
+
+                $cardFields = [
+                    'card_number',
+                    'card_cvc',
+                    'card_name',
+                    'card_exp_month',
+                    'card_exp_year',
+                    'card_expiry'
+                ];
+
+                foreach ($argument->legacyPaymentData['post_data'] as $fieldName => $data) {
+                    if (in_array($fieldName, $cardFields, true)) {
+                        unset($argument->legacyPaymentData['post_data'][$fieldName]);
+                    }
+                }
             }
 
             if ($argument instanceof CardInfo) {

--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -7,6 +7,7 @@ use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\ValueObjects\CardInfo;
 
 /**
+ * @unreleased Remove card information from post_data from legacyPaymentData property of GatewayPaymentData
  * @since 2.19.6 remove cardInfo from log
  * @since 2.18.0
  */

--- a/src/PaymentGateways/PayPalCommerce/Actions/GetPayPalOrderFromRequest.php
+++ b/src/PaymentGateways/PayPalCommerce/Actions/GetPayPalOrderFromRequest.php
@@ -2,7 +2,6 @@
 
 namespace Give\PaymentGateways\PayPalCommerce\Actions;
 
-use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
 use Give\PaymentGateways\PayPalCommerce\Exceptions\PayPalOrderIdException;
 use Give\PaymentGateways\PayPalCommerce\Repositories\PayPalOrder;
 use PayPalHttp\HttpException;
@@ -21,7 +20,7 @@ class GetPayPalOrderFromRequest
      */
     public function __invoke()
     {
-        $paypalOrderId = give_clean($_POST['payPalOrderId']);
+        $paypalOrderId = !empty($_POST['payPalOrderId']) ? give_clean($_POST['payPalOrderId']) : null;
 
         if (!$paypalOrderId) {
             throw new PayPalOrderIdException(

--- a/src/PaymentGateways/PayPalCommerce/Migrations/RemoveLogWithCardInfoInLegacyPaymentData.php
+++ b/src/PaymentGateways/PayPalCommerce/Migrations/RemoveLogWithCardInfoInLegacyPaymentData.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Give\PaymentGateways\PayPalCommerce\Migrations;
+
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * @unreleased
+ */
+class RemoveLogWithCardInfoInLegacyPaymentData extends Migration
+{
+    /**
+     * @inheritDoc
+     */
+    public function run()
+    {
+        $tableName = DB::prefix('give_log');
+
+        DB::query(
+            "
+            DELETE FROM {$tableName}
+            WHERE data like '%card_%'
+            "
+        );
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public static function id()
+    {
+        return 'remove-log-with-card-info-in-legacy-payment-data';
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public static function timestamp()
+    {
+        return strtotime('2022-04-28');
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public static function title()
+    {
+        return 'Remove Log With CardInfo In Legacy Payment Data';
+    }
+}

--- a/src/PaymentGateways/ServiceProvider.php
+++ b/src/PaymentGateways/ServiceProvider.php
@@ -14,6 +14,7 @@ use Give\PaymentGateways\Gateways\Stripe\Controllers\UpdateStatementDescriptorAj
 use Give\PaymentGateways\Gateways\Stripe\Migrations\AddMissingTransactionIdForUncompletedDonations;
 use Give\PaymentGateways\Gateways\Stripe\Migrations\AddStatementDescriptorToStripeAccounts;
 use Give\PaymentGateways\PayPalCommerce\Migrations\RemoveLogWithCardInfo;
+use Give\PaymentGateways\PayPalCommerce\Migrations\RemoveLogWithCardInfoInLegacyPaymentData;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
 /**
@@ -66,6 +67,7 @@ class ServiceProvider implements ServiceProviderInterface
             AddStatementDescriptorToStripeAccounts::class,
             AddMissingTransactionIdForUncompletedDonations::class,
             RemoveLogWithCardInfo::class,
+            RemoveLogWithCardInfoInLegacyPaymentData::class
         ]);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6327

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I discovered that card information stores in these places in `GatewayPaymentData` data transfer object:
1. In `cardInfo` property
2. In array key `card_info` in `legacyPaymentData` property
3. In array keys start with `card_` under `post_data` in `legacyPaymentData` property

We already fixed first two places mentioned in above list in https://github.com/impress-org/givewp/pull/6326

This pull request addresses third place mentioned in above list and also has migration to remove log which has card information.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This will only affect logs generated with `PaymentGatewayLog`

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Use Paypal donations in the existing GiveWP ( or `master` branch) to reproduce it. you should not able to reproduce this issue with this pull request.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

