### PR TITLE
Enhancement: Query is now caught and logged in failed queries

### DIFF
--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -239,7 +239,7 @@ class DB
         $wpError = self::getQueryErrors($errorCount);
 
         if (!empty($wpError->errors)) {
-            throw new DatabaseQueryException('Query Exception', $wpError->errors);
+            throw new DatabaseQueryException($wpdb->last_query, $wpError->errors);
         }
 
         return $output;

--- a/src/Framework/Database/Exceptions/DatabaseQueryException.php
+++ b/src/Framework/Database/Exceptions/DatabaseQueryException.php
@@ -21,8 +21,23 @@ class DatabaseQueryException extends Exception
      */
     private $queryErrors;
 
-    public function __construct(string $message, array $queryErrors, $code = 0, Throwable $previous = null)
-    {
+    /**
+     * @var string
+     */
+    private $query;
+
+    /**
+     * @unreleased include query and query errors, and make auto-logging compatible
+     * @since 2.9.2
+     */
+    public function __construct(
+        string $query,
+        array $queryErrors,
+        string $message = 'Database Query',
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        $this->query = $query;
         $this->queryErrors = $queryErrors;
 
         parent::__construct($message, $code, $previous);
@@ -40,6 +55,11 @@ class DatabaseQueryException extends Exception
         return $this->queryErrors;
     }
 
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
     /**
      * @inheritDoc
      */
@@ -47,6 +67,7 @@ class DatabaseQueryException extends Exception
     {
         return [
             'category' => 'Uncaught database exception',
+            'Query' => $this->query,
             'Query Errors' => $this->queryErrors,
         ];
     }


### PR DESCRIPTION
## Description

Recently I added the errors to be included in the `DatabaseQueryException`, and set it up for auto-logging. I did not, however, include the failed log within the query. Frankly, I didn't know this was so easily doable until the illustrious @ravinderk pointed it out to me.

This PR adds the query to the exception to make it even easier to troubleshoot! 🪄✨

## Affects

Failed database queries

## Testing Instructions

1. Make some failed query (syntax, or whatever)
2. Check the exception to include the failed query
3. Check the log to include the failed query

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

