### PR TITLE
Improvement: update DatabaseQueryException to log when uncaught

### DIFF
--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -239,7 +239,7 @@ class DB
         $wpError = self::getQueryErrors($errorCount);
 
         if (!empty($wpError->errors)) {
-            throw DatabaseQueryException::create($wpError->get_error_messages());
+            throw new DatabaseQueryException('Query Exception', $wpError->errors);
         }
 
         return $output;

--- a/src/Framework/Database/Exceptions/DatabaseQueryException.php
+++ b/src/Framework/Database/Exceptions/DatabaseQueryException.php
@@ -47,7 +47,6 @@ class DatabaseQueryException extends Exception
     {
         return [
             'category' => 'Uncaught database exception',
-            'Exception' => $this,
             'Query Errors' => $this->queryErrors,
         ];
     }

--- a/src/Framework/Database/Exceptions/DatabaseQueryException.php
+++ b/src/Framework/Database/Exceptions/DatabaseQueryException.php
@@ -2,7 +2,8 @@
 
 namespace Give\Framework\Database\Exceptions;
 
-use Exception;
+use Give\Framework\Exceptions\Primitives\Exception;
+use Throwable;
 
 /**
  * Class DatabaseQueryException
@@ -10,6 +11,7 @@ use Exception;
  * An exception for when errors occurred within the database while performing a query, which stores the SQL errors the
  * database returned
  *
+ * @unreleased Use the GiveWP exception class
  * @since 2.9.2
  */
 class DatabaseQueryException extends Exception
@@ -19,24 +21,11 @@ class DatabaseQueryException extends Exception
      */
     private $queryErrors;
 
-    /**
-     * Creates a new instance wih the query errors
-     *
-     * @since 2.9.2
-     *
-     * @param string|string[] $queryErrors
-     * @param string|null     $message
-     *
-     * @return DatabaseQueryException
-     */
-    public static function create($queryErrors, $message = null)
+    public function __construct(string $message, array $queryErrors, $code = 0, Throwable $previous = null)
     {
-        $error = new self();
+        $this->queryErrors = $queryErrors;
 
-        $error->message = $message ?: 'Query failed in database';
-        $error->queryErrors = (array)$queryErrors;
-
-        return $error;
+        parent::__construct($message, $code, $previous);
     }
 
     /**
@@ -46,32 +35,20 @@ class DatabaseQueryException extends Exception
      *
      * @return string[]
      */
-    public function getQueryErrors()
+    public function getQueryErrors(): array
     {
         return $this->queryErrors;
     }
 
     /**
-     * Returns a human readable form of the exception for logging
-     *
-     * @since 2.9.2
-     *
-     * @return string
+     * @inheritDoc
      */
-    public function getLogOutput()
+    public function getLogContext(): array
     {
-        $queryErrors = array_map(
-            function ($error) {
-                return " - {$error}";
-            },
-            $this->queryErrors
-        );
-
-        return "
-			Code: {$this->getCode()}\n
-			Message: {$this->getMessage()}\n
-			DB Errors: \n
-			{$queryErrors}
-		";
+        return [
+            'category' => 'Uncaught database exception',
+            'Exception' => $this,
+            'Query Errors' => $this->queryErrors,
+        ];
     }
 }

--- a/src/Framework/Exceptions/Contracts/LoggableException.php
+++ b/src/Framework/Exceptions/Contracts/LoggableException.php
@@ -8,17 +8,13 @@ interface LoggableException
      * Returns the human-readable message for the log
      *
      * @since 2.11.1
-     *
-     * @return string
      */
-    public function getLogMessage();
+    public function getLogMessage(): string;
 
     /**
      * Returns an associated array with additional context for the log
      *
      * @since 2.11.1
-     *
-     * @return array
      */
-    public function getLogContext();
+    public function getLogContext(): array;
 }

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -9,7 +9,7 @@ trait Loggable
      *
      * @since 2.11.1
      */
-    abstract public function getMessage(): string;
+    abstract public function getMessage();
 
     /**
      * Returns the human-readable log message

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -8,19 +8,15 @@ trait Loggable
      * Gets the Exception::getMessage() method
      *
      * @since 2.11.1
-     *
-     * @return string
      */
-    abstract public function getMessage();
+    abstract public function getMessage(): string;
 
     /**
      * Returns the human-readable log message
      *
      * @since 2.11.1
-     *
-     * @return string
      */
-    public function getLogMessage()
+    public function getLogMessage(): string
     {
         return $this->getMessage();
     }
@@ -32,7 +28,7 @@ trait Loggable
      *
      * @return array
      */
-    public function getLogContext()
+    public function getLogContext(): array
     {
         return [
             'category' => 'Uncaught Exception',

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -3,9 +3,7 @@
 namespace Give\Revenue\Repositories;
 
 use Give\Framework\Database\DB;
-use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
-use Give\Log\Log;
 
 /**
  * Class Revenue

--- a/src/Revenue/Repositories/Revenue.php
+++ b/src/Revenue/Repositories/Revenue.php
@@ -5,6 +5,7 @@ namespace Give\Revenue\Repositories;
 use Give\Framework\Database\DB;
 use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Log\Log;
 
 /**
  * Class Revenue
@@ -52,28 +53,16 @@ class Revenue
      * @param $revenueId
      *
      * @return false|int
-     * @throws DatabaseQueryException
      */
     public function deleteByDonationId($revenueId)
     {
         global $wpdb;
 
-        try {
-            return DB::delete(
-                $wpdb->give_revenue,
-                ['donation_id' => $revenueId],
-                ['%d']
-            );
-        } catch (DatabaseQueryException $exception) {
-            give_record_log(
-                'Revenue delete by donation failed',
-                $exception->getLogOutput(),
-                0,
-                'database'
-            );
-
-            throw $exception;
-        }
+        return DB::delete(
+            $wpdb->give_revenue,
+            ['donation_id' => $revenueId],
+            ['%d']
+        );
     }
 
     /**

--- a/tests/unit/tests/Framework/Exceptions/UncaughtExceptionLoggerTest.php
+++ b/tests/unit/tests/Framework/Exceptions/UncaughtExceptionLoggerTest.php
@@ -27,11 +27,11 @@ class UncaughtExceptionLoggerTest extends Give_Unit_Test_Case
 }
 
 class ExceptionLogged extends Exception implements LoggableException {
-	public function getLogMessage() {
+	public function getLogMessage(): string {
 		return '';
 	}
 
-	public function getLogContext() {
+	public function getLogContext(): array {
 		return [];
 	}
 }


### PR DESCRIPTION
## Description

The `DatabaseQueryException` was created before the uncaught exception logging was created, as such it's extending the base `Exception`, instead of the GiveWP primitive. This PR remedies this and adds the methods to best log the broken query.

I also cleaned up a couple minor, related things.

## Affects

Specifically, how uncaught query exceptions are handled. But it does broadly touch all queries.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Throw a `DatabaseQueryException` without catching it, then check the logs to make sure it's there.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

