### PR TITLE
Fix: iframe forms now are loaded when other plugins or themes hook a function to the 'the_title' filter

### DIFF
--- a/src/DonorDashboards/resources/views/donordashboard.php
+++ b/src/DonorDashboards/resources/views/donordashboard.php
@@ -5,11 +5,13 @@
  * @since 2.10.0
  */
 
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Views\IframeContentView;
 
+$formId     = FrontendFormTemplateUtils::getFormId();
 $iframeView = new IframeContentView();
 
 echo $iframeView
-    ->setTitle(esc_html__('Donor Dashboard', 'give'))
+    ->setTitle(esc_html__('Donor Dashboard', 'give'))->setFormId($formId)
     ->setBody('<div id="give-donor-dashboard"></div>')
     ->render();

--- a/src/DonorDashboards/resources/views/donordashboard.php
+++ b/src/DonorDashboards/resources/views/donordashboard.php
@@ -5,13 +5,12 @@
  * @since 2.10.0
  */
 
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Views\IframeContentView;
 
-$formId     = FrontendFormTemplateUtils::getFormId();
+$pageId     = give_get_option('donor_dashboard_page');
 $iframeView = new IframeContentView();
 
 echo $iframeView
-    ->setTitle(esc_html__('Donor Dashboard', 'give'))->setFormId($formId)
+    ->setTitle(esc_html__('Donor Dashboard', 'give'))->setPostId($pageId)
     ->setBody('<div id="give-donor-dashboard"></div>')
     ->render();

--- a/src/Views/Form/Templates/Classic/resources/views/receipt.php
+++ b/src/Views/Form/Templates/Classic/resources/views/receipt.php
@@ -1,7 +1,6 @@
 <?php
 
 use Give\Helpers\Form\Template;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Receipt\DonationReceipt;
 use Give\Receipt\LineItem;
 use Give\Receipt\Section;
@@ -149,8 +148,8 @@ ob_start();
 
 <?php
 
-$formId = FrontendFormTemplateUtils::getFormId();
+$pageId = give_get_option('success_page');
 echo (new IframeContentView())
-    ->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
+    ->setTitle(esc_html__('Donation Receipt', 'give'))->setPostId($pageId)
     ->setBody(ob_get_clean())
     ->renderBody();

--- a/src/Views/Form/Templates/Classic/resources/views/receipt.php
+++ b/src/Views/Form/Templates/Classic/resources/views/receipt.php
@@ -1,6 +1,7 @@
 <?php
 
 use Give\Helpers\Form\Template;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Receipt\DonationReceipt;
 use Give\Receipt\LineItem;
 use Give\Receipt\Section;
@@ -122,29 +123,34 @@ ob_start();
                                 <dd class="value"
                                     data-value="<?= esc_attr($lineItem->value) ?>"><?= $lineItem->value ?></dd>
                             </div>
-                        <?php endforeach; ?>
+                        <?php
+                        endforeach; ?>
 
                     </dl>
                 </div>
 
-            <?php endforeach; ?>
+            <?php
+            endforeach; ?>
         </div>
 
         <div class="dashboard-link-container">
             <a class="dashboard-link" href="<?= esc_url($donorDashboardUrl); ?>" target="_parent">
                 <?= esc_html__('Go to my Donor Dashboard', 'give'); ?><i class="fas fa-long-arrow-alt-right"></i>
             </a>
-            <?php if (isset($section['receiptLink'])) : ?>
+            <?php
+            if (isset($section['receiptLink'])) : ?>
                 <div class="give-btn download-btn">
                     <?= $section['receiptLink']->value; ?>
                 </div>
-            <?php endif; ?>
+            <?php
+            endif; ?>
         </div>
     </article>
 
 <?php
 
+$formId = FrontendFormTemplateUtils::getFormId();
 echo (new IframeContentView())
-    ->setTitle(esc_html__('Donation Receipt', 'give'))
+    ->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
     ->setBody(ob_get_clean())
     ->renderBody();

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -1,7 +1,6 @@
 <?php
 
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Receipt\DonationReceipt;
 use Give\Receipt\LineItem;
 use Give\Receipt\Section;
