### PR TITLE
Hot Fix: send new user email notifications with correct user data when using the gateway API

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.22.2
+ * Version: 2.22.3
  * Requires at least: 5.0
  * Requires PHP: 7.0
  * Text Domain: give
@@ -302,7 +302,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.22.2');
+            define('GIVE_VERSION', '2.22.3');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 2.22.2
+Stable tag: 2.22.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -251,6 +251,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.22.3: October 13th, 2022 =
+* Fix: When a donor creates an account the email is assured to be sent the right account
+
 = 2.22.2: September, 28th 2022 =
 * Fix: The give_goal and give_form shortcodes once again display correctly with the goal progress
 * Fix: Translating in Google Chrome no longer prevents disconnecting the PayPal account

--- a/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
+++ b/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
@@ -35,7 +35,7 @@ class DispatchGiveInsertPayment
             'currency' => $donation->amount->getCurrency()->getCode(),
             'paymentGateway' => $donation->gatewayId,
             'userInfo' => [
-                'id' => $donor->id,
+                'id' => $donor->userId,
                 'firstName' => $donor->firstName,
                 'lastName' => $donor->lastName,
                 'title' => $donor->prefix,

--- a/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
+++ b/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
@@ -9,7 +9,7 @@ use Give\PaymentGateways\DataTransferObjects\GiveInsertPaymentData;
 class DispatchGiveInsertPayment
 {
     /**
-     * @unreleased Use $donor->userId instead of $donor->id on the userInfo key
+     * @since 2.22.3 Use $donor->userId instead of $donor->id on the userInfo key
      * @since      2.20.0 only run this listener if the legacy hook is used
      * @since      2.19.6
      *

--- a/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
+++ b/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
@@ -9,8 +9,9 @@ use Give\PaymentGateways\DataTransferObjects\GiveInsertPaymentData;
 class DispatchGiveInsertPayment
 {
     /**
-     * @since 2.20.0 only run this listener if the legacy hook is used
-     * @since 2.19.6
+     * @unreleased Use $donor->userId instead of $donor->id on the userInfo key
+     * @since      2.20.0 only run this listener if the legacy hook is used
+     * @since      2.19.6
      *
      * @param Donation $donation
      *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6570

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR sets the correct WP user id instead of the donor id in the `give_insert_payment` hook.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

All the gateways that use the Gateway API as PayPal and Stripe for example.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Just follow the same instruction describe here: https://github.com/impress-org/givewp/issues/6570

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

