### PR TITLE
Fix: Tool tabs display correctly

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -281,6 +281,10 @@ div.give-field-description {
 	font-size: 14px;
 }
 
+.give-tools-logs-tab, .give-tools-data-tab{
+    margin-left: 22px;
+}
+
 //--------------------------------------------------------------
 // Payment Gateways
 //--------------------------------------------------------------

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -282,7 +282,7 @@ div.give-field-description {
 }
 
 .give-tools-logs-tab, .give-tools-data-tab{
-    margin-left: 22px;
+    padding-left: 22px;
 }
 
 //--------------------------------------------------------------

--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -281,9 +281,6 @@ div.give-field-description {
 	font-size: 14px;
 }
 
-.give-tools-logs-tab, .give-tools-data-tab{
-    padding-left: 22px;
-}
 
 //--------------------------------------------------------------
 // Payment Gateways

--- a/src/Views/Components/ListTable/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage.module.scss
@@ -5,7 +5,6 @@
 
     .post-type-give_forms #wpbody {
         box-sizing: border-box;
-        padding-left: 0;
 
         & > a {
             text-decoration: underline
@@ -53,6 +52,7 @@
     background-color: #fff;
     padding-block: 1em;
     padding-inline: 1.5em;
+    margin-left: -20px;
     border-bottom: 0.0625rem solid #dbdbdb;
 
     & > * {
@@ -72,6 +72,7 @@
     margin: 0;
     font-size: 1.5rem;
     font-weight: 600;
+
 }
 
 .pageContent {
@@ -149,6 +150,7 @@
     background-color: rgba(248, 248, 248);
     padding-inline: 1.5em;
     padding-block: 1em;
+    margin: 0 -20px 0 -22px;
     border-bottom: 0.0625rem solid #dbdbdb;
 }
 


### PR DESCRIPTION
Resolves #6426

## Description

In ListTablePage.module.scss the default padding of #wpbody is removed. This is necessary to avoid odd spacing in "All Forms", "Donations" & "Donors". This style however will be applied to any page that contains the ListTable component. Both the Log & Data tab use this component. As a result it will have the default padding removed & uneven styles across the tool tabs.  This PR corrects this issue by reintroducing the same amount of padding to the specific tabs that are affected.

## Affects

Donations > Tools > Log & Data tabs

## Visuals
<img width="1530" alt="Log Tab" src="https://user-images.githubusercontent.com/75056371/169880601-e374f048-396c-4bc2-8abf-a6ac8fa2045a.png">

<img width="1530" alt="Data Tab" src="https://user-images.githubusercontent.com/75056371/169880613-0a1279c4-bbf4-4e16-9c7d-e6bfea61de56.png">

## Testing Instructions

1. View Donations > Tools > Log & Data tabs
2. Check that all tabs are spaced/styled the same
3. Check that Donations > All Forms, Donations & Donors are unaffected
4. Collapse Side Navigation and ensure spacing works as intended
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

