### PR TITLE
Fix: add legacy subscription data to initial donation meta

### DIFF
--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -73,9 +73,6 @@ class LegacyPaymentGatewayAdapter
                 'donationFormId' => $formData->formId
             ]);
 
-            $donation->subscriptionId = $subscription->id;
-            $donation->save();
-
             give()->donations->updateLegacyDonationMetaAsInitialSubscriptionDonation($donation->id);
             give()->subscriptions->updateLegacyColumns(
                 $subscription->id,

--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -72,6 +72,10 @@ class LegacyPaymentGatewayAdapter
                 'donationFormId' => $formData->formId
             ]);
 
+            $donation->subscriptionId = $subscription->id;
+            $donation->save();
+
+            give()->donations->updateLegacyDonationMetaAsInitialSubscriptionDonation($donation->id);
             give()->subscriptions->updateLegacyColumns(
                 $subscription->id,
                 [

--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -35,7 +35,8 @@ class LegacyPaymentGatewayAdapter
     /**
      * First we create a payment, then move on to the gateway processing
      *
-     * @unreleased Replace give_insert_payment with donation model.
+     * @unreleased Replace give_insert_payment with donation model. Store legacy subscription data in donation meta.
+     *             Attach subscription id to donation.
      * @since 2.19.0 Replace is_recurring with is_donation_recurring to detect recurring donations.
      * @since 2.18.0
      *
@@ -43,7 +44,7 @@ class LegacyPaymentGatewayAdapter
      */
     public function handleBeforeGateway(array $legacyDonationData, PaymentGatewayInterface $registeredGateway)
     {
-       $formData = FormData::fromRequest($legacyDonationData);
+        $formData = FormData::fromRequest($legacyDonationData);
 
         $this->validateGatewayNonce($formData->gatewayNonce);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6434

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This pull request adds the missing donation meta for the initial subscription donation.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should have `_give_subscription_payment ` in the subscription initial donation. `subscription_id ` meta key value is also set to subscription id instead of zero.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

