### PR TITLE
Hot Fix: Restore ability to change subscriptions via legacy subscription shortcode

### DIFF
--- a/includes/gateways/stripe/class-give-stripe.php
+++ b/includes/gateways/stripe/class-give-stripe.php
@@ -161,16 +161,19 @@ if ( ! class_exists( 'Give_Stripe' ) ) {
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/filters.php';
 			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/give-stripe-scripts.php';
 
-			// Classes.
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-logger.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-invoice.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-customer.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-payment-intent.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-payment-method.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-checkout-session.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-gateway.php';
-			require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-webhooks.php';
-		}
+            // Classes.
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-logger.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-invoice.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-customer.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-payment-intent.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-payment-method.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-checkout-session.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-gateway.php';
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/class-give-stripe-webhooks.php';
+
+            // Payment Methods.
+            require_once GIVE_PLUGIN_DIR . 'includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php';
+        }
 
 		/**
 		 * Register the payment methods supported by Stripe.

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-card.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Give - Stripe Card Payments
+ *
+ * @package    Give
+ * @subpackage Stripe Core
+ * @copyright  Copyright (c) 2019, GiveWP
+ * @license    https://opensource.org/licenses/gpl-license GNU Public License
+ */
+
+use Give\PaymentGateways\Gateways\Stripe\Traits\CreditCardForm;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Check for Give_Stripe_Card existence.
+ *
+ * @since 2.5.0
+ */
+if ( ! class_exists( 'Give_Stripe_Card' ) ) {
+
+	/**
+	 * Class Give_Stripe_Card.
+	 *
+	 * @since 2.5.0
+	 */
+	class Give_Stripe_Card {
+        use CreditCardForm;
+
+
+		/**
+         * @unreleased recover method for legacy give-recurring usage.
+         * @since  1.0
+         *
+		 * Stripe uses it's own credit card form because the card details are tokenized.
+		 *
+		 * We don't want the name attributes to be present on the fields in order to
+		 * prevent them from getting posted to the server.
+		 *
+		 * @param int   $form_id Donation Form ID.
+        *  @param array $args    Donation Form Arguments.
+		 *
+		 * @access public
+		 *
+		 * @return string $form
+		 */
+		public function addCreditCardForm( $form_id, $args, $echo = true ) {
+            $form = $this->getCreditCardFormHTML($form_id, $args);
+            
+            if ( false !== $echo ) {
+				echo $form;
+			}
+
+			return $form;
+		}
+	}
+}
+return new Give_Stripe_Card();


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves:
https://feedback.givewp.com/admin/feedback/bug-reports/p/editing-stripe-credit-card-for-recurring-subscriptions-should-work-properly-usin?boards=bug-reports

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

While recently updating the Stripe gateway to use the new gateway api, some legacy files were removed.  One of those being `Give_Stripe_Card` which was still being used by give-recurring.  This was preventing subscription updates on the legacy donor dashboard.  This PR adds back the necessary file with just what is currently needed.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Stripe give-recurring subscription updates

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a page with the [give_subscriptions] shortcode at [example.com/legacy-subs](http://example.com/legacy-subs)
- Create a form that creates a WP user for all donors (disable guest donations and add registration/login fields
- Disable email access (Settings > General > Access control)
- Create a Stripe CC subscription in an incognito browser
- Navigate after the donation to the [example.com/legacy-subs](http://example.com/legacy-subs) page you created earlier
- Click the "update Payment Info" link.
- You should NOT see a fatal error.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

