### PR TITLE
Fix: Add check before calling getMaxLength

### DIFF
--- a/src/Form/LegacyConsumer/templates/base.html.php
+++ b/src/Form/LegacyConsumer/templates/base.html.php
@@ -19,6 +19,10 @@
     echo $field->isRequired() ? 'required' : ''; ?>
     <?php
     echo $field->isReadOnly() ? 'readonly' : ''; ?>
+
     <?php
-    echo ($maxLength = $field->getMaxLength()) ? "maxlength=\"$maxLength\"" : ''; ?>
+    if( method_exists( $field, 'getMaxLength' ) ) {
+        echo ($maxLength = $field->getMaxLength()) ? "maxlength=\"$maxLength\"" : '';
+    }
+    ?>
 >


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR prevents a fatal error when using the base template in the Legacy Consumer for a date field. There is no specific template for the date field, so the base template is being used. However, the base template assumes that the field type uses `HasMaxLength`, which the date field does not. This will additionally prevent a fatal error for any field type that uses the base template but does not support a max length property.

```diff
     <?php
-    echo ($maxLength = $field->getMaxLength()) ? "maxlength=\"$maxLength\"" : ''; ?>
+    if( method_exists( $field, 'getMaxLength' ) ) {
+        echo ($maxLength = $field->getMaxLength()) ? "maxlength=\"$maxLength\"" : '';
+    }
+    ?>
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Register a custom date field on a donation form and check that no uncaught `BadMethodCallException` is thrown.

```php
add_action( 'give_fields_after_donation_amount', function( $group ) {
    $group->append(
        give_field( 'date', 'date' )
            ->label( __( 'Any date' ))
    );
});
```




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203450933278106