### PR TITLE
Refactor/speed up endpoint performance

### DIFF
--- a/src/DonationForms/Endpoints/ListDonationForms.php
+++ b/src/DonationForms/Endpoints/ListDonationForms.php
@@ -3,6 +3,7 @@
 namespace Give\DonationForms\Endpoints;
 
 use Give\DonationForms\ListTable\DonationFormsListTable;
+use Give\DonationForms\Models\DonationForm;
 use Give\Framework\Models\ModelQueryBuilder;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -176,7 +177,11 @@ class ListDonationForms extends Endpoint
      */
     public function getTotalFormsCount(): int
     {
-        $query = give()->donationForms->prepareQuery();
+        $builder = new ModelQueryBuilder(DonationForm::class);
+
+        $query = $builder->from('posts')
+            ->where('post_type', 'give_forms');
+
         $query = $this->getWhereConditions($query);
 
         return $query->count();

--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -3,6 +3,7 @@
 namespace Give\Donations;
 
 use Give\Donations\ListTable\DonationsListTable;
+use Give\Framework\Database\DB;
 use Give\Helpers\EnqueueScript;
 use WP_REST_Request;
 
@@ -117,26 +118,14 @@ class DonationsAdminPage
      */
     private function getForms()
     {
-        $queryParameters = [
-            'page' => 1,
-            'perPage' => 50,
-            'status' => 'any',
-            'return' => 'model',
-        ];
-
-        $request = WP_REST_Request::from_url(esc_url_raw(add_query_arg(
-            $queryParameters,
-            rest_url('give-api/v2/admin/forms')
-        )));
-
-        $data = rest_do_request($request)->get_data();
-
-        $options = array_map(static function ($form) {
-            return [
-                'value' => $form->id,
-                'text' => $form->title,
-            ];
-        }, $data['items']);
+        $options = DB::table('posts')
+            ->select(
+                ['ID', 'value'],
+                ['post_title', 'text']
+            )
+            ->where('post_type', 'give_forms')
+            ->whereIn('post_status', ['publish', 'draft', 'pending', 'private'])
+            ->getAll(ARRAY_A);
 
         return array_merge([
             [

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -3,6 +3,8 @@
 namespace Give\Donations\Endpoints;
 
 use Give\Donations\ListTable\DonationsListTable;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Donations\ValueObjects\DonationMode;
 use Give\Framework\ListTable\Exceptions\ColumnIdCollisionException;
 use Give\Framework\Models\ModelQueryBuilder;
@@ -189,7 +191,26 @@ class ListDonations extends Endpoint
      */
     public function getTotalDonationsCount(): int
     {
-        $query = give()->donations->prepareQuery();
+        $builder = new ModelQueryBuilder(Donation::class);
+
+        $columnsForAttachMetaQuery = [
+            DonationMetaKeys::EMAIL(),
+            DonationMetaKeys::FIRST_NAME(),
+            DonationMetaKeys::LAST_NAME(),
+            DonationMetaKeys::DONOR_ID(),
+            DonationMetaKeys::FORM_ID(),
+            DonationMetaKeys::MODE(),
+        ];
+
+        $query = $builder->from('posts')
+            ->attachMeta(
+                'give_donationmeta',
+                'ID',
+                'donation_id',
+                ...DonationMetaKeys::getColumnsForAttachMetaQueryFromArray($columnsForAttachMetaQuery)
+            )
+            ->where('post_type', 'give_payment');
+
         $query = $this->getWhereConditions($query);
 
         return $query->count();

--- a/src/Donors/Endpoints/ListDonors.php
+++ b/src/Donors/Endpoints/ListDonors.php
@@ -3,6 +3,7 @@
 namespace Give\Donors\Endpoints;
 
 use Give\Donors\ListTable\DonorsListTable;
+use Give\Donors\Models\Donor;
 use Give\Framework\Models\ModelQueryBuilder;
 use Give\Framework\QueryBuilder\QueryBuilder;
 use WP_REST_Request;
@@ -181,7 +182,9 @@ class ListDonors extends Endpoint
      */
     public function getTotalDonorsCount(): int
     {
-        $query = give()->donors->prepareQuery();
+        $builder = new ModelQueryBuilder(Donor::class);
+
+        $query = $builder->from('give_donors');
         $query = $this->getWhereConditions($query);
 
         return $query->count();

--- a/src/Framework/Models/ModelQueryBuilder.php
+++ b/src/Framework/Models/ModelQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Give\Framework\Models;
 
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Framework\Database\DB;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\Models\Contracts\ModelCrud;
@@ -43,7 +44,8 @@ class ModelQueryBuilder extends QueryBuilder
     {
         $column = ( ! $column || $column === '*') ? '1' : trim($column);
 
-        $this->selects[] = new RawSQL('COUNT(%1s) AS count', $column);
+        $this->selects = [];
+        $this->selectRaw('SELECT COUNT(%1s) AS count', $column);
 
         return +parent::get()->count;
     }

--- a/src/Framework/Support/ValueObjects/EnumInteractsWithQueryBuilder.php
+++ b/src/Framework/Support/ValueObjects/EnumInteractsWithQueryBuilder.php
@@ -27,4 +27,29 @@ trait EnumInteractsWithQueryBuilder
 
         return $columns;
     }
+
+    /**
+     * @unreleased
+     *
+     * Returns array of meta aliases to be used with attachMeta based on the given array of ENUMs
+     *
+     * [ ['_give_payment_total', 'amount'], etc. ]
+     *
+     * @param array<Enum> $enums An array of Enums. Eg.: [ DonationMetaKeys::AMOUNT(), etc. ]
+     *
+     * @return array
+     */
+    public static function getColumnsForAttachMetaQueryFromArray(array $enums): array
+    {
+        $columns = [];
+
+        foreach ($enums as $enum) {
+            $value = $enum->getValue();
+            $keyFormatted = $enum->getKeyAsCamelCase();
+
+            $columns[] = [$value, $keyFormatted];
+        }
+
+        return $columns;
+    }
 }

--- a/src/Subscriptions/Endpoints/ListSubscriptions.php
+++ b/src/Subscriptions/Endpoints/ListSubscriptions.php
@@ -2,6 +2,8 @@
 
 namespace Give\Subscriptions\Endpoints;
 
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Framework\Models\ModelQueryBuilder;
 use Give\Framework\QueryBuilder\QueryBuilder;
 use Give\Subscriptions\ListTable\SubscriptionsListTable;
@@ -184,7 +186,9 @@ class ListSubscriptions extends Endpoint
      */
     public function getTotalSubscriptionsCount(): int
     {
-        $query = give()->subscriptions->prepareQuery();
+        $builder = new ModelQueryBuilder(Donation::class);
+
+        $query = $builder->from('give_subscriptions');
         $query = $this->getWhereConditions($query);
 
         return $query->count();


### PR DESCRIPTION
## Description

Optimize list table endpoints performance replacing expensive queries with simple ones.

## Affects

- On `DonationsAdminPage.php`, `DonorsAdminPage.php` and `SubscriptionsAdminPage.php` there is a method `getForms` that was triggering a request to the ListDonationForms endpoint what needed to load the entire model. We are replacing that request with a simple DB query returning only the necessary columns.
- When calling the method `count()` in a query it used to just append `COUNT(*) as count` to the query then get that value from the results. We are now removing any other column from the `SELECT` statement so that the query only results the count column.
- On every list table endpoint we have a counter method that returns the total number of items based on the current arguments so that we calculate paginations. It used to make use of the `prepareQuery()` method but that attaches many extra meta data not necessary for the counting method. We are replacing the `prepareQuery()` call with a custom `ModelQueryBuilder` where only the necessary meta data for that endpoint is now being attached.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

