### PR TITLE
Fix: Php errors from enabled comments inside the Donor Wall have been corrected

### DIFF
--- a/assets/src/css/frontend/_components.donor.scss
+++ b/assets/src/css/frontend/_components.donor.scss
@@ -111,7 +111,10 @@ $donor-space-triple: $donor-space * 3;
         flex: 1;
         display: flex;
         justify-content: center;
+        width: 70%;
         align-items: center;
+        word-break: normal !important;
+        white-space: nowrap;
     }
 
     &-content {

--- a/assets/src/css/frontend/_components.donor.scss
+++ b/assets/src/css/frontend/_components.donor.scss
@@ -112,7 +112,6 @@ $donor-space-triple: $donor-space * 3;
         display: flex;
         justify-content: center;
         align-items: center;
-        width: 70%;
         word-break: normal !important;
     }
 
@@ -156,7 +155,8 @@ $donor-space-triple: $donor-space * 3;
         &__wrapper {
             display: flex;
             flex-direction: column;
-            width: 100%;
+            width: 70%;
+            word-break: normal !important;
 
             span:first-child {
                 color: $donor-color;
@@ -182,6 +182,7 @@ $donor-space-triple: $donor-space * 3;
             letter-spacing: 0;
             text-align: right;
             overflow-wrap: normal;
+            word-break: normal !important;
         }
     }
 

--- a/assets/src/css/frontend/_components.donor.scss
+++ b/assets/src/css/frontend/_components.donor.scss
@@ -111,17 +111,16 @@ $donor-space-triple: $donor-space * 3;
         flex: 1;
         display: flex;
         justify-content: center;
-        width: 70%;
         align-items: center;
+        width: 70%;
         word-break: normal !important;
