### PR TITLE
Fix: Prevent amount selection when scrolling on mobile

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -396,13 +396,13 @@ jQuery( function( $ ) {
 	} );
 
 	// Multi-level Buttons: Update Amount Field based on Multi-level Donation Select
-	doc.on( 'click touchend', '.give-donation-level-btn', function( e ) {
+	doc.on( 'click', '.give-donation-level-btn', function( e ) {
 		e.preventDefault(); //don't let the form submit
 		Give.form.fn.autoSetMultiLevel( $( this ) );
 	} );
 
 	// Multi-level Radios: Update Amount Field based on Multi-level Donation Select
-	doc.on( 'click touchend', '.give-radio-input-level', function( e ) {
+	doc.on( 'click', '.give-radio-input-level', function( e ) {
 		Give.form.fn.autoSetMultiLevel( $( this ) );
 	} );
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6580 

## Description

On mobile, when scrolling the page while touching a donation level button is triggering the event to set the donation amount. This PR removes the `touchend` even listener as the `click` event listener remains and it's properly triggered when intended.

## Affects

Donation level buttons on touch screens.

## Visuals


https://user-images.githubusercontent.com/3921017/196291288-26b97a9a-893c-477f-a360-bc03227f9bc6.mp4



## Testing Instructions

Create a multi-step form with multiple donation levels.
On mobile, scroll down the form page while touching one of the donation levels, after you scroll, the donation amount must remain the same.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

