### PR TITLE
Fix: prevent MAX_JOIN_SIZE limit from occurring and blocking queries

### DIFF
--- a/give.php
+++ b/give.php
@@ -57,6 +57,7 @@ use Give\Form\LegacyConsumer\ServiceProvider as FormLegacyConsumerServiceProvide
 use Give\Form\Templates;
 use Give\Framework\Exceptions\UncaughtExceptionLogger;
 use Give\Framework\Migrations\MigrationsServiceProvider;
+use Give\Framework\Database\ServiceProvider as DatabaseServiceProvider;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\Framework\WordPressShims\ServiceProvider as WordPressShimsServiceProvider;
 use Give\LegacySubscriptions\ServiceProvider as LegacySubscriptionsServiceProvider;
@@ -197,6 +198,7 @@ final class Give
         PromotionsServiceProvider::class,
         LegacySubscriptionsServiceProvider::class,
         WordPressShimsServiceProvider::class,
+        DatabaseServiceProvider::class,
     ];
 
     /**

--- a/src/Framework/Database/Actions/EnableBigSqlSelects.php
+++ b/src/Framework/Database/Actions/EnableBigSqlSelects.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Framework\Database\Actions;
+
+class EnableBigSqlSelects
+{
+    /**
+     * @unreleased
+     *
+     * Enables mysql big selects for the session using a session system variable.
+     *
+     * @see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_big_selects
+     * @see https://dev.mysql.com/doc/refman/5.7/en/system-variable-privileges.html
+     *
+     */
+    public function __invoke()
+    {
+        static $bigSelects = false;
+
+        if (!$bigSelects) {
+            global $wpdb;
+
+            $wpdb->query('SET SESSION SQL_BIG_SELECTS=1;');
+
+            $bigSelects = true;
+        }
+    }
+}

--- a/src/Framework/Database/Actions/EnableBigSqlSelects.php
+++ b/src/Framework/Database/Actions/EnableBigSqlSelects.php
@@ -11,6 +11,10 @@ class EnableBigSqlSelects
      *
      * Enables mysql big selects for the session using a session system variable.
      *
+     * This is necessary for hosts that have an arbitrary MAX_JOIN_SIZE limit, which prevents more complex queries from
+     * running properly. Setting SQL_BIG_SELECTS ignores this limit. This is also done by WooCommerce, supporting the
+     * idea that this is a viable option. There also doesn't seem to be a way for hosts to prevent this.
+     *
      * @see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_big_selects
      * @see https://dev.mysql.com/doc/refman/5.7/en/system-variable-privileges.html
      *

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -283,26 +283,4 @@ class DB
 
         return $wpError;
     }
