### PR TITLE
fix: show migration and log table in system info

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -565,6 +565,22 @@ $give_updates = Give_Updates::get_instance();
 				Table::prefixTableName( 'give_revenue' )
 			);
 
+            $isMigrationTableExist = Table::tableExists(Table::prefixTableName('give_migrations'));
+            $db_table_list .= sprintf(
+                '<li><mark class="%1$s"><span class="dashicons dashicons-%2$s"></mark> %3$s</li>',
+                $isMigrationTableExist ? 'yes' : 'error',
+                $isMigrationTableExist ? 'yes' : 'no-alt',
+                Table::prefixTableName('give_migrations')
+            );
+
+            $isLogTableExist = Table::tableExists(Table::prefixTableName('give_log'));
+            $db_table_list .= sprintf(
+                '<li><mark class="%1$s"><span class="dashicons dashicons-%2$s"></mark> %3$s</li>',
+                $isLogTableExist ? 'yes' : 'error',
+                $isLogTableExist ? 'yes' : 'no-alt',
+                Table::prefixTableName('give_log')
+            );
+
 			echo "<ul>{$db_table_list}</ul>";
 			?>
 		</td>


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we were not showing migration and log table installation status in system info (`Donations > Tools  > System Info`). This pull request adds these tables to the system information page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
this pull request affects only the system information page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
<img width="941" alt="Screenshot 2022-05-12 at 11 06 37 AM" src="https://user-images.githubusercontent.com/1784821/167999445-95dac3d5-8b42-41ab-9f97-47d0270b25d2.png">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should able to see migration and log table on system information page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

