### PR TITLE
Fix: admin notice's correctly display beneath the header

### DIFF
--- a/assets/src/js/admin/reports/app/index.js
+++ b/assets/src/js/admin/reports/app/index.js
@@ -45,7 +45,8 @@ const App = () => {
 						<SettingsToggle />
 					</div>
 				</div>
-				<Tabs />
+                <div className="wp-header-end hidden"> </div>
+                <Tabs />
 				<Routes />
 			</div>
 		</StoreProvider>

--- a/assets/src/js/admin/reports/app/index.js
+++ b/assets/src/js/admin/reports/app/index.js
@@ -45,7 +45,7 @@ const App = () => {
 						<SettingsToggle />
 					</div>
 				</div>
-                <div className="wp-header-end hidden"> </div>
+                <hr className="wp-header-end hidden"/>
                 <Tabs />
 				<Routes />
 			</div>

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -70,8 +70,12 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 
 		</div>
 
-        // Default behavior of WordPress places admin notices directly after the first h-tag inside any element
-        with the class of wrap. The tag below will instruct WordPress to place these notices below the header.
+        <?php
+        /*
+            Default behavior of WordPress places admin notices directly after the first h-tag inside any element
+            with the class of wrap. The tag below will instruct WordPress to place these notices below the header.
+        */
+        ?>
         <hr class="wp-header-end hidden">
 
         <div class="nav-tab-wrapper give-nav-tab-wrapper">

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -41,6 +41,7 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 		)
 	);
 	?>
+
 	<div class="wrap give-settings-page <?php echo esc_html( $wrapper_class ); ?>">
 
 		<?php echo $form_open_tag; ?>
@@ -69,7 +70,9 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 
 		</div>
 
-		<div class="nav-tab-wrapper give-nav-tab-wrapper">
+        <div class="wp-header-end hidden"></div>
+
+        <div class="nav-tab-wrapper give-nav-tab-wrapper">
 				<?php
 				foreach ( $tabs as $name => $label ) {
 					echo '<a href="' . admin_url( 'edit.php?post_type=give_forms&page=' . self::$setting_filter_prefix . "&tab={$name}" ) . '" class="nav-tab ' . ( $current_tab === $name ? 'nav-tab-active' : 'give-mobile-hidden' ) . '">' . $label . '</a>';

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -22,7 +22,7 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 	/**
 	 * Filter the main form tab.
 	 *
-	 * Note: You can stop print main form if you want to.filter dynamically fire on basis of setting page slug
+	 * Note: You can stop print main form if you want to filter dynamically fire on basis of setting page slug
 	 * For example: if you register a setting page with give-settings menu slug
 	 *              then filter will be give-settings_open_form, give-settings_close_form
 	 *              We are using this filter in includes/admin/tools/class-settings-data.php#L52

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -70,7 +70,7 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 
 		</div>
 
-        <div class="wp-header-end hidden"></div>
+        <hr class="wp-header-end hidden">
 
         <div class="nav-tab-wrapper give-nav-tab-wrapper">
 				<?php

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -70,6 +70,8 @@ if ( ! empty( $tabs ) && array_key_exists( give_get_current_setting_tab(), $tabs
 
 		</div>
 
+        // Default behavior of WordPress places admin notices directly after the first h-tag inside any element
+        with the class of wrap. The tag below will instruct WordPress to place these notices below the header.
         <hr class="wp-header-end hidden">
 
         <div class="nav-tab-wrapper give-nav-tab-wrapper">


### PR DESCRIPTION
Resolves #6365

## Description

By default Wordpress will place admin notices directly after the first H-tag element. This was causing various notices to be placed inside our header component. This PR corrects that issue in the Reports & Settings pages by introducing a hidden element "wp-header-end". The admin notices now display beneath the header and are structured the same as the other pages.

## Visuals
<img width="1424" alt="Settings" src="https://user-images.githubusercontent.com/75056371/169106995-9016baa6-994a-4b6b-a059-f6b06d59711e.png">

<img width="1424" alt="Reports" src="https://user-images.githubusercontent.com/75056371/169107003-99fb83bf-8d3c-41c3-909c-122262bc7988.png">

## Testing Instructions

1. Donations > Settings
2. Donations > Reports

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

