### PR TITLE
refactor: use official gren color

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -538,7 +538,7 @@ class Give_Addon_Activation_Banner {
 			div.give-addon-alert.updated {
 				padding: 20px;
 				position: relative;
-				border-color: #66BB6A;
+				border-color: #69B868;
 				min-height: 85px;
 			}
 
@@ -560,11 +560,11 @@ class Give_Addon_Activation_Banner {
 
 			div.give-addon-alert h3 span {
 				font-weight: 700;
-				color: #66BB6A;
+				color: #69B868;
 			}
 
 			div.give-addon-alert a {
-				color: #66BB6A;
+				color: #69B868;
 			}
 
 			div.give-addon-alert .alert-actions a {

--- a/includes/admin/class-i18n-module.php
+++ b/includes/admin/class-i18n-module.php
@@ -211,12 +211,12 @@ class Give_i18n_Banner {
 			div.give-addon-alert.updated {
 				padding: 10px 20px;
 				position: relative;
-				border-color: #66BB6A;
+				border-color: #69B868;
 				overflow: hidden;
 			}
 
 			div.give-addon-alert a {
-				color: #66BB6A;
+				color: #69B868;
 			}
 
 			#give-i18n-notice > .give-i18n-icon {

--- a/includes/admin/reports/class-give-graph.php
+++ b/includes/admin/reports/class-give-graph.php
@@ -242,7 +242,7 @@ endforeach;
 							hoverable      : true
 						},
 
-						colors: ["#66bb6a", "#546e7a"], //Give Colors
+						colors: ["#69B868", "#546e7a"], //Give Colors
 
 						xaxis: {
 							mode        : "<?php echo $this->options['x_mode']; ?>",


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The green that was implemented in the legacy code is not the official GiveWP green. It should instead be: `#69b868`
