### PR TITLE
Fix/subscription payment mode column

### DIFF
--- a/src/Subscriptions/Factories/SubscriptionFactory.php
+++ b/src/Subscriptions/Factories/SubscriptionFactory.php
@@ -12,6 +12,7 @@ use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Actions\GenerateNextRenewalForSubscription;
 use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionMode;
 use Give\Subscriptions\ValueObjects\SubscriptionPeriod;
 use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 
@@ -39,6 +40,7 @@ class SubscriptionFactory extends ModelFactory
             'status' => SubscriptionStatus::PENDING(),
             'renewsAt' => give(GenerateNextRenewalForSubscription::class)(SubscriptionPeriod::MONTH(), $frequency),
             'donationFormId' => 1,
+            'mode' => SubscriptionMode::TEST(),
         ];
     }
 

--- a/src/Subscriptions/Factories/SubscriptionFactory.php
+++ b/src/Subscriptions/Factories/SubscriptionFactory.php
@@ -19,6 +19,7 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 class SubscriptionFactory extends ModelFactory
 {
     /**
+     * @unreleased add mode property
      * @since 2.20.0 update default donorId to create factory
      * @since 2.19.6
      *

--- a/src/Subscriptions/ListTable/Columns/FormColumn.php
+++ b/src/Subscriptions/ListTable/Columns/FormColumn.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Give\Subscriptions\ListTable\Columns;
 
-use Give\Subscriptions\Models\Subscription;
 use Give\Framework\ListTable\ModelColumn;
+use Give\Subscriptions\Models\Subscription;
 
 /**
  * @unreleased
@@ -46,6 +46,10 @@ class FormColumn extends ModelColumn
     public function getCellValue($model): string
     {
         $form = give()->donationForms->getById($model->donationFormId);
+
+        if ( ! $form) {
+            return sprintf( __( 'Form #%d', 'give' ), $model->donationFormId );
+        }
 
         return sprintf(
             '<a href="%s" aria-label="%s">%s</a>',

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -125,6 +125,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add payment_mode column to insert
      * @since 2.21.0 replace actions with givewp_subscription_creating and givewp_subscription_created
      * @since 2.19.6
      *
@@ -182,6 +183,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add payment_mode column to update
      * @since 2.21.0 replace actions with givewp_subscription_updating and givewp_subscription_updated
      * @since 2.19.6
      *

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -161,6 +161,7 @@ class SubscriptionRepository
                 'bill_times' => $subscription->installments,
                 'transaction_id' => $subscription->transactionId ?? '',
                 'product_id' => $subscription->donationFormId,
+                'payment_mode' => $subscription->mode->getValue(),
             ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');
@@ -215,6 +216,7 @@ class SubscriptionRepository
                     'bill_times' => $subscription->installments,
                     'transaction_id' => $subscription->transactionId ?? '',
                     'product_id' => $subscription->donationFormId,
+                    'payment_mode' => $subscription->mode->getValue(),
                 ]);
         } catch (Exception $exception) {
             DB::query('ROLLBACK');

--- a/tests/Unit/Subscriptions/Endpoints/TestListSubscriptions.php
+++ b/tests/Unit/Subscriptions/Endpoints/TestListSubscriptions.php
@@ -6,6 +6,7 @@ use Exception;
 use Give\Subscriptions\Endpoints\ListSubscriptions;
 use Give\Subscriptions\ListTable\SubscriptionsListTable;
 use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionMode;
 use GiveTests\TestCase;
 use GiveTests\TestTraits\RefreshDatabase;
 use WP_REST_Request;
@@ -30,6 +31,7 @@ class TestListSubscriptions extends TestCase
         $mockRequest->set_param('page', 1);
         $mockRequest->set_param('perPage', 30);
         $mockRequest->set_param('locale', 'us-US');
+        $mockRequest->set_param('testMode', true);
 
         $listSubscriptions = new ListSubscriptions();
 
@@ -53,6 +55,7 @@ class TestListSubscriptions extends TestCase
         $mockRequest->set_param('page', 1);
         $mockRequest->set_param('perPage', 30);
         $mockRequest->set_param('locale', 'us-US');
+        $mockRequest->set_param('testMode', true);
         $mockRequest->set_param('sortColumn', 'id');
         $mockRequest->set_param('sortDirection', $sortDirection);
 

--- a/tests/Unit/Subscriptions/Repositories/TestSubscriptionRepository.php
+++ b/tests/Unit/Subscriptions/Repositories/TestSubscriptionRepository.php
@@ -84,6 +84,7 @@ class TestSubscriptionRepository extends TestCase
         $this->assertEquals($subscriptionQuery->bill_times, $subscriptionInstance->installments);
         $this->assertEquals($subscriptionQuery->transaction_id, $subscriptionInstance->transactionId);
         $this->assertEquals($subscriptionQuery->status, $subscriptionInstance->status->getValue());
+        $this->assertEquals($subscriptionQuery->payment_mode, $subscriptionInstance->mode->getValue());
     }
 
     /**


### PR DESCRIPTION
## Description

When the `payment_mode` column was added to the subscription table, we missed including it in the insert/update methods on the subscription repository so that the new column was not saved once the model was saved.

## Affects

- `SubscriptionRepository->insert()` and `SubscriptionRepository->update()` methods now have the `mode` property to be inserted or updated to the database;
- The `SubscriptionFactory` now brings a value for the `mode` property;
- The `mode` parameter has been added to the mocked request.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

