### PR TITLE
fix: Localize the admin URL base

### DIFF
--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -17,10 +17,16 @@ class DonationsAdminPage
      */
     private $apiNonce;
 
+    /**
+     * @var string
+     */
+    private $adminUrl;
+
     public function __construct()
     {
         $this->apiRoot = esc_url_raw(rest_url('give-api/v2/admin/donations'));
         $this->apiNonce = wp_create_nonce('wp_rest');
+        $this->adminUrl = admin_url();
     }
 
     /**
@@ -51,6 +57,7 @@ class DonationsAdminPage
 
     /**
      * @since 2.20.0
+     * @unreleased Localized the admin URL as a base for URL concatenation.
      */
     public function loadScripts()
     {
@@ -59,6 +66,7 @@ class DonationsAdminPage
             'apiNonce' => $this->apiNonce,
             'preload' => $this->preloadDonations(),
             'forms' => $this->getForms(),
+            'adminUrl' => $this->adminUrl,
         ];
 
         EnqueueScript::make('give-admin-donations', 'assets/dist/js/give-admin-donations.js')

--- a/src/Donations/resources/ListTable.tsx
+++ b/src/Donations/resources/ListTable.tsx
@@ -46,7 +46,7 @@ export default function () {
         return (
             <>
                 <RowAction
-                    href={`/wp-admin/edit.php?post_type=give_forms&page=give-payment-history&view=view-payment-details&id=${item.id}`}
+                    href={window.GiveDonations.adminUrl + `edit.php?post_type=give_forms&page=give-payment-history&view=view-payment-details&id=${item.id}`}
                     displayText={__('View/Edit', 'give')}
                 />
                 <RowAction
@@ -94,7 +94,7 @@ export default function () {
             text: __('Donor Name', 'give'),
             inlineSize: '9rem',
             render: (donation: { name, donorId }) => (
-                <a href={`edit.php?post_type=give_forms&page=give-donors&view=overview&id=${donation.donorId}`}>
+                <a href={window.GiveDonations.adminUrl + `edit.php?post_type=give_forms&page=give-donors&view=overview&id=${donation.donorId}`}>
                     {donation.name}
                 </a>
             ),
@@ -104,7 +104,7 @@ export default function () {
             text: __('Donation Form', 'give'),
             inlineSize: '9rem',
             render: (donation: { formTitle, formId }) => (
-                <a href={`post.php?post=${donation.formId}&action=edit`}>
+                <a href={window.GiveDonations.adminUrl + `post.php?post=${donation.formId}&action=edit`}>
                     {donation.formTitle}
                 </a>
             )
@@ -234,7 +234,7 @@ export default function () {
             filterSettings={filters}
         >
             <a className={tableStyles.addFormButton}
-               href={'edit.php?post_type=give_forms&page=give-tools&tab=import&importer-type=import_donations'}
+               href={window.GiveDonations.adminUrl + 'edit.php?post_type=give_forms&page=give-tools&tab=import&importer-type=import_donations'}
             >
                 {__('Import Donations', 'give')}
             </a>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6487

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

One of the URL in the Donations list table wasn't relative to the sub-directory URL, which resulted in a 404 Not Found error for the link. Other links were not affected because they were relative to the current URL.

This PR localizes the admin URL as a base for concatenation, with which absolute URLs can be used.

A simpler solution would be to remove the leading slash from the one affected URL, but that does not make it obvious that we are supporting sub-directory installs (which is why this bug was easily missed). Localizing the base URL makes this obvious for future maintenance/development.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Donation View/Edit action row link
2. Donor Name column link
3. Donation Form column link
4. Import Donations header link

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

