### PR TITLE
fix: catch all exceptions when process one time or recurring donation

### DIFF
--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -80,7 +80,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
         try {
             $command = $this->createPayment($donation);
             $this->handleGatewayPaymentCommand($command, $donation);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             PaymentGatewayLog::error(
                 $exception->getMessage(),
                 [
@@ -107,7 +107,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
         try {
             $command = $this->createSubscription($donation, $subscription);
             $this->handleGatewaySubscriptionCommand($command, $donation, $subscription);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             PaymentGatewayLog::error(
                 $exception->getMessage(),
                 [
@@ -296,7 +296,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
      *
      * @since 2.19.0
      */
-    private function handleExceptionResponse(Exception $exception, string $message)
+    private function handleExceptionResponse(\Exception $exception, string $message)
     {
         if ($exception instanceof PaymentGatewayException) {
             $message = $exception->getMessage();

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -73,6 +73,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
     }
 
     /**
+     * @unreleased Handle PHP exception.
      * @since 2.19.0
      */
     public function handleCreatePayment(Donation $donation)
@@ -99,6 +100,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
     }
 
     /**
+     * @unreleased Handle PHP exception.
      * @since 2.19.0
      *
      */
@@ -294,6 +296,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface, LegacyPaymentG
      * 1. Redirect to donation form if donation form submit.
      * 2. Return json response if processing payment on ajax.
      *
+     * @unreleased Handle PHP exception.
      * @since 2.19.0
      */
     private function handleExceptionResponse(\Exception $exception, string $message)


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that we are not catching all exceptions when processing one-time or recurring donations. The `try…catch` should catch the PHP Exception, not our own primitive.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should redirect back to the donation form page with an error when throwing a custom PHP Exception.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

