### PR TITLE
Fix: LoggedIn donor can perform authorized actions in donor dashboard

### DIFF
--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
@@ -1,11 +1,10 @@
-import axios from 'axios';
-import {getAPIRoot} from '../../../utils';
+import {donorDashboardApi} from '../../../utils';
 import {fetchSubscriptionsDataFromAPI} from '../../../tabs/recurring-donations/utils';
 
 export const cancelSubscriptionWithAPI = (id) => {
-    return axios
+    return donorDashboardApi
         .post(
-            getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscription/cancel',
+            'recurring-donations/subscription/cancel',
             {
                 id: id,
             },

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.js
@@ -62,7 +62,9 @@ const SubscriptionManager = ({id, subscription}) => {
 
         setIsUpdating(true);
 
-        const paymentMethod = await gatewayRef.current.getPaymentMethod();
+        const paymentMethod = gatewayRef.current ?
+            await gatewayRef.current.getPaymentMethod() :
+            {};
 
         if ('error' in paymentMethod) {
             setIsUpdating(false);
@@ -99,7 +101,7 @@ const SubscriptionManager = ({id, subscription}) => {
                     <Button onClick={handleUpdate}>
                         {updated ? (
                             <Fragment>
-                                {__('Updated', 'give')} <FontAwesomeIcon icon="check" fixedWidth />
+                                {__('Updated', 'give')} <FontAwesomeIcon icon="check" fixedWidth/>
                             </Fragment>
                         ) : (
                             <Fragment>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
@@ -1,11 +1,10 @@
-import axios from 'axios';
-import {getAPIRoot} from '../../../utils';
+import {donorDashboardApi} from '../../../utils';
 import {fetchSubscriptionsDataFromAPI} from '../../../tabs/recurring-donations/utils';
 
 export const updateSubscriptionWithAPI = ({id, amount, paymentMethod}) => {
-    return axios
+    return donorDashboardApi
         .post(
-            getAPIRoot() + 'give-api/v2/donor-dashboard/recurring-donations/subscription/update',
+            'recurring-donations/subscription/update',
             {
                 id: id,
                 amount: amount,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that the donor dashboard does not perform subscription actions like update subsection and cancel subscriptions for logged donors (with WP user account, email access disabled). I update logic to add authentication nonce to the rest API query to prevent request failure issues.

## Steps to reproduce
-  Disable email access
-  Create a subscription with Stripe credit card
-  Login to donor dashboard with WP user
- Perform cancel subscription or modify subscription action.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Donors should be able to update credit cards, recurring donation amounts, and cancel subscriptions for stripe credit card payment methods when donors logged in with WordPress user accounts.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

