### PR TITLE
Hot Fix: Add additional escaping when adding query args

### DIFF
--- a/includes/admin/donors/donor-actions.php
+++ b/includes/admin/donors/donor-actions.php
@@ -161,16 +161,18 @@ function give_edit_donor( $args ) {
 
 	if ( $output['success'] ) {
 		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'post_type'       => 'give_forms',
-					'page'            => 'give-donors',
-					'view'            => 'overview',
-					'id'              => $donor_id,
-					'give-messages[]' => 'profile-updated',
-				),
-				esc_url( admin_url( 'edit.php' ) )
-			)
+            esc_url(
+                 add_query_arg(
+                     array(
+                         'post_type'       => 'give_forms',
+                         'page'            => 'give-donors',
+                         'view'            => 'overview',
+                         'id'              => $donor_id,
+                         'give-messages[]' => 'profile-updated',
+                     ),
+                     admin_url( 'edit.php' )
+                 )
+            )
 		);
 	}
 

--- a/includes/admin/emails/filters.php
+++ b/includes/admin/emails/filters.php
@@ -23,32 +23,19 @@ function give_email_notification_row_actions_callback( $row_actions, $email ) {
 	if ( Give_Email_Notification_Util::is_email_preview( $email ) ) {
 		$preview_link = sprintf(
 			'<a href="%1$s" target="_blank">%2$s</a>',
-			wp_nonce_url(
-				add_query_arg(
-					array(
-						'give_action' => 'preview_email',
-						'email_type'  => $email->config['id'],
-					),
-					home_url()
-				),
-				'give-preview-email'
-			),
+            esc_url(
+                wp_nonce_url(
+                    add_query_arg(
+                        array(
+                            'give_action' => 'preview_email',
+                            'email_type'  => $email->config['id'],
+                        ),
+                        home_url()
+                    ),
+                    'give-preview-email'
+                )
+            ),
 			__( 'Preview', 'give' )
-		);
-
-		$send_preview_email_link = sprintf(
-			'<a href="%1$s">%2$s</a>',
-			wp_nonce_url(
-				add_query_arg(
-					array(
-						'give_action'     => 'send_preview_email',
-						'email_type'      => $email->config['id'],
-						'give-messages[]' => 'sent-test-email',
-					)
-				),
-				'give-send-preview-email'
-			),
-			__( 'Send test email', 'give' )
 		);
 
 		$send_preview_email_link = give()->tooltips->render_link( [
@@ -57,7 +44,7 @@ function give_email_notification_row_actions_callback( $row_actions, $email ) {
 				esc_html__( 'Click this link to send a test email to yourself at %s', 'give' ),
 				wp_get_current_user()->user_email
 			),
-			'link'        => wp_nonce_url(
+			'link'        => esc_url(wp_nonce_url(
 				add_query_arg(
 					array(
 						'give_action'     => 'send_preview_email',
@@ -66,7 +53,7 @@ function give_email_notification_row_actions_callback( $row_actions, $email ) {
 					)
 				),
 				'give-send-preview-email'
-			)
+			))
 		] );
 
 		$row_actions['email_preview']      = $preview_link;

--- a/includes/admin/give-metabox-functions.php
+++ b/includes/admin/give-metabox-functions.php
@@ -1158,33 +1158,37 @@ function give_email_preview_buttons( $field ) {
 
 	echo sprintf(
 		'<a href="%1$s" class="button-secondary" target="_blank">%2$s</a>',
-		wp_nonce_url(
-			add_query_arg(
-				[
-					'give_action' => 'preview_email',
-					'email_type'  => $field_id,
-					'form_id'     => $post->ID,
-				],
-				home_url()
-			),
-			'give-preview-email'
-		),
+        esc_url(
+            wp_nonce_url(
+                 add_query_arg(
+                     [
+                         'give_action' => 'preview_email',
+                         'email_type'  => $field_id,
+                         'form_id'     => $post->ID,
+                     ],
+                     home_url()
+                 ),
+                 'give-preview-email'
+            )
+        ),
 		$field['name']
 	);
 
 	echo sprintf(
 		' <a href="%1$s" aria-label="%2$s" class="button-secondary">%3$s</a>',
-		wp_nonce_url(
-			add_query_arg(
-				[
-					'give_action'     => 'send_preview_email',
-					'email_type'      => $field_id,
-					'give-messages[]' => 'sent-test-email',
-					'form_id'         => $post->ID,
-				]
-			),
-			'give-send-preview-email'
-		),
+        esc_url(
+            wp_nonce_url(
+                 add_query_arg(
+                     [
+                         'give_action'     => 'send_preview_email',
+                         'email_type'      => $field_id,
+                         'give-messages[]' => 'sent-test-email',
+                         'form_id'         => $post->ID,
+                     ]
+                 ),
+                 'give-send-preview-email'
+            )
+        ),
 		esc_attr__( 'Send Test Email.', 'give' ),
 		esc_html__( 'Send Test Email', 'give' )
 	);

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -1120,5 +1120,5 @@ function give_import_page_url( $parameter = [] ) {
 	];
 	$import_query_arg  = wp_parse_args( $parameter, $defalut_query_arg );
 
-	return add_query_arg( $import_query_arg, admin_url( 'edit.php' ) );
+	return esc_url( add_query_arg( $import_query_arg, admin_url( 'edit.php' ) ) );
 }

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -606,16 +606,18 @@ class Give_Payment_History_Table extends WP_List_Table {
 
 			$actions['email_links'] = sprintf(
 				'<a class="resend-single-donation-receipt" href="%1$s" aria-label="%2$s">%3$s</a>',
-				wp_nonce_url(
-					add_query_arg(
-						[
-							'give-action' => 'email_links',
-							'purchase_id' => $payment->ID,
-						],
-						$this->base_url
-					),
-					'give_payment_nonce'
-				),
+                esc_url(
+                    wp_nonce_url(
+                        add_query_arg(
+                            [
+                                'give-action' => 'email_links',
+                                'purchase_id' => $payment->ID,
+                            ],
+                            $this->base_url
+                        ),
+                        'give_payment_nonce'
+                    )
+                ),
 				sprintf( __( 'Resend Donation %s Receipt', 'give' ), $payment->ID ),
 				__( 'Resend Receipt', 'give' )
 			);
@@ -625,16 +627,18 @@ class Give_Payment_History_Table extends WP_List_Table {
 		if ( current_user_can( 'view_give_payments' ) ) {
 			$actions['delete'] = sprintf(
 				'<a class="delete-single-donation" href="%1$s" aria-label="%2$s">%3$s</a>',
-				wp_nonce_url(
-					add_query_arg(
-						[
-							'give-action' => 'delete_payment',
-							'purchase_id' => $payment->ID,
-						],
-						$this->base_url
-					),
-					'give_donation_nonce'
-				),
+                esc_url(
+                    wp_nonce_url(
+                        add_query_arg(
+                            [
+                                'give-action' => 'delete_payment',
+                                'purchase_id' => $payment->ID,
+                            ],
+                            $this->base_url
+                        ),
+                        'give_donation_nonce'
+                    )
+                ),
 				sprintf( __( 'Delete Donation %s', 'give' ), $payment->ID ),
 				__( 'Delete', 'give' )
 			);

--- a/includes/admin/payments/view-payment-details.php
+++ b/includes/admin/payments/view-payment-details.php
@@ -137,16 +137,18 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 										echo sprintf(
 											'<span class="delete-donation" id="delete-donation-%d"><a class="delete-single-donation delete-donation-button dashicons dashicons-trash" href="%s" aria-label="%s"></a></span>',
 											$payment_id,
-											wp_nonce_url(
-												add_query_arg(
-													array(
-														'give-action' => 'delete_payment',
-														'purchase_id' => $payment_id,
-													),
-													$base_url
-												),
-												'give_donation_nonce'
-											),
+                                            esc_url(
+                                                wp_nonce_url(
+                                                    add_query_arg(
+                                                        array(
+                                                            'give-action' => 'delete_payment',
+                                                            'purchase_id' => $payment_id,
+                                                        ),
+                                                        $base_url
+                                                    ),
+                                                    'give_donation_nonce'
+                                                )
+                                            ),
 											sprintf( __( 'Delete Donation %s', 'give' ), $payment_id )
 										);
 									}
@@ -357,7 +359,7 @@ $base_url       = admin_url( 'edit.php?post_type=give_forms&page=give-payment-hi
 												<a href="<?php echo $purchase_url; ?>"><?php _e( 'View all donations for this donor &raquo;', 'give' ); ?></a>
 											</p>
 										</div>
-										
+
 									</div>
 									<!-- /.column-container -->
 

--- a/includes/admin/reports/class-gateways-reports-table.php
+++ b/includes/admin/reports/class-gateways-reports-table.php
@@ -74,13 +74,15 @@ class Give_Gateway_Reports_Table extends WP_List_Table {
 				$value = $item[ $column_name ] ?
 					sprintf(
 						'<a href="%s">%s</a>',
-						add_query_arg(
-							array(
-								'status'  => 'publish',
-								'gateway' => $item['ID'],
-							),
-							$donation_list_page_url
-						),
+                        esc_url(
+                            add_query_arg(
+                                array(
+                                    'status'  => 'publish',
+                                    'gateway' => $item['ID'],
+                                ),
+                                $donation_list_page_url
+                            )
+                        ),
 						$item[ $column_name ]
 					) :
 					$item[ $column_name ];
@@ -90,13 +92,15 @@ class Give_Gateway_Reports_Table extends WP_List_Table {
 				$value = $item[ $column_name ] ?
 					sprintf(
 						'<a href="%s">%s</a>',
-						add_query_arg(
-							array(
-								'status'  => 'pending',
-								'gateway' => $item['ID'],
-							),
-							$donation_list_page_url
-						),
+                        esc_url(
+                            add_query_arg(
+                                array(
+                                    'status'  => 'pending',
+                                    'gateway' => $item['ID'],
+                                ),
+                                $donation_list_page_url
+                            )
+                        ),
 						$item[ $column_name ]
 					) :
 					$item[ $column_name ];
@@ -106,12 +110,14 @@ class Give_Gateway_Reports_Table extends WP_List_Table {
 				$value = $item[ $column_name ] ?
 					sprintf(
 						'<a href="%s">%s</a>',
-						add_query_arg(
-							array(
-								'gateway' => $item['ID'],
-							),
-							$donation_list_page_url
-						),
+                        esc_url(
+                            add_query_arg(
+                                array(
+                                    'gateway' => $item['ID'],
+                                ),
+                                $donation_list_page_url
+                            )
+                        ),
 						$item[ $column_name ]
 					) :
 					$item[ $column_name ];

--- a/includes/admin/reports/graphing.php
+++ b/includes/admin/reports/graphing.php
@@ -809,7 +809,7 @@ function give_parse_report_dates( $data ) {
 	$tab  = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'earnings';
 	$id   = isset( $_GET['form-id'] ) ? $_GET['form-id'] : null;
 
-	wp_redirect( add_query_arg( $dates, admin_url( 'edit.php?post_type=give_forms&page=give-reports&legacy=true&tab=' . esc_attr( $tab ) . '&view=' . esc_attr( $view ) . '&form-id=' . absint( $id ) ) ) );
+	wp_redirect( esc_url(add_query_arg( $dates, admin_url( 'edit.php?post_type=give_forms&page=give-reports&legacy=true&tab=' . esc_attr( $tab ) . '&view=' . esc_attr( $view ) . '&form-id=' . absint( $id ) ) ) ) );
 	give_die();
 }
 

--- a/includes/admin/tools/export/export-functions.php
+++ b/includes/admin/tools/export/export-functions.php
@@ -116,7 +116,7 @@ function give_do_ajax_export() {
 
 		$json_data = [
 			'step' => 'done',
-			'url'  => add_query_arg( $args, admin_url() ),
+			'url'  => esc_url(add_query_arg( $args, admin_url() )),
 		];
 
 	}

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -130,7 +130,7 @@ function give_get_ajax_url( $query = [] ) {
 		$ajax_url = add_query_arg( $query, $ajax_url );
 	}
 
-	return apply_filters( 'give_ajax_url', $ajax_url );
+	return esc_url( apply_filters( 'give_ajax_url', $ajax_url ) );
 }
 
 /**

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -1194,7 +1194,7 @@ function give_stripe_connect_button() {
 			'website_url'           => get_bloginfo( 'url' ),
 			'give_stripe_connected' => '0',
 		],
-		esc_url_raw( 'https://connect.givewp.com/stripe/connect.php' )
+		'https://connect.givewp.com/stripe/connect.php'
 	);
 
 	return sprintf(
@@ -1234,8 +1234,8 @@ function give_stripe_disconnect_url( $account_id = '', $account_name = '' ) {
 	}
 
 	// Prepare Stripe Disconnect URL.
-	return add_query_arg(
+	return esc_url_raw( add_query_arg(
 		$args,
-		esc_url_raw( 'https://connect.givewp.com/stripe/connect.php' )
-	);
+		'https://connect.givewp.com/stripe/connect.php'
+    ) );
 }

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -114,31 +114,35 @@ function give_email_preview_buttons_callback( $field ) {
 
 	echo sprintf(
 		'<a href="%1$s" class="button-secondary" target="_blank">%2$s</a>',
-		wp_nonce_url(
-			add_query_arg(
-				array(
-					'give_action' => 'preview_email',
-					'email_type'  => $field_id,
-				),
-				home_url()
-			),
-			'give-preview-email'
-		),
+        esc_url(
+            wp_nonce_url(
+                add_query_arg(
+                    array(
+                        'give_action' => 'preview_email',
+                        'email_type'  => $field_id,
+                    ),
+                    home_url()
+                ),
+                'give-preview-email'
+            )
+        ),
 		$field['name']
 	);
 
 	echo sprintf(
 		' <a href="%1$s" aria-label="%2$s" class="button-secondary">%3$s</a>',
-		wp_nonce_url(
-			add_query_arg(
-				array(
-					'give_action'     => 'send_preview_email',
-					'email_type'      => $field_id,
-					'give-messages[]' => 'sent-test-email',
-				)
-			),
-			'give-send-preview-email'
-		),
+        esc_url(
+            wp_nonce_url(
+                add_query_arg(
+                    array(
+                        'give_action'     => 'send_preview_email',
+                        'email_type'      => $field_id,
+                        'give-messages[]' => 'sent-test-email',
+                    )
+                ),
+                'give-send-preview-email'
+            )
+        ),
 		esc_attr__( 'Send Test Email.', 'give' ),
 		esc_html__( 'Send Test Email', 'give' )
 	);

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -219,7 +219,7 @@ function give_send_back_to_checkout( $args = [] ) {
 	/**
 	 * Filter the redirect url
 	 */
-	wp_safe_redirect( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) );
+	wp_safe_redirect( esc_url_raw( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) ) );
 
 	give_die();
 }

--- a/includes/gateways/paypal/paypal-standard.php
+++ b/includes/gateways/paypal/paypal-standard.php
@@ -305,7 +305,7 @@ function give_build_paypal_url($payment_id, $payment_data)
         'charset'       => get_bloginfo('charset'),
         'custom'        => $payment_id,
         'rm'            => '2',
-        'return'        => $return_url,
+        'return'        => esc_url_raw( $return_url ),
         'cancel_return' => give_get_failed_transaction_uri(),
         'notify_url'    => $listener_url,
         'page_style'    => give_get_paypal_page_style(),

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -1348,10 +1348,10 @@ function give_stripe_get_admin_settings_page_url( $args = [] ) {
 
 	$args = wp_parse_args( $args, $default_args );
 
-	return add_query_arg(
+	return esc_url_raw( add_query_arg(
 		$args,
-		esc_url_raw( admin_url( 'edit.php' ) )
-	);
+		admin_url( 'edit.php' )
+	) );
 }
 
 /**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -61,7 +61,7 @@ function give_get_current_page_url() {
 	 *
 	 * @since 1.0
 	 */
-	return apply_filters( 'give_get_current_page_url', $current_uri );
+	return esc_url_raw( apply_filters( 'give_get_current_page_url', $current_uri ) );
 
 }
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -555,9 +555,9 @@ function give_process_profile_editor_updates( $data ) {
 		 * If the password is changed, then logout and redirect to the same page.
 		 */
 		if ( '2' === $update_code || '3' === $update_code ) {
-			wp_logout( wp_redirect( add_query_arg( $profile_edit_redirect_args, $data['give_redirect'] ) ) );
+			wp_logout();
 		} else {
-			wp_redirect( add_query_arg( $profile_edit_redirect_args, $data['give_redirect'] ) );
+			wp_redirect( esc_url_raw( add_query_arg( $profile_edit_redirect_args, $data['give_redirect'] ) ) );
 		}
 
 		give_die();

--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -117,10 +117,10 @@ class DonationsAdminPage
             $queryParameters['search'] = urldecode($_GET['search']);
         }
 
-        $request = WP_REST_Request::from_url(add_query_arg(
+        $request = WP_REST_Request::from_url(esc_url(add_query_arg(
             $queryParameters,
             $this->apiRoot
-        ));
+        )));
 
         return rest_do_request($request)->get_data();
     }

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -53,7 +53,7 @@ class App
             $queryArgs['action'] = urlencode(give_clean($_GET['action']));
         }
 
-        $url = add_query_arg($queryArgs, $url);
+        $url = esc_url(add_query_arg($queryArgs, $url));
 
         $loader = $this->getIframeLoader($attributes['accent_color']);
 

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -107,10 +107,10 @@ class DonorsAdminPage
             'status' => 'any'
         ];
 
-        $url = add_query_arg(
+        $url = esc_url_raw(add_query_arg(
             $queryParameters,
-            esc_url_raw(rest_url('give-api/v2/admin/forms'))
-        );
+            rest_url('give-api/v2/admin/forms')
+        ));
 
         $request = \WP_REST_Request::from_url($url);
         $response = rest_do_request($request);

--- a/src/Framework/PaymentGateways/Actions/GenerateGatewayRouteUrl.php
+++ b/src/Framework/PaymentGateways/Actions/GenerateGatewayRouteUrl.php
@@ -26,9 +26,9 @@ class GenerateGatewayRouteUrl
             $queryArgs = array_merge($queryArgs, $args);
         }
 
