### PR TITLE
Changed: use givewp prefix for gateway registration actions

### DIFF
--- a/src/PaymentGateways/Actions/RegisterPaymentGateways.php
+++ b/src/PaymentGateways/Actions/RegisterPaymentGateways.php
@@ -62,24 +62,26 @@ class RegisterPaymentGateways
     /**
      * Register 3rd party payment gateways
      *
+     * @unreleased use givewp prefix for action
      * @since 2.18.0
      *
      * @param  PaymentGatewayRegister  $paymentGatewayRegister
      */
     private function register3rdPartyPaymentGateways(PaymentGatewayRegister $paymentGatewayRegister)
     {
-        do_action('give_register_payment_gateway', $paymentGatewayRegister);
+        do_action('givewp_register_payment_gateway', $paymentGatewayRegister);
     }
 
     /**
      * Unregister 3rd party payment gateways
      *
+     * @unreleased use givewp prefix for action
      * @since 2.18.0
      *
      * @param  PaymentGatewayRegister  $paymentGatewayRegister
      */
     private function unregister3rdPartyPaymentGateways(PaymentGatewayRegister $paymentGatewayRegister)
     {
-        do_action('give_unregister_payment_gateway', $paymentGatewayRegister);
+        do_action('givewp_unregister_payment_gateway', $paymentGatewayRegister);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Since merging https://github.com/impress-org/givewp/pull/6427 there are still some _new_ hooks that need to be converted to use the givewp prefix for their actions.  This PR notably changes the `give_register_payment_gateway` and `give_unregister_payment_gateway` to `givewp_register_payment_gateway` and `givewp_unregister_payment_gateway`.

Please note this is a _breaking change_ since some internal gateways are using this hook.  Since this api is not documented yet for the public, we should safely be able to update our internal gateways with these.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

External gateway registration


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Register a gateway with this hook

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

