### PR TITLE
Tests: Introducing api for add-on test suite bootstrapping

### DIFF
--- a/tests/Config/Config.php
+++ b/tests/Config/Config.php
@@ -16,11 +16,4 @@ interface Config {
      * @unreleased
      */
     public function bootstrap(): string;
-
-    /**
-     * Return the functions file path
-     *
-     * @unreleased
-     */
-    public function functions(): string;
 }

--- a/tests/Config/Local.php
+++ b/tests/Config/Local.php
@@ -25,13 +25,4 @@ class Local implements Config
     {
         return __DIR__ . '/../../vendor/wordpress/wordpress/tests/phpunit/includes/bootstrap.php';
     }
-
-    /**
-     * @inheritDoc
-     * @unreleased
-     */
-    public function functions(): string
-    {
-        return __DIR__ . '/../../vendor/wordpress/wordpress/tests/phpunit/includes/functions.php';
-    }
 }

--- a/tests/Config/Workflow.php
+++ b/tests/Config/Workflow.php
@@ -25,13 +25,4 @@ class Workflow implements Config
     {
         return '/tmp/wordpress-tests-lib/includes/bootstrap.php';
     }
-
-    /**
-     * @inheritDoc
-     * @unreleased
-     */
-    public function functions(): string
-    {
-        return '/tmp/wordpress-tests-lib/includes/functions.php';
-    }
 }

