### PR TITLE
Fix: Prevent "switch view" buttons from showing up incorrectly

### DIFF
--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -652,7 +652,7 @@ function give_import_page_link_callback() {
         }
     </script>
     <button onclick="showReactTable()" class="page-title-action">
-        <?php _e('Show Updated View', 'give') ?>
+        <?php _e('Switch to New View', 'give') ?>
     </button>
 
 	<?php

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -153,7 +153,7 @@ class DonationFormsAdminPage
             }
             jQuery( function() {
                 jQuery(jQuery(".wrap .page-title-action")[0]).after(
-                    '<button class="page-title-action" onclick="showReactTable()">Switch to Updated View</button>'
+                    '<button class="page-title-action" onclick="showReactTable()">Switch to New View</button>'
                 );
             });
         </script>
@@ -163,11 +163,21 @@ class DonationFormsAdminPage
     /**
      * Helper function to determine if current page is Give Add-ons admin page
      *
-     * @return bool
+     * @since 2.20.0
      */
-    public static function isShowing()
+    public static function isShowing(): bool
     {
         return isset($_GET['page']) && $_GET['page'] === 'give-forms';
+    }
+
+    /**
+     * Helper function to determine if the current page is the legacy donation forms list page
+     *
+     * @unreleased
+     */
+    public static function isShowingLegacyPage(): bool
+    {
+        return isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms' && empty($_GET['page']);
     }
 
     /**

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -36,7 +36,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Hooks::addAction('admin_enqueue_scripts', DonationFormsAdminPage::class, 'loadScripts');
             }
         }
-        else
+        elseif(DonationFormsAdminPage::isShowingLegacyPage())
         {
             Hooks::addAction( 'admin_head', DonationFormsAdminPage::class, 'renderReactSwitch');
         }

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -164,7 +164,7 @@ class DonorsAdminPage
             }
             jQuery( function() {
                 jQuery(jQuery(".wrap .wp-header-end")).before(
-                    '<button class="page-title-action" onclick="showReactTable()">Switch to Updated View</button>'
+                    '<button class="page-title-action" onclick="showReactTable()">Switch to New View</button>'
                 );
             });
         </script>

--- a/src/Donors/ServiceProvider.php
+++ b/src/Donors/ServiceProvider.php
@@ -35,7 +35,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Hooks::addAction('admin_enqueue_scripts', DonorsAdminPage::class, 'loadScripts');
             }
         }
-        else
+        elseif(DonorsAdminPage::isShowing())
         {
             Hooks::addAction( 'admin_head', DonorsAdminPage::class, 'renderReactSwitch');
         }


### PR DESCRIPTION
Resolves #6419 

## Description

In 2.20.0 we introduced new admin UI list pages — donors and donations. On these pages you can switch and from the new view to the old one. Unfortunately, if the user switched to the legacy view the button they were given to return to the new view would show up all over the admin dashboard, not just on the list view pages they make sense on. Oops.

This PR fixes that. It also makes a minor correction to some inconsistent wording in the buttons that returned to the new view.

## Affects

The new admin list views, and in a way all the pages that the buttons were incorrectly showing up on before.

## Testing Instructions

1. Switch the form, donation, and donor list screens to the legacy view
2. Check the plugins page, edit form page, and anywhere else to make sure the buttons don't show up
3. Switch back to the new views and make sure they still work properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

