### PR TITLE
fix: PayPal wording is correct.

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Views/PayPalStandardBillingFields.php
@@ -40,7 +40,7 @@ class PayPalStandardBillingFields
                 esc_html__('Make your donation quickly and securely with PayPal', 'give'),
                 esc_html__('How it works:', 'give'),
                 esc_html__(
-                    'You will be redirected to PayPal to pay using your PayPal account, or with a credit or debit card. You will then be brought back to this page to view your receipt.',
+                    'You will be redirected to PayPal to complete your donation with your debit card, credit card, or with your PayPal account. Once complete, you\'ll be redirected back to this site to view your receipt.',
                     'give'
                 ),
                 $this->getLogo()


### PR DESCRIPTION
There was a comma splice. Now there is not.

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6494

## Description

The text was grammatically incorrect. Now it is not.

## Affects

Just changes the text on that one screen.


## Testing Instructions

Should not affect anything, just the words on the PayPal legacy screen.
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

