### PR TITLE
Hot Fix: Resolve nonce issue on exporters

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.21.3
+ * Version: 2.21.4
  * Requires at least: 5.0
  * Requires PHP: 7.0
  * Text Domain: give
@@ -300,7 +300,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.21.3');
+            define('GIVE_VERSION', '2.21.4');
         }
 
         // Plugin Root File.

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -74,6 +74,13 @@ class Give_Earnings_Export extends Give_Export
         return $cols;
     }
 
+    /**
+     * Include a nonce check when authenticating
+     *
+     * @since 2.21.4
+     *
+     * @return bool
+     */
     public function can_export() {
         return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ) && wp_verify_nonce($_REQUEST['give-nonce'], 'give_earnings_export'));
     }

--- a/includes/admin/tools/export/class-export-earnings.php
+++ b/includes/admin/tools/export/class-export-earnings.php
@@ -74,6 +74,10 @@ class Give_Earnings_Export extends Give_Export
         return $cols;
     }
 
+    public function can_export() {
+        return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ) && wp_verify_nonce($_REQUEST['give-nonce'], 'give_earnings_export'));
+    }
+
     /**
      * Get the Export Data
      *

--- a/includes/admin/tools/export/class-export.php
+++ b/includes/admin/tools/export/class-export.php
@@ -38,7 +38,7 @@ class Give_Export {
 	 * @return bool Whether we can export or not
 	 */
 	public function can_export() {
-		return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ) && wp_verify_nonce($_REQUEST['give-nonce'], 'give_earnings_export'));
+		return (bool) apply_filters( 'give_export_capability', current_user_can( 'export_give_reports' ));
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 2.21.3
+Stable tag: 2.21.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.21.4: July 8th, 2022 =
+* Fix: The CSRF patch for the stats exporter was breaking other exporters. The patch is still in place but the other exporters are working again.
+
 = 2.21.3: July 7th, 2022 =
 * Security: Protect against CSRF and DOS attacks against the donation stats exporter
 * Security: Protect against XSS attacks for the currency endpoint


### PR DESCRIPTION
## Description

#6511 adds a nonce to the donation stats export to prevent CSRF attacks. Unfortunately, we missed that the check for the nonce was being applied to the parent class, affecting all exporters. They don't have the nonce, so they broke. This limits the nonce check to _only_ the stats exporter.

## Affects

Exporters

## Testing Instructions

Make sure the nonce is required for the stats exporter, and make sure all other exporters still work.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