-        white-space: nowrap;
     }
 
     &-content {
         flex: 1;
         width: 100%;
-        margin-bottom: 20px;
         line-height: 20px;
+        margin: 12px 0;
         padding-left: 16px;
         border-left: 2px solid #219653;
         font-weight: 400;

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -130,9 +130,18 @@ class Give_Donor_Wall {
 			ob_start();
 
 			foreach ( $donations as $donation ) {
-				// Give/templates/shortcode-donor-wall.php.
-				give_get_template( 'shortcode-donor-wall', [ $donation, $give_settings, $atts ] );
-			}
+                $donor = new Give_Donor($donation['_give_payment_donor_id']);
+                // Give/templates/shortcode-donor-wall.php.
+                give_get_template(
+                    'shortcode-donor-wall',
+                    [
+                        $donation,
+                        $give_settings,
+                        $atts,
+                        $donor
+                    ]
+                );
+            }
 
 			$html = ob_get_clean();
 

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -98,7 +98,7 @@ function give_manual_payment( $purchase_data ) {
 
 	if ( $payment ) {
         $is_anonymous = isset($purchase_data['post_data']['give_anonymous_donation']) && absint($purchase_data['post_data']['give_anonymous_donation']);
-        update_post_meta($payment, '_give_anonymous_donation', $is_anonymous);
+        update_post_meta($payment, '_give_anonymous_donation', (int)$is_anonymous);
 		give_update_payment_status( $payment, 'publish' );
 		give_send_to_success_page();
 	} else {

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -97,6 +97,8 @@ function give_manual_payment( $purchase_data ) {
 	$payment = give_insert_payment( $payment_data );
 
 	if ( $payment ) {
+        $is_anonymous = isset($purchase_data['post_data']['give_anonymous_donation']) && absint($purchase_data['post_data']['give_anonymous_donation']);
+        update_post_meta($payment, '_give_anonymous_donation', $is_anonymous);
 		give_update_payment_status( $payment, 'publish' );
 		give_send_to_success_page();
 	} else {

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -99,7 +99,8 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                         $total_chars = strlen($comment);
                         $max_chars = $atts['comment_length'];
                         $read_more_text = $atts['readmore_text'];
-
+                        $stripped_comment = str_replace(' ', '', $comment);
+                        $stripped_comment_length = strlen($stripped_comment);
 
                         // A truncated excerpt is displayed if the comment is too long.
                         if ($max_chars < $total_chars) {
@@ -122,7 +123,9 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                                    </p>";
 
                             echo "<p class='give-donor-content__comment'> $comment </p>";
-                        } else {
+
+                        }
+                        else if ($stripped_comment_length <= $max_chars) {
                             echo "<p class='give-donor-content__excerpt'>
                                     $comment
                             </p>";

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -8,11 +8,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/** @var $args array */
+/** @var $donation array kind of like Give_Payment */
 /** @var $donor Give_Donor */
-$donation = $args[0];
+/** @var $atts array  Shortcode attributes */
+/** @var $give_settings array  Give settings */
 
-$give_settings = $args[1]; // Give settings.
-$atts = $args[2]; // Shortcode attributes.
+list($donation, $give_settings, $atts, $donor) = $args;
 
 $primary_color = $atts['color'];
 $avatarSize = (int)$atts['avatar_size'];

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -89,7 +89,6 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                 $atts['show_comments']
                 && absint($atts['comment_length'])
                 && !empty($donation['donor_comment'])
-                && !empty($donation['_give_anonymous_donation'])
             ) :
                 ?>
                 <div class="give-donor-wrapper">

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -118,10 +118,14 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                             $excerpt = trim($excerpt, '.!,:;');
 
                             echo "<p class='give-donor-content__excerpt'>$excerpt &hellip;
-                                    <span> <a class='give-donor-content__read-more' style='color: {$primary_color}'> $read_more_text </a></span>
+                                    <span> <a class='give-donor-content__read-more' style='color: $primary_color'> $read_more_text </a></span>
                                    </p>";
 
                             echo "<p class='give-donor-content__comment'> $comment </p>";
+                        } else {
+                            echo "<p class='give-donor-content__excerpt'>
+                                    $comment
+                            </p>";
                         }
                         ?>
                     </div>

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -126,7 +126,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
 
                         }
                         else     {
-                            echo "<p class='give-donor-content__excerpt'>
+                            echo "<p class='give-donor-content__comment'>
                                     $comment
                             </p>";
                         }

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -96,11 +96,11 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                          style="border-color: <?php echo !empty($atts['color']) ? $atts['color'] : '#219653' ?>">
                         <?php
                         $comment = trim($donation['donor_comment']);
-                        $total_chars = strlen($comment);
+                        $stripped_comment = str_replace(' ', '', $comment);
+
+                        $total_chars = strlen($stripped_comment);
                         $max_chars = $atts['comment_length'];
                         $read_more_text = $atts['readmore_text'];
-                        $stripped_comment = str_replace(' ', '', $comment);
-                        $stripped_comment_length = strlen($stripped_comment);
 
                         // A truncated excerpt is displayed if the comment is too long.
                         if ($max_chars < $total_chars) {
@@ -125,7 +125,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                             echo "<p class='give-donor-content__comment'> $comment </p>";
 
                         }
-                        else if ($stripped_comment_length <= $max_chars) {
+                        else     {
                             echo "<p class='give-donor-content__excerpt'>
                                     $comment
                             </p>";

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -95,7 +95,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                     <div class="give-donor-content"
                          style="border-color: <?php echo !empty($atts['color']) ? $atts['color'] : '#219653' ?>">
                         <?php
-                        $comment = trim($donation['donor_comment']);
+                        $comment = esc_html($donation['donor_comment']);
                         $stripped_comment = str_replace(' ', '', $comment);
 
                         $total_chars = strlen($stripped_comment);

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -89,7 +89,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                 $atts['show_comments']
                 && absint($atts['comment_length'])
                 && !empty($donation['donor_comment'])
-                && !$donation['_give_anonymous_donation']
+                && !empty($donation['_give_anonymous_donation'])
             ) :
                 ?>
                 <div class="give-donor-wrapper">


### PR DESCRIPTION
Resolves #6477

## Description

This PR includes several fixes for the Donor Wall. It fixes two Php warnings/errors from within the Donor Wall, includes some style updates for the block and improves the functionality that displays comments. 

We found that the test donation gateway was not saving  anonymous donations to the database.  This caused an error for donations marked as anonymous on the front end. 

We also found that if the comment length set by the inspector control was higher than the actual length of the comment, it would not display.

- Undefined variable $donor has been corrected by being properly passed to the template.
- Undefined index ['_give_anonymous_donation'] has been corrected by being properly saved to the database.
- Donation amounts will no longer wrap to the next line.
- Comments now display regardless of the character length. 

## Affects

- Donor Wall
- Test gateway

## Visuals

https://user-images.githubusercontent.com/75056371/175374410-b6e16924-4a16-4667-bae4-0a980eb8822a.mov

https://user-images.githubusercontent.com/75056371/175408178-76277c9a-6b84-477d-b318-7c700f0a9304.mov



## Testing Instructions

- Create a Donor Wall block
- Toggle 'Show Comments' on & view page for thrown errors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

