### PR TITLE
Hotfix: `give_goal` and `give_form' display the goal progress correctly

### DIFF
--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -3,7 +3,6 @@
  * This template is used to display the goal with [give_goal]
  */
 
-$form_id          = get_the_ID(); // Form ID.
 $form        = new Give_Donate_Form( $form_id );
 
 $goal_option = give_get_meta( $form->ID, '_give_goal_option', true );

--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -209,7 +209,6 @@ $progress = apply_filters( 'give_goal_amount_funded_percentage_output', $progres
         </div>
     <?php endif; ?>
 
-
     <?php if ( ! empty( $show_bar ) ) :
         $style = "width:{$progress_bar_value}%";
 


### PR DESCRIPTION
Resolves #6563

## Description

The PR removes a get_id() Wordpress function in the `give_goal` shortcode. The function was not being used and causing the shortcode to fail when rendering. It was an oversight from PR https://github.com/impress-org/givewp/pull/6541.  Because the Legacy template relies on `give_goal` to display the goal progress  - fixing the issue in `give_goal` has corrected the issue with `give_form` while using a legacy template.

## Affects

`give_goal` shortcode

## Visuals

https://user-images.githubusercontent.com/75056371/191848931-c33b6e21-afe5-44d6-9131-03fc89b94dee.mov

## Testing Instructions

- Create a form with the Legacy template.
- Enable & set donation goal options to amount raised.
- Process a donation.
- Create a page using `give_goal` and `give_form`
-  View Page to verify the goal section displays.
- Change the donation goal to each different option and view each option from the shortcodes to verify the different goal options continue to work.
- Repeat steps with all templates.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

