### PR TITLE
Enhancement: Add redaction and better context handling to logs

### DIFF
--- a/src/Log/Admin/Logs/index.js
+++ b/src/Log/Admin/Logs/index.js
@@ -81,7 +81,7 @@ const Logs = () => {
             description: log.description,
             date: log.date,
             message: log.message,
-            context: log.context,
+            context: JSON.stringify(log.context, null, '    '),
         });
     };
 

--- a/src/Views/Components/Modal/styles.module.scss
+++ b/src/Views/Components/Modal/styles.module.scss
@@ -20,6 +20,8 @@
 .modal {
     display: block;
     max-width: 600px;
+    max-height: calc(100% - 2rem);
+    overflow-y: auto;
     width: 100%;
     position: absolute;
     top: 50%;

--- a/src/Views/Components/Table/index.js
+++ b/src/Views/Components/Table/index.js
@@ -5,7 +5,7 @@ import {LoadingOverlay, Spinner} from '@givewp/components';
 
 import styles from './style.module.scss';
 
-import { __ } from '@wordpress/i18n'
+import {__} from '@wordpress/i18n';
 
 const Table = ({title, columns, data, columnFilters, stripped, isLoading, isSorting, ...rest}) => {
     const [state, setState] = useState({});


### PR DESCRIPTION
## Description

We're running into an issue with sensitive information being stored in logs. We've handled this in a couple specific places, but we really should be trying to prevent this information from being stored on a Log level, otherwise we'll keep patching this sort of stuff as time goes on. Obviously this doesn't perfectly catch everything, but it would've caught all known issues thus far.

This PR adds checking for sensitive information and also makes a couple other improvements:
1. It makes sure the details modal fits within the available vertical space and provides scrolling in case of overflow.
2. It stores the contextual data as actual JSON, rather than a `print_r()` string. This is important as it helps us to better format and display the data on the front-end.

As a note, in cleaning up when objects are stored, I opted to add a "class" property when an object is being serialized. This way we have all of the properties stored, but also the name of the class the properties belong to.

Related: #6389 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<img width="659" alt="image" src="https://user-images.githubusercontent.com/2024145/166342997-1d98f7db-8bd6-4002-acd9-02af3e12a561.png">


## Testing Instructions

You can use the following to reproduce the visual:
```php
use Give\Log\Log;

Log::info('Here\'s some stuff', [
  'name' => 'Jason Adams',
  'password' => 'password1!',
  'confirm_password' => 'mypassword',
  'credit_card' => '4242',
  'deeper_array' => [
    'business' => 'GiveWP',
    'business_card' => '4242 4242',
    'foo' => new Foo()
  ]
]);

class Foo {
  public $bar = 'bar';
  public $secret = 'so secret';
}
```

Also view some old logs where the context was stored using `print_r` to make sure there's no regressions.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

