### PR TITLE
Fix/Donations made with zero "Number of Decimals" will now display on the Donor Wall

### DIFF
--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -159,11 +159,11 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
 
                 <?php
                 $donation_total = give_donation_amount($donation['donation_id'], true);
-                $donation_amount = esc_html(substr($donation_total, 0, strpos($donation_total, ".")));
+                $donation_amount = esc_html($donation_total);
 
                 if ($atts['show_total']) {
                     echo "
-                             <span class= 'give-donor-details__total' style='color: {$primary_color}'> $donation_amount </span>
+                             <span class= 'give-donor-details__total' style='color: $primary_color'> $donation_amount </span>
                         ";
                 }
                 ?>


### PR DESCRIPTION
Resolves #6490

## Description

This PR removes a function that was stripping decimals from donation totals. It was also causing other currencies such as Euros from being displayed on the Donor Wal.

## Affects

Donor Wall.

## Visuals

<img width="1076" alt="Screen Shot 2022-06-27 at 1 16 01 PM" src="https://user-images.githubusercontent.com/75056371/176033225-fe77df30-84fb-4a75-bab4-92e29b86402a.png">

## Testing Instructions

1. Set "Number of Decimals" to zero.
2. Process a donation.
3. Set currency as Euro.
4. Process A donation.
5. View the Donor Wall block to verify donation amounts display.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

