### PR TITLE
Fix: renewals now display the correct payment type

### DIFF
--- a/src/Donations/Controllers/DonationsRequestController.php
+++ b/src/Donations/Controllers/DonationsRequestController.php
@@ -48,18 +48,7 @@ class DonationsRequestController
                 'give_donationmeta',
                 'id',
                 'donation_id',
-                DonationMetaKeys::FORM_ID,
-                DonationMetaKeys::FORM_TITLE,
-                DonationMetaKeys::AMOUNT,
-                DonationMetaKeys::DONOR_ID,
-                DonationMetaKeys::FIRST_NAME,
-                DonationMetaKeys::LAST_NAME,
-                DonationMetaKeys::EMAIL,
-                DonationMetaKeys::GATEWAY,
-                DonationMetaKeys::MODE,
-                DonationMetaKeys::ANONYMOUS,
-                DonationMetaKeys::SUBSCRIPTION_INITIAL_DONATION,
-                DonationMetaKeys::IS_RECURRING
+                ...DonationMetaKeys::getColumnsForAttachMetaQuery()
             )
             ->where('post_type', 'give_payment');
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6461

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The donations table was not recognizing renewals and instead saying they were "one time" donations within the payment type column.  This PR fixes that and improves the stability of the query utilizing the `DonationMetaKeys` helper.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Donations list table.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1207" alt="Screen Shot 2022-06-15 at 5 08 37 PM" src="https://user-images.githubusercontent.com/10138447/173930405-1e1415c7-6cd1-4032-bf00-ef89ff1b24a5.png">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure you have a mix of donations, subscriptions, and renewals in your site and view the donations list table.  The Payment types should all make sense and specifically renewals have a renewal payment type.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

