### PR TITLE
Feature: cache model relations

### DIFF
--- a/tests/unit/tests/Framework/Models/TestModel.php
+++ b/tests/unit/tests/Framework/Models/TestModel.php
@@ -239,6 +239,18 @@ class TestModel extends \Give_Unit_Test_Case
 
     /**
      * @unreleased
+     */
+    public function testModelRelationsShouldBeCached()
+    {
+        $model = new MockModelWithRelationship();
+
+        $post = $model->relatedAndCallableHasOne;
+
+        self::assertSame($model->relatedAndCallableHasOne, $post);
+    }
+
+    /**
+     * @unreleased
      *
      * @return array
      */


### PR DESCRIPTION
## Description

Consider the following:
```php
$donation->donor->firstName = 'Jason';
$donation->donor->lastName = 'Adams';
```

Presently, this will actually trigger two implicit queries. When the `donor` property is accessed it queries the donor under the hood. This means that in both cases when the donor is accessed it's querying the model. This is bad for a few reasons:
1. It's really counterintuitive
2. It's an easy performance sink
3. The object returned changes every time, so the second line is actually done to a different model

This PR adds a very light caching layer that stores relations after the first query. This allows for things like the example to happen and perform as one would intuit.

## Affects

Model relationships

## Testing Instructions

Grab a donation and then retrieve the donor twice. The two objects should be the literal (`===`) same.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

