### PR TITLE
Fix: Honor form goal settings in form grid

### DIFF
--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -222,7 +222,7 @@ class Give_Donor_Wall {
 				'order'             => 'DESC',
 				'hide_empty'        => true,  // Deprecated in 2.3.0
 				'only_donor_html'   => false, // Only for internal use.,
-                'show_time'    => true,
+                'show_time'         => true,
 			],
 			$atts
 		);
@@ -239,7 +239,7 @@ class Give_Donor_Wall {
 			'hide_empty',
 			'only_comments',
 			'only_donor_html',
-            'show_timestamp'
+            'show_time'
 		];
 
 		foreach ( $boolean_attributes as $att ) {

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -205,6 +205,15 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                 <?php
                 $form        = new Give_Donate_Form( $form_id );
                 $goal_option = give_get_meta( $form->ID, '_give_goal_option', true );
+
+                // Sanity check - ensure form has pass all condition to show goal.
+                if ( ( isset( $atts['show_goal'] ) && ! filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
+                    || empty( $form->ID )
+                    || ( is_singular( 'give_forms' ) && ! give_is_setting_enabled( $goal_option ) )
+                    || ! give_is_setting_enabled( $goal_option ) || 0 === $form->goal ) {
+                    return false;
+                }
+
                 $goal_progress_stats = give_goal_progress_stats( $form );
                 $goal_format         = $goal_progress_stats['format'];
                 $color               = $atts['progress_bar_color'];
@@ -220,10 +229,10 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                     $args
                 );
 
-
                 $income = $shortcode_stats['income'];
                 $goal   = $shortcode_stats['goal'];
-
+//                var_dump($goal_option);
+//                die();
 
                 switch ( $goal_format ) {
 

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -231,8 +231,6 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
 
                 $income = $shortcode_stats['income'];
                 $goal   = $shortcode_stats['goal'];
-//                var_dump($goal_option);
-//                die();
 
                 switch ( $goal_format ) {
 

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -207,58 +207,57 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                 $goal_option = give_get_meta( $form->ID, '_give_goal_option', true );
 
                 // Sanity check - ensure form has pass all condition to show goal.
-                if ( ( isset( $atts['show_goal'] ) && ! filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
+                $hide_goal = ( isset( $atts['show_goal'] ) && ! filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN ) )
                     || empty( $form->ID )
                     || ( is_singular( 'give_forms' ) && ! give_is_setting_enabled( $goal_option ) )
-                    || ! give_is_setting_enabled( $goal_option ) || 0 === $form->goal ) {
-                    return false;
-                }
+                    || ! give_is_setting_enabled( $goal_option ) || 0 === $form->goal;
 
-                $goal_progress_stats = give_goal_progress_stats( $form );
-                $goal_format         = $goal_progress_stats['format'];
-                $color               = $atts['progress_bar_color'];
-                $show_bar            = isset( $atts['show_bar'] ) ? filter_var( $atts['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
-                $shortcode_stats = apply_filters(
-                    'give_goal_shortcode_stats',
-                    array(
-                        'income' => $form->get_earnings(),
-                        'goal'   => $goal_progress_stats['raw_goal'],
-                    ),
-                    $form_id,
-                    $goal_progress_stats,
-                    $args
-                );
+                // Maybe display the goal progress bar.
 
-                $income = $shortcode_stats['income'];
-                $goal   = $shortcode_stats['goal'];
+                if (!$hide_goal) :
+                    $goal_progress_stats = give_goal_progress_stats( $form );
+                    $goal_format         = $goal_progress_stats['format'];
+                    $color               = $atts['progress_bar_color'];
+                    $show_bar            = isset( $atts['show_bar'] ) ? filter_var( $atts['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
+                    $shortcode_stats = apply_filters(
+                        'give_goal_shortcode_stats',
+                        array(
+                            'income' => $form->get_earnings(),
+                            'goal'   => $goal_progress_stats['raw_goal'],
+                        ),
+                        $form_id,
+                        $goal_progress_stats,
+                        $args
+                    );
 
-                switch ( $goal_format ) {
+                    $income = $shortcode_stats['income'];
+                    $goal   = $shortcode_stats['goal'];
 
-                    case 'donation':
-                        $progress           = $goal ? round( ( $form->get_sales() / $goal ) * 100, 2 ) : 0;
-                        $progress_bar_value = $form->get_sales() >= $goal ? 100 : $progress;
-                        break;
+                    switch ( $goal_format ) {
 
-                    case 'donors':
-                        $progress           = $goal ? round( ( give_get_form_donor_count( $form->ID ) / $goal ) * 100, 2 ) : 0;
-                        $progress_bar_value = give_get_form_donor_count( $form->ID ) >= $goal ? 100 : $progress;
-                        break;
+                        case 'donation':
+                            $progress           = $goal ? round( ( $form->get_sales() / $goal ) * 100, 2 ) : 0;
+                            $progress_bar_value = $form->get_sales() >= $goal ? 100 : $progress;
+                            break;
 
-                    case 'percentage':
-                        $progress           = $goal ? round( ( $income / $goal ) * 100, 2 ) : 0;
-                        $progress_bar_value = $income >= $goal ? 100 : $progress;
-                        break;
+                        case 'donors':
+                            $progress           = $goal ? round( ( give_get_form_donor_count( $form->ID ) / $goal ) * 100, 2 ) : 0;
+                            $progress_bar_value = give_get_form_donor_count( $form->ID ) >= $goal ? 100 : $progress;
+                            break;
 
-                    default:
-                        $progress           = $goal ? round( ( $income / $goal ) * 100, 2 ) : 0;
-                        $progress_bar_value = $income >= $goal ? 100 : $progress;
-                        break;
+                        case 'percentage':
+                            $progress           = $goal ? round( ( $income / $goal ) * 100, 2 ) : 0;
+                            $progress_bar_value = $income >= $goal ? 100 : $progress;
+                            break;
 
-                }
+                        default:
+                            $progress           = $goal ? round( ( $income / $goal ) * 100, 2 ) : 0;
+                            $progress_bar_value = $income >= $goal ? 100 : $progress;
+                            break;
 
-                    // Maybe display the goal progress bar.
+                    }
 
-                if ($atts['show_goal'] && give_is_setting_enabled( get_post_meta( $form_id, '_give_goal_option', true ) )) :?>
+                    ?>
                     <div class="give-form-grid-progress">
                         <?php
                             if ($atts['show_bar']){


### PR DESCRIPTION
Resolves #6499

## Description

From within the Form Grid the  function give_goal_progress_stats() was being used to retrieve data for the goal section. It was being called regardless of the Donation Goal form options being enabled. This was causing a warning to be displayed by the goal section on the Form Grid with Fee Recovery enabled and Donation Goals disabled. This PR adds a check for the settings to be enabled before continuing.

## Affects

1. Form Grid

## Visuals

https://user-images.githubusercontent.com/75056371/176282418-3cf44adc-aaf6-4df6-a4aa-357e7eb520e0.mov


## Testing Instructions

1. Enable define( 'WP_DEBUG_DISPLAY', true );
2. Create a form
3. Enabled Fee Recovery
4. Disable Donation Goals
5. View FormGrid - make sure Show_Goal is toggled on in the inspector controls 
6. View page for warnings
7. Enable Donation Goals from form settings
8. View page to verify the Progress bar displays with no warning
9. Toggle Show Goal in the Form Grid inspector controls to verify that it still controls whether to display the goal section
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

