### PR TITLE
Security: add nonce to donation stats export

### DIFF
--- a/includes/admin/tools/export/class-export.php
+++ b/includes/admin/tools/export/class-export.php
@@ -38,7 +38,7 @@ class Give_Export {
 	 * @return bool Whether we can export or not
 	 */
 	public function can_export() {
-		return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ) );
+		return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ) && wp_verify_nonce($_REQUEST['give-nonce'], 'give_earnings_export'));
 	}
 
 	/**

--- a/includes/admin/tools/views/html-admin-page-exports.php
+++ b/includes/admin/tools/views/html-admin-page-exports.php
@@ -102,6 +102,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                                 );
                                 ?>
 								<input type="hidden" name="give-action" value="earnings_export"/>
+								<input type="hidden" name="give-nonce" value="<?= wp_create_nonce('give_earnings_export') ?>"/>
 								<input type="submit" value="<?php esc_attr_e( 'Generate CSV', 'give' ); ?>" class="button-secondary"/>
 							</form>
 						</td>


### PR DESCRIPTION
## Description

To help prevent against CSRF attacks, a nonce has been added to the donation stats exporter.

## Affects

Donation stats exporter

## Testing Instructions

Make sure that the stats still work. Otherwise, try triggering an export without the nonce and it should block you.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

