### PR TITLE
feature: update default context for loggable exception

### DIFF
--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -24,6 +24,7 @@ trait Loggable
     /**
      * Returns an array with the basic context details
      *
+     * @unreleased Log meaningful data instead of exception object.
      * @since 2.11.1
      *
      * @return array

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -36,7 +36,7 @@ trait Loggable
             'exception' => [
                 'File' => basename($this->getFile()),
                 'Line' => $this->getLine(),
-                'Massage' => $this->getMessage(),
+                'Message' => $this->getMessage(),
                 'Code' => $this->getCode()
             ]
         ];

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -32,7 +32,12 @@ trait Loggable
     {
         return [
             'category' => 'Uncaught Exception',
-            'exception' => $this,
+            'exception' => [
+                'File' => basename($this->getFile()),
+                'Line' => $this->getLine(),
+                'Massage' => $this->getMessage(),
+                'Code' => $this->getCode()
+            ]
         ];
     }
 }

--- a/src/Framework/Exceptions/Traits/Loggable.php
+++ b/src/Framework/Exceptions/Traits/Loggable.php
@@ -24,7 +24,7 @@ trait Loggable
     /**
      * Returns an array with the basic context details
      *
-     * @unreleased Log meaningful data instead of exception object.
+     * @unreleased Log meaningful data instead of entire exception object.
      * @since 2.11.1
      *
      * @return array

--- a/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
+++ b/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Give\Framework\Exceptions\Contracts\LoggableException;
+use Give\Framework\Exceptions\Traits\Loggable;
+
+class LoggableTest extends Give_Unit_Test_Case
+{
+    public function testExceptionHasContext()
+    {
+        $e = new MockLoggableException( 'This is a loggable exception.', 42 );
+
+        $logContext = $e->getLogContext();
+
+        // @NOTE: Not asserting the logged exception "Line" because the value is coupled to the test code itself.
+        $this->assertEquals( 'LoggableTest.php', $logContext[ 'exception' ][ 'File' ] );
+        $this->assertEquals( 'This is a loggable exception.', $logContext[ 'exception' ][ 'Message' ] );
+        $this->assertEquals( 42, $logContext[ 'exception' ][ 'Code' ] );
+    }
+}
+
+class MockLoggableException extends Exception implements LoggableException {
+    use Loggable;
+}

--- a/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
+++ b/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
@@ -18,6 +18,7 @@ class LoggableTest extends Give_Unit_Test_Case
         $this->assertEquals('LoggableTest.php', $logContext['exception']['File']);
         $this->assertEquals('This is a loggable exception.', $logContext['exception']['Message']);
         $this->assertEquals(42, $logContext['exception']['Code']);
+        $this->arrayHasKey('Line')->evaluate($logContext['exception']);
     }
 }
 

--- a/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
+++ b/tests/unit/tests/Framework/Exceptions/Traits/LoggableTest.php
@@ -1,23 +1,29 @@
 <?php
 
-use Give\Framework\Exceptions\Contracts\LoggableException;
-use Give\Framework\Exceptions\Traits\Loggable;
-
+/**
+ * @unreleased
+ */
 class LoggableTest extends Give_Unit_Test_Case
 {
+    /**
+     * @unreleased
+     */
     public function testExceptionHasContext()
     {
-        $e = new MockLoggableException( 'This is a loggable exception.', 42 );
+        $e = new MockLoggableException('This is a loggable exception.', 42);
 
         $logContext = $e->getLogContext();
 
         // @NOTE: Not asserting the logged exception "Line" because the value is coupled to the test code itself.
-        $this->assertEquals( 'LoggableTest.php', $logContext[ 'exception' ][ 'File' ] );
-        $this->assertEquals( 'This is a loggable exception.', $logContext[ 'exception' ][ 'Message' ] );
-        $this->assertEquals( 42, $logContext[ 'exception' ][ 'Code' ] );
+        $this->assertEquals('LoggableTest.php', $logContext['exception']['File']);
+        $this->assertEquals('This is a loggable exception.', $logContext['exception']['Message']);
+        $this->assertEquals(42, $logContext['exception']['Code']);
     }
 }
 
-class MockLoggableException extends Exception implements LoggableException {
-    use Loggable;
+/**
+ * @unreleased
+ */
+class MockLoggableException extends \Give\Framework\Exceptions\Primitives\Exception
+{
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I am periodically fatal errors because of logging logic for uncaught exceptions. It happened because we are hiding confidential data  (present in context). Exception object contains debug backtrace data which causes an infinite loop (few times).
I updated logic to log only meaning for data instead of an object.

ref: https://github.com/impress-org/givewp/blob/d54be4c35c8e3342cc6d928697b6868419aa259c/src/Framework/Exceptions/Traits/Loggable.php#L35

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

