### PR TITLE
Fix/Changed: Bring back filter support for income goal stats

### DIFF
--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -21,7 +21,7 @@ $show_text           = isset( $args['show_text'] ) ? filter_var( $args['show_tex
 $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
 
 /**
- * This filter will be used to convert the income amounts to different currencies.
+ * Allow filtering the goal stats used for this shortcode context.
  *
  * @since TBD
  *

--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -23,14 +23,14 @@ $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'
 /**
  * This filter will be used to convert the income amounts to different currencies.
  *
- * @since 2.5.4
+ * @since TBD
  *
  * @param array $stats               The income and goal values for this form goal.
  * @param int   $form_id             Donation Form ID.
  * @param array $goal_progress_stats The full goal progress stats.
  * @param array $args                The full list of shortcode arguments passed.
  */
-$income_amounts = apply_filters(
+$shortcode_stats = apply_filters(
     'give_goal_shortcode_stats',
     array(
         'income' => $form->get_earnings(),
@@ -41,8 +41,8 @@ $income_amounts = apply_filters(
     $args
 );
 
-$income = $income_amounts['income'];
-$goal   = $income_amounts['goal'];
+$income = $shortcode_stats['income'];
+$goal   = $shortcode_stats['goal'];
 
 switch ( $goal_format ) {
 

--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -20,8 +20,29 @@ $color               = give_get_meta( $form_id, '_give_goal_color', true );
 $show_text           = isset( $args['show_text'] ) ? filter_var( $args['show_text'], FILTER_VALIDATE_BOOLEAN ) : true;
 $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
 
-$income = $form->get_earnings();
-$goal   = $goal_progress_stats['raw_goal'];
+/**
+ * This filter will be used to convert the income amounts to different currencies.
+ *
+ * @since 2.5.4
+ *
+ * @param array $stats               The income and goal values for this form goal.
+ * @param int   $form_id             Donation Form ID.
+ * @param array $goal_progress_stats The full goal progress stats.
+ * @param array $args                The full list of shortcode arguments passed.
+ */
+$income_amounts = apply_filters(
+    'give_goal_shortcode_stats',
+    array(
+        'income' => $form->get_earnings(),
+        'goal'   => $goal_progress_stats['raw_goal'],
+    ),
+    $form_id,
+    $goal_progress_stats,
+    $args
+);
+
+$income = $income_amounts['income'];
+$goal   = $income_amounts['goal'];
 
 switch ( $goal_format ) {
 


### PR DESCRIPTION
## Description

https://github.com/impress-org/givewp/commit/16e564b22272d326ddc12fccbaa162e49cdbe43b removed support for the filtered income value `$goal_progress_stats['raw_actual']` and this just makes that filterable again. It does this in a generalized way that lets anyone filter the income OR goal values in the context of this goal shortcode.

An added bonus here in this PR is that it passes the `$args` so that it can support even more complex queries for customization at the shortcode level for custom shortcode args like date ranges, etc.

# Use-case

Customizing the current goal so that it's based on a date range. For instance, fundraising for specific versions of a free plugin so that once the fundraiser is over, the next version can have it's own separate income/goal without creating totally separate forms.

## Affects

The goal shortcode output for actual income and goal amounts.

## Visuals

<img width="1005" alt="Screen Shot 2022-05-15 at 4 52 52 PM" src="https://user-images.githubusercontent.com/709662/168495395-6315e008-fb36-46fa-944a-2a4a352e7ed1.png">

## Testing Instructions

1. Add the code below to a custom plugin
2. See the income of 1234 and the goal of 5678.

```php
// Basic example filter for overriding the goal shortcode income/goal stats used.
add_filter( 'give_goal_shortcode_stats', static function( $stats ) {
	$stats['income'] = 1234;
	$stats['goal']   = 5678;

	return $stats;
} );
```

<img width="981" alt="Screen Shot 2022-05-15 at 5 05 07 PM" src="https://user-images.githubusercontent.com/709662/168495793-523742ec-1f36-44d7-ad61-6cdf8d9302ba.png">

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

