### PR TITLE
Fix: List table page styling consistencies

### DIFF
--- a/assets/src/css/admin/_components.admin-header.scss
+++ b/assets/src/css/admin/_components.admin-header.scss
@@ -32,12 +32,15 @@
 	// Remove padding so admin banner can stretch full width.
 	#wpcontent {
 		padding: 0;
+
+        .wrap {
+            padding-left: 20px;
+        }
 	}
 
 	// Add padding to #wpbody accept on builder and settings screens.
 	#wpbody {
 		color: #000;
-		padding-left: 20px;
 		position: relative;
 
 		// Create a faux toolbar to position at the top of edit pages.

--- a/src/Donors/resources/components/DonorsRowActions.module.scss
+++ b/src/Donors/resources/components/DonorsRowActions.module.scss
@@ -24,6 +24,16 @@
     left: 4.6125rem;
     display: flex;
     align-items: center;
-    column-gap: 2rem;
+    column-gap: 1.25rem;
     word-break: keep-all;
+
+    > * + ::before {
+        position: absolute;
+        content: "";
+        inset-block: auto;
+        inset-inline-start: calc(2.1925rem);
+        block-size: 100%;
+        inline-size: 0.125rem;
+        background-color: #dedede;
+    }
 }

--- a/src/Views/Components/ListTable/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage.module.scss
@@ -3,6 +3,11 @@
         --give-primary-color: #69b868;
     }
 
+    // Accounts for padding placed on all subscription pages with #wpbody
+    #give-admin-donation-forms-root {
+        margin-left: -20px;
+    }
+
     .post-type-give_forms #wpbody {
         box-sizing: border-box;
 
@@ -52,7 +57,6 @@
     background-color: #fff;
     padding-block: 1em;
     padding-inline: 1.5em;
-    margin-left: -20px;
     border-bottom: 0.0625rem solid #dbdbdb;
 
     & > * {
@@ -150,7 +154,6 @@
     background-color: rgba(248, 248, 248);
     padding-inline: 1.5em;
     padding-block: 1em;
-    margin: 0 -20px 0 -22px;
     border-bottom: 0.0625rem solid #dbdbdb;
 }
 

--- a/src/Views/Components/ListTable/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage.module.scss
@@ -3,11 +3,6 @@
         --give-primary-color: #69b868;
     }
 
-    // Accounts for padding placed on all subscription pages with #wpbody
-    #give-admin-donation-forms-root {
-        margin-left: -20px;
-    }
-
     .post-type-give_forms #wpbody {
         box-sizing: border-box;
 

--- a/src/Views/Components/ListTable/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage.module.scss
@@ -30,6 +30,10 @@
         white-space: nowrap;
         border-width: 0;
     }
+
+    #wpcontent {
+        padding: 0;
+    }
 }
 
 .page {

--- a/src/Views/Components/ListTable/ListTableRows.module.scss
+++ b/src/Views/Components/ListTable/ListTableRows.module.scss
@@ -27,7 +27,7 @@ tr.duplicated {
 
     display: flex;
     align-items: center;
-    column-gap: 2rem;
+    column-gap: 1.25rem;
     word-break: keep-all;
     transition: opacity 150ms ease-in-out;
 
@@ -43,7 +43,7 @@ tr.duplicated {
         position: absolute;
         content: "";
         inset-block: auto;
-        inset-inline-start: calc(-1.0625rem);
+        inset-inline-start: calc(-.7125rem);
         block-size: 110%;
         inline-size: 0.125rem;
         background-color: #dedede;

--- a/src/Views/Components/ListTable/ListTableRows.module.scss
+++ b/src/Views/Components/ListTable/ListTableRows.module.scss
@@ -43,7 +43,7 @@ tr.duplicated {
         position: absolute;
         content: "";
         inset-block: auto;
-        inset-inline-start: calc(-.7125rem);
+        inset-inline-start: calc(-.6725rem);
         block-size: 110%;
         inline-size: 0.125rem;
         background-color: #dedede;


### PR DESCRIPTION
Resolves #6504

## Description

The padding and margin styling were affecting how the List Table components were being aligned within certain pages.
This PR removes and simplifies styling so that the List Table Components are also symmetrically aligned everywhere the component is used without affecting the other pages that it is not used on. This PR also slightly lowers the gap in between the actionable buttons on each Table row within the List Tables.

## Affects

- All Give Subscription tabs
- Tools > Logs Tab
- Tools > Data Tab

## Visuals


https://user-images.githubusercontent.com/75056371/177422215-bc0a47b7-ce01-4436-98c9-6964ae08ee3e.mov


## Testing Instructions

- View "Donations" [Top Level admin Tab]
- View all subscription tabs for the correct spacing on the header and content.
- View Donation Forms for slimmer spacing between "edit, view ,trash and duplicate buttons".
- View Tools > Logs & Data Tab for aligned spacing on the table components.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

