### PR TITLE
Hot Fix: prevent XSS vulnerability in currency symbol

### DIFF
--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -205,7 +205,7 @@ function give_currency_symbol( $currency = '', $decode_currency = false ) {
 	 * @param string $symbol
 	 * @param string $currency
 	 */
-	return esc_html(apply_filters( 'give_currency_symbol', $symbol, $currency ));
+	return esc_js(apply_filters( 'give_currency_symbol', $symbol, $currency ));
 }
 
 

--- a/includes/currency-functions.php
+++ b/includes/currency-functions.php
@@ -180,6 +180,7 @@ function give_currency_symbols( $decode_currencies = false ) {
  * Given a currency determine the symbol to use. If no currency given, site default is used. If no symbol is determine,
  * the currency string is returned.
  *
+ * @unreleased escape the currency symbol to prevent XSS attacks
  * @since      1.0
  *
  * @param  string $currency        The currency string.
@@ -204,7 +205,7 @@ function give_currency_symbol( $currency = '', $decode_currency = false ) {
 	 * @param string $symbol
 	 * @param string $currency
 	 */
-	return apply_filters( 'give_currency_symbol', $symbol, $currency );
+	return esc_html(apply_filters( 'give_currency_symbol', $symbol, $currency ));
 }
 
 

--- a/src/Onboarding/Routes/CurrencyRoute.php
+++ b/src/Onboarding/Routes/CurrencyRoute.php
@@ -16,15 +16,12 @@ class CurrencyRoute implements RestRoute
     protected $endpoint = 'onboarding/settings/currency';
 
     /**
-     * @var SettingsRepository
+     * @var SettingsRepositoryFactory
      */
     protected $settingsRepository;
 
     /**
      * @since 2.8.0
-     *
-     * @param SettingsRepository $settingsRepository
-     *
      */
     public function __construct(SettingsRepositoryFactory $settingsRepositoryFactory)
     {
@@ -95,6 +92,6 @@ class CurrencyRoute implements RestRoute
      */
     public function validateSetting($value): bool
     {
-        return preg_match('/^[A-Z]{3}$/i', $value) === 1;
+        return array_key_exists(json_decode($value, false), give_get_currencies_list());
     }
 }

--- a/src/Onboarding/Routes/CurrencyRoute.php
+++ b/src/Onboarding/Routes/CurrencyRoute.php
@@ -81,7 +81,6 @@ class CurrencyRoute implements RestRoute
                             'type' => 'string',
                             'required' => true,
                             'validate_callback' => [$this, 'validateSetting'],
-                            'sanitize_callback' => 'sanitize_text_field',
                         ],
                     ],
                 ],
@@ -90,12 +89,12 @@ class CurrencyRoute implements RestRoute
     }
 
     /**
-     * Limits the symbol to a 2-letter country code
+     * Limits the symbol to a 3-letter currency code
      *
      * @unreleased
      */
     public function validateSetting($value): bool
     {
-        return preg_match('/^[A-Z]{2}$/i', $value) === 1;
+        return preg_match('/^[A-Z]{3}$/i', $value) === 1;
     }
 }

--- a/src/Onboarding/Routes/CurrencyRoute.php
+++ b/src/Onboarding/Routes/CurrencyRoute.php
@@ -80,36 +80,22 @@ class CurrencyRoute implements RestRoute
                         'value' => [
                             'type' => 'string',
                             'required' => true,
-                            // 'validate_callback' => [ $this, 'validateSetting' ],
+                            'validate_callback' => [$this, 'validateSetting'],
                             'sanitize_callback' => 'sanitize_text_field',
                         ],
                     ],
                 ],
-                'schema' => [$this, 'getSchema'],
             ]
         );
     }
 
     /**
-     * @since 2.8.0
-     * @return array
+     * Limits the symbol to a 2-letter country code
      *
+     * @unreleased
      */
-    public function getSchema()
+    public function validateSetting($value): bool
     {
-        return [
-            // This tells the spec of JSON Schema we are using which is draft 4.
-            '$schema' => 'http://json-schema.org/draft-04/schema#',
-            // The title property marks the identity of the resource.
-            'title' => 'onboarding',
-            'type' => 'object',
-            // In JSON Schema you can specify object properties in the properties attribute.
-            'properties' => [
-                'currencyCode' => [
-                    'description' => esc_html__('Two letter code representing a country.', 'give'),
-                    'type' => 'string',
-                ],
-            ],
-        ];
+        return preg_match('/^[A-Z]{2}$/i', $value) === 1;
     }
 }


### PR DESCRIPTION
## Description

This cleans up an admin vulnerability wherein an admin could, through some real effort, set the currency symbol to something crazy. The `give_currency_symbol` function would then load it into random places as-is, creating a vulnerability. A big note here is that it must be a user with admin access to exploit the vulnerability.

I patched the issue in two places:
1. The endpoint that opened up the vulnerability now validates the incoming value such that it can only be a 2-letter value, anything else will be rejected.
2. The `give_currency_symbol` function now escapes HTML so XSS scripts and such should be prevented from doing anything.

## Affects

The endpoint for setting a currency symbol and the function used to retrieve said symbols.

## Testing Instructions

Contact me for testing instructions.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

