### PR TITLE
Feature: reflect required field in donation form

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -484,7 +484,7 @@
     /**
      * Limited scope of optional input labels, specifically to User Info, see issue #5160.
      */
-    setupOptionalInputLabels(Array.from(document.querySelectorAll('#give_checkout_user_info input[type="text"]')));
+    setupOptionalInputLabels(Array.from(document.querySelectorAll('.give-form .required[placeholder]')));
 
     /**
      * Denote non-required fields as optional.
@@ -494,12 +494,8 @@
      * @param {array} inputs An iteratable list of input elements.
      */
     function setupOptionalInputLabels(inputs) {
-        inputs
-            .filter(function (input) {
-                return !input.required;
-            })
-            .map(function (input) {
-                input.placeholder += templateL10n.optionalLabel;
+        inputs.map(function (input) {
+                input.placeholder += '*';
             });
     }
 

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -406,6 +406,7 @@
 
                             if ($(node).attr('id') && $(node).attr('id').includes('give-checkout-login-register')) {
                                 setupRegistrationFormInputFields();
+                                setupInputIcons();
                             }
 
                             if ($(node).prop('tagName') && $(node).prop('tagName').toLowerCase() === 'select') {

--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -414,6 +414,10 @@
                                     $(node).prepend(`<option value="" disabled selected>${placeholder}</option>`);
                                 }
                             }
+
+                            if ($(node).find('.required[placeholder]').length) {
+                                setupRequiredFieldPlaceholders(Array.from($(node).get(0).querySelectorAll('.required[placeholder]')));
+                            }
                         }
                     });
                 });
@@ -480,23 +484,22 @@
     setupRegistrationFormInputFields();
     setupFFMInputs();
     setupInputIcons();
+    setupRequiredFieldPlaceholders(Array.from(document.querySelectorAll('.give-form .required[placeholder]')));
 
     /**
-     * Limited scope of optional input labels, specifically to User Info, see issue #5160.
-     */
-    setupOptionalInputLabels(Array.from(document.querySelectorAll('.give-form .required[placeholder]')));
-
-    /**
-     * Denote non-required fields as optional.
+     * Denote required fields as required by adding a asterisks (*) prefix to placeholder.
      *
-     * @since 2.8.0
+     * @unreleased
      *
      * @param {array} inputs An iteratable list of input elements.
      */
-    function setupOptionalInputLabels(inputs) {
+    function setupRequiredFieldPlaceholders(inputs) {
         inputs.map(function (input) {
-                input.placeholder += '*';
-            });
+            if ('*' !== input.placeholder.trim().slice(-1)) {
+                input.placeholder = `${input.placeholder.trim()}*`;
+            }
+
+        });
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #4944

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This pull request adds logic to reflect the required field in the donation form in the Multi-step form template instead of the optional field. The asterisk (*) will be added to the required field placeholder.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects the donation form required field placeholders in the Multi step form template.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
<img width="756" alt="image" src="https://user-images.githubusercontent.com/1784821/175875557-a1acc692-4aaf-458f-99f3-d9328cf7c2b7.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
All required field placeholders should contain the `*` asterisk symbol in the placeholder.

Test this pull request in user cases where a new field will be added to donation for like:

- Tributes addon adds fields to the donation form
- The gift Aid add-on adds fields to the donation form
- You can enable a few fields like address fields, donor comment, company name, name title prefix, etc.

Make sure the field should mark correctly when a few donation fields appear dynamically on the donation form.
For example the donor can open the login form and then choose cancel which causes re-rendering for personal information section  fields,

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