@@ -124,9 +123,9 @@ ob_start();
 
 <?php
 
-$formId     = FrontendFormTemplateUtils::getFormId();
+$pageId     = give_get_option('success_page');
 $iframeView = new IframeContentView();
 
-echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
+echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setPostId($pageId)
                 ->setBody(ob_get_clean())
                 ->renderBody();

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -1,6 +1,7 @@
 <?php
 
 use Give\Helpers\Form\Template as FormTemplateUtils;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Receipt\DonationReceipt;
 use Give\Receipt\LineItem;
 use Give\Receipt\Section;
@@ -122,8 +123,10 @@ ob_start();
     </div>
 
 <?php
+
+$formId     = FrontendFormTemplateUtils::getFormId();
 $iframeView = new IframeContentView();
 
-echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))
-    ->setBody(ob_get_clean())
-    ->renderBody();
+echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
+                ->setBody(ob_get_clean())
+                ->renderBody();

--- a/src/Views/Form/defaultFormReceiptTemplate.php
+++ b/src/Views/Form/defaultFormReceiptTemplate.php
@@ -5,11 +5,10 @@
  * @since 2.7.0
  */
 
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Views\IframeContentView;
 
-$formId     = FrontendFormTemplateUtils::getFormId();
+$pageId     = give_get_option('success_page');
 $iframeView = new IframeContentView();
 
-echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
+echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setPostId($pageId)
                 ->setBody('<div id="give-receipt"></div>')->render();

--- a/src/Views/Form/defaultFormReceiptTemplate.php
+++ b/src/Views/Form/defaultFormReceiptTemplate.php
@@ -5,9 +5,11 @@
  * @since 2.7.0
  */
 
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Views\IframeContentView;
 
+$formId     = FrontendFormTemplateUtils::getFormId();
 $iframeView = new IframeContentView();
 
-echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))
-    ->setBody('<div id="give-receipt"></div>')->render();
+echo $iframeView->setTitle(esc_html__('Donation Receipt', 'give'))->setFormId($formId)
+                ->setBody('<div id="give-receipt"></div>')->render();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -15,6 +15,6 @@ $iframeView = new IframeContentView();
 ob_start();
 give_get_donation_form(['id' => $formId]);
 
-echo $iframeView->setTitle(get_post_field('post_title', $formId))
-    ->setBody(ob_get_clean())
-    ->render();
+echo $iframeView->setTitle(get_post_field('post_title', $formId))->setFormId($formId)
+                ->setBody(ob_get_clean())
+                ->render();

--- a/src/Views/Form/defaultFormTemplate.php
+++ b/src/Views/Form/defaultFormTemplate.php
@@ -15,6 +15,6 @@ $iframeView = new IframeContentView();
 ob_start();
 give_get_donation_form(['id' => $formId]);
 
-echo $iframeView->setTitle(get_post_field('post_title', $formId))->setFormId($formId)
+echo $iframeView->setTitle(get_post_field('post_title', $formId))->setPostId($formId)
                 ->setBody(ob_get_clean())
                 ->render();

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -50,7 +50,7 @@ class IframeContentView
      *
      * @return int|null
      */
