### PR TITLE
Fix: Percentage wildcards are now passed via a substitution argument containing the complete LIKE string

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1243,9 +1243,9 @@ function give_v189_upgrades() {
 			"
 					DELETE FROM $wpdb->usermeta
 					WHERE meta_key
-					LIKE '%%%s%%'
+					LIKE '%s'
 					",
-			'_give_hide_license_notices_permanently'
+			'%_give_hide_license_notices_permanently%'
 		)
 	);
 
@@ -1255,9 +1255,9 @@ function give_v189_upgrades() {
 			"
 					DELETE FROM $wpdb->options
 					WHERE option_name
-					LIKE '%%%s%%'
+					LIKE '%s'
 					",
-			'__give_hide_license_notices_shortly_'
+			'%__give_hide_license_notices_shortly_%'
 		)
 	);
 }

--- a/includes/class-give-cache.php
+++ b/includes/class-give-cache.php
@@ -338,8 +338,8 @@ class Give_Cache {
 				"SELECT option_name, option_value
 						FROM {$wpdb->options}
 						Where option_name
-						LIKE '%%%s%%'",
-				'give_cache'
+						LIKE '%s'",
+				'%give_cache%'
 			),
 			ARRAY_A
 		);
@@ -397,8 +397,8 @@ class Give_Cache {
 					"SELECT {$field_names }
 						FROM {$wpdb->options}
 						Where option_name
-						LIKE '%%%s%%'",
-					"give_cache_{$option_name}"
+						LIKE '%s'",
+					"%give_cache_{$option_name}%"
 				),
 				ARRAY_A
 			);
@@ -408,8 +408,8 @@ class Give_Cache {
 					"SELECT *
 						FROM {$wpdb->options}
 						Where option_name
-						LIKE '%%%s%%'",
-					"give_cache_{$option_name}"
+						LIKE '%s'",
+					"%give_cache_{$option_name}%"
 				),
 				1
 			);

--- a/includes/class-give-cli-commands.php
+++ b/includes/class-give-cli-commands.php
@@ -779,10 +779,10 @@ class GIVE_CLI_COMMAND {
 
 		$stat_option_names = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT option_name FROM {$wpdb->options} where (option_name LIKE '%%%s%%' OR option_name LIKE '%%%s%%')",
+				"SELECT option_name FROM {$wpdb->options} where (option_name LIKE '%s' OR option_name LIKE '%s')",
 				array(
-					'_transient_give_stats_',
-					'give_cache',
+					'%_transient_give_stats_%',
+					'%give_cache%',
 				)
 			),
 			ARRAY_A

--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -255,10 +255,10 @@ class Give_Donor {
 					"
 				SELECT meta_key, meta_value FROM {$wpdb->donormeta}
 				WHERE meta_key
-				LIKE '%%%s%%'
+				LIKE '%s'
 				AND {$meta_type}_id=%d
 				",
-					'give_donor_address',
+					'%give_donor_address%',
 					$this->id
 				),
 				ARRAY_N
@@ -1395,12 +1395,12 @@ class Give_Donor {
 						"
 						SELECT meta_key FROM {$wpdb->donormeta}
 						WHERE meta_key
-						LIKE '%%%s%%'
+						LIKE '%s'
 						AND {$meta_type}_id=%d
 						ORDER BY meta_id DESC
 						LIMIT 1
 						",
-						"_give_donor_address_{$address_type}_line1",
+						"%_give_donor_address_{$address_type}_line1%",
 						$this->id
 					)
 				);

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -257,7 +257,11 @@ function give_akismet_is_email_logged( $email ) {
 	global $wpdb;
 
 	return (bool) DB::get_var(
-		DB::prepare( "SELECT COUNT(id) FROM {$wpdb->give_log} WHERE log_type = %s AND data LIKE '%%%s%%';", LogType::SPAM, esc_sql( $email ) )
+		DB::prepare(
+            "SELECT COUNT(id) FROM {$wpdb->give_log} WHERE log_type = %s AND data LIKE '%s';",
+            LogType::SPAM,
+            '%' . esc_sql( $email ) . '%'
+        )
 	);
 }
 

--- a/src/Framework/QueryBuilder/Concerns/WhereClause.php
+++ b/src/Framework/QueryBuilder/Concerns/WhereClause.php
@@ -487,7 +487,7 @@ trait WhereClause
                     $where->comparisonOperator,
                     strpos($where->value, '%') !== false
                         ? $where->value
-                        : sprintf('%%%s%%', $where->value )
+                        : '%' . $where->value . '%'
                 );
 
             // Handle NULL conditions

--- a/src/LegacySubscriptions/includes/give-subscriptions-db.php
+++ b/src/LegacySubscriptions/includes/give-subscriptions-db.php
@@ -640,8 +640,8 @@ class Give_Subscriptions_DB extends Give_DB
                     "
 				SELECT id,name FROM {$donors_db->table_name}
 				WHERE name
-				LIKE '%%%s%%'",
-                    $args['search']
+				LIKE '%s'",
+                    '%' . $args['search'] . '%'
                 );
                 $subscription_donor_id = [];
                 $donor_ids = $wpdb->get_results($query, ARRAY_A);

--- a/tests/includes/legacy/tests-cache.php
+++ b/tests/includes/legacy/tests-cache.php
@@ -196,8 +196,8 @@ class Tests_Cache extends Give_Unit_Test_Case {
 					"SELECT option_name
 						FROM {$wpdb->options}
 						Where option_name
-						LIKE '%%%s%%'",
-					'give_cache'
+						LIKE '%s'",
+					'%give_cache%'
 				),
 				ARRAY_A
 			),
@@ -221,8 +221,8 @@ class Tests_Cache extends Give_Unit_Test_Case {
 				"SELECT option_name
 						FROM {$wpdb->options}
 						Where option_name
-						LIKE '%%%s%%'",
-				'give_cache'
+						LIKE '%s'",
+				'%give_cache%'
 			),
 			ARRAY_A
 		);

--- a/uninstall.php
+++ b/uninstall.php
@@ -121,9 +121,9 @@ if ( give_is_setting_enabled( give_get_option( 'uninstall_on_delete' ) ) ) {
 			"
 			SELECT option_name
 			FROM {$wpdb->options}
-			WHERE option_name LIKE '%%%s%%'
+			WHERE option_name LIKE '%s'
 			",
-			'give'
+			'%give%'
 		)
 	);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6572

Related to https://github.com/impress-org/give-recurring/pull/1139

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the use of wildcard placeholders when calling `WPDB::prepare()`.

When using a substitution argument in conjunction with a prepared `LIKE` clause, the wildcard placeholders should be passed as a part of the argument and not concatenated in the query.

While this did not previously result in a syntax error, the recent changes in 6.1 highlight this issue.

> Literal percentage signs (%) in the query string must be written as %%. Percentage wildcards (for example, to use in LIKE syntax) must be passed via a substitution argument containing the complete LIKE string, these cannot be inserted directly in the query string.

See https://developer.wordpress.org/reference/classes/wpdb/prepare/

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Update WordPress to version `6.1` (or a related pre-release).
-  Activate the GiveWP plugin.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

