### PR TITLE
Hotfix: prevent PayPal disconnect from be blocking by JS errors

### DIFF
--- a/assets/src/js/admin/paypal-commerce/index.js
+++ b/assets/src/js/admin/paypal-commerce/index.js
@@ -162,14 +162,14 @@ window.addEventListener( 'DOMContentLoaded', function() {
 					desc: givePayPalCommerce.translations.disconnectPayPalAccount,
 				},
 				successConfirm: () => {
+					fetch( ajaxurl + '?action=give_paypal_commerce_disconnect_account' );
+					
 					connectionSettingContainer.classList.remove( 'give-hidden' );
 					disConnectionSettingContainer.classList.add( 'give-hidden' );
 					countryField.parentElement.parentElement.classList.remove( 'hide-with-position' );
 
 					let billingSettingContainer = document.querySelector('label[for=\'paypal_commerce_collect_billing_details\']');
-					billingSettingContainer.parentElement.parentElement.classList.add('give-hidden');
-
-					fetch( ajaxurl + '?action=give_paypal_commerce_disconnect_account' );
+					billingSettingContainer.parentElement.parentElement.classList.add('give-hidden');					
 				},
 			} ).render();
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6566

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR moves the fetch call to disconnect the PayPal account from the end to the beginning of the successConfirm method. 

This way, we first disconnect the account, and just after that, we try clean up the user interface. So, if the cleaning process throws any error in the browser console, it will not block the PayPal disconnection action.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

PayPal Donations gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

There is no test instructions because this is a random error that cannot be easily replicated.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

