### PR TITLE
Fix: resolve broken email previews for specific donations

### DIFF
--- a/includes/admin/emails/class-donor-register-email.php
+++ b/includes/admin/emails/class-donor-register-email.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'Give_Donor_Register_Email' ) ) :
 			// Remove user id query param if set from request url.
 			$query = remove_query_arg( array( 'user_id' ), $query );
 
-			$request_url = esc_url( home_url( '/?' . str_replace( '', '', $query ) ) );
+			$request_url = esc_url_raw( home_url( '/?' . str_replace( '', '', $query ) ) );
 			?>
 
 			<!-- Start constructing HTML output.-->

--- a/includes/admin/emails/class-new-donor-register-email.php
+++ b/includes/admin/emails/class-new-donor-register-email.php
@@ -169,7 +169,7 @@ if ( ! class_exists( 'Give_New_Donor_Register_Email' ) ) :
 			// Remove user id query param if set from request url.
 			$query = remove_query_arg( array( 'user_id' ), $query );
 
-			$request_url = esc_url( home_url( '/?' . str_replace( '', '', $query ) ) );
+			$request_url = esc_url_raw( home_url( '/?' . str_replace( '', '', $query ) ) );
 			?>
 			<script type="text/javascript">
 				function change_preview() {

--- a/includes/admin/emails/filters.php
+++ b/includes/admin/emails/filters.php
@@ -44,7 +44,7 @@ function give_email_notification_row_actions_callback( $row_actions, $email ) {
 				esc_html__( 'Click this link to send a test email to yourself at %s', 'give' ),
 				wp_get_current_user()->user_email
 			),
-			'link'        => esc_url(wp_nonce_url(
+			'link'        => esc_url_raw(wp_nonce_url(
 				add_query_arg(
 					array(
 						'give_action'     => 'send_preview_email',

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -204,7 +204,7 @@ function give_get_preview_email_header() {
 	$query            = $request_url_data['query'];
 	$query            = remove_query_arg( array( 'preview_id' ), $query );
 
-	$request_url = esc_url( home_url( '/?' . str_replace( '', '', $query ) ) );
+	$request_url = esc_url_raw( home_url( '/?' . str_replace( '', '', $query ) ) );
 
 	$transaction_header .= '<script>
 				 function change_preview(){


### PR DESCRIPTION
Resolves #6502 

## Description

We've been adding a lot of `esc_url` throughout the codebase to protect against XSS attacks. In some cases, however, the function is too aggressive and `esc_url_raw` should be used. One such affected place was when previewing an email for a specific donation. This PR uses the raw function to prevent those URLs from breaking.

## Affects

Previewing an email for a specific donation

## Testing Instructions

1. Go to Settings > Emails
2. Choose an email(e.g. Donation Receipt) and click Preview
3. Select a donation to preview
4. Should work! ✨

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

