### PR TITLE
Log does not generate PHP warnings

### DIFF
--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -82,7 +82,7 @@ class Log
             );
 
             // Additional context
-            $data['context'] = array_diff(
+            $data['context'] = array_diff_key(
                 $context,
                 $data
             );

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -11,6 +11,7 @@ use Give\Log\ValueObjects\LogType;
  *
  * The static facade intended to be the primary way of logging within GiveWP to make life easier.
  *
+ * @unreleased Use array_diff_key to filter context data to prevent php wanring with multi-dimesion array
  * @unreleased add sensitive information redaction; store context as arrays for JSON serialization
  * @since 2.19.6 added debug
  * @since 2.10.0


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/issues/6410

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that `array_diff` generates a warning for multi-dimensional arrays, so I replace it with. `array_diff_key` to prevent PHP from warning. We were using `array_diff` to remove log config keys from `context`, we can achieve same result with `array_diff_key`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
It only affects `Log`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should not able to reproduce issue when follow `Steps to reproduce`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

