### PR TITLE
Fix: ZIP and country corrected for donor exports

### DIFF
--- a/src/Exports/DonorsExport.php
+++ b/src/Exports/DonorsExport.php
@@ -121,10 +121,10 @@ class DonorsExport extends Give_Batch_Export
                 'donor_id',
                 ['_give_donor_address_billing_line1_0', 'address_line1'],
                 ['_give_donor_address_billing_line2_0', 'address_line2'],
-                ['_give_donor_address_billing_city_0', 'address_city'],
+                ['_give_donor_address_billing_city_0',  'address_city'],
                 ['_give_donor_address_billing_state_0', 'address_state'],
-                ['_give_donor_address_billing_country_0', 'address_country'],
-                ['_give_donor_address_billing_zip_0', 'address_zip']
+                ['_give_donor_address_billing_zip_0',   'address_zip'],
+                ['_give_donor_address_billing_country_0', 'address_country']
             );
         }
 


### PR DESCRIPTION
Resolves: #6597

In class-batch-export.php, it's important to have the same order for column names and data. Otherwise, in the export file, ZIP and country are reversed.

First the print_csv_cols() function prepares the column names in the order in which they are defined.
Then the print_csv_rows() function prepares the data, regardless of column slug,in the order in which it is defined.



<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203193833018171
  - https://app.asana.com/0/0/1203271226884734