### PR TITLE
refactor: Remove Donor Wall REST API endpoint

### DIFF
--- a/includes/api/class-give-api-v2.php
+++ b/includes/api/class-give-api-v2.php
@@ -114,16 +114,6 @@ class Give_API_V2 {
 				'permission_callback' => '__return_true',
 			]
 		);
-
-		register_rest_route(
-			$this->rest_base,
-			'/donor-wall',
-			[
-				'methods'             => 'GET',
-				'callback'            => [ $this, 'get_donor_wall' ],
-				'permission_callback' => '__return_true',
-			]
-		);
 	}
 
 	/**
@@ -176,20 +166,6 @@ class Give_API_V2 {
 		$parameters = $request->get_params();
 
 		return give_form_grid_shortcode( $parameters );
-	}
-
-	/**
-	 * Rest fetch form data callback
-	 *
-	 * @param WP_REST_Request $request
-	 *
-	 * @access public
-	 * @return array|mixed|object
-	 */
-	public function get_donor_wall( $request ) {
-		$parameters = $request->get_params();
-
-		return Give_Donor_Wall::get_instance()->render_shortcode( $parameters );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6374

Related #6375

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the endpoint `give-api/v2/donor-wall` from the REST API.

It was determined that this endpoint is not in use, so instead of patching the endpoint with a nonce we decided to remove it all together.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Making a request to `/wp-json/give-api/v2/donor-wall` should return a `404 Not Found`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

