### PR TITLE
Fix: Display error messages on Classic template

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -252,7 +252,12 @@ jQuery( document ).ready( function( $ ) {
 				$this.val( complete_purchase_val );
 				loading_animation.fadeOut();
 				this_form.find( '.give_errors' ).remove();
-				this_form.find( '#give_purchase_submit input[type="submit"].give-submit' ).before( data );
+
+                if ( this_form.has( '.give-payment-details-section .give-payment-mode-label' ) ) {
+                    this_form.find( '.give-payment-details-section .give-payment-mode-label' ).after( data );
+                } else {
+                    this_form.find( '#give_purchase_submit input[type="submit"].give-submit' ).before( data );
+                }
 
 				// Enable the form donation button.
 				Give.form.fn.disable( this_form, false );

--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -248,13 +248,15 @@ jQuery( document ).ready( function( $ ) {
 
 				this_form.trigger( 'give_form_validation_passed' );
 			} else {
+                var $giveFormHeader = this_form.parent().find( '.give-form-header' );
+
 				//There was an error / remove old errors and prepend new ones
 				$this.val( complete_purchase_val );
 				loading_animation.fadeOut();
-				this_form.find( '.give_errors' ).remove();
+				this_form.parent().find( '.give_errors' ).remove();
 
-                if ( this_form.has( '.give-payment-details-section .give-payment-mode-label' ) ) {
-                    this_form.find( '.give-payment-details-section .give-payment-mode-label' ).after( data );
+                if ( $giveFormHeader.length > 0 ) {
+                    $giveFormHeader.after( data );
                 } else {
                     this_form.find( '#give_purchase_submit input[type="submit"].give-submit' ).before( data );
                 }

--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -248,7 +248,7 @@ jQuery( document ).ready( function( $ ) {
 
 				this_form.trigger( 'give_form_validation_passed' );
 			} else {
-                var $giveFormHeader = this_form.parent().find( '.give-form-header' );
+                const $giveFormHeader = this_form.parent().find( '.give-form-header' );
 
 				//There was an error / remove old errors and prepend new ones
 				$this.val( complete_purchase_val );
@@ -260,6 +260,8 @@ jQuery( document ).ready( function( $ ) {
                 } else {
                     this_form.find( '#give_purchase_submit input[type="submit"].give-submit' ).before( data );
                 }
+
+                this_form.closest( 'body' )[0].scrollIntoView({ behavior: 'smooth' });
 
 				// Enable the form donation button.
 				Give.form.fn.disable( this_form, false );

--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -258,10 +258,10 @@ jQuery( document ).ready( function( $ ) {
                 if ( $giveFormHeader.length > 0 ) {
                     $giveFormHeader.after( data );
                 } else {
-                    this_form.find( '#give_purchase_submit input[type="submit"].give-submit' ).before( data );
+                    this_form.parent().find( '.give-form-title' ).after( data );
                 }
 
-                this_form.closest( 'body' )[0].scrollIntoView({ behavior: 'smooth' });
+                this_form.parent()[0].scrollIntoView({ behavior: 'smooth' });
 
 				// Enable the form donation button.
 				Give.form.fn.disable( this_form, false );

--- a/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
@@ -8,13 +8,6 @@
     padding-inline: fn.scaleBetween(1rem, 4.375rem);
 }
 
-// This is specifically where the errors display into the payment section
-.give-payment-details-section {
-    :is(.give_errors,.give_notices):not(:last-child) {
-        margin-bottom: 0.9rem;
-    }
-}
-
 // Base error/notice class
 .give_error,
 .give_notice {
@@ -29,13 +22,10 @@
     font-size: 1rem;
     font-weight: 500;
     line-height: 1.3;
+    margin-bottom: 0.9rem;
     padding-block: 0.625rem;
     padding-inline: 0.75rem;
     position: relative;
-
-    &:not(:last-child) {
-        margin-bottom: 0.9rem;
-    }
 
     &::before {
         --border: 0.0625rem solid rgb(0 0 0 / 0.05);

--- a/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
@@ -8,6 +8,13 @@
     padding-inline: fn.scaleBetween(1rem, 4.375rem);
 }
 
+// This is specifically where the errors display into the payment section
+.give-payment-details-section {
+    :is(.give_errors,.give_notices):not(:last-child) {
+        margin-bottom: 0.9rem;
+    }
+}
+
 // Base error/notice class
 .give_error,
 .give_notice {
@@ -25,6 +32,10 @@
     padding-block: 0.625rem;
     padding-inline: 0.75rem;
     position: relative;
+
+    &:not(:last-child) {
+        margin-bottom: 0.9rem;
+    }
 
     &::before {
         --border: 0.0625rem solid rgb(0 0 0 / 0.05);
@@ -58,10 +69,6 @@
 }
 
 // Styles for error and notice types
-#give_error_test_mode {
-    margin-bottom: 0.9rem;
-}
-
 .give_error {
     --color: #ff3c00;
     --icon: '\f12a';

--- a/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_errors-notices.scss
@@ -2,8 +2,6 @@
 
 // This is specifically where the errors display after the header
 .give-form-header + .give_errors.give_notices {
-    display: grid;
-    row-gap: 1rem;
     padding-block-start: fn.scaleBetween(1.75rem, 3.375rem);
     padding-inline: fn.scaleBetween(1rem, 4.375rem);
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6584

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Errors messages are not being displayed on forms using the Classic template. This PR fixes the selector being used to print the ajax response data when on a Classic template form and adds margins when multiple errors are displayed at the same time.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Classic template

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![CleanShot 2022-10-18 at 15 28 28](https://user-images.githubusercontent.com/3921017/196514215-169dfdf8-319f-4779-a27d-56a61996aeee.jpg)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Create a form using the Classic template
2. Go to the page with that form
3. Enter "123" as the first name
4. An error must be displayed

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

