### PR TITLE
Fix: Disconnecting from PayPal works correctly when translated in Chrome

### DIFF
--- a/assets/src/css/admin/paypal-commerce.scss
+++ b/assets/src/css/admin/paypal-commerce.scss
@@ -1,3 +1,11 @@
+#js-give-paypal-disconnect-paypal-account {
+    background-color: transparent;
+    border: none;
+    color: #2271b1;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 .give-modal.paypal-commerce-connect {
 	max-width: 596px;
 

--- a/assets/src/js/plugins/dynamicListener.js
+++ b/assets/src/js/plugins/dynamicListener.js
@@ -1,7 +1,7 @@
-( function( globalSope ) {
-	'use strict';
+(function (globalSope) {
+    'use strict';
 
-	/**
+    /**
      * Including this file adds the `addDynamicListener` to the ELement prototype.
      *
      * The dynamic listener gets an extra `selector` parameter that only calls the callback
@@ -13,43 +13,28 @@
      * Browser support: IE9+
      */
 
-	// Polyfil Element.matches
-	// https://developer.mozilla.org/en/docs/Web/API/Element/matches#Polyfill
-	if ( ! Element.prototype.matches ) {
-		Element.prototype.matches =
-            Element.prototype.matchesSelector ||
-            Element.prototype.mozMatchesSelector ||
-            Element.prototype.msMatchesSelector ||
-            Element.prototype.oMatchesSelector ||
-            Element.prototype.webkitMatchesSelector ||
-            function( s ) {
-            	let matches = ( this.document || this.ownerDocument ).querySelectorAll( s ),
-            		i = matches.length;
-            	while ( --i >= 0 && matches.item( i ) !== this ) {}
-            	return i > -1;
-            };
-	}
-
-	/**
+    /**
      * Returns a modified callback function that calls the
      * initial callback function only if the target element matches the given selector
+     *
+     * @unreleased check to see if the target element is a child of the container element
      *
      * @param {string} selector
      * @param {function} callback
      */
-	function getConditionalCallback( selector, callback ) {
-		return function( e ) {
-			if ( ! e.target ) {
-				return;
-			}
-			if ( ! e.target.matches( selector ) ) {
-				return;
-			}
-			callback.apply( this, arguments );
-		};
-	}
+    function getConditionalCallback(selector, callback) {
+        return function (e) {
+            if (!e.target) {
+                return;
+            }
+            if (!e.target.matches(selector) && !e.target.closest(selector)) {
+                return;
+            }
+            callback.apply(this, arguments);
+        };
+    }
 
-	/**
+    /**
      *
      *
      * @param {Element} rootElement The root element to add the linster too.
@@ -60,7 +45,7 @@
      *                                 Set to `true` to use capture.
      *                                 Usually used as an object to add the listener as `passive`
      */
-	globalSope.addDynamicEventListener = function( rootElement, eventType, selector, callback, options ) {
-		rootElement.addEventListener( eventType, getConditionalCallback( selector, callback ), options );
-	};
-}( window ) );
+    globalSope.addDynamicEventListener = function (rootElement, eventType, selector, callback, options) {
+        rootElement.addEventListener(eventType, getConditionalCallback(selector, callback), options);
+    };
+})(window);

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -181,9 +181,9 @@ class AdminSettingFields
                             ?>
 						</span>
                                 <span class="actions">
-							<a href="#"
+							<button
                                id="js-give-paypal-disconnect-paypal-account"><?php
-                                esc_html_e('Disconnect', 'give'); ?></a>
+                                    esc_html_e('Disconnect', 'give'); ?></button>
 						</span>
                             </div>
                             <div class="api-access-feature-list-wrap">


### PR DESCRIPTION
Resolves #6566 

## Description

This is another stab after #6567 didn't resolve the problem. The true problem is the fact that when a user translates a page using Chrome the browser swaps out the disconnect anchor and doesn't move over its event listeners properly, as well as adding font tags which does more strangeness. This is not a problem in Safari, for example.

This PR changes the anchor to a button for two reasons:
1. An anchor with a "#" href is semantically incorrect. It doesn't go anywhere, so it's not an anchor — it's a button (that looks like text).
2. Buttons handle what is inside them differently, so the translated tags inside aren't an issue. Buttons assume everything inside of them belong to themselves. Anchors are more flexible as folks put all sorts of stuff in anchors, so they're less predictable.

Next, and for the same translations issue, I added checking if the selector matches a parent of the target in the "Dynamic Listener" plugin. Again, Chrome was adding a font tag, so if the user clicked on the text it wasn't actually matching the button target.

I also removed a pollyfill as it hasn't been necessary in a long, long time.

## Affects

PayPal settings and the Give Modal

## Testing Instructions

1. Use a site in another language
2. Translate it to your language via Chrome
3. Try disconnecting a PayPal Account — also clicking "Cancel" in the modal

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

