### PR TITLE
Fix: Bulk checkboxes reset checked value after sorting 

### DIFF
--- a/src/Donations/ValueObjects/DonationStatus.php
+++ b/src/Donations/ValueObjects/DonationStatus.php
@@ -53,16 +53,16 @@ class DonationStatus extends Enum
     public static function labels(): array
     {
         return [
-            self::PENDING => __( 'Pending', 'give' ),
-            self::PROCESSING => __( 'Processing', 'give' ),
-            self::COMPLETE => __( 'Completed', 'give' ),
-            self::REFUNDED => __( 'Refunded', 'give' ),
-            self::FAILED => __( 'Failed', 'give' ),
-            self::CANCELLED => __( 'Cancelled', 'give' ),
-            self::ABANDONED => __( 'Abandoned', 'give' ),
-            self::PREAPPROVAL => __( 'Preapproval Pending', 'give' ),
-            self::REVOKED => __( 'Revoked', 'give' ),
-            self::RENEWAL => __( 'Renewal', 'give' ),
+            self::PENDING => __('Pending', 'give'),
+            self::PROCESSING => __('Processing', 'give'),
+            self::COMPLETE => __('Completed', 'give'),
+            self::REFUNDED => __('Refunded', 'give'),
+            self::FAILED => __('Failed', 'give'),
+            self::CANCELLED => __('Cancelled', 'give'),
+            self::ABANDONED => __('Abandoned', 'give'),
+            self::PREAPPROVAL => __('Preapproval', 'give'),
+            self::REVOKED => __('Revoked', 'give'),
+            self::RENEWAL => __('Renewal', 'give'),
         ];
     }
 

--- a/src/Views/Components/ListTable/BulkActions/BulkActionCheckbox.tsx
+++ b/src/Views/Components/ListTable/BulkActions/BulkActionCheckbox.tsx
@@ -12,9 +12,11 @@ export const BulkActionCheckbox = ({id, name, singleName}) => {
     }, []);
 
     useEffect(() => {
-        // cleanup function to remove the ref when the component unmounts
+        // cleanup function to remove the ref checked value when the component unmounts
         return () => {
-            checkboxRefs.current = checkboxRefs.current.filter((checkbox) => checkbox.dataset.id === id);
+            checkboxRefs.current.forEach((checkbox) => {
+                checkbox.checked = false;
+            });
         };
     }, []);
 


### PR DESCRIPTION
## Description

This PR updates the bulk action checkboxes to reset the refs checked value to false which will be triggered after sorting a column. It also updates the pre-approval message on the donations table. 

## Affects

- Bulk action checkboxes on the react list tables.
- Donations table.

## Visuals
## Previous Donations table pre-approval message:
<img width="1725" alt="Screen Shot 2022-12-05 at 3 20 29 PM" src="https://user-images.githubusercontent.com/75056371/205773449-16021fc4-cec4-4f7a-a88b-ce94a69ab243.png">

## New Donations table pre-approval message:
<img width="1725" alt="Screen Shot 2022-12-05 at 3 20 19 PM" src="https://user-images.githubusercontent.com/75056371/205773454-ccd361c6-451d-4a10-a4b7-e073aee710fd.png">

## Testing Instructions

- Select several items via checkbox and use the bulk action filter to update the statuses of your items.
- Sort your table via any column.
- Reselect the checkboxes you originally updated.
- Resubmit a new bulk status update.
- Verify the items selected update again.

https://user-images.githubusercontent.com/75056371/205779102-8c34b10b-7be4-4427-9736-59add7ce67b8.mov


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

