### PR TITLE
Fix: only add enable-funding param to PayPal donations if value exists

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -151,12 +151,15 @@ EOT;
             'components' => 'hosted-fields,buttons',
             'locale' => get_locale(),
             'disable-funding' => 'credit',
-            'enable-funding' => give_is_setting_enabled( $settings['paypal_commerce_accept_venmo'] ) ? 'venmo' : '',
             'vault' => true,
             'data-partner-attribution-id' => give('PAYPAL_COMMERCE_ATTRIBUTION_ID'),
             'data-client-token' => $this->merchantRepository->getClientToken(),
         ];
 
+        if (give_is_setting_enabled($settings['paypal_commerce_accept_venmo'])) {
+            $payPalSdkQueryParameters['enable-funding'] = 'venmo';
+        }
+        
         wp_enqueue_script(
             $scriptId,
             GIVE_PLUGIN_URL . 'assets/dist/js/paypal-commerce.js',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Since the addition of #6388 we have a new param for PayPal called `enable-funding`.  Without enabling this option PayPal was throwing a js error and causing a conflict with the donation form.  This is the error below:

<img width="989" alt="Screen Shot 2022-05-02 at 2 55 45 PM" src="https://user-images.githubusercontent.com/10138447/166309374-9a304363-64a3-4272-ba57-57ddc04b0ef9.png">

This PR makes sure we are only passing this param to PayPal if a value exists to prevent any errors.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Paypal donations

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Disable Venmo and make sure paypal donations work correctly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

