### PR TITLE
Fix: correct visual PayPal Donations issues in Classic template

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/css/form.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/form.scss
@@ -24,11 +24,12 @@ label.give-hidden {
 @import 'reset';
 
 // Icons
-@import '~@givewp/fontawesome/fontawesome';
-@import '~@givewp/fontawesome/regular';
-@import '~@givewp/fontawesome/solid';
-@import '~@givewp/fontawesome/brands';
-@import '~@givewp/hint.css';
+@import '~@givewp/css/icons/fa/fontawesome';
+@import '~@givewp/css/icons/fa/regular';
+@import '~@givewp/css/icons/fa/solid';
+@import '~@givewp/css/icons/fa/brands';
+@import '~@givewp/css/plugins/hint.min.scss';
+@import '~@givewp/css/plugins/utils.scss';
 @import 'icons';
 
 // Context

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -60,8 +60,7 @@ mix.webpackConfig({
    resolve: {
         alias: {
             '@givewp/components': path.resolve(__dirname, 'src/Views/Components/'),
-            '@givewp/fontawesome': path.resolve(__dirname, 'assets/src/css/icons/fa/'),
-            '@givewp/hint.css': path.resolve(__dirname, 'assets/src/css/plugins/hint.min.scss'),
+            '@givewp/css': path.resolve(__dirname, 'assets/src/css/'),
             '@givewp/promotions': path.resolve(__dirname, 'src/Promotions/sharedResources/'),
         },
     },


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6408 

## Description

There are some visual issues when using the PayPal Donations gateway in the Classic template, as documented in the Issue. Unfortunately, the button width issue is a limitation of the PayPal styles that we don't have control over and can't target — since the elements are inside an iFrame.

This does fix the "Or pay with card" section, though, which is arguably the worse of the two.

## Affects

PayPal Donations in the Classic template

## Visuals

<img width="864" alt="image" src="https://user-images.githubusercontent.com/2024145/167507023-e0514c3f-ced5-419d-85c9-bd22cdb69e4f.png">


## Testing Instructions

Use the PayPal Donations gateway in a Classic template form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] ~Relevant `@unreleased` tags included in DocBlocks~
-   [x] ~Includes unit and/or end-to-end tests~
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