--- a/tests/Framework/Addons/Bootstrap.php
+++ b/tests/Framework/Addons/Bootstrap.php
@@ -10,20 +10,33 @@ use GiveTests\Framework\TestHooks;
 class Bootstrap
 {
     /**
+     * @var string
+     */
+    protected $addonPath;
+
+    /**
+     * @unreleased
+     */
+    public function __construct(string $pathToMainAddonFile)
+    {
+        $this->addonPath = $pathToMainAddonFile;
+    }
+
+    /**
      * This is the all-in-one solution for bootstrapping a test environment in an add-on.
-     * All you would need to do in tests/bootstrap.php is require the main give autoload file,
-     * then call this method.
+     * All you need to do in tests/bootstrap.php is require the main give autoload file,
+     * instantiate this class, then call this method.
      *
-     * For more advanced use cases, loadAddon and loadGiveWP can be called directly with flexibility of running addHooks..
+     * For more advanced use cases, addHooks can be called before this method.
      *
      * @unreleased
      *
      * @return void
      */
-    final public function load(string $pathToMainPluginFile)
+    final public function load()
     {
-        $this->loadAddon($pathToMainPluginFile);
-        $this->loadGiveWP();
+        $this->loadAddon();
+        $this->loadGiveWPBootstrapFile();
     }
 
     /**
@@ -32,24 +45,21 @@ class Bootstrap
      *
      * @unreleased
      */
-    public function loadAddon(string $pathToPluginFile): Bootstrap
+    protected function loadAddon(): Bootstrap
     {
-        TestHooks::addFilter('muplugins_loaded', static function () use ($pathToPluginFile) {
-            require_once $pathToPluginFile;
+        TestHooks::addFilter('muplugins_loaded', function () {
+            require_once $this->addonPath;
         });
 
         return $this;
     }
 
     /**
-     * This is the public way of loading the main GiveWP bootstrap file.
-     * It returns void so will only be called once.
-     *
      * @unreleased
      *
      * @return void
      */
-    final public function loadGiveWP()
+    final protected function loadGiveWPBootstrapFile()
     {
         require_once __DIR__ . '/../../../tests/bootstrap.php';
     }

--- a/tests/Framework/Addons/Bootstrap.php
+++ b/tests/Framework/Addons/Bootstrap.php
@@ -5,6 +5,14 @@ namespace GiveTests\Framework\Addons;
 use GiveTests\Framework\TestHooks;
 
 /**
+ * This is our api for bootstrapping GiveWP add-on test suites.
+ * It is intended to be used directly in an add-on's test/bootstrap.php file.
+ *
+ * All you need to do in tests/bootstrap.php is require the main give autoload file,
+ * instantiate this class with a path to the main root add-on file, then call the load() method.
+ *
+ * For more advanced use cases, addHooks can be used before load().
+ *
  * @unreleased
  */
 class Bootstrap

--- a/tests/Framework/Addons/Bootstrap.php
+++ b/tests/Framework/Addons/Bootstrap.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace GiveTests\Framework\Addons;
+
+use GiveTests\Framework\TestHooks;
+
+/**
+ * @unreleased
+ */
+class Bootstrap
+{
+    /**
+     * This is the all-in-one solution for bootstrapping a test environment in an add-on.
+     * All you would need to do in tests/bootstrap.php is require the main give autoload file,
+     * then call this method.
+     *
+     * For more advanced use cases, loadAddon and loadGiveWP can be called directly with flexibility of running addHooks..
+     *
+     * @unreleased
+     *
+     * @return void
+     */
+    final public function load(string $pathToMainPluginFile)
+    {
+        $this->loadAddon($pathToMainPluginFile);
+        $this->loadGiveWP();
+    }
+
+    /**
+     * A declarative method for loading a plugin (GiveWP add-on) before the main WordPress testing environment boots.
+     * This will ensure the add-on files will be available within testing.
+     *
+     * @unreleased
+     */
+    public function loadAddon(string $pathToPluginFile): Bootstrap
+    {
+        TestHooks::addFilter('muplugins_loaded', static function () use ($pathToPluginFile) {
+            require_once $pathToPluginFile;
+        });
+
+        return $this;
+    }
+
+    /**
+     * This is the public way of loading the main GiveWP bootstrap file.
+     * It returns void so will only be called once.
+     *
+     * @unreleased
+     *
+     * @return void
+     */
+    final public function loadGiveWP()
+    {
+        require_once __DIR__ . '/../../../tests/bootstrap.php';
+    }
+
+    /**
+     * If the add-on needs to run additional hooks, this method can be used to do so within a callback.
+     *
+     * @unreleased
+     */
+    public function addHooks(callable $callback): Bootstrap
+    {
+        $callback();
+
+        return $this;
+    }
+}

--- a/tests/Framework/TestHooks.php
+++ b/tests/Framework/TestHooks.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace GiveTests\Framework;
+
+use Closure;
+
+/**
+ * A convenient facade for using WordPress test suite hooks.
+ *
+ * @unreleased
+ */
+class TestHooks
+{
+    /**
+     * Extracts the WordPress tests_add_filter method for use in our bootstrapping process.
+     *
+     * @unreleased
+     */
+    public static function addFilter(
+        string $tag,
+        Closure $function_to_add,
+        int $priority = 10,
+        int $accepted_args = 1
+    ): bool {
+        global $wp_filter;
+
+        if (function_exists('add_filter')) {
+            add_filter($tag, $function_to_add, $priority, $accepted_args);
+        } else {
+            $idx = self::buildUniqueIdFromFunction($function_to_add);
+
+            $wp_filter[$tag][$priority][$idx] = array(
+                'function' => $function_to_add,
+                'accepted_args' => $accepted_args,
+            );
+        }
+
+        return true;
+    }
+
+
+    /**
+     *
+     * Fork from WordPress _test_filter_build_unique_id()
+     *
+     * @unreleased
+     *
+     * @param $function
+     * @return string|void
+     */
+    protected static function buildUniqueIdFromFunction($function)
+    {
+        if (is_string($function)) {
+            return $function;
+        }
+
+        if (is_object($function)) {
+            // Closures are currently implemented as objects.
+            $function = array($function, '');
+        } else {
+            $function = (array)$function;
+        }
+
+        if (is_object($function[0])) {
+            // Object class calling.
+            return spl_object_hash($function[0]) . $function[1];
+        }
+
+        if (is_string($function[0])) {
+            // Static calling.
+            return $function[0] . '::' . $function[1];
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,9 +20,6 @@ $currentTestEnvironment = $testEnvironment->current();
 // define for use in WP bootstrap file
 define('WP_TESTS_CONFIG_FILE_PATH', $currentTestEnvironment->config());
 
-// pull in wp test functions like tests_add_filter
-require_once $currentTestEnvironment->functions();
-
 // load GiveWP
 TestHooks::addFilter('muplugins_loaded', static function () {
     require_once __DIR__ . '/../give.php';
@@ -33,6 +30,9 @@ TestHooks::addFilter('setup_theme', static function () {
     echo 'Installing GiveWP.....' . PHP_EOL;
     give()->install();
 });
+
+// pull in wp test functions like tests_add_filter
+require_once $currentTestEnvironment->functions();
 
 // pull in WP bootstrap file which looks for WP_TESTS_CONFIG_FILE_PATH defined above
 require_once $currentTestEnvironment->bootstrap();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,9 +31,6 @@ TestHooks::addFilter('setup_theme', static function () {
     give()->install();
 });
 
-// pull in wp test functions like tests_add_filter
-require_once $currentTestEnvironment->functions();
-
 // pull in WP bootstrap file which looks for WP_TESTS_CONFIG_FILE_PATH defined above
 require_once $currentTestEnvironment->bootstrap();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use GiveTests\Framework\TestHooks;
 use GiveTests\TestEnvironment;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -23,12 +24,12 @@ define('WP_TESTS_CONFIG_FILE_PATH', $currentTestEnvironment->config());
 require_once $currentTestEnvironment->functions();
 
 // load GiveWP
-tests_add_filter('muplugins_loaded', static function () {
+TestHooks::addFilter('muplugins_loaded', static function () {
     require_once __DIR__ . '/../give.php';
 });
 
 // install GiveWP
-tests_add_filter('setup_theme', static function () {
+TestHooks::addFilter('setup_theme', static function () {
     echo 'Installing GiveWP.....' . PHP_EOL;
     give()->install();
 });


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Introducing a new way of bootstrapping our test suite in GiveWP add-ons: `GiveTests\Framework\Addons\Bootstrap`. 

**Imaginary Give Addon**

```
give-addon
  - give-addon.php
  - tests
    - bootstrap.php
```

**bootstrap.php file**

```
<?php

use GiveTests\Framework\Addons\Bootstrap;

require __DIR__ . '/../../give/vendor/autoload.php';

(new Bootstrap(__DIR__ . '/../give-addon.php'))
    ->load();
```

Notice all we need to do is
1. Pull in the main give autoload file
2. Instantiate the `Bootstrap` class with the path to our main add-on file and call `->load()`

Under the hood, we are using the path to load our add-on using the WP test filter `'muplugins_loaded'` - then loading the GiveWP bootstrap file.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This does not directly affect anything until used.  

There's one minor update in our main GiveWP bootstrap file to use our new `TestHooks::addFilter`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This would need to be tested within a real add-on which will accompany this PR in the near future.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

