### PR TITLE
Fix Import GiveWP settings errors

### DIFF
--- a/includes/admin/tools/import/class-give-import-core-settings.php
+++ b/includes/admin/tools/import/class-give-import-core-settings.php
@@ -485,6 +485,7 @@ if ( ! class_exists( 'Give_Import_Core_Settings' ) ) {
 		public static function json_upload_mimes( $existing_mimes = array() ) {
 
 			$existing_mimes['json'] = 'application/json';
+            $existing_mimes['text'] = 'text/plain';
 
 			return $existing_mimes;
 		}


### PR DESCRIPTION
There is often an error while importing GiveWP settings:  [error] => 'Sorry, you are not allowed to upload this file type'. I sent an email in January 2019 and Sam suggested using the plugin called Disable Real Mime Check. But this plugin can be dangerous as it allows the upload of any file type. So I investigated. I saw there is 2 passes in the wp_check_filetype_and_ext() function, the first with mime type 'application/json', the second with 'text/plain'. So I suggest you to add 'text/plain' at the authorized mime types.

