### PR TITLE
New: allow add-on to use 'Requires GiveWP' to define dependency

### DIFF
--- a/includes/class-give-readme-parser.php
+++ b/includes/class-give-readme-parser.php
@@ -1,60 +1,62 @@
 <?php
+
 /**
  * Give Readme Parser
  *
  * @package     Give
- * @subpackage  Admin/Readme_Parser
+ * @since       2.1.4
  * @copyright   Copyright (c) 2018, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
- * @since       2.1.4
+ * @subpackage  Admin/Readme_Parser
  */
-class Give_Readme_Parser {
-	/**
-	 * Readme file url
-	 *
-	 * @since  2.1.4
-	 * @access private
-	 * @var
-	 */
-	private $file_url;
+class Give_Readme_Parser
+{
+    /**
+     * Readme file url
+     *
+     * @since  2.1.4
+     * @access private
+     * @var
+     */
+    private $file_url;
 
-	/**
-	 * Readme file content
-	 *
-	 * @since  2.1.4
-	 * @access private
-	 * @var
-	 */
-	private $file_content;
+    /**
+     * Give_Readme_Parser constructor.
+     *
+     * @param string $file_url
+     */
+    public function __construct(string $file_url)
+    {
+        $this->file_url = $file_url;
+    }
 
-	/**
-	 * Give_Readme_Parser constructor.
-	 *
-	 * @param string $file_url
-	 */
-	function __construct( $file_url ) {
-		$this->file_url     = $file_url;
-		$this->file_content = wp_remote_retrieve_body( wp_remote_get( $this->file_url ) );
-	}
+    /**
+     * Get required Give core minimum version for addon
+     *
+     * @since 2.1.4
+     * @access public
+     *
+     * @return string
+     */
+    public function requires_at_least()
+    {
+        // Regex to extract Give core minimum version from the readme.txt file.
+        preg_match('/Requires (Give|GiveWP):(.*)/i', $this->get_readme_file_content(), $_requires_at_least);
 
-	/**
-	 * Get required Give core minimum version for addon
-	 *
-	 * @since 2.1.4
-	 * @access public
-	 *
-	 * @return string
-	 */
-	public function requires_at_least() {
-		// Regex to extract Give core minimum version from the readme.txt file.
-		preg_match( '|Requires (Give|GiveWP):(.*)|i', $this->file_content, $_requires_at_least );
+        if (is_array($_requires_at_least) && 3 === count($_requires_at_least)) {
+            $_requires_at_least = trim($_requires_at_least[2]);
+        } else {
+            $_requires_at_least = null;
+        }
 
-		if ( is_array( $_requires_at_least ) && 1 < count( $_requires_at_least ) ) {
-			$_requires_at_least = trim( $_requires_at_least[1] );
-		} else {
-			$_requires_at_least = null;
-		}
+        return $_requires_at_least;
+    }
 
-		return $_requires_at_least;
-	}
+    /**
+     * @unreleased
+     */
+    protected function get_readme_file_content(): string
+    {
+        return wp_remote_retrieve_body(wp_remote_get($this->file_url));
+    }
 }

--- a/includes/class-give-readme-parser.php
+++ b/includes/class-give-readme-parser.php
@@ -47,7 +47,7 @@ class Give_Readme_Parser {
 	 */
 	public function requires_at_least() {
 		// Regex to extract Give core minimum version from the readme.txt file.
-		preg_match( '|Requires Give:(.*)|i', $this->file_content, $_requires_at_least );
+		preg_match( '|Requires (Give|GiveWP):(.*)|i', $this->file_content, $_requires_at_least );
 
 		if ( is_array( $_requires_at_least ) && 1 < count( $_requires_at_least ) ) {
 			$_requires_at_least = trim( $_requires_at_least[1] );

--- a/tests/unit/legacy/test-addon-readme-parser.php
+++ b/tests/unit/legacy/test-addon-readme-parser.php
@@ -58,8 +58,8 @@ class Mock_GiveWP_Readme_Parser extends Give_Readme_Parser
         return '=== Give - Addon ===
 Requires at least: 5.0
 Requires PHP: 7.0
-Requires Give: 2.26.0
+Requires GiveWP: 2.26.0
 
-Add-on for Give.';
+Add-on for GiveWP.';
     }
 }

--- a/tests/unit/legacy/test-addon-readme-parser.php
+++ b/tests/unit/legacy/test-addon-readme-parser.php
@@ -1,0 +1,65 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once GIVE_PLUGIN_DIR . 'includes/class-give-readme-parser.php';
+
+/**
+ * @unreleased
+ */
+class Tests_Give_Readme_Parser extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function test_should_return_requires_give()
+    {
+        $this->assertEquals('2.25.0', (new Mock_Give_Readme_Parser('fake_url_value'))->requires_at_least());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function test_should_return_requires_givewp()
+    {
+        $this->assertEquals('2.26.0', (new Mock_GiveWP_Readme_Parser('fake_url_value'))->requires_at_least());
+    }
+}
+
+/**
+ * @unreleased
+ */
+class Mock_Give_Readme_Parser extends Give_Readme_Parser
+{
+    /**
+     * @unreleased
+     */
+    protected function get_readme_file_content(): string
+    {
+        return '=== Give - Addon ===
+Requires at least: 5.0
+Requires PHP: 7.0
+Requires Give: 2.25.0
+
+Add-on for Give.';
+    }
+}
+
+/**
+ * @unreleased
+ */
+class Mock_GiveWP_Readme_Parser extends Give_Readme_Parser
+{
+    /**
+     * @unreleased
+     */
+    protected function get_readme_file_content(): string
+    {
+        return '=== Give - Addon ===
+Requires at least: 5.0
+Requires PHP: 7.0
+Requires Give: 2.26.0
+
+Add-on for Give.';
+    }
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This pulls updated regex to extract the Give core minimum version from the add-on readme.txt file. It support `Requires Give` and `Requires GiveWP` readme.txt header tag.

I created this pull request for: 

<img width="765" alt="Screen Shot 2022-05-20 at 2 53 04 PM" src="https://user-images.githubusercontent.com/10138447/169593727-c4127277-d79c-43a3-80a9-3e554270452e.png">

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
It will affect the plugin's updated process.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Replace 'Requires Give' with  'Requires GiveWP' and set the version number to `2.25.0` in any add-on readme.txt and use a custom snippet to find out version.
```php
require_once GIVE_PLUGIN_DIR . 'includes/class-give-readme-parser.php';

$readmeParser = new Give_Readme_Parser(WP_PLUGIN_URL . '/give-square/readme.txt');

$readmeParser->requires_at_least(); // output value of "Requires GiveWP" or "Requires Give"
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

