### PR TITLE
Fix: php 8.1 compatibility issue

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -167,6 +167,7 @@ function give_send_to_success_page( $query_string = null ) {
  * @param array|string $args
  *
  * @access public
+ * @unreleased Auto set "payment-mode" in redirect url.
  * @since  1.0
  * @return Void
  */

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -174,21 +174,23 @@ function give_send_back_to_checkout( $args = [] ) {
 
 	$url     = isset( $_POST['give-current-url'] ) ? sanitize_text_field( $_POST['give-current-url'] ) : '';
 	$form_id = 0;
+    $defaults = [];
 
 	// Set the form_id.
 	if ( isset( $_POST['give-form-id'] ) ) {
-		$form_id = sanitize_text_field( $_POST['give-form-id'] );
+        $defaults['form-id'] = (int) sanitize_text_field( $_POST['give-form-id'] );
 	}
+
+    // Set the payment mode.
+    if ( isset( $_POST['payment-mode'] ) ) {
+        $defaults['payment-mode'] = sanitize_text_field( $_POST['payment-mode'] );
+    }
 
 	// Need a URL to continue. If none, redirect back to single form.
 	if ( empty( $url ) ) {
 		wp_safe_redirect( get_permalink( $form_id ) );
 		give_die();
 	}
-
-	$defaults = [
-		'form-id' => (int) $form_id,
-	];
 
 	// Set the $level_id.
 	if ( isset( $_POST['give-price-id'] ) ) {

--- a/src/Framework/PaymentGateways/CommandHandlers/PaymentProcessingHandler.php
+++ b/src/Framework/PaymentGateways/CommandHandlers/PaymentProcessingHandler.php
@@ -18,7 +18,7 @@ class PaymentProcessingHandler extends PaymentHandler
     /**
      * @return DonationStatus
      */
-    protected function getPaymentStatus()
+    protected function getPaymentStatus(): DonationStatus
     {
         return DonationStatus::PROCESSING();
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
- I was getting an error on PHP8.1 when processing donations with SEPA.

```
[20-May-2022 14:52:46 UTC] PHP Fatal error:  Declaration of Give\Framework\PaymentGateways\CommandHandlers\PaymentProcessingHandler::getPaymentStatus() must be compatible with Give\Framework\PaymentGateways\CommandHandlers\PaymentHandler::getPaymentStatus(): Give\Donations\ValueObjects\DonationStatus in /Users/ravinderkumar/ValetSites/givewp/wp-content/plugins/give/src/Framework/PaymentGateways/CommandHandlers/PaymentProcessingHandler.php on line 21
```
2. Payment method does not auto-select when donor redirects back to donation form error on error. 
https://github.com/impress-org/givewp/blob/143c526e508d208b2e322b5f086591871ed49a66/src/Framework/PaymentGateways/PaymentGateway.php#L310

I fixed both issues on this pull request.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should able to process donation with Stripe SEPA on PHP8.1 and the payment gateway should auto-select when redirected to the donation form on error. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

