### PR TITLE
chore: Add automation for closing stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -2,6 +2,4 @@ name: 'Close stale issues'
 
 jobs:
     stale:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: impress-org/givewp-github-actions/.github/workflows/close-stale-issues.yml@master
+        uses: impress-org/givewp-github-actions/.github/workflows/close-stale-issues.yml@master

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,3 +16,4 @@ jobs:
                   days-before-pr-stale: 45 # ~6 weeks accounts for cycle length
                   days-before-issue-close: 14 # 2 weeks accounts for cool-down
                   days-before-pr-close: -1 # Never close pull requests
+                  debug-only: true # Dry-run. No GitHub API calls that can alter your issues and pull requests will happen.

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,19 +1,7 @@
 name: 'Close stale issues'
-on:
-    schedule:
-        - cron: '30 1 * * *' # at 1:30am every day
 
 jobs:
     stale:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v5
-              with:
-                  stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 14 additional days.'
-                  stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Stale PRs will NOT be automatically closed.'
-                  close-issue-message: 'This issue was closed because it has been stalled for an additional 14 days with no activity.'
-                  days-before-issue-stale: 45 # ~6 weeks accounts for cycle length
-                  days-before-pr-stale: 45 # ~6 weeks accounts for cycle length
-                  days-before-issue-close: 14 # 2 weeks accounts for cool-down
-                  days-before-pr-close: -1 # Never close pull requests
-                  debug-only: true # Dry-run. No GitHub API calls that can alter your issues and pull requests will happen.
+            - uses: impress-org/givewp-github-actions/.github/workflows/close-stale-issues.yml@master

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues'
+on:
+    schedule:
+        - cron: '30 1 * * *' # at 1:30am every day
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v5
+              with:
+                  stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 14 additional days.'
+                  stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Stale PRs will NOT be automatically closed.'
+                  close-issue-message: 'This issue was closed because it has been stalled for an additional 14 days with no activity.'
+                  days-before-issue-stale: 45 # ~6 weeks accounts for cycle length
+                  days-before-pr-stale: 45 # ~6 weeks accounts for cycle length
+                  days-before-issue-close: 14 # 2 weeks accounts for cool-down
+                  days-before-pr-close: -1 # Never close pull requests


### PR DESCRIPTION
Related: https://github.com/impress-org/givewp-github-actions/commit/de33e10b5cb9734495deeb97734cfe2f8086dbef

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new workflow for marking stale issues and automatically closing stalled issues.

Note: This workflow is initially configured in debug mode and will result only in a dry-run so that we can test the configuration without altering any issues incorrectly.

## Visuals

Note: For the full configuration, see [impress-org/givewp-github-actions/.github/workflows/close-stale-issues.yml](https://github.com/impress-org/givewp-github-actions/blob/master/.github/workflows/close-stale-issues.yml)

<!-- Include screenshots or video to better communicate your changes. -->

```yml
days-before-issue-stale: 45 # ~6 weeks accounts for cycle length
days-before-pr-stale: 45 # ~6 weeks accounts for cycle length
days-before-issue-close: 14 # 2 weeks accounts for cool-down
days-before-pr-close: -1 # Never close pull requests
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

