### PR TITLE
Refactor: remove GatewayPaymentData class reference from code

### DIFF
--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -2,6 +2,7 @@
 
 namespace Give\Framework\PaymentGateways\Log;
 
+use Give\Donations\Models\Donation;
 use Give\Log\Log;
 
 /**
@@ -17,6 +18,13 @@ class PaymentGatewayLog extends Log
     {
         $arguments[1]['category'] = 'Payment Gateway';
         $arguments[1]['source'] = 'Payment Gateway';
+
+        if (
+            array_key_exists('Donation', $arguments[1]) &&
+            $arguments[1]['Donation'] instanceof Donation
+        ) {
+            $arguments[1]['source'] = $arguments[1]['Donation']->gateway()->getName();
+        }
 
         parent::__callStatic($name, $arguments);
     }

--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -3,8 +3,6 @@
 namespace Give\Framework\PaymentGateways\Log;
 
 use Give\Log\Log;
-use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
-use Give\ValueObjects\CardInfo;
 
 /**
  * @since 2.19.6 remove cardInfo from log
@@ -19,17 +17,6 @@ class PaymentGatewayLog extends Log
     {
         $arguments[1]['category'] = 'Payment Gateway';
         $arguments[1]['source'] = 'Payment Gateway';
-
-
-        foreach ($arguments[1] as $argument) {
-            if ($argument instanceof GatewayPaymentData) {
-                unset($argument->cardInfo, $argument->legacyPaymentData['card_info']);
-            }
-
-            if ($argument instanceof CardInfo) {
-                unset($argument);
-            }
-        }
 
         parent::__callStatic($name, $arguments);
     }

--- a/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
+++ b/src/Framework/PaymentGateways/Log/PaymentGatewayLog.php
@@ -6,6 +6,7 @@ use Give\Donations\Models\Donation;
 use Give\Log\Log;
 
 /**
+ * @unreleased Remove GatewayPaymentData related code and Update 'source' to payment gateway name
  * @since 2.19.6 remove cardInfo from log
  * @since 2.18.0
  */

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreateCheckoutSession.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreateCheckoutSession.php
@@ -6,7 +6,6 @@ use Give\Donations\Models\Donation;
 use Give\Donations\Models\DonationNote;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\PaymentGateways\DonationSummary;
-use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\Exceptions\InvalidPropertyName;
 use Give\PaymentGateways\Gateways\Stripe\ValueObjects\CheckoutSession;
 use Give_Stripe_Customer;
@@ -19,10 +18,6 @@ class CreateCheckoutSession
     /**
      * @since 2.20.0 Update function to get input value to line_items[0][name]
      * @since 2.19.0
-     *
-     * @param  GatewayPaymentData  $paymentData
-     * @param  DonationSummary  $donationSummary
-     * @param  Give_Stripe_Customer  $giveStripeCustomer
      *
      * @return CheckoutSession
      * @throws InvalidPropertyName

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -9,7 +9,6 @@ use Give\Framework\PaymentGateways\Commands\PaymentComplete;
 use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Helpers\Call;
-use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use Give\PaymentGateways\PayPalCommerce\Actions\GetPayPalOrderFromRequest;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 

--- a/tests/unit/tests/PaymentGateways/PaymentGatewaysRegisterTest.php
+++ b/tests/unit/tests/PaymentGateways/PaymentGatewaysRegisterTest.php
@@ -6,7 +6,6 @@ use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\PaymentGateways\Exceptions\OverflowException;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
-use Give\PaymentGateways\DataTransferObjects\GatewayPaymentData;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
`GatewayPaymentData` class has been removed from the GiveWP core. I find out about this class at a few places in code. In this pull request, I removed them.

I also added logic to change log `source` to the payment gateway name when the log generates from `PaymentGatewayLog`. this help to quickly catch the source of the log.

<img width="1462" alt="image" src="https://user-images.githubusercontent.com/1784821/170106419-80f91bd8-a5d4-4b54-8bd7-6b7e15a9167b.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Generate the `PaymentGatewayLog` log. You should see the payment gateway name in the `source` column in the log listing table.

```php
  PaymentGatewayLog::error(
                '{Error Message}',
                [
                    'Payment Gateway' => $this->getId(),
                    'Donation' => $donation,
                ]
            );
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