-
-    /**
-     * @unreleased
-     *
-     * Enables mysql big selects for the session using a session system variable.
-     *
-     * @see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_big_selects
-     * @see https://dev.mysql.com/doc/refman/5.7/en/system-variable-privileges.html
-     *
-     */
-    public static function enableBigSelects()
-    {
-        static $bigSelects = false;
-
-        if (!$bigSelects) {
-            global $wpdb;
-
-            $wpdb->query('SET SESSION SQL_BIG_SELECTS=1;');
-
-            $bigSelects = true;
-        }
-    }
 }

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -288,7 +288,11 @@ class DB
     /**
      * @unreleased
      *
-     * Enables mysql big selects for the session
+     * Enables mysql big selects for the session using a session system variable.
+     *
+     * @see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_sql_big_selects
+     * @see https://dev.mysql.com/doc/refman/5.7/en/system-variable-privileges.html
+     *
      */
     public static function enableBigSelects()
     {
@@ -297,7 +301,7 @@ class DB
         if (!$bigSelects) {
             global $wpdb;
 
-            $wpdb->query('SET SESSION SQL_BIG_SELECTS=1');
+            $wpdb->query('SET SESSION SQL_BIG_SELECTS=1;');
 
             $bigSelects = true;
         }

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -6,7 +6,6 @@ use Exception;
 use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use Give\Framework\QueryBuilder\Clauses\RawSQL;
 use Give\Framework\QueryBuilder\QueryBuilder;
-use Give\Framework\Support\Facades\Str;
 use Give\Helpers\Hooks;
 use WP_Error;
 
@@ -89,8 +88,8 @@ class DB
             static function () use ($name, $arguments) {
                 global $wpdb;
 
-                if (Str::contains($name, 'get')) {
-                    Hooks::doAction('givewp_db_pre_query', $wpdb);
+                if (in_array($name, ['get_row', 'get_col', 'get_results', 'query'], true)) {
+                    Hooks::doAction('givewp_db_pre_query', current($arguments));
                 }
 
                 return call_user_func_array([$wpdb, $name], $arguments);

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -6,6 +6,8 @@ use Exception;
 use Give\Framework\Database\Exceptions\DatabaseQueryException;
 use Give\Framework\QueryBuilder\Clauses\RawSQL;
 use Give\Framework\QueryBuilder\QueryBuilder;
+use Give\Framework\Support\Facades\Str;
+use Give\Helpers\Hooks;
 use WP_Error;
 
 /**
@@ -72,6 +74,7 @@ class DB
     /**
      * Magic method which calls the static method on the $wpdb while performing error checking
      *
+     * @unreleased add givewp_db_pre_query action
      * @since 2.9.6
      *
      * @param $name
@@ -83,8 +86,12 @@ class DB
     public static function __callStatic($name, $arguments)
     {
         return self::runQueryWithErrorChecking(
-            function () use ($name, $arguments) {
+            static function () use ($name, $arguments) {
                 global $wpdb;
+
+                if (Str::contains($name, 'get')) {
+                    Hooks::doAction('givewp_db_pre_query', $wpdb);
+                }
 
                 return call_user_func_array([$wpdb, $name], $arguments);
             }

--- a/src/Framework/Database/DB.php
+++ b/src/Framework/Database/DB.php
@@ -284,4 +284,22 @@ class DB
 
         return $wpError;
     }
+
+    /**
+     * @unreleased
+     *
+     * Enables mysql big selects for the session
+     */
+    public static function enableBigSelects()
+    {
+        static $bigSelects = false;
+
+        if (!$bigSelects) {
+            global $wpdb;
+
+            $wpdb->query('SET SESSION SQL_BIG_SELECTS=1');
+
+            $bigSelects = true;
+        }
+    }
 }

--- a/src/Framework/Database/ServiceProvider.php
+++ b/src/Framework/Database/ServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Framework\Database;
+
+use Give\Framework\Database\Actions\EnableBigSqlSelects;
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
+
+class ServiceProvider implements ServiceProviderContract
+{
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function boot()
+    {
+        Hooks::addAction('givewp_db_pre_query', EnableBigSqlSelects::class);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6527

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds an action `givewp_db_pre_query` to our DB class for optimizing mysql before running data retrieval queries.

There is also an easy way to set mysql big selects using the DB class `DB::enableBigSelects()`.

With this action people can do things like this:

```
add_action('givewp_db_pre_query', function() {
    static $bigSelects = false;

    if (!$bigSelects) {
        global $wpdb;

        $wpdb->query('SET SESSION SQL_BIG_SELECTS=1;');

        $bigSelects = true;
    }
});
```

or with our helper
```

add_action('givewp_db_pre_query', function() {
    \Give\Framework\Database\DB::enableBigSelects();
});

```

or target more specific queries

```
use Give\Framework\Database\DB;
use Give\Framework\Support\Facades\Str;

add_action('givewp_db_pre_query', function($sql) {
    if (Str::contains($sql, 'LEFT JOIN')){
        DB::enableBigSelects();
    }
});
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Our database queries using the query builder.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Set your mysql to max_join_size = 1500000000
- Try to view the donations list table (should not load)
- add snippet below and view donations list table (should load now)

```
add_action('givewp_db_pre_query', function() {
    \Give\Framework\Database\DB::enableBigSelects();
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

