### PR TITLE
Feature: add function to count results rows

### DIFF
--- a/src/Framework/QueryBuilder/Clauses/From.php
+++ b/src/Framework/QueryBuilder/Clauses/From.php
@@ -26,6 +26,6 @@ class From
     public function __construct($table, $alias = null)
     {
         $this->table = QueryBuilder::prefixTable($table);
-        $this->alias = trim($alias);
+        $this->alias = $alias ? trim($alias) : '';
     }
 }

--- a/src/Framework/QueryBuilder/Clauses/Select.php
+++ b/src/Framework/QueryBuilder/Clauses/Select.php
@@ -24,6 +24,6 @@ class Select
     public function __construct($column, $alias = null)
     {
         $this->column = trim($column);
-        $this->alias  = trim($alias);
+        $this->alias  = $alias ? trim($alias) : '';
     }
 }

--- a/src/Framework/QueryBuilder/Concerns/Aggregate.php
+++ b/src/Framework/QueryBuilder/Concerns/Aggregate.php
@@ -22,18 +22,24 @@ trait Aggregate
     {
         $column = (!$column || $column === '*') ? '1' : trim($column);
 
-        if ($this->limit || $this->offset) {
-            $result = $this->getAll();
+        $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
+        $result = $this->get();
 
-            $count = $result ? count($result) : 0;
-        } else {
-            $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
-            $result = $this->get();
+        return +$result->count;
+    }
 
-            $count = $result ? +$result->count : 0;
-        }
+    /**
+     * Returns the number of rows returned by a query
+     *
+     * @unreleased
+     *
+     * @return int
+     */
+    public function countRows()
+    {
+        $result = $this->getAll();
 
-        return $count;
+        return $result ? count($result) : 0;
     }
 
     /**

--- a/src/Framework/QueryBuilder/Concerns/Aggregate.php
+++ b/src/Framework/QueryBuilder/Concerns/Aggregate.php
@@ -13,24 +13,35 @@ trait Aggregate
      * Returns the number of rows returned by a query
      *
      * @since 2.19.0
-     * @param  null|string  $column
+     *
+     * @param null|string $column
      *
      * @return int
      */
     public function count($column = null)
     {
-        $column = ( ! $column || $column === '*') ? '1' : trim($column);
+        $column = (!$column || $column === '*') ? '1' : trim($column);
 
-        $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
+        if ($this->limit || $this->offset) {
+            $result = $this->getAll();
 
-        return +$this->get()->count;
+            $count = $result ? count($result) : 0;
+        } else {
+            $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
+            $result = $this->get();
+
+            $count = $result ? +$result->count : 0;
+        }
+
+        return $count;
     }
 
     /**
      * Returns the total sum in a set of values
      *
      * @since 2.19.0
-     * @param  string  $column
+     *
+     * @param string $column
      *
      * @return int|float
      */
@@ -46,7 +57,8 @@ trait Aggregate
      * Get the average value in a set of values
      *
      * @since 2.19.0
-     * @param  string  $column
+     *
+     * @param string $column
      *
      * @return int|float
      */
@@ -61,7 +73,8 @@ trait Aggregate
      * Returns the minimum value in a set of values
      *
      * @since 2.19.0
-     * @param  string  $column
+     *
+     * @param string $column
      *
      * @return int|float
      */
@@ -76,7 +89,8 @@ trait Aggregate
      * Returns the maximum value in a set of values
      *
      * @since 2.19.0
-     * @param  string  $column
+     *
+     * @param string $column
      *
      * @return int|float
      */

--- a/tests/unit/tests/Framework/QueryBuilder/AggregateTest.php
+++ b/tests/unit/tests/Framework/QueryBuilder/AggregateTest.php
@@ -105,6 +105,44 @@ final class AggregateTest extends TestCase
     }
 
     /**
+     *
+     * @since 2.19.0
+     *
+     * @return void
+     */
+    public function testCountRowsShouldReturnTheTotalNumberOfRecords()
+    {
+        $data = [
+            [
+                'post_title' => 'Query Builder Aggregate test 0',
+            ],
+            [
+                'post_title' => 'Query Builder Aggregate test 1',
+            ],
+            [
+                'post_title' => 'Query Builder Aggregate test 2',
+            ]
+        ];
+
+        foreach ($data as $row) {
+            DB::table('posts')->insert($row);
+        }
+
+        $postsCount = DB::table('posts')
+            ->limit(2)
+            ->countRows();
+
+        $this->assertEquals(2, $postsCount);
+
+        $nonExistentPostTypeCount = DB::table('posts')
+            ->where('post_type', 'dummy')
+            ->limit(2)
+            ->countRows();
+
+        $this->assertEquals(0, $nonExistentPostTypeCount);
+    }
+
+    /**
      * @since 2.19.0
      *
      * @return void


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I added a function to count the number of rows in the result because the existing `count` function returns total rows and it does not consider for example `limit`, and `offset`.


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Use can test `countRows` function:

```php
DB::table('posts')
            ->where('post_type', 'give_payment')
            ->where('post_status', 'give_subscription')
            ->limit(2)
            ->offset(0)
    	    ->countRow();
    		
// Total items: 199
// Result: 2
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

