### PR TITLE
feature: show notice to donor when payment method does not support subscription

### DIFF
--- a/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
+++ b/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
@@ -30,7 +30,7 @@ class PaymentGatewayGatewayNotSupportSubscription
                     sprintf(
                     /* translators: 1. Payment gateway name.*/
                         esc_html__(
-                            'Currently, we are not supporting recurring donations with %1$s.',
+                            'Recurring Donations are not supported with %1$s.',
                             'give'
                         ),
                         $registeredGateway->getName()

--- a/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
+++ b/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Give\LegacySubscriptions\Notices;
+
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+
+/**
+ * @unreleased
+ */
+class PaymentGatewayGatewayNotSupportSubscription
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(array $legacyDonationData)
+    {
+        $paymentGatewayRegister = give(PaymentGatewayRegister::class);
+        $gatewayId = $legacyDonationData['gateway'];
+        $legacyFormData = ['post_data' => give_clean($_POST)];
+
+        if (array_key_exists($gatewayId, $paymentGatewayRegister->getPaymentGateways())) {
+            $registeredGateway = give(PaymentGatewayRegister::class)->getPaymentGateway($gatewayId);
+
+            if (
+                give_recurring_is_donation_recurring($legacyFormData) &&
+                !$registeredGateway->supportsSubscriptions()
+            ) {
+                give_set_error(
+                    'payment-gateway-not-support-subscription',
+                    sprintf(
+                    /* translators: 1. Payment gateway name.*/
+                        esc_html__(
+                            'Currently, we are not supporting recurring donations with %1$s.',
+                            'give'
+                        ),
+                        $registeredGateway->getName()
+                    )
+                );
+            }
+        }
+    }
+}

--- a/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
+++ b/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
@@ -33,7 +33,7 @@ class PaymentGatewayGatewayNotSupportSubscription
                             'Recurring Donations are not supported with %1$s.',
                             'give'
                         ),
-                        $registeredGateway->getName()
+                        $registeredGateway->getPaymentMethodLabel()
                     )
                 );
             }

--- a/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
+++ b/src/LegacySubscriptions/Notices/PaymentGatewayGatewayNotSupportSubscription.php
@@ -23,7 +23,14 @@ class PaymentGatewayGatewayNotSupportSubscription
 
             if (
                 give_recurring_is_donation_recurring($legacyFormData) &&
-                !$registeredGateway->supportsSubscriptions()
+                (
+                    !$registeredGateway->supportsSubscriptions() &&
+
+                    // All gateways which registers with new gateway api do not have subscription module,
+                    // But they can process subscription with legacy gateway api.
+                    // This check will make sure that we don't show the notice for those gateways.
+                    empty(\Give_Recurring::get_gateway_class($registeredGateway->getId()))
+                )
             ) {
                 give_set_error(
                     'payment-gateway-not-support-subscription',

--- a/src/LegacySubscriptions/ServiceProvider.php
+++ b/src/LegacySubscriptions/ServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Give\LegacySubscriptions;
 
 use Closure;
+use Give\Helpers\Hooks;
+use Give\LegacySubscriptions\Notices\PaymentGatewayGatewayNotSupportSubscription;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
 /**
@@ -37,6 +39,7 @@ class ServiceProvider implements ServiceProviderInterface
      */
     public function boot()
     {
+        Hooks::addAction('give_checkout_error_checks', PaymentGatewayGatewayNotSupportSubscription::class);
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I added a notice which displays when a donor selected a payment method that does not support recurring donations.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
<img width="599" alt="image" src="https://user-images.githubusercontent.com/1784821/172666649-0887dd1c-9b4d-46b8-80eb-6a1a9c7ade49.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should see a notice on the donation form when creating a subscription with payment gateway registered with new gateway API but does not have a subscription module.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

