### PR TITLE
Fix: activate donor dashboard Gutenberg edit mode when admin clicks on interface

### DIFF
--- a/src/DonorDashboards/Block.php
+++ b/src/DonorDashboards/Block.php
@@ -46,7 +46,20 @@ class Block
      **/
     public function renderCallback($attributes)
     {
-        return $this->donorDashboard->getOutput($attributes);
+        $output =  $this->donorDashboard->getOutput($attributes);
+
+        if( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+            $output = str_replace(
+                'onload="',
+                sprintf(
+                    'onload="%s;',
+                    'const iframe = this;this.contentWindow.document.addEventListener(\'mouseup\', function(){iframe.parentElement.parentElement.parentElement.focus();})'
+                ),
+                $output
+            );
+        }
+
+        return $output;
     }
 
     /**

--- a/src/DonorDashboards/Block.php
+++ b/src/DonorDashboards/Block.php
@@ -55,7 +55,7 @@ class Block
                 'onload="',
                 sprintf(
                     'onload="%s;',
-                    'const iframe = this;this.contentWindow.document.addEventListener(\'mouseup\', function(){iframe.parentElement.parentElement.parentElement.focus({preventScroll: true});})'
+                    'const iframe = this;this.contentWindow.document.addEventListener(\'click\', function(){iframe.closest(\'.wp-block\').focus({preventScroll: true});})'
                 ),
                 $output
             );

--- a/src/DonorDashboards/Block.php
+++ b/src/DonorDashboards/Block.php
@@ -53,7 +53,7 @@ class Block
                 'onload="',
                 sprintf(
                     'onload="%s;',
-                    'const iframe = this;this.contentWindow.document.addEventListener(\'mouseup\', function(){iframe.parentElement.parentElement.parentElement.focus();})'
+                    'const iframe = this;this.contentWindow.document.addEventListener(\'mouseup\', function(){iframe.parentElement.parentElement.parentElement.focus({preventScroll: true});})'
                 ),
                 $output
             );

--- a/src/DonorDashboards/Block.php
+++ b/src/DonorDashboards/Block.php
@@ -42,6 +42,8 @@ class Block
     /**
      * Returns Donor Profile block markup
      *
+     * @unreleased Add script for iframe onload event to activate gutenberg edit mode.
+     *             Gutenberg block edit mode activates when focus set to block container.
      * @since 2.10.0
      **/
     public function renderCallback($attributes)


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6553 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Gutenberg edit mode activates when clicking event fires on block container children (DOM elements) or focus set to block container. I find out that clicking on an element in the iframe does not bubble the element in the parent window.

I added logic to set focus to block containers when the admin clicks iframe elements.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
https://user-images.githubusercontent.com/1784821/186596276-d22f55c6-0cc9-452d-a1ef-0c7ff8db5b60.mov

## Testing Instructions

You should be able to edit the donor dashboard Gutenberg block and settings should display when clicking on the donor dashboard interface.

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

