### PR TITLE
Hot Fix: anonymous donations are now supported across donation types

### DIFF
--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -97,21 +97,20 @@ add_action( 'give_payment_deleted', '__give_remove_donor_donation_comment', 10 )
  *
  * @unreleased
  *
- * @param $donationId
- *
+ * @retrun void
  */
-function updateAnonymousDonationForLegacyGateways($donationId)
+function giveUpdateAnonymousDonationForLegacyGateways(int $donationId)
 {
-    $gatewayId = give_get_meta($donationId,'_give_payment_gateway');
+    $gatewayId = give_get_meta($donationId,'_give_payment_gateway', true);
 
     /** @var PaymentGatewayRegister $registrar */
     $registrar = give(PaymentGatewayRegister::class);
 
     if (!$registrar->hasPaymentGateway($gatewayId)){
-        $isAnonymousDonation = isset( $_POST['give_anonymous_donation'] ) ? absint( $_POST['give_anonymous_donation'] ) : 0;
+        $isAnonymousDonation = isset( $_POST['give_anonymous_donation'] ) ? absint( give_clean($_POST['give_anonymous_donation']) ) : 0;
 
         give_update_meta( $donationId, '_give_anonymous_donation', $isAnonymousDonation );
     }
 }
 
-add_action('give_insert_payment', 'updateAnonymousDonationForLegacyGateways', 10, 2);
+add_action('give_insert_payment', 'giveUpdateAnonymousDonationForLegacyGateways');

--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -1,4 +1,7 @@
 <?php
+
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+
 /**
  * Insert donor comment to donation.
  *
@@ -27,6 +30,7 @@ function __give_insert_donor_donation_comment( $donation_id, $donation_data ) {
 }
 
 add_action( 'give_insert_payment', '__give_insert_donor_donation_comment', 10, 2 );
+
 
 
 /**
@@ -86,3 +90,28 @@ function __give_remove_donor_donation_comment( $donation_id ) {
 }
 
 add_action( 'give_payment_deleted', '__give_remove_donor_donation_comment', 10 );
+
+
+/**
+ * Update anonymous donation for legacy gateways
+ *
+ * @unreleased
+ *
+ * @param $donationId
+ *
+ */
+function updateAnonymousDonationForLegacyGateways($donationId)
+{
+    $gatewayId = give_get_meta($donationId,'_give_payment_gateway');
+
+    /** @var PaymentGatewayRegister $registrar */
+    $registrar = give(PaymentGatewayRegister::class);
+
+    if (!$registrar->hasPaymentGateway($gatewayId)){
+        $isAnonymousDonation = isset( $_POST['give_anonymous_donation'] ) ? absint( $_POST['give_anonymous_donation'] ) : 0;
+
+        give_update_meta( $donationId, '_give_anonymous_donation', $isAnonymousDonation );
+    }
+}
+
+add_action('give_insert_payment', 'updateAnonymousDonationForLegacyGateways', 10, 2);

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -97,8 +97,6 @@ function give_manual_payment( $purchase_data ) {
 	$payment = give_insert_payment( $payment_data );
 
 	if ( $payment ) {
-        $is_anonymous = isset($purchase_data['post_data']['give_anonymous_donation']) && absint($purchase_data['post_data']['give_anonymous_donation']);
-        update_post_meta($payment, '_give_anonymous_donation', (int)$is_anonymous);
 		give_update_payment_status( $payment, 'publish' );
 		give_send_to_success_page();
 	} else {

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -457,6 +457,7 @@ class Give_Subscription {
 	 *
 	 * Records a new payment on the subscription.
 	 *
+	 * @unreleased add support for anonymous donations
 	 * @since 1.12.7 Set donor first and last name in new donation
 	 *
 	 * @param array $args Array of values for the payment, including amount and transaction ID.
@@ -541,6 +542,10 @@ class Give_Subscription {
 		$payment->update_meta( 'subscription_id', $this->id );
 		$donor->increase_purchase_count( 1 );
 		$donor->increase_value( $args['amount'] );
+
+        if ($parent->get_meta('_give_anonymous_donation')) {
+            $payment->update_meta('_give_anonymous_donation', 1);
+        }
 
 		// Add give recurring subscription notification
 		do_action( 'give_recurring_add_subscription_payment', $payment, $this );

--- a/tests/unit/tests/Donations/Models/TestDonation.php
+++ b/tests/unit/tests/Donations/Models/TestDonation.php
@@ -8,6 +8,7 @@ use Give\Donations\Models\DonationNote;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Donors\Models\Donor;
 use Give\Framework\Database\DB;
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -61,6 +62,13 @@ class TestDonation extends \Give_Unit_Test_Case
     public function testCreateShouldInsertDonation()
     {
         $donor = Donor::factory()->create();
+
+        /** @var PaymentGatewayRegister $registrar */
+        $registrar = give(PaymentGatewayRegister::class);
+
+        if (!$registrar->hasPaymentGateway(TestGateway::id())){
+            $registrar->registerGateway(TestGateway::class);
+        }
 
         $donation = Donation::create([
             'status' => DonationStatus::PENDING(),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #1131

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

At some point we removed legacy code that updated the anonymous donation meta. This PR adds back support to update the `_give_anonymous_donation` meta that will cover one-time donations using legacy gateways, subscription initial donations, and renewals (legacy subscriptions).  

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

One-time donations (legacy gateways), New subscriptions (initial donation) and renewals (legacy subscriptions)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a subscription with anonymous donation enabled & make sure the subscription _Initial Donation_ reflects this.
- Create a renewal and make sure it's anonymous donation is enabled.
- Check the donor wall for a visual.
- Try donating one-time with "Test Gateway" or any other legacy gateway to make sure anonymous is working.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

