### PR TITLE
Fix: remove php dependency validation logic

### DIFF
--- a/give.php
+++ b/give.php
@@ -85,6 +85,7 @@ if (!defined('ABSPATH')) {
 /**
  * Main Give Class
  *
+ * @unreleased Remove php dependency validation logic and constant
  * @since 2.19.6 add $donations, $subscriptions, and replace $donors class with DonorRepositoryProxy
  * @since 2.8.0 build in a service container
  * @since 1.0

--- a/give.php
+++ b/give.php
@@ -218,18 +218,6 @@ final class Give
      */
     public function boot()
     {
-        // PHP version
-        if (!defined('GIVE_REQUIRED_PHP_VERSION')) {
-            define('GIVE_REQUIRED_PHP_VERSION', '5.6.0');
-        }
-
-        // Bailout: Need minimum php version to load plugin.
-        if (function_exists('phpversion') && version_compare(GIVE_REQUIRED_PHP_VERSION, phpversion(), '>')) {
-            add_action('admin_notices', [$this, 'minimum_phpversion_notice']);
-
-            return;
-        }
-
         $this->setup_constants();
 
         // Add compatibility notice for recurring and stripe support with Give 2.5.0.
@@ -355,55 +343,6 @@ final class Give
         unload_textdomain('give');
         load_textdomain('give', WP_LANG_DIR . '/give/give-' . $locale . '.mo');
         load_plugin_textdomain('give', false, $give_lang_dir);
-    }
-
-    /**
-     *  Show minimum PHP version notice.
-     *
-     * @since  1.8.12
-     * @access public
-     */
-    public function minimum_phpversion_notice()
-    {
-        // Bailout.
-        if (!is_admin()) {
-            return;
-        }
-
-        $notice_desc = '<p><strong>' . __(
-                'Your site could be faster and more secure with a newer PHP version.',
-                'give'
-            ) . '</strong></p>';
-        $notice_desc .= '<p>' . __(
-                'Hey, we\'ve noticed that you\'re running an outdated version of PHP. PHP is the programming language that WordPress and GiveWP are built on. The version that is currently used for your site is no longer supported. Newer versions of PHP are both faster and more secure. In fact, your version of PHP no longer receives security updates, which is why we\'re sending you this notice.',
-                'give'
-            ) . '</p>';
-        $notice_desc .= '<p>' . __(
-                'Hosts have the ability to update your PHP version, but sometimes they don\'t dare to do that because they\'re afraid they\'ll break your site.',
-                'give'
-            ) . '</p>';
-        $notice_desc .= '<p><strong>' . __('To which version should I update?', 'give') . '</strong></p>';
-        $notice_desc .= '<p>' . __(
-                'You should update your PHP version to either 5.6 or to 7.0 or 7.1. On a normal WordPress site, switching to PHP 5.6 should never cause issues. We would however actually recommend you switch to PHP7. There are some plugins that are not ready for PHP7 though, so do some testing first. PHP7 is much faster than PHP 5.6. It\'s also the only PHP version still in active development and therefore the better option for your site in the long run.',
-                'give'
-            ) . '</p>';
-        $notice_desc .= '<p><strong>' . __('Can\'t update? Ask your host!', 'give') . '</strong></p>';
-        $notice_desc .= '<p>' . sprintf(
-                __(
-                    'If you cannot upgrade your PHP version yourself, you can send an email to your host. If they don\'t want to upgrade your PHP version, we would suggest you switch hosts. Have a look at one of the recommended %1$sWordPress hosting partners%2$s.',
-                    'give'
-                ),
-                sprintf(
-                    '<a href="%1$s" target="_blank">',
-                    esc_url('https://wordpress.org/hosting/')
-                ),
-                '</a>'
-            ) . '</p>';
-
-        echo sprintf(
-            '<div class="notice notice-error">%1$s</div>',
-            wp_kses_post($notice_desc)
-        );
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
WordPress 5.5 handles plugin PHP version requirements. Suppose the plugin added PHP version in the plugin header and readme.txt file that is sufficient for WordPress to validate PHP compatibility before installing or activating the plugin. I think it is safe to remove the custom minimum PHP version compatibility validation logic.

I discussed it with @JasonTheAdams  and he agrees that it is safe to remove.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Change the PHP version to `9.0` or anything greater than your PHP version in the plugin header after that try to install and activate the plugin. On WordPress 5.5, you should not able to install/activate the plugin if the PHP version is lesser than the required version.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