-        return add_query_arg(
+        return esc_url_raw(add_query_arg(
             $queryArgs,
             home_url()
-        );
+        ));
     }
 }

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -119,10 +119,10 @@ class Utils
     {
         $args = array_merge($args, ['giveDonationAction' => 'showReceipt']);
 
-        return add_query_arg(
+        return esc_url_raw(add_query_arg(
             $args,
             $url
-        );
+        ));
     }
 
     /**
@@ -198,10 +198,10 @@ class Utils
     {
         $args = array_merge($args, ['giveDonationAction' => 'failedDonation']);
 
-        return add_query_arg(
+        return esc_url_raw(add_query_arg(
             $args,
             $url
-        );
+        ));
     }
 
     /**

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -68,7 +68,7 @@ class Utils
             }
         }
 
-        return $url;
+        return esc_url_raw($url);
     }
 
     /**

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -835,10 +835,10 @@ class Give_Subscription {
 	 */
 	public function get_update_url() {
 
-		$url = add_query_arg( array(
+		$url = esc_url(add_query_arg( array(
 			'action'          => 'update',
 			'subscription_id' => $this->id,
-		) );
+		) ) );
 
 		return apply_filters( 'give_subscription_update_url', $url, $this );
 	}
@@ -851,10 +851,10 @@ class Give_Subscription {
 	 */
 	public function get_edit_subscription_url() {
 
-		$url = add_query_arg( array(
+		$url = esc_url(add_query_arg( array(
 			'action'          => 'edit_subscription',
 			'subscription_id' => $this->id,
-		), give_get_subscriptions_page_uri() );
+		), give_get_subscriptions_page_uri() ));
 
 		return apply_filters( 'give_subscription_edit_subscription_url', $url, $this );
 	}

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -113,10 +113,10 @@ class PayPalStandard extends PaymentGateway
     {
         $donationId = (int)$queryParams['donation-id'];
 
-        return new RedirectResponse(add_query_arg(
+        return new RedirectResponse(esc_url_raw(add_query_arg(
             [ 'payment-confirmation' => $this->getId() ],
             Call::invoke(GenerateDonationReceiptPageUrl::class, $donationId)
-        ));
+        )));
     }
 
     /**

--- a/src/PaymentGateways/Gateways/Stripe/Helpers/CheckoutHelper.php
+++ b/src/PaymentGateways/Gateways/Stripe/Helpers/CheckoutHelper.php
@@ -16,14 +16,14 @@ class CheckoutHelper
      */
     public function getRedirectUrl( $sessionId, $formId )
     {
-        return add_query_arg(
+        return esc_url_raw(add_query_arg(
             [
                 'action'  => 'checkout_processing',
                 'session' => $sessionId,
                 'id'      => $formId,
             ],
             site_url()
-        );
+        ));
     }
 
     /**

--- a/src/PaymentGateways/Gateways/Stripe/Traits/CheckoutRedirect.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/CheckoutRedirect.php
@@ -16,14 +16,14 @@ trait CheckoutRedirect
      */
     public function getRedirectUrl( $sessionId, $formId )
     {
-        return add_query_arg(
+        return esc_url_raw(add_query_arg(
             [
                 'action'  => 'checkout_processing',
                 'session' => $sessionId,
                 'id'      => $formId,
             ],
             site_url()
-        );
+        ));
     }
 
     /**

--- a/src/PaymentGateways/Stripe/Admin/AccountManagerSettingField.php
+++ b/src/PaymentGateways/Stripe/Admin/AccountManagerSettingField.php
@@ -247,22 +247,22 @@ class AccountManagerSettingField
             return;
         }
 
-        $disconnectUrl = add_query_arg(
+        $disconnectUrl = esc_url_raw(add_query_arg(
             [
                 'account_type' => $stripeAccount['type'],
                 'action' => 'disconnect_stripe_account',
                 'account_slug' => $stripeAccountSlug,
             ],
             wp_nonce_url(admin_url('admin-ajax.php'), 'give_disconnect_connected_stripe_account_' . $stripeAccountSlug)
-        );
+        ));
 
-        $editStatementDescriptorUrl = add_query_arg(
+        $editStatementDescriptorUrl = esc_url_raw(add_query_arg(
             [
                 'action' => 'edit_stripe_account_statement_descriptor',
                 'account-slug' => $stripeAccountSlug,
             ],
             admin_url('admin-ajax.php')
-        );
+        ));
 
         $classes = $stripeAccountSlug === $this->defaultStripeAccountSlug ? ' give-stripe-boxshadow-option-wrap__selected' : '';
         ?>

--- a/src/Route/Form.php
+++ b/src/Route/Form.php
@@ -137,13 +137,13 @@ class Form
 
         return get_option('permalink_structure')
             ? home_url("/{$this->base}/{$form_id}", $scheme)
-            : add_query_arg(
+            : esc_url(add_query_arg(
                 [
                     'give_form_id' => $form_id,
                     'url_prefix' => $this->base,
                 ],
                 home_url('', $scheme)
-            );
+            ));
     }
 
     /**


### PR DESCRIPTION
## Description

This resolves a request from wp.org to add additional escaping when using the `add_query_arg` functions. As such, I went through the code and audited every use of the function. I did my best to add escaping as makes sense. Honestly, I don't fully understand the difference between `esc_url` and `esc_url_raw` so I tried to follow contextual use and the functions' docs.

WP.org also mentioned potentially escaping for the `remove_query_arg` function as well... but that honestly makes less sense to me as something dynamic isn't being added, just removed, which isn't a security risk. 🤷‍♂️

## Affects

This touches quite a bit of the code base, ranging from the new donor list UI, to importing, exporting, emails, and so forth. 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Due to the challenge in being exactly sure what all is affected, we should try and do a fairly thorough and eclectic poke around to make sure things are good.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed