### PR TITLE
Fix: update offline donation instruction tags to resolve when used globally in a form

### DIFF
--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -972,10 +972,8 @@ function give_email_tag_form_title( $tag_args ) {
             $donation_form_title = give_get_payment_meta($tag_args['payment_id'], '_give_payment_form_title');
             break;
         case give_check_variable($tag_args, 'isset', 0, 'form_id'):
-            /** @var WP_Post $form */
-            $form = get_post($tag_args['form_id']);
-            
-            $donation_form_title = $form ? $form->post_title : null;
+            $donation_form_title = get_the_title($tag_args['form_id']);
+            break;
     }
 
     /**
@@ -983,7 +981,7 @@ function give_email_tag_form_title( $tag_args ) {
      *
      * @since 2.0
      *
-     * @param  string  $form_title
+     * @param  string  $donation_form_title
      * @param  array  $tag_args
      */
     return apply_filters(

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -962,30 +962,35 @@ function give_email_tag_donation( $tag_args ) {
  * @return string $form_title
  */
 function give_email_tag_form_title( $tag_args ) {
-	$donation_form_title = '';
+    $donation_form_title = '';
 
-	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+    // Backward compatibility.
+    $tag_args = __give_20_bc_str_type_email_tag_param($tag_args);
 
-	switch ( true ) {
-		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
-			$donation_form_title = give_get_payment_meta( $tag_args['payment_id'], '_give_payment_form_title' );
-			break;
-	}
+    switch (true) {
+        case give_check_variable($tag_args, 'isset', 0, 'payment_id'):
+            $donation_form_title = give_get_payment_meta($tag_args['payment_id'], '_give_payment_form_title');
+            break;
+        case give_check_variable($tag_args, 'isset', 0, 'form_id'):
+            /** @var WP_Post $form */
+            $form = get_post($tag_args['form_id']);
+            
+            $donation_form_title = $form ? $form->post_title : null;
+    }
 
-	/**
-	 * Filter the {form_title} email template tag output.
-	 *
-	 * @since 2.0
-	 *
-	 * @param string $form_title
-	 * @param array  $tag_args
-	 */
-	return apply_filters(
-		'give_email_tag_form_title',
-		$donation_form_title,
-		$tag_args
-	);
+    /**
+     * Filter the {form_title} email template tag output.
+     *
+     * @since 2.0
+     *
+     * @param  string  $form_title
+     * @param  array  $tag_args
+     */
+    return apply_filters(
+        'give_email_tag_form_title',
+        $donation_form_title,
+        $tag_args
+    );
 }
 
 /**

--- a/includes/gateways/offline-donations.php
+++ b/includes/gateways/offline-donations.php
@@ -404,7 +404,7 @@ function get_formatted_offline_instructions( $instructions, $form_id, $wpautop =
 		$settings_url
 	);
 
-	$offline_instructions = give_do_email_tags( $offline_instructions, null );
+	$offline_instructions = give_do_email_tags($offline_instructions, ['form_id' => $form_id]);
 
 	return $wpautop ? wpautop( do_shortcode( $offline_instructions ) ) : $offline_instructions;
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4671

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

When using form specific tags in the offline donations instruction global content like `{form_title}`, the form does not render anything when offline is selected.  This is because these tags are looking for a `payment_id` which doesn't exist.  We just needed to pass along the `form_id` we already have.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The underlying class is `Give_Email_Template_Tags` which is used for email rendering and apparently other things like offline donation content rendering on a form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="714" alt="Screen Shot 2022-04-28 at 4 10 44 PM" src="https://user-images.githubusercontent.com/10138447/165837357-7c230e7d-534a-48b9-90ce-d53bfd71dd58.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Use `{form_title}` in your global offline instructions content and make sure the correct title is displayed on your form when selecting offline donation.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

