### PR TITLE
Fix: disable give-setup link in settings when page does not exist

### DIFF
--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -59,6 +59,7 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 			$settings = [];
 
 			$current_section = give_get_current_setting_section();
+            $setupPage = esc_url(admin_url('edit.php?post_type=give_forms&page=give-setup'));
 
 			switch ( $current_section ) {
 				case 'advanced-options':
@@ -125,17 +126,21 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
 							'name'          => __( 'Setup Page', 'give' ),
 							/* translators: %s: about page URL */
 							'desc'          => sprintf(
-								wp_kses(
-									__( 'This option controls the display of the <a href="%s" target="_blank">GiveWP Setup page</a> when GiveWP is first installed.', 'give' ),
-									[
-										'a' => [
-											'href'   => [],
-											'target' => [],
-										],
-									]
-								),
-								esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-setup' ) )
-							),
+                                wp_kses(
+                                    __(
+                                        'This option controls the display of the %s when GiveWP is first installed.',
+                                        'give'
+                                    ),
+                                    [
+                                        'a' => [
+                                            'href' => [],
+                                            'target' => [],
+                                        ],
+                                    ]
+                                ),
+                                SetupPage::getSetupPageEnabledOrDisabled(
+                                ) === SetupPage::ENABLED ? "<a href='$setupPage' target='_blank'>GiveWP Setup page</a>" : 'GiveWP Setup page'
+                            ),
 							'id'            => 'setup_page_enabled',
 							'type'          => 'radio_inline',
 							'default'       => give_is_setting_enabled(


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4930

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Unless the give-setup page is enabled, it just returns a 403.   I think this because the page doesn't actually exist until it's enabled.  So for a quick fix we can just conditionally enable the link depending on the settings. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The advanced settings page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="827" alt="Screen Shot 2022-04-29 at 5 49 48 PM" src="https://user-images.githubusercontent.com/10138447/166073541-6fd605f1-6ee7-44c0-95d9-6a432992764f.png">

<img width="829" alt="Screen Shot 2022-04-29 at 5 49 41 PM" src="https://user-images.githubusercontent.com/10138447/166073550-47a0bc2f-891e-4447-b333-f8b04235c8d3.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- enable and disable the option 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

