### PR TITLE
Fix: header background color properly displays when enabled

### DIFF
--- a/src/Views/Form/Templates/Classic/optionConfig.php
+++ b/src/Views/Form/Templates/Classic/optionConfig.php
@@ -97,6 +97,9 @@ return [
                 'desc'    => __('This color is used to tint the header image (if set), or be the header color if no image is present, as well as the receipt page header color.', 'give'),
                 'type'    => 'colorpicker',
                 'default' => '#1E8CBE',
+                'attributes' => [
+                    'data-field-visibility' => htmlspecialchars(json_encode([ 'classic[visual_appearance][display_header]' => 'enabled' ])),
+                ],
             ],
             [
                 'id'      => 'secure_badge',


### PR DESCRIPTION
Resolves #6452

## Description

This PR adds visibility attribute to header background color on Classic form templates. This is used to either display or hide the header options when enabled/disabled.  Previously it was always visible, leaving the impression that you can somehow change the color of a header that doesn't show up on the donation form.

## Affects
z
Classic Form templates

## Visuals

https://user-images.githubusercontent.com/75056371/173668742-b2a2f7ec-f34d-4ac3-ad52-b01ce8d501c0.mov


## Testing Instructions

1. Create a form using the Classic form template.
2. Form Template - Visual Appearance - Display Header
3. Enable & Disable
4. Ensure header options properly display and work when enabled & are hidden when disabled
## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

