### PR TITLE
Nodes in the Fields API can now be tapped

### DIFF
--- a/src/Framework/FieldsAPI/Concerns/TapNode.php
+++ b/src/Framework/FieldsAPI/Concerns/TapNode.php
@@ -2,9 +2,14 @@
 
 namespace Give\Framework\FieldsAPI\Concerns;
 
+/**
+ * @unreleased
+ */
 trait TapNode
 {
     /**
+     * @unreleased
+     *
      * @param callable $callback
      *
      * @return $this

--- a/src/Framework/FieldsAPI/Concerns/TapNode.php
+++ b/src/Framework/FieldsAPI/Concerns/TapNode.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Give\Framework\FieldsAPI\Concerns;
+
+trait TapNode
+{
+    /**
+     * @param callable $callback
+     *
+     * @return $this
+     */
+    public function tap(callable $callback)
+    {
+        call_user_func($callback, $this);
+
+        return $this;
+    }
+}

--- a/src/Framework/FieldsAPI/Element.php
+++ b/src/Framework/FieldsAPI/Element.php
@@ -10,11 +10,11 @@ use Give\Framework\FieldsAPI\Contracts\Node;
  */
 abstract class Element implements Node
 {
-
     use Concerns\HasName;
     use Concerns\HasType;
     use Concerns\HasVisibilityConditions;
     use Concerns\SerializeAsJson;
+    use Concerns\TapNode;
 
     /**
      * @since 2.12.0

--- a/src/Framework/FieldsAPI/Element.php
+++ b/src/Framework/FieldsAPI/Element.php
@@ -5,8 +5,9 @@ namespace Give\Framework\FieldsAPI;
 use Give\Framework\FieldsAPI\Contracts\Node;
 
 /**
- * @since 2.12.0
- * @since 2.13.0 Support visibility conditions
+ * @since      2.12.0
+ * @since      2.13.0 Support visibility conditions
+ * @unreleased Add TapNode trait
  */
 abstract class Element implements Node
 {

--- a/src/Framework/FieldsAPI/Field.php
+++ b/src/Framework/FieldsAPI/Field.php
@@ -22,6 +22,7 @@ abstract class Field implements Node
     use Concerns\IsRequired;
     use Concerns\Macroable;
     use Concerns\SerializeAsJson;
+    use Concerns\TapNode;
 
     /** @var ValidationRules */
     protected $validationRules;
@@ -35,7 +36,7 @@ abstract class Field implements Node
      */
     public function __construct($name)
     {
-        if ( ! $name) {
+        if (!$name) {
             throw new EmptyNameException();
         }
 
@@ -63,7 +64,7 @@ abstract class Field implements Node
      */
     public static function make($name)
     {
-        if ( ! $name) {
+        if (!$name) {
             throw new EmptyNameException();
         }
 

--- a/src/Framework/FieldsAPI/Field.php
+++ b/src/Framework/FieldsAPI/Field.php
@@ -7,9 +7,10 @@ use Give\Framework\FieldsAPI\Contracts\Node;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
 
 /**
- * @since 2.17.0 allow fields to be macroable
- * @since 2.12.0
- * @since 2.13.0 Support visibility conditions
+ * @since      2.17.0 allow fields to be macroable
+ * @since      2.12.0
+ * @since      2.13.0 Support visibility conditions
+ * @unreleased Add TapNode trait
  */
 abstract class Field implements Node
 {

--- a/src/Framework/FieldsAPI/Group.php
+++ b/src/Framework/FieldsAPI/Group.php
@@ -6,8 +6,9 @@ use Give\Framework\FieldsAPI\Contracts\Collection;
 use Give\Framework\FieldsAPI\Contracts\Node;
 
 /**
- * @since 2.12.0
- * @since 2.13.0 Support visibility conditions
+ * @since      2.12.0
+ * @since      2.13.0 Support visibility conditions
+ * @unreleased Add TapNode trait
  */
 class Group implements Node, Collection
 {

--- a/src/Framework/FieldsAPI/Group.php
+++ b/src/Framework/FieldsAPI/Group.php
@@ -20,6 +20,7 @@ class Group implements Node, Collection
     use Concerns\NameCollision;
     use Concerns\RemoveNode;
     use Concerns\SerializeAsJson;
+    use Concerns\TapNode;
     use Concerns\WalkNodes;
 
     /**

--- a/tests/unit/tests/Framework/FieldsAPI/Concerns/TapNodeTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/Concerns/TapNodeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Give\Framework\FieldsAPI\Concerns\TapNode;
+use PHPUnit\Framework\TestCase;
+
+final class TapNodeTest extends TestCase
+{
+
+    public function testTappedNodeReturnsOriginalNode()
+    {
+        $node = new class {
+            use TapNode;
+        };
+
+        $this->assertEquals($node, $node->tap(function ($tappedNode) {
+            // This section intentionally left blank.
+        }));
+    }
+
+    public function testTappedNodeIsUpdated()
+    {
+        $node = new class {
+            use TapNode;
+
+            public $updated = false;
+        };
+
+        $this->assertTrue($node->tap(function ($tappedNode) {
+            $tappedNode->updated = true;
+        })->updated);
+    }
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR introduces a tap method to `Element`, `Field`, and `Group` nodes. Tapping a node allows for that node to be updated without breaking the fluent syntax of the Fields API.

```php
$field = Field::make( 'my-field' )
    ->label( 'My Field' )
    ->tap(function( $node ) {
        // Custom code here
    })
    ->isRequired();

```

For group, child nodes can be tapped using the fluent syntax of the Fields API.

```php
// Tap a nested node by name.
$group->getNodeByName( 'child' )->tap( ... );
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a node and call the tap function. Changes to that node should be reflected and the fluent syntax should not be broken.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x]  Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

