### PR TITLE
Nodes in a Group can now be tapped

### DIFF
--- a/src/Framework/FieldsAPI/Group.php
+++ b/src/Framework/FieldsAPI/Group.php
@@ -59,9 +59,17 @@ class Group implements Node, Collection
         return new static($name);
     }
 
-    public function tapNode($name, callable $callback)
+    /**
+     * Gives th ability to fluently "tap" a specific node within the group. This is useful when fluently calling methods
+     * on the group, and making a change to a specific node without breaking the fluency.
+     *
+     * @unreleased
+     *
+     * @return $this
+     */
+    public function tapNode(string $name, callable $callback)
     {
-        call_user_func($callback, $this->getNodeByName($name));
+        $callback($this->getNodeByName($name));
 
         return $this;
     }

--- a/src/Framework/FieldsAPI/Group.php
+++ b/src/Framework/FieldsAPI/Group.php
@@ -58,4 +58,11 @@ class Group implements Node, Collection
     {
         return new static($name);
     }
+
+    public function tapNode($name, callable $callback)
+    {
+        call_user_func($callback, $this->getNodeByName($name));
+
+        return $this;
+    }
 }

--- a/tests/unit/tests/Framework/FieldsAPI/GroupTest.php
+++ b/tests/unit/tests/Framework/FieldsAPI/GroupTest.php
@@ -1,32 +1,58 @@
 <?php
 
+use Give\Framework\FieldsAPI\Concerns\TapNode;
 use Give\Framework\FieldsAPI\Group;
 use Give\Framework\FieldsAPI\Text;
 use PHPUnit\Framework\TestCase;
 
-final class GroupTest extends TestCase {
+final class GroupTest extends TestCase
+{
 
-    public function testHasName() {
-        $this->assertEquals( 'group', Group::make( 'group' )->getName() );
+    public function testHasName()
+    {
+        $this->assertEquals('group', Group::make('group')->getName());
     }
 
-    public function testGetNodeByName() {
-        $group = Group::make( 'group')->append(
-            Text::make( 'firstTextField' ),
-            Text::make( 'secondTextField' )
+    public function testGetNodeByName()
+    {
+        $group = Group::make('group')->append(
+            Text::make('firstTextField'),
+            Text::make('secondTextField')
         );
 
-        $this->assertEquals( 'secondTextField', $group->getNodeByName( 'secondTextField' )->getName() );
+        $this->assertEquals('secondTextField', $group->getNodeByName('secondTextField')->getName());
     }
 
-    public function testGetNestedNodeByName() {
-	    $group = Group::make( 'group')->append(
-		    Text::make( 'firstTextField' ),
-		    Group::make( 'nestedGroup' )->append(
-			    Text::make( 'secondTextField' )
-		    )
-	    );
+    public function testGetNestedNodeByName()
+    {
+        $group = Group::make('group')->append(
+            Text::make('firstTextField'),
+            Group::make('nestedGroup')->append(
+                Text::make('secondTextField')
+            )
+        );
 
-        $this->assertEquals( 'secondTextField', $group->getNodeByName( 'secondTextField' )->getName() );
+        $this->assertEquals('secondTextField', $group->getNodeByName('secondTextField')->getName());
+    }
+
+    public function testNestedNodeCanBeTappedAndOriginalGroupIsReturned()
+    {
+        $group = Group::make('group')->append(
+            $node = new class extends Text {
+
+                public $updated = false;
+
+                public function __construct()
+                {
+                    $this->name = 'myField';
+                }
+            }
+        );
+
+        $this->assertEquals($group, $group->tapNode('myField', function ($tappedNode) {
+            $tappedNode->updated = true;
+        }));
+
+        $this->assertTrue($node->updated);
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR introduces a `tapNode()` method to the `Group` node type. Similar to the `tap()` method, except that `tapNode()` will return the group node.

```php
$group = Group::make('my-group')->append(
    $node = Text::make('my-text')
)->tapNode('my-text', function( $tappedNode ) {
    //
}); // returns $group
``` 

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a group with a nested node and call the `tapNode()` method on the group, specifying the nested node by name. Changes to that node should be reflected and the fluent syntax should not be broken.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

