### PR TITLE
Fix: Limited subscription tooltip messages use correct nouns.

### DIFF
--- a/src/Subscriptions/ListTable/Columns/StatusColumn.php
+++ b/src/Subscriptions/ListTable/Columns/StatusColumn.php
@@ -78,10 +78,15 @@ class StatusColumn extends ModelColumn
             $extra = [
                 'label' => __('limited', 'give'),
                 'status' => 'limited',
-                'text' => sprintf(_n('This subscription has <strong>%s</strong> remaining donation',
-                    'This subscription has <strong>%s</strong> remaining donations', $remainingInstallments,
-                    'give'), $remainingInstallments),
-
+                'text' => sprintf(
+                    _n(
+                        'This subscription has <strong>%s</strong> remaining donation',
+                        'This subscription has <strong>%s</strong> remaining donations',
+                        $remainingInstallments,
+                        'give'
+                    ),
+                    $remainingInstallments
+                ),
             ];
         }
 
@@ -89,7 +94,7 @@ class StatusColumn extends ModelColumn
             $template,
             $model->status,
             $model->status->label(),
-            isset( $extra ) ? sprintf(
+            isset($extra) ? sprintf(
                 $extraTemplate,
                 GIVE_PLUGIN_URL . 'assets/dist/images/list-table/' . $extra['status'] . '-subscription-icon.svg',
                 $extra['label'],

--- a/src/Subscriptions/ListTable/Columns/StatusColumn.php
+++ b/src/Subscriptions/ListTable/Columns/StatusColumn.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Give\Subscriptions\ListTable\Columns;
 
-use Give\Subscriptions\Models\Subscription;
 use Give\Framework\ListTable\ModelColumn;
+use Give\Subscriptions\Models\Subscription;
 
 /**
  * @unreleased
@@ -78,10 +78,10 @@ class StatusColumn extends ModelColumn
             $extra = [
                 'label' => __('limited', 'give'),
                 'status' => 'limited',
-                'text' => sprintf(
-                    __('This subscription has <strong>%d</strong> remaining donations', 'give'),
-                    $remainingInstallments
-                )
+                'text' => sprintf(_n('This subscription has <strong>%s</strong> remaining donation',
+                    'This subscription has <strong>%s</strong> remaining donations', $remainingInstallments,
+                    'give'), $remainingInstallments),
+
             ];
         }
 

--- a/src/Subscriptions/ListTable/Columns/StatusColumn.php
+++ b/src/Subscriptions/ListTable/Columns/StatusColumn.php
@@ -66,7 +66,7 @@ class StatusColumn extends ModelColumn
             $extra = [
                 'label' => __('failed', 'give'),
                 'status' => 'failed',
-                'text' => __('This subscription has failed', 'give'),
+                'text' => __('This subscription has <strong>failed</strong>', 'give'),
             ];
         } elseif ($model->isIndefinite()) {
             $extra = [


### PR DESCRIPTION
Resolves #6624

## Description

- Adds wordpress _n function to determine if a limited recurring donation amount has one or several donations left and uses the correct noun to represent the sentence.
- Also includes a strong tag to bolden the word failed on the failing subscription tool tip. 

## Affects

-Subscription Table

## Visuals

<img width="1725" alt="Failed tooltip" src="https://user-images.githubusercontent.com/75056371/206228529-88c7b68e-0540-44e1-b12c-75edae9d04cb.png">

<img width="1725" alt="Singular limited subscription" src="https://user-images.githubusercontent.com/75056371/206228540-f7c1f24e-4504-4806-a12a-def2655eec8c.png">


## Testing Instructions

- Create a limited subscription with only one donation left,
- Create a limited subscription with several donations left.
- View the subscriptions table.
- Hover over the limited subscriptions to view the tooltip and verify the sentences have either a singular or a plural noun for the word donation/donations.
- View A failing subscription to verify the word failed is now bold.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

