### PR TITLE
Fix: prevent php deprecation notices on php8

### DIFF
--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -1086,7 +1086,7 @@ class Give_Donor {
 	 *
 	 * @return bool               False for failure. True for success.
 	 */
-	public function add_meta( $meta_key = '', $meta_value, $unique = false ) {
+	public function add_meta( $meta_key, $meta_value, $unique = false ) {
 		return Give()->donor_meta->add_meta( $this->id, $meta_key, $meta_value, $unique );
 	}
 
@@ -1102,7 +1102,7 @@ class Give_Donor {
 	 *
 	 * @return bool               False on failure, true if success.
 	 */
-	public function update_meta( $meta_key = '', $meta_value, $prev_value = '' ) {
+	public function update_meta( $meta_key, $meta_value, $prev_value = '' ) {
 		return Give()->donor_meta->update_meta( $this->id, $meta_key, $meta_value, $prev_value );
 	}
 

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -485,7 +485,7 @@ function give_delete_purchase( $payment_id = 0, $update_customer = true ) {
  *
  * @return void
  */
-function give_undo_purchase( $form_id = false, $payment_id ) {
+function give_undo_purchase( $form_id, $payment_id ) {
 
 	$backtrace = debug_backtrace();
 
@@ -546,7 +546,7 @@ function give_increase_purchase_count( $form_id = 0, $quantity = 1 ) {
  *
  * @return void
  */
-function give_record_sale_in_log( $give_form_id = 0, $payment_id, $price_id = false, $sale_date = null ) {
+function give_record_sale_in_log( $give_form_id, $payment_id, $price_id = false, $sale_date = null ) {
 	$backtrace = debug_backtrace();
 
 	_give_deprecated_function( __FUNCTION__, '1.8.9', 'give_record_donation_in_log', $backtrace );
@@ -777,7 +777,7 @@ function give_get_payment_amount( $payment_id ) {
  *
  * @return bool|int
  */
-function give_decrease_earnings( $form_id = 0, $amount ) {
+function give_decrease_earnings( $form_id, $amount ) {
 	return give_decrease_form_earnings( $form_id, $amount );
 }
 

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -791,7 +791,7 @@ function give_validate_nonce( $nonce, $action = - 1, $wp_die_args = array() ) {
  *
  * @return bool
  */
-function give_verify_donation_form_nonce( $nonce = '', $form_id ) {
+function give_verify_donation_form_nonce( $nonce, $form_id ) {
 
 	// Form nonce action.
 	$nonce_action = "give_donation_form_nonce_{$form_id}";


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6606

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I found out that a few functions have the first function argument optional but the second required which caused PHP deprecated notices. I made these arguments required.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
You should not get PHP deprecation notices on php8.0 when processing a donation.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

