### PR TITLE
Fix/display classic form summary heading

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/css/_donation-summary.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_donation-summary.scss
@@ -4,7 +4,6 @@
 
     .heading {
         margin-bottom: 2rem;
-        font-size: 1.1rem;
         text-align: center;
         font-weight: 500;
         color: #6b6b6b;

--- a/src/Views/Form/Templates/Classic/resources/css/_donation-summary.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_donation-summary.scss
@@ -1,9 +1,15 @@
 @use 'fn';
 
 .give-donation-summary-section {
-    // Hide the heading
+
     .heading {
-        display: none;
+        margin-bottom: 2rem;
+        font-size: 1.1rem;
+        text-align: center;
+        font-weight: 500;
+        color: #6b6b6b;
+        font-style: italic;
+
     }
 
     table {


### PR DESCRIPTION
Resolves #6457

## Description

The classic form summary heading was not displaying on the form when filled out. There was a css style that was hiding the display of it. I removed the display style and added mark up that was consistent with the Multi Step Form summary heading section.

## Affects

Classic form summary headings

## Visuals
<img width="1106" alt="Screen Shot 2022-06-15 at 11 05 44 AM" src="https://user-images.githubusercontent.com/75056371/173895211-ce136f47-0397-4967-9c5b-d4e2782ffceb.png">
<img width="1106" alt="Screen Shot 2022-06-15 at 11 06 01 AM" src="https://user-images.githubusercontent.com/75056371/173895217-2acf4280-8334-4cf1-a9b1-b3496bdd9bf7.png">


## Testing Instructions

1. Create a form using the Classic Form Template
2. Form template - Payment Method - Summary Heading
3. Fill out the Summary Heading Section
4. View Form - scroll to Donation Summary Section (Verify that it displays)
5. Remove Summary Heading 
6. View Form - scroll to Donation Summary Section (Verify that it does not display)
7. Repeat steps with Multi Step form to ensure that they work properly as well

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

