### PR TITLE
Hotfix: prevent 400 HTTP error for Stripe webhook event

### DIFF
--- a/includes/gateways/stripe/includes/class-give-stripe-webhooks.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-webhooks.php
@@ -76,11 +76,9 @@ if (!class_exists('Give_Stripe_Webhooks')) {
             $payload = json_decode($payload, true);
 
             try {
-                $event = \Stripe\Event::retrieve(
-                    Event::constructFrom(
+                $event = Event::constructFrom(
                         $payload
-                    )->id
-                );
+                    );
             } catch (\Exception $exception) {
                 Log::warning(
                     'Stripe - Webhook Received',

--- a/includes/gateways/stripe/includes/class-give-stripe-webhooks.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-webhooks.php
@@ -57,7 +57,8 @@ if (!class_exists('Give_Stripe_Webhooks')) {
         /**
          * Listen for Stripe events.
          *
-         * @access public
+         * @unreleased fetching event detail in this function can cause of 400 HTTP response for Stripe webhook because
+         *             stripe app setup with correct account in event listener class.
          * @since  2.5.0
          *
          * @return void

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
@@ -17,6 +17,7 @@ abstract class StripeEventListener implements EventListener
     use CanSetupStripeApp;
 
     /**
+     * @unreleased fetch event detail to validate stripe webhook event.
      * @since 2.21.0
      * @throws Exception
      */

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
@@ -26,6 +26,7 @@ abstract class StripeEventListener implements EventListener
             $this->setupStripeApp($formId);
             $this->logEventReceiveTime();
 
+            $event = \Stripe\Event::retrieve($event->id);
             $this->processEvent($this->getEventFromStripe($event->id));
         }
     }

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/StripeEventListener.php
@@ -17,7 +17,6 @@ abstract class StripeEventListener implements EventListener
     use CanSetupStripeApp;
 
     /**
-     * @unreleased fetch event detail to validate stripe webhook event.
      * @since 2.21.0
      * @throws Exception
      */
@@ -27,7 +26,6 @@ abstract class StripeEventListener implements EventListener
             $this->setupStripeApp($formId);
             $this->logEventReceiveTime();
 
-            $event = \Stripe\Event::retrieve($event->id);
             $this->processEvent($this->getEventFromStripe($event->id));
         }
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Plugin users can set different Stripe accounts for donation processing within the donation form. Although donation completes but Stripe webhooks are getting `400` HTTP responses. This issue happens because fetching stripe webhook event details with the wrong stripe account. (`Give\PaymentGateways\Gateways\Stripe\Webhooks\StripeEventListener`) Event Listener base class has logic to fetch stripe event detail from Stripe, so there is not any requirement for this logic, and can be removed without side effects. 

Slack discussion:
- https://lw.slack.com/archives/C02PQ6F648P/p1656518031239759
- https://lw.slack.com/archives/C02PQ6F648P/p1656612107795789

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This will affect  Stripe webhook handling logic to one-time and recurring donations.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Stripe webhook should get `200` HTTP response if a donation (one-time or recurring) is processed with a donation form that has either a global stripe account or a different stripe account.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

