### PR TITLE
Feature: Giving Tuesday 2022 Banner

### DIFF
--- a/src/Promotions/InPluginUpsells/SaleBanners.php
+++ b/src/Promotions/InPluginUpsells/SaleBanners.php
@@ -33,6 +33,7 @@ class SaleBanners
     /**
      * Get banners definitions
      *
+     * @unreleased add Giving Tuesday 2022 banner
      * @since 2.17.0
      *
      * @note id must be unique for each definition

--- a/src/Promotions/InPluginUpsells/SaleBanners.php
+++ b/src/Promotions/InPluginUpsells/SaleBanners.php
@@ -4,6 +4,7 @@ namespace Give\Promotions\InPluginUpsells;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use Exception;
 use Give\Framework\Shims\Shim;
 
 /**
@@ -21,6 +22,9 @@ class SaleBanners
      */
     private $hiddenBanners;
 
+    /**
+     * @since 2.17.0
+     */
     public function __construct()
     {
         $this->hiddenBanners = get_option($this->optionName, []);
@@ -29,11 +33,11 @@ class SaleBanners
     /**
      * Get banners definitions
      *
-     * @note id must be unique for each definition
+     * @since 2.17.0
      *
-     * @return array[]
+     * @note id must be unique for each definition
      */
-    public function getBanners()
+    public function getBanners(): array
     {
         return [
             [
@@ -47,15 +51,26 @@ class SaleBanners
                 'startDate' => '2021-11-26 00:00',
                 'endDate' => '2021-11-30 23:59',
             ],
+            [
+                'id' => 'bfgt2022',
+                'iconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/sale-icon.png',
+                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+                'leadText' => __('Save 40% on all Plans for a limited time.', 'give'),
+                'contentText' => __('Black Friday through Giving Tuesday.', 'give'),
+                'actionText' => __('Shop Now', 'give'),
+                'actionURL' => 'https://go.givewp.com/bf22',
+                'startDate' => '2022-11-01 00:00',
+                'endDate' => '2022-11-29 23:59',
+            ],
         ];
     }
 
     /**
      * Get the banners that should be displayed.
      *
-     * @return array[]
+     * @since 2.17.0
      */
-    public function getVisibleBanners()
+    public function getVisibleBanners(): array
     {
         $currentDateTime = current_datetime();
         $currentUserId = get_current_user_id();
@@ -64,19 +79,28 @@ class SaleBanners
         return array_filter(
             $this->getBanners(),
             function ($banner) use ($currentDateTime, $currentUserId, $giveWPWebsiteTimezone) {
-                $isHidden = in_array($banner['id'] . $currentUserId, $this->hiddenBanners);
-                $isFuture = $currentDateTime < new DateTimeImmutable($banner['startDate'], $giveWPWebsiteTimezone);
-                $isPast = $currentDateTime > new DateTimeImmutable($banner['endDate'], $giveWPWebsiteTimezone);
+                $isHidden = in_array($banner['id'] . $currentUserId, $this->hiddenBanners, true);
 
-                return ! ($isHidden || $isFuture || $isPast);
+                try {
+                    $isFuture = $currentDateTime < new DateTimeImmutable($banner['startDate'], $giveWPWebsiteTimezone);
+                    $isPast = $currentDateTime > new DateTimeImmutable($banner['endDate'], $giveWPWebsiteTimezone);
+                } catch(Exception $exception) {
+                    return false;
+                }
+
+                return !($isHidden || $isFuture || $isPast);
             }
         );
     }
 
     /**
-     * @param string $banner
+     * Marks the given banner id as hidden for the current user so it will not display again.
+     *
+     * @since 2.17.0
+     *
+     * @return void
      */
-    public function hideBanner($banner)
+    public function hideBanner(string $banner)
     {
         $this->hiddenBanners[] = $banner;
 
@@ -88,18 +112,22 @@ class SaleBanners
 
     /**
      * Render admin page
+     *
+     * @since 2.17.0
      */
     public function render()
     {
         $banners = $this->getVisibleBanners();
 
-        if ( ! empty($banners)) {
+        if (!empty($banners)) {
             include __DIR__ . '/resources/views/sale-banners.php';
         }
     }
 
     /**
      * Load scripts
+     *
+     * @since 2.17.0
      */
     public function loadScripts()
     {
@@ -131,9 +159,9 @@ class SaleBanners
     /**
      * Helper function to determine if the current page Give admin page
      *
-     * @return bool
+     * @since 2.17.0
      */
-    public static function isShowing()
+    public static function isShowing(): bool
     {
         return isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms';
     }


### PR DESCRIPTION
## Description

This PR adds the banner for the upcoming Giving Tuesday sale. I also made some minor code improvements.

Please make sure the messaging and go link are all correct.

## Visuals

View on Loom: https://www.loom.com/share/3419c207833145b390eaf59fb7ac3954

## Testing Instructions

The banner should show up in the settings and add-ons page.

Clicking the "x" should hide the banner for that user, including reloading the page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

