### PR TITLE
Form Grid donate button text color now defaults to black

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -791,7 +791,7 @@ add_shortcode( 'give_totals', 'give_totals_shortcode' );
  * @type string $display_style How the form is displayed, either in new page or modal popup.
  *                                       Default 'redirect'. Accepts 'redirect', 'modal'.
  *
- * @unreleased Updates the default text color for the donate button, see #6591.
+ * @unreleased Updated the default text color for the donate button, see #6591.
  * @since 2.21.2 change tag_background_color, progress_bar_color to official green color #69b868.
  *             change tag_text_color color to #333333.
  * @since 2.20.0 $show_donate_button Option to show donate button

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -791,6 +791,7 @@ add_shortcode( 'give_totals', 'give_totals_shortcode' );
  * @type string $display_style How the form is displayed, either in new page or modal popup.
  *                                       Default 'redirect'. Accepts 'redirect', 'modal'.
  *
+ * @unreleased Updates the default text color for the donate button, see #6591.
  * @since 2.21.2 change tag_background_color, progress_bar_color to official green color #69b868.
  *             change tag_text_color color to #333333.
  * @since 2.20.0 $show_donate_button Option to show donate button

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -822,7 +822,7 @@ function give_form_grid_shortcode( $atts ) {
 			'show_goal'           => true,
 			'show_excerpt'        => true,
 			'show_featured_image' => true,
-			'show_donate_button'  => false,
+			'show_donate_button'  => true,
 			'donate_button_text'  => '',
 			'tag_background_color' => '#69b868',
             'tag_text_color'      => '#333333',

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -826,7 +826,7 @@ function give_form_grid_shortcode( $atts ) {
 			'donate_button_text'  => '',
 			'tag_background_color' => '#69b868',
             'tag_text_color'      => '#333333',
-            'donate_button_text_color' => 'inherit',
+            'donate_button_text_color' => '#000000',
 			'image_size'          => 'medium',
 			'image_height'        => 'auto',
 			'excerpt_length'      => 16,

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -825,7 +825,7 @@ function give_form_grid_shortcode( $atts ) {
 			'donate_button_text'  => '',
 			'tag_background_color' => '#69b868',
             'tag_text_color'      => '#333333',
-            'donate_button_text_color' => '#fff',
+            'donate_button_text_color' => 'inherit',
 			'image_size'          => 'medium',
 			'image_height'        => 'auto',
 			'excerpt_length'      => 16,

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -190,6 +190,9 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                             ? $atts['donate_button_text']
                             : give_get_meta( $form_id, '_give_form_grid_donate_button_text', true );
 
+                         /**
+                          * @unreleased Updates the default text color for the donate button, see #6591.
+                          */
                         $button_text_color = ! empty( $atts['donate_button_text_color'] )
                             ? $atts['donate_button_text_color']
                             : 'inherit';

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -192,7 +192,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
 
                         $button_text_color = ! empty( $atts['donate_button_text_color'] )
                             ? $atts['donate_button_text_color']
-                            : '#fff';
+                            : 'inherit';
                         ?>
                         <button style="text-decoration-color: <?php echo $button_text_color; ?>">
                                     <span style="color: <?php echo $button_text_color; ?>">

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -195,7 +195,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                           */
                         $button_text_color = ! empty( $atts['donate_button_text_color'] )
                             ? $atts['donate_button_text_color']
-                            : 'inherit';
+                            : '#000000';
                         ?>
                         <button style="text-decoration-color: <?php echo $button_text_color; ?>">
                                     <span style="color: <?php echo $button_text_color; ?>">

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -191,7 +191,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                             : give_get_meta( $form_id, '_give_form_grid_donate_button_text', true );
 
                          /**
-                          * @unreleased Updates the default text color for the donate button, see #6591.
+                          * @unreleased Updated the default text color for the donate button, see #6591.
                           */
                         $button_text_color = ! empty( $atts['donate_button_text_color'] )
                             ? $atts['donate_button_text_color']


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6590

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the default value for the `donate_button_text_color` property of the `give_form_grid` shortcode to inherit the text color to match the surrounding elements.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `give_form_grid` shortcode used directly uses the `donate_button_text_color`, where as the newer Block wrapper for the shortcode always specifies a text color, thus the default is not used.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Shortcode used directly |
| :---: |
| `[give_form_grid show_donate_button=true]` |
| ![Screen Shot 2022-10-20 at 15 57 26](https://user-images.githubusercontent.com/10858303/197045640-7ed250e6-4c14-4fff-9d67-483e5b5211b6.png) |

| Block wrapping the shortcode |
| --- |
| ![Screen Shot 2022-10-20 at 15 57 56](https://user-images.githubusercontent.com/10858303/197045792-4135bc62-1de2-480a-9c89-143090fc626d.png) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Add the Form Grid shortcode to a page/post with the `show_donate_button` attribute enabled.

Example: `[give_form_grid show_donate_button=true]`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203209111237825