### PR TITLE
Security: protect against invalid export dates

### DIFF
--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -5,15 +5,17 @@
  * This class handles earnings export
  *
  * @package     Give
- * @subpackage  Admin/Reports
+ * @since       1.0
  * @copyright   Copyright (c) 2016, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
- * @since       1.0
+ * @subpackage  Admin/Reports
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+use Give\Donations\Repositories\DonationRepository;
+
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 /**
@@ -21,116 +23,154 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.0
  */
-class Give_Earnings_Export extends Give_Export {
+class Give_Earnings_Export extends Give_Export
+{
 
-	/**
-	 * Our export type. Used for export-type specific filters/actions
-	 *
-	 * @var string
-	 * @since 1.0
-	 */
-	public $export_type = 'earnings';
+    /**
+     * Our export type. Used for export-type specific filters/actions
+     *
+     * @since 1.0
+     * @var string
+     */
+    public $export_type = 'earnings';
 
-	/**
-	 * Set the export headers
-	 *
-	 * @access public
-	 * @since  1.6
-	 * @return void
-	 */
-	public function headers() {
-		give_ignore_user_abort();
+    /**
+     * Set the export headers
+     *
+     * @access public
+     * @since  1.6
+     * @return void
+     */
+    public function headers()
+    {
+        give_ignore_user_abort();
 
-		nocache_headers();
-		header( 'Content-Type: text/csv; charset=utf-8' );
-		header( 'Content-Disposition: attachment; filename=' . apply_filters( 'give_earnings_export_filename', 'give-export-' . $this->export_type . '-' . date( 'n' ) . '-' . date( 'Y' ) ) . '.csv' );
-		header( 'Expires: 0' );
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header(
+            'Content-Disposition: attachment; filename=' . apply_filters(
+                'give_earnings_export_filename',
+                'give-export-' . $this->export_type . '-' . date('n') . '-' . date('Y')
+            ) . '.csv'
+        );
+        header('Expires: 0');
+    }
 
-	}
+    /**
+     * Set the CSV columns
+     *
+     * @access public
+     * @since  1.0
+     * @return array $cols All the columns
+     */
+    public function csv_cols()
+    {
+        $cols = [
+            'date' => __('Date', 'give'),
+            'donations' => __('Donations', 'give'),
+            /* translators: %s: currency */
+            'earnings' => sprintf(__('Revenue (%s)', 'give'), give_currency_symbol('', true)),
+        ];
 
-	/**
-	 * Set the CSV columns
-	 *
-	 * @access public
-	 * @since  1.0
-	 * @return array $cols All the columns
-	 */
-	public function csv_cols() {
+        return $cols;
+    }
 
-		$cols = [
-			'date'      => __( 'Date', 'give' ),
-			'donations' => __( 'Donations', 'give' ),
-			/* translators: %s: currency */
-			'earnings'  => sprintf( __( 'Revenue (%s)', 'give' ), give_currency_symbol( '', true ) ),
-		];
+    /**
+     * Get the Export Data
+     *
+     * @access public
+     * @since  1.0
+     * @return array $data The data for the CSV file
+     */
+    public function get_data()
+    {
+        $dates = $this->getDatesFromRequest();
 
-		return $cols;
-	}
+        $data = [];
+        $year = $dates->startYear;
+        $stats = new Give_Payment_Stats();
 
-	/**
-	 * Get the Export Data
-	 *
-	 * @access public
-	 * @since  1.0
-	 * @return array $data The data for the CSV file
-	 */
-	public function get_data() {
+        while ($year <= $dates->endYear) {
+            if ($year === $dates->startYear && $year === $dates->endYear) {
+                $m1 = $dates->startMonth;
+                $m2 = $dates->endMonth;
+            } elseif ($year === $dates->startYear) {
+                $m1 = $dates->startMonth;
+                $m2 = 12;
+            } elseif ($year === $dates->endYear) {
+                $m1 = 1;
+                $m2 = $dates->endMonth;
+            } else {
+                $m1 = 1;
+                $m2 = 12;
+            }
 
-		$start_year  = isset( $_POST['start_year'] ) ? absint( $_POST['start_year'] ) : date( 'Y' );
-		$end_year    = isset( $_POST['end_year'] ) ? absint( $_POST['end_year'] ) : date( 'Y' );
-		$start_month = isset( $_POST['start_month'] ) ? absint( $_POST['start_month'] ) : date( 'n' );
-		$end_month   = isset( $_POST['end_month'] ) ? absint( $_POST['end_month'] ) : date( 'n' );
+            while ($m1 <= $m2) {
+                $date1 = mktime(0, 0, 0, $m1, 1, $year);
+                $date2 = mktime(0, 0, 0, $m1, cal_days_in_month(CAL_GREGORIAN, $m1, $year), $year);
 
-		$data  = [];
-		$year  = $start_year;
-		$stats = new Give_Payment_Stats();
+                $data[] = [
+                    'date' => date_i18n('F Y', $date1),
+                    'donations' => $stats->get_sales(0, $date1, $date2),
+                    'earnings' => give_format_amount($stats->get_earnings(0, $date1, $date2), ['sanitize' => false]),
+                ];
 
-		while ( $year <= $end_year ) {
+                $m1++;
+            }
 
-			if ( $year == $start_year && $year == $end_year ) {
+            $year++;
+        }
 
-				$m1 = $start_month;
-				$m2 = $end_month;
+        $data = apply_filters('give_export_get_data', $data);
+        $data = apply_filters("give_export_get_data_{$this->export_type}", $data);
 
-			} elseif ( $year == $start_year ) {
+        return $data;
+    }
 
-				$m1 = $start_month;
-				$m2 = 12;
+    /**
+     * @unreleased
+     */
+    private function getDatesFromRequest(): \stdClass
+    {
+        $dates = new \stdClass();
+        $firstDonationDate = give(DonationRepository::class)->getFirstDonationDate();
+        $lastDonationDate = give(DonationRepository::class)->getLastDonationDate();
 
-			} elseif ( $year == $end_year ) {
+        if (!isset($_POST['start_year'], $_POST['end_year'], $_POST['start_month'], $_POST['end_month'])) {
+            throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
+                'Start year & month, End year & month can not be empty. Please enter validate dates to export revenue and donation stats.'
+            );
+        }
 
-				$m1 = 1;
-				$m2 = $end_month;
+        $dates->startYear = (string)absint($_POST['start_year']);
+        $dates->endYear = (string)absint($_POST['end_year']);
+        $dates->startMonth = (string)absint($_POST['start_month']);
+        $dates->endMonth = (string)absint($_POST['end_month']);
 
-			} else {
+        // Start/End year can not lesser than first donation year and month.
+        // If lesser than correct them.
+        if ($firstDonationDate) {
+            $dates->startYear = $firstDonationDate->format('Y') > $dates->startYear ?
+                $firstDonationDate->format('Y') :
+                $dates->startYear;
 
-				$m1 = 1;
-				$m2 = 12;
+            $dates->endYear = $firstDonationDate->format('Y') > $dates->endYear ?
+                $firstDonationDate->format('Y') :
+                $dates->startYear;
+        }
 
-			}
+        // Start/End year can not greater than last donation year and month.
+        // If greater than correct them.
+        if ($lastDonationDate) {
+            $dates->startYear = $lastDonationDate->format('Y') < $dates->startYear ?
+                $lastDonationDate->format('Y') :
+                $dates->startYear;
 
-			while ( $m1 <= $m2 ) {
+            $dates->endYear = $lastDonationDate->format('Y') < $dates->endYear ?
+                $lastDonationDate->format('Y') :
+                $dates->endYear;
+        }
 
-				$date1 = mktime( 0, 0, 0, $m1, 1, $year );
-				$date2 = mktime( 0, 0, 0, $m1, cal_days_in_month( CAL_GREGORIAN, $m1, $year ), $year );
-
-				$data[] = [
-					'date'      => date_i18n( 'F Y', $date1 ),
-					'donations' => $stats->get_sales( 0, $date1, $date2 ),
-					'earnings'  => give_format_amount( $stats->get_earnings( 0, $date1, $date2 ), [ 'sanitize' => false ] ),
-				];
-
-				$m1 ++;
-
-			}
-
-			$year ++;
-
-		}
-
-		$data = apply_filters( 'give_export_get_data', $data );
-		$data = apply_filters( "give_export_get_data_{$this->export_type}", $data );
-
-		return $data;
-	}
+        return $dates;
+    }
 }

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -161,8 +161,8 @@ class Give_Earnings_Export extends Give_Export
         // Start/End year can not greater than last donation year and month. Throw exception upon invalid year
         if ($lastDonationDate) {
             if (
-                $firstDonationDate->format('Y') < $dates->startYear ||
-                $firstDonationDate->format('Y') < $dates->endYear
+                $lastDonationDate->format('Y') < $dates->startYear ||
+                $lastDonationDate->format('Y') < $dates->endYear
             ) {
                 throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
                     'Start year or End year can not be greater that last donation year. Please enter validate dates to export revenue and donation stats.'

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -12,7 +12,6 @@
  */
 
 // Exit if accessed directly.
-use Give\Donations\Repositories\DonationRepository;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -133,8 +132,8 @@ class Give_Earnings_Export extends Give_Export
     private function getDatesFromRequest(): \stdClass
     {
         $dates = new \stdClass();
-        $firstDonationDate = give(DonationRepository::class)->getFirstDonationDate();
-        $lastDonationDate = give(DonationRepository::class)->getLastDonationDate();
+        $firstDonationDate = give()->donations->getFirstDonationDate();
+        $lastDonationDate = give()->donations->getLastDonationDate();
 
         if (!isset($_POST['start_year'], $_POST['end_year'], $_POST['start_month'], $_POST['end_month'])) {
             throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
@@ -149,7 +148,7 @@ class Give_Earnings_Export extends Give_Export
 
         // Start/End year can not lesser than first donation year and month. Throw exception upon invalid year.
         if ($firstDonationDate) {
-            if(
+            if (
                 $firstDonationDate->format('Y') > $dates->startYear ||
                 $firstDonationDate->format('Y') > $dates->endYear
             ) {
@@ -161,7 +160,7 @@ class Give_Earnings_Export extends Give_Export
 
         // Start/End year can not greater than last donation year and month. Throw exception upon invalid year
         if ($lastDonationDate) {
-            if(
+            if (
                 $firstDonationDate->format('Y') < $dates->startYear ||
                 $firstDonationDate->format('Y') < $dates->endYear
             ) {

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -132,8 +132,8 @@ class Give_Earnings_Export extends Give_Export
     private function getDatesFromRequest(): \stdClass
     {
         $dates = new \stdClass();
-        $firstDonationDate = give()->donations->getFirstDonationDate();
-        $lastDonationDate = give()->donations->getLastDonationDate();
+        $firstDonation = give()->donations->getFirstDonation();
+        $lastDonation = give()->donations->getLatestDonation();
 
         if (!isset($_POST['start_year'], $_POST['end_year'], $_POST['start_month'], $_POST['end_month'])) {
             throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
@@ -146,28 +146,16 @@ class Give_Earnings_Export extends Give_Export
         $dates->startMonth = (string)absint($_POST['start_month']);
         $dates->endMonth = (string)absint($_POST['end_month']);
 
-        // Start/End year can not lesser than first donation year and month. Throw exception upon invalid year.
-        if ($firstDonationDate) {
-            if (
-                $firstDonationDate->format('Y') > $dates->startYear ||
-                $firstDonationDate->format('Y') > $dates->endYear
-            ) {
-                throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
-                    'Start year or End year can not be lesser that first donation year. Please enter validate dates to export revenue and donation stats.'
-                );
-            }
+        if ($firstDonation && $firstDonation->createdAt->format('Y') > $dates->startYear) {
+            throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
+                'Start year cannot be less than first donation year'
+            );
         }
 
-        // Start/End year can not greater than last donation year and month. Throw exception upon invalid year
-        if ($lastDonationDate) {
-            if (
-                $lastDonationDate->format('Y') < $dates->startYear ||
-                $lastDonationDate->format('Y') < $dates->endYear
-            ) {
-                throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
-                    'Start year or End year can not be greater that last donation year. Please enter validate dates to export revenue and donation stats.'
-                );
-            }
+        if ($lastDonation && $lastDonation->createdAt->format('Y') < $dates->endYear) {
+            throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
+                'End year cannot be greater than last donation year'
+            );
         }
 
         return $dates;

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -147,28 +147,28 @@ class Give_Earnings_Export extends Give_Export
         $dates->startMonth = (string)absint($_POST['start_month']);
         $dates->endMonth = (string)absint($_POST['end_month']);
 
-        // Start/End year can not lesser than first donation year and month.
-        // If lesser than correct them.
+        // Start/End year can not lesser than first donation year and month. Throw exception upon invalid year.
         if ($firstDonationDate) {
-            $dates->startYear = $firstDonationDate->format('Y') > $dates->startYear ?
-                $firstDonationDate->format('Y') :
-                $dates->startYear;
-
-            $dates->endYear = $firstDonationDate->format('Y') > $dates->endYear ?
-                $firstDonationDate->format('Y') :
-                $dates->endYear;
+            if(
+                $firstDonationDate->format('Y') > $dates->startYear ||
+                $firstDonationDate->format('Y') > $dates->endYear
+            ) {
+                throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
+                    'Start year or End year can not be lesser that first donation year. Please enter validate dates to export revenue and donation stats.'
+                );
+            }
         }
 
-        // Start/End year can not greater than last donation year and month.
-        // If greater than correct them.
+        // Start/End year can not greater than last donation year and month. Throw exception upon invalid year
         if ($lastDonationDate) {
-            $dates->startYear = $lastDonationDate->format('Y') < $dates->startYear ?
-                $lastDonationDate->format('Y') :
-                $dates->startYear;
-
-            $dates->endYear = $lastDonationDate->format('Y') < $dates->endYear ?
-                $lastDonationDate->format('Y') :
-                $dates->endYear;
+            if(
+                $firstDonationDate->format('Y') < $dates->startYear ||
+                $firstDonationDate->format('Y') < $dates->endYear
+            ) {
+                throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(
+                    'Start year or End year can not be greater that last donation year. Please enter validate dates to export revenue and donation stats.'
+                );
+            }
         }
 
         return $dates;

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -156,7 +156,7 @@ class Give_Earnings_Export extends Give_Export
 
             $dates->endYear = $firstDonationDate->format('Y') > $dates->endYear ?
                 $firstDonationDate->format('Y') :
-                $dates->startYear;
+                $dates->endYear;
         }
 
         // Start/End year can not greater than last donation year and month.

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -3,8 +3,6 @@
  * Admin View: Exports
  */
 
-use Give\Donations\Repositories\DonationRepository;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } ?>

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -81,8 +81,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<form method="post">
                                 <?php
                                 // @unreleased
-                                // Year in year downdown should begin from first donation year instead of only display first five recent year.
-                                $firstDonationDate = give(DonationRepository::class)->getFirstDonationDate();
+                                // Year in year dropdown should begin from first donation year instead of only display first five recent year.
+                                $firstDonationDate = give()->donations->getFirstDonationDate();
                                 $currentYear = date('Y', current_time('timestamp'));
 
                                 $start_year_dropdown = Give()->html->year_dropdown(

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -80,7 +80,8 @@ if ( ! defined( 'ABSPATH' ) ) {
                                 <?php
                                 // @unreleased
                                 // Year in year dropdown should begin from first donation year instead of only display first five recent year.
-                                $firstDonationDate = give()->donations->getFirstDonationDate();
+                                $firstDonation = give()->donations->getFirstDonation();
+                                $firstDonationDate = $firstDonation->createdAt ?? null;
                                 $currentYear = date('Y', current_time('timestamp'));
 
                                 $start_year_dropdown = Give()->html->year_dropdown(

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -80,6 +80,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<td>
 							<form method="post">
                                 <?php
+                                // @unreleased
+                                // Year in year downdown should begin from first donation year instead of only display first five recent year.
                                 $firstDonationDate = give(DonationRepository::class)->getFirstDonationDate();
                                 $currentYear = date('Y', current_time('timestamp'));
 

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -3,6 +3,8 @@
  * Admin View: Exports
  */
 
+use Give\Donations\Repositories\DonationRepository;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } ?>
@@ -77,14 +79,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</td>
 						<td>
 							<form method="post">
-								<?php
-								printf(
-									/* translators: 1: start date dropdown 2: end date dropdown */
-									esc_html__( '%1$s to %2$s', 'give' ),
-									Give()->html->year_dropdown( 'start_year' ) . ' ' . Give()->html->month_dropdown( 'start_month' ),
-									Give()->html->year_dropdown( 'end_year' ) . ' ' . Give()->html->month_dropdown( 'end_month' )
-								);
-								?>
+                                <?php
+                                $firstDonationDate = give(DonationRepository::class)->getFirstDonationDate();
+                                $currentYear = date('Y', current_time('timestamp'));
+
+                                $start_year_dropdown = Give()->html->year_dropdown(
+                                    'start_year',
+                                    0,
+                                    $firstDonationDate ? ($currentYear - $firstDonationDate->format('Y')) : 0
+                                );
+
+                                $end_year_dropdown = Give()->html->year_dropdown(
+                                    'end_year',
+                                    0,
+                                    $firstDonationDate ? ($currentYear - $firstDonationDate->format('Y')) : 0
+                                );
+                                printf(
+                                    esc_html__('%1$s to %2$s', 'give'),
+                                    $start_year_dropdown . ' ' . Give()->html->month_dropdown('start_month'),
+                                    $end_year_dropdown . ' ' . Give()->html->month_dropdown('end_month')
+                                );
+                                ?>
 								<input type="hidden" name="give-action" value="earnings_export"/>
 								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>" class="button-secondary"/>
 							</form>

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -2,6 +2,7 @@
 
 namespace Give\Donations\Repositories;
 
+use DateTimeInterface;
 use Give\Donations\Actions\GeneratePurchaseKey;
 use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationMetaKeys;
@@ -551,5 +552,50 @@ class DonationRepository
                 ->getAll(),
             'donation_id'
         );
+    }
+
+
+    /**
+     * @unreleased
+     *
+     * @return DateTimeInterface|null
+     */
+    public function getLastDonationDate(){
+        /**
+         * @var array{createdAt:string} $date
+         */
+        $date = DB::table('posts')
+            ->select(['post_date', 'createdAt'])
+            ->where('post_type', 'give_payment')
+            ->limit(1)->orderBy('post_date', 'DESC')
+            ->get();
+
+        if( $date ) {
+            return  Temporal::toDateTime($date->createdAt);
+        }
+
+        return null;
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return DateTimeInterface|null
+     */
+    public function getFirstDonationDate(){
+        /**
+         * @var array{createdAt:string} $date
+         */
+        $date = DB::table('posts')
+            ->select(['post_date', 'createdAt'])
+            ->where('post_type', 'give_payment')
+            ->limit(1)->orderBy('post_date', 'ASC')
+            ->get();
+
+        if( $date ) {
+            return  Temporal::toDateTime($date->createdAt);
+        }
+
+        return null;
     }
 }

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -555,6 +555,8 @@ class DonationRepository
     }
 
     /**
+     * @unreleased
+     *
      * @return Donation|null
      */
     public function getFirstDonation() {
@@ -565,6 +567,8 @@ class DonationRepository
     }
 
     /**
+     * @unreleased
+     *
      * @return Donation|null
      */
     public function getLatestDonation() {

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -554,48 +554,23 @@ class DonationRepository
         );
     }
 
-
     /**
-     * @unreleased
-     *
-     * @return DateTimeInterface|null
+     * @return Donation|null
      */
-    public function getLastDonationDate(){
-        /**
-         * @var array{createdAt:string} $date
-         */
-        $date = DB::table('posts')
-            ->select(['post_date', 'createdAt'])
-            ->where('post_type', 'give_payment')
-            ->limit(1)->orderBy('post_date', 'DESC')
+    public function getFirstDonation() {
+        return $this->prepareQuery()
+            ->limit(1)
+            ->orderBy('post_date', 'DESC')
             ->get();
-
-        if( $date ) {
-            return  Temporal::toDateTime($date->createdAt);
-        }
-
-        return null;
     }
 
     /**
-     * @unreleased
-     *
-     * @return DateTimeInterface|null
+     * @return Donation|null
      */
-    public function getFirstDonationDate(){
-        /**
-         * @var array{createdAt:string} $date
-         */
-        $date = DB::table('posts')
-            ->select(['post_date', 'createdAt'])
-            ->where('post_type', 'give_payment')
-            ->limit(1)->orderBy('post_date', 'ASC')
+    public function getLatestDonation() {
+        return $this->prepareQuery()
+            ->limit(1)
+            ->orderBy('post_date', 'ASC')
             ->get();
-
-        if( $date ) {
-            return  Temporal::toDateTime($date->createdAt);
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
While exporting revenue and donation stats, the start year and end year should be in the valid year range. The year value should be in the first donation and last donation year range. I update the business logic to revoke exporting process if the year is invalid.

#### Highlight
- throw an exception if any date param missing from request
- throw an exception upon an invalid year. it should be in the valid year range. the first year of donation to last year of donation is a valid donation year range.
-  show valid year choices in the year dropdown.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
It will affect `Export Revenue and Donation Stats` feature.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Exported data should remain the same when compared with the latest GivewP release.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

