### PR TITLE
Fix: shortcode `give_form_grid` now only uses `show_goal` to display progress bar

### DIFF
--- a/assets/src/css/frontend/form-grid.scss
+++ b/assets/src/css/frontend/form-grid.scss
@@ -170,7 +170,6 @@ $MIN_REM_SIZE: 16px;
             text-align: right;
         }
     }
-
 }
 
 .give-form-grid-progress-bar {
@@ -179,7 +178,8 @@ $MIN_REM_SIZE: 16px;
         position: relative;
         height: 12px;
         border-radius: 25px;
-
+        background: #D9DFDB;
+        box-shadow: 0px 2px 2px -1px #0000001C inset;
 
         > span {
             display: block;

--- a/blocks/donation-form-grid/class-give-donation-form-grid-block.php
+++ b/blocks/donation-form-grid/class-give-donation-form-grid-block.php
@@ -216,7 +216,6 @@ class Give_Donation_Form_Grid_Block {
 			'columns'             => $attributes['columns'],
 			'show_title'          => $attributes['showTitle'],
 			'show_goal'           => $attributes['showGoal'],
-			'show_bar'            => $attributes['showProgressBar'],
 			'show_excerpt'        => $attributes['showExcerpt'],
             'excerpt_length'      => $attributes['excerptLength'],
 			'show_featured_image' => $attributes['showFeaturedImage'],

--- a/blocks/donation-form-grid/data/attributes.js
+++ b/blocks/donation-form-grid/data/attributes.js
@@ -67,10 +67,6 @@ const blockAttributes = {
 		type: 'boolean',
 		default: true,
 	},
-    showProgressBar: {
-        type: 'boolean',
-        default: true,
-    },
 	showFeaturedImage: {
 		type: 'boolean',
 		default: true,

--- a/blocks/donation-form-grid/edit/inspector.js
+++ b/blocks/donation-form-grid/edit/inspector.js
@@ -45,7 +45,6 @@ const Inspector = ({attributes, setAttributes}) => {
         showExcerpt,
         excerptLength,
         showGoal,
-        showProgressBar,
         showFeaturedImage,
         showDonateButton,
         tagBackgroundColor,
@@ -168,13 +167,6 @@ const Inspector = ({attributes, setAttributes}) => {
                         label={__('Show Excerpt', 'give')}
                         checked={!!showExcerpt}
                         onChange={(value) => saveSetting('showExcerpt', value)}
-                    />
-                    <ToggleControl
-                        className="give-form-grid-inspector"
-                        name="showProgressBar"
-                        label={__('Show Progress Bar', 'give')}
-                        checked={!!showProgressBar}
-                        onChange={(value) => saveSetting('showProgressBar', value)}
                     />
                     <ToggleControl
                         className="give-form-grid-inspector"

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -819,7 +819,6 @@ function give_form_grid_shortcode( $atts ) {
 			'columns'             => '1',
 			'show_title'          => true,
 			'show_goal'           => true,
-			'show_bar'            => false,
 			'show_excerpt'        => true,
 			'show_featured_image' => true,
 			'show_donate_button'  => false,

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -10,12 +10,11 @@
  */
 
 // Exit if accessed directly.
-use Give\Views\IframeView;
-use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
-use Give\Helpers\Form\Utils as FormUtils;
-use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Frontend\ConfirmDonation;
+use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
+use Give\Views\IframeView;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -789,7 +788,7 @@ add_shortcode( 'give_totals', 'give_totals_shortcode' );
  * @type string $image_size          Featured image size. Default 'medium'. Accepts WordPress image sizes.
  * @type string $image_height        Featured image height. Default 'auto'. Accepts valid CSS heights.
  * @type int    $excerpt_length      Number of words before excerpt is truncated. Default '16'.
- * @type string $display_style       How the form is displayed, either in new page or modal popup.
+ * @type string $display_style How the form is displayed, either in new page or modal popup.
  *                                       Default 'redirect'. Accepts 'redirect', 'modal'.
  *
  * @since 2.21.2 change tag_background_color, progress_bar_color to official green color #69b868.
@@ -799,6 +798,7 @@ add_shortcode( 'give_totals', 'give_totals_shortcode' );
  * @since 2.20.0 $donate_button_background_color Default #66bb6a
  * @since 2.20.0 $donate_button_text_color Default #fff
  * @since 2.20.0 $show_bar Default false
+ * @unreleased remove $show_bar attribute in favor of show_goal
  *
  * @return string|bool The markup of the form grid or false.
  */

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -218,7 +218,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                     $goal_progress_stats = give_goal_progress_stats( $form );
                     $goal_format         = $goal_progress_stats['format'];
                     $color               = $atts['progress_bar_color'];
-                    $show_bar            = isset( $atts['show_bar'] ) ? filter_var( $atts['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
+                    $show_goal           = isset( $atts['show_goal'] ) ? filter_var( $atts['show_goal'], FILTER_VALIDATE_BOOLEAN ) : true;
                     $shortcode_stats = apply_filters(
                         'give_goal_shortcode_stats',
                         array(
@@ -260,7 +260,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                     ?>
                     <div class="give-form-grid-progress">
                         <?php
-                            if ($atts['show_bar']){
+                            if ($atts['show_goal']){
                                     $style = "width:$progress_bar_value%;";
                                     $style .= "background: linear-gradient(180deg, {$color} 0%, {$color} 100%); background-blend-mode: multiply;";
                                         echo "

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -260,7 +260,6 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                     ?>
                     <div class="give-form-grid-progress">
                         <?php
-                            if ($atts['show_goal']){
                                     $style = "width:$progress_bar_value%;";
                                     $style .= "background: linear-gradient(180deg, {$color} 0%, {$color} 100%); background-blend-mode: multiply;";
                                         echo "
@@ -270,7 +269,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                                                     </div>
                                             </div>
                                         ";
-                                    }
+
                             ?>
                                     <div class="form-grid-raised">
                                         <?php


### PR DESCRIPTION
Resolves #6533

## Description

This PR removes the [show_bar] attribtue for the FormGrid block/shortcode.The Progressbar will now display properly for all users who use the FormGrid Shortcode. The [show_goal] attribute is now the determining factor for displaying all goal statistics. It also includes the proper background for the progressbar within the FormGrid.

## Affects

- FormGrid

## Visuals / Testing Instructions
<img width="1192" alt="Screen Shot 2022-08-16 at 2 00 47 PM" src="https://user-images.githubusercontent.com/75056371/184985151-a2ac3ec5-d3cb-4b17-af0c-364383c42164.png">


https://user-images.githubusercontent.com/75056371/184986681-78d62561-4978-4499-a9cf-48c6bf6a0f99.mov



- Create a page and use the FormGrid shortcode [give_form_grid]. View the page and Verify the FormGrid displays with the progressbar. The default value is true.
- Use the FormGrid shortcode again with attribute "show_goal" = false [give_form_grid show_goal=false]. Verify the goal section of the FormGrid is hidden.
- Use the FormGrid block and toggle the show goal option. Verify it displays and hides accordingly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