-    protected function getFormId() {
+    protected function getFormIdFromBody() {
 
         $form_id = null;
 
@@ -122,7 +122,7 @@ class IframeContentView
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title><?php
-                echo apply_filters( 'the_title', $this->title, $this->getFormId() ); ?></title>
+                echo apply_filters( 'the_title', $this->title, $this->getFormIdFromBody() ); ?></title>
             <?php
             /**
              * Fire the action hook in header

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -46,22 +46,13 @@ class IframeContentView
     protected $bodyClasses = ['give-form-templates'];
 
     /**
-     * Get the Form ID based on the body content.
+     * Form ID.
      *
-     * @return int|null
+     * This will be use as parameter for 'the_title' filter.
+     *
+     * @var int
      */
-    protected function getFormIdFromBody()
-    {
-        $form_id = null;
-
-        $prefix = '<input type="hidden" name="give-form-id" value';
-        $re     = '/' . preg_quote($prefix) . '=([\'"])?((?(1).+?|[^\s>]+))(?(1)\1)/is';
-        if (preg_match($re, $this->body, $match)) {
-            $form_id = absint($match[2]);
-        }
-
-        return $form_id;
-    }
+    protected $formId;
 
     /**
      * Set document page title.
@@ -106,6 +97,20 @@ class IframeContentView
     }
 
     /**
+     * Set form ID.
+     *
+     * @param $formId
+     *
+     * @return IframeContentView $this
+     */
+    public function setFormId($formId)
+    {
+        $this->formId = $formId;
+
+        return $this;
+    }
+
+    /**
      * Render view.
      *
      * Note: if you want to overwrite this function then do not forget to add action hook in footer and header.
@@ -124,7 +129,7 @@ class IframeContentView
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title><?php
-                echo apply_filters('the_title', $this->title, $this->getFormIdFromBody()); ?></title>
+                echo apply_filters('the_title', $this->title, $this->formId); ?></title>
             <?php
             /**
              * Fire the action hook in header

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -43,21 +43,21 @@ class IframeContentView
      * @since 2.7.0
      * @var array
      */
-    protected $bodyClasses = [ 'give-form-templates' ];
+    protected $bodyClasses = ['give-form-templates'];
 
     /**
      * Get the Form ID based on the body content.
      *
      * @return int|null
      */
-    protected function getFormIdFromBody() {
-
+    protected function getFormIdFromBody()
+    {
         $form_id = null;
 
         $prefix = '<input type="hidden" name="give-form-id" value';
-        $re     = '/' . preg_quote( $prefix ) . '=([\'"])?((?(1).+?|[^\s>]+))(?(1)\1)/is';
-        if ( preg_match( $re, $this->body, $match ) ) {
-            $form_id = absint( $match[2] );
+        $re     = '/' . preg_quote($prefix) . '=([\'"])?((?(1).+?|[^\s>]+))(?(1)\1)/is';
+        if (preg_match($re, $this->body, $match)) {
+            $form_id = absint($match[2]);
         }
 
         return $form_id;
@@ -70,7 +70,8 @@ class IframeContentView
      *
      * @return IframeContentView $this
      */
-    public function setTitle( $title ) {
+    public function setTitle($title)
+    {
         $this->title = $title;
 
         return $this;
@@ -112,7 +113,8 @@ class IframeContentView
      *
      * @since 2.7.0
      */
-    public function render() {
+    public function render()
+    {
         ob_start();
         ?>
         <!DOCTYPE html>
@@ -122,23 +124,23 @@ class IframeContentView
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title><?php
-                echo apply_filters( 'the_title', $this->title, $this->getFormIdFromBody() ); ?></title>
+                echo apply_filters('the_title', $this->title, $this->getFormIdFromBody()); ?></title>
             <?php
             /**
              * Fire the action hook in header
              */
-            do_action( 'give_embed_head' );
+            do_action('give_embed_head');
             ?>
         </head>
         <body class="<?php
-        echo implode( ' ', $this->bodyClasses ); ?>">
+        echo implode(' ', $this->bodyClasses); ?>">
         <?php
         echo $this->body;
 
         /**
          * Fire the action hook in footer
          */
-        do_action( 'give_embed_footer' );
+        do_action('give_embed_footer');
         ?>
         </body>
         </html>

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -50,6 +50,7 @@ class IframeContentView
      *
      * This will be use as parameter for 'the_title' filter.
      *
+     * @unreleased
      * @var int
      */
     protected $formId;
@@ -101,6 +102,7 @@ class IframeContentView
      *
      * @param $formId
      *
+     * @unreleased
      * @return IframeContentView $this
      */
     public function setFormId($formId)

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -43,7 +43,20 @@ class IframeContentView
      * @since 2.7.0
      * @var array
      */
-    protected $bodyClasses = ['give-form-templates'];
+    protected $bodyClasses = [ 'give-form-templates' ];
+
+    protected function getFormId() {
+
+        $form_id = null;
+
+        $prefix = '<input type="hidden" name="give-form-id" value';
+        $re     = '/' . preg_quote( $prefix ) . '=([\'"])?((?(1).+?|[^\s>]+))(?(1)\1)/is';
+        if ( preg_match( $re, $this->body, $match ) ) {
+            $form_id = absint( $match[2] );
+        }
+
+        return $form_id;
+    }
 
     /**
      * Set document page title.
@@ -52,8 +65,7 @@ class IframeContentView
      *
      * @return IframeContentView $this
      */
-    public function setTitle($title)
-    {
+    public function setTitle( $title ) {
         $this->title = $title;
 
         return $this;
@@ -95,8 +107,7 @@ class IframeContentView
      *
      * @since 2.7.0
      */
-    public function render()
-    {
+    public function render() {
         ob_start();
         ?>
         <!DOCTYPE html>
@@ -106,23 +117,23 @@ class IframeContentView
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title><?php
-                echo apply_filters('the_title', $this->title); ?></title>
+                echo apply_filters( 'the_title', $this->title, $this->getFormId() ); ?></title>
             <?php
             /**
              * Fire the action hook in header
              */
-            do_action('give_embed_head');
+            do_action( 'give_embed_head' );
             ?>
         </head>
         <body class="<?php
-        echo implode(' ', $this->bodyClasses); ?>">
+        echo implode( ' ', $this->bodyClasses ); ?>">
         <?php
         echo $this->body;
 
         /**
          * Fire the action hook in footer
          */
-        do_action('give_embed_footer');
+        do_action( 'give_embed_footer' );
         ?>
         </body>
         </html>

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -60,7 +60,7 @@ class IframeContentView
     }
 
     /**
-     * Set document page title.
+     * Set document page body.
      *
      * @param string $body
      *
@@ -74,7 +74,7 @@ class IframeContentView
     }
 
     /**
-     * Set document page title.
+     * Set body classes.
      *
      * @param array $classes
      *

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -45,6 +45,11 @@ class IframeContentView
      */
     protected $bodyClasses = [ 'give-form-templates' ];
 
+    /**
+     * Get the Form ID based on the body content.
+     *
+     * @return int|null
+     */
     protected function getFormId() {
 
         $form_id = null;

--- a/src/Views/IframeContentView.php
+++ b/src/Views/IframeContentView.php
@@ -46,14 +46,14 @@ class IframeContentView
     protected $bodyClasses = ['give-form-templates'];
 
     /**
-     * Form ID.
+     * Post ID.
      *
      * This will be use as parameter for 'the_title' filter.
      *
      * @unreleased
      * @var int
      */
-    protected $formId;
+    protected $postId;
 
     /**
      * Set document page title.
@@ -98,16 +98,16 @@ class IframeContentView
     }
 
     /**
-     * Set form ID.
+     * Set post ID.
      *
-     * @param $formId
+     * @param $postId
      *
      * @unreleased
      * @return IframeContentView $this
      */
-    public function setFormId($formId)
+    public function setPostId($postId)
     {
-        $this->formId = $formId;
+        $this->postId = $postId;
 
         return $this;
     }
@@ -131,7 +131,7 @@ class IframeContentView
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title><?php
-                echo apply_filters('the_title', $this->title, $this->formId); ?></title>
+                echo apply_filters('the_title', $this->title, $this->postId); ?></title>
             <?php
             /**
              * Fire the action hook in header


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6550

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the second parameter of `the_title` filter in the iframe content view to prevent a fatal error from being generated when another plugin or theme uses this same filter with the [two available parameters](https://developer.wordpress.org/reference/hooks/the_title/#parameters) - **$title** and **$id** - but without setting a default value for the second one.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- IframeContentView

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a form and add it to a page
2. In the **/wp-content/mu-plugins/** folder add a **test.php** file with the following content:

```
<?php

add_filter( 'the_title', function ( $title, $id ) {
	return '$id = ' . $id . ' | ' . $title;
}, 10, 2 );
```

3. Access the form's page and now it should load without generating any error or delay

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

