### PR TITLE
Fix: prevent stalled migration issue

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -337,7 +337,6 @@ function give_show_upgrade_notices( $give_updates ) {
 			'callback' => 'give_v20_rename_donor_tables_callback',
 			'depend'   => [
 				'v20_move_metadata_into_new_table',
-				'v20_logs_upgrades',
 				'v20_upgrades_form_metadata',
 				'v20_upgrades_payment_metadata',
 				'v20_upgrades_user_address',

--- a/src/Log/LogServiceProvider.php
+++ b/src/Log/LogServiceProvider.php
@@ -6,6 +6,7 @@ use Give\Framework\Migrations\MigrationsRegister;
 use Give\Helpers\Hooks;
 use Give\Log\Commands\FlushLogsCommand;
 use Give\Log\Helpers\Environment;
+use Give\Log\Migrations\CompleteRemovedLegacyLogMigration;
 use Give\Log\Migrations\CreateNewLogTable;
 use Give\Log\Migrations\DeleteOldLogTables;
 use Give\Log\Migrations\MigrateExistingLogs;
@@ -61,6 +62,7 @@ class LogServiceProvider implements ServiceProvider
         give(MigrationsRegister::class)->addMigrations([
             CreateNewLogTable::class,
             RemoveSensitiveLogs::class,
+            CompleteRemovedLegacyLogMigration::class
         ]);
 
         // Check if Logs migration batch processing is completed

--- a/src/Log/Migrations/CompleteRemovedLegacyLogMigration.php
+++ b/src/Log/Migrations/CompleteRemovedLegacyLogMigration.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Give\Log\Migrations;
+
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * @unreleased
+ */
+class CompleteRemovedLegacyLogMigration extends Migration
+{
+    /**
+     * @unreleased
+     * @inheritdoc
+     */
+    public static function id(): string
+    {
+        return 'complete-removed-legacy-log-migration';
+    }
+
+    /**
+     * @unreleased
+     * @inheritdoc
+     */
+    public static function timestamp()
+    {
+        return strtotime('2022-06-16');
+    }
+
+    /**
+     * @unreleased
+     * @inheritdoc
+     */
+    public static function title()
+    {
+        return esc_html__('Complete Removed Legacy Log Migration', 'give');
+    }
+
+    /**
+     * @unreleased
+     * @inheritdoc
+     */
+    public function run()
+    {
+        give_set_upgrade_complete('v20_logs_upgrades');
+    }
+}

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -88,6 +88,7 @@ class MigrateExistingLogs extends Migration
 
         // Check if legacy table exist
         if ( ! $this->legacyLogsTable->exist()) {
+            give_set_upgrade_complete(self::id());
             return;
         }
 

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -81,6 +81,8 @@ class MigrateExistingLogs extends Migration
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Migration should complete when log table does not exist.
      */
     public function run()
     {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and Why you made the choices you made. -->
Migration should complete when the plugin users upgrade from GiveWP <=2.0.  Rick provided me with a database that has an issue and after investigation, I find out that the migration process was blocked by a migration that has a dependency migration that was removed earlier. I added a fix to complete the migration.

Slack discussion: https://lw.slack.com/archives/C02PQ6F648P/p1654813134457039


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You will find out that database dump in the slack channel. You should be able to complete the migration.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

