### PR TITLE
Fix: limit date range to current year/month when no donations

### DIFF
--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -128,12 +128,23 @@ class Give_Earnings_Export extends Give_Export
 
     /**
      * @since 2.21.2
+     *
+     * @return object|null
      */
-    private function getDatesFromRequest(): \stdClass
+    private function getDatesFromRequest()
     {
-        $dates = new \stdClass();
+        $dates = new stdClass();
         $firstDonation = give()->donations->getFirstDonation();
         $lastDonation = give()->donations->getLatestDonation();
+
+        if ($firstDonation === null ) {
+            return (object)[
+                'startYear' => date('Y'),
+                'endYear' => date('Y' ),
+                'startMonth' => date('m'),
+                'endMonth' => date('m')
+            ];
+        }
 
         if (!isset($_POST['start_year'], $_POST['end_year'], $_POST['start_month'], $_POST['end_month'])) {
             throw new \Give\Framework\Exceptions\Primitives\InvalidArgumentException(


### PR DESCRIPTION
## Description

This is a follow up to #6482. That prevented invalid dates, but didn't cover the edge case wherein the site has no donations. This covers that scenario by simply forcing the export to the current month and year. It doesn't matter as there aren't any donations, and it's not worth a bunch of UI effort as having zero donations is an incredibly unlikely scenario in GiveWP — much less someone trying to export statistics for such a site.

## Affects

The donation stats exporter

## Testing Instructions

1. Delete all donations
2. Run the exporter with some crazy dates
3. Check that the resulting file just reflects the current month/year and is empty

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

