### PR TITLE
Refactor/speed up endpoint performance

### DIFF
--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -276,9 +276,9 @@ class ListDonations extends Endpoint
         }
 
         if ($hasWhereConditions) {
-            $query->having('give_donationmeta_attach_meta_mode.meta_value', '=', $testMode ? 'test' : 'live');
+            $query->having('give_donationmeta_attach_meta_mode.meta_value', '=', $testMode ? DonationMode::TEST : DonationMode::LIVE);
         } else {
-            $query->where('give_donationmeta_attach_meta_mode.meta_value', $testMode ? 'test' : 'live');
+            $query->where('give_donationmeta_attach_meta_mode.meta_value', $testMode ? DonationMode::TEST : DonationMode::LIVE);
         }
 
         return [

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -212,11 +212,10 @@ class ListDonations extends Endpoint
      * @since      2.21.0
      *
      * @param QueryBuilder $query
-     * @param string       $filterUsing
      *
-     * @return array
+     * @return array{0: QueryBuilder, 1: array<DonationMetaKeys>}
      */
-    private function getWhereConditions(QueryBuilder $query, string $filterUsing = 'where'): array
+    private function getWhereConditions(QueryBuilder $query): array
     {
         $search = $this->request->get_param('search');
         $start = $this->request->get_param('start');
@@ -226,7 +225,7 @@ class ListDonations extends Endpoint
         $testMode = $this->request->get_param('testMode');
 
         $dependencies = [
-            DonationMetaKeys::MODE()
+            DonationMetaKeys::MODE(),
         ];
 
         $hasWhereConditions = $search || $start || $end || $form || $donor;

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -146,7 +146,7 @@ class ListDonations extends Endpoint
             [
                 'items' => $items,
                 'totalItems' => $donationsCount,
-                'totalPages' => $totalPages
+                'totalPages' => $totalPages,
             ]
         );
     }
@@ -165,7 +165,7 @@ class ListDonations extends Endpoint
         $sortDirection = $this->request->get_param('sortDirection') ?: 'desc';
 
         $query = give()->donations->prepareQuery();
-        $query = $this->getWhereConditions($query);
+        list($query) = $this->getWhereConditions($query);
 
         foreach ($sortColumns as $sortColumn) {
             $query->orderBy($sortColumn, $sortDirection);
@@ -191,38 +191,32 @@ class ListDonations extends Endpoint
      */
     public function getTotalDonationsCount(): int
     {
-        $columnsForAttachMetaQuery = [
-            DonationMetaKeys::EMAIL(),
-            DonationMetaKeys::FIRST_NAME(),
-            DonationMetaKeys::LAST_NAME(),
-            DonationMetaKeys::DONOR_ID(),
-            DonationMetaKeys::FORM_ID(),
-            DonationMetaKeys::MODE(),
-        ];
-
         $query = DB::table('posts')
-            ->attachMeta(
-                'give_donationmeta',
-                'ID',
-                'donation_id',
-                ...DonationMetaKeys::getColumnsForAttachMetaQueryFromArray($columnsForAttachMetaQuery)
-            )
-            ->where('post_type', 'give_payment');
+            ->where('post_type', 'give_payment')
+            ->groupBy('mode');
 
-        $query = $this->getWhereConditions($query);
+        list($query, $dependencies) = $this->getWhereConditions($query);
+
+        $query->attachMeta(
+            'give_donationmeta',
+            'ID',
+            'donation_id',
+            ...DonationMetaKeys::getColumnsForAttachMetaQueryFromArray($dependencies)
+        );
 
         return $query->count();
     }
 
     /**
      * @unreleased Remove joins as it uses ModelQueryBuilder and change clauses to use attach_meta
-     * @since 2.21.0
+     * @since      2.21.0
      *
      * @param QueryBuilder $query
+     * @param string       $filterUsing
      *
-     * @return QueryBuilder
+     * @return array
      */
-    private function getWhereConditions(QueryBuilder $query): QueryBuilder
+    private function getWhereConditions(QueryBuilder $query, string $filterUsing = 'where'): array
     {
         $search = $this->request->get_param('search');
         $start = $this->request->get_param('start');
@@ -231,16 +225,25 @@ class ListDonations extends Endpoint
         $donor = $this->request->get_param('donor');
         $testMode = $this->request->get_param('testMode');
 
+        $dependencies = [
+            DonationMetaKeys::MODE()
+        ];
+
+        $hasWhereConditions = $search || $start || $end || $form || $donor;
+
         if ($search) {
             if (ctype_digit($search)) {
                 $query->where('id', $search);
             } elseif (strpos($search, '@') !== false) {
                 $query
                     ->whereLike('give_donationmeta_attach_meta_email.meta_value', $search);
+                $dependencies[] = DonationMetaKeys::EMAIL();
             } else {
                 $query
                     ->whereLike('give_donationmeta_attach_meta_firstName.meta_value', $search)
                     ->orWhereLike('give_donationmeta_attach_meta_lastName.meta_value', $search);
+                $dependencies[] = DonationMetaKeys::FIRST_NAME();
+                $dependencies[] = DonationMetaKeys::LAST_NAME();
             }
         }
 
@@ -248,16 +251,20 @@ class ListDonations extends Endpoint
             if (ctype_digit($donor)) {
                 $query
                     ->where('give_donationmeta_attach_meta_donorId.meta_value', $donor);
+                $dependencies[] = DonationMetaKeys::DONOR_ID();
             } else {
                 $query
                     ->whereLike('give_donationmeta_attach_meta_firstName.meta_value', $donor)
                     ->orWhereLike('give_donationmeta_attach_meta_lastName.meta_value', $donor);
+                $dependencies[] = DonationMetaKeys::FIRST_NAME();
+                $dependencies[] = DonationMetaKeys::LAST_NAME();
             }
         }
 
         if ($form) {
             $query
                 ->where('give_donationmeta_attach_meta_formId.meta_value', $form);
+            $dependencies[] = DonationMetaKeys::FORM_ID();
         }
 
         if ($start && $end) {
@@ -268,9 +275,15 @@ class ListDonations extends Endpoint
             $query->where('post_date', $end, '<=');
         }
 
-        $query->where('give_donationmeta_attach_meta_mode.meta_value',
-            $testMode ? DonationMode::TEST : DonationMode::LIVE);
+        if ($hasWhereConditions) {
+            $query->having('give_donationmeta_attach_meta_mode.meta_value', '=', $testMode ? 'test' : 'live');
+        } else {
+            $query->where('give_donationmeta_attach_meta_mode.meta_value', $testMode ? 'test' : 'live');
+        }
 
-        return $query;
+        return [
+            $query,
+            $dependencies,
+        ];
     }
 }

--- a/src/Framework/QueryBuilder/Concerns/Aggregate.php
+++ b/src/Framework/QueryBuilder/Concerns/Aggregate.php
@@ -21,10 +21,11 @@ trait Aggregate
     {
         $column = ( ! $column || $column === '*') ? '1' : trim($column);
 
-        if ('1' === $column) {
-            $this->selects = [];
+        if (empty($this->selects)) {
+            $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
+        } else {
+            $this->selects[] = new RawSQL('COUNT(%1s) AS count', $column);
         }
-        $this->selects[] = new RawSQL('SELECT COUNT(%1s) AS count', $column);
 
         return +$this->get()->count;
     }

--- a/src/Framework/QueryBuilder/Concerns/HavingClause.php
+++ b/src/Framework/QueryBuilder/Concerns/HavingClause.php
@@ -303,7 +303,7 @@ trait HavingClause
         }
 
         return DB::prepare(
-            "%1s %s %3s %s",
+            "%1s %2s %3s %s",
             $having->logicalOperator,
             $having->column,
             $having->comparisonOperator,

--- a/src/Subscriptions/Endpoints/ListSubscriptions.php
+++ b/src/Subscriptions/Endpoints/ListSubscriptions.php
@@ -141,7 +141,7 @@ class ListSubscriptions extends Endpoint
             [
                 'items' => $items,
                 'totalItems' => $subscriptionsCount,
-                'totalPages' => $pageCount
+                'totalPages' => $pageCount,
             ]
         );
     }
@@ -184,7 +184,7 @@ class ListSubscriptions extends Endpoint
      */
     public function getTotalSubscriptionsCount(): int
     {
-        $query = DB::table('give_subscriptions');
+        $query = DB::table('give_subscriptions')->groupBy('payment_mode');
         $query = $this->getWhereConditions($query);
 
         return $query->count();
@@ -205,6 +205,8 @@ class ListSubscriptions extends Endpoint
         $end = $this->request->get_param('end');
         $form = $this->request->get_param('form');
         $testMode = $this->request->get_param('testMode');
+
+        $hasWhereConditions = $search || $start || $end || $form;
 
         if ($search) {
             if (ctype_digit($search)) {
@@ -241,7 +243,11 @@ class ListSubscriptions extends Endpoint
                 });
         }
 
-        $query->where('payment_mode', $testMode ? SubscriptionMode::TEST : SubscriptionMode::LIVE);
+        if ($hasWhereConditions) {
+            $query->having('payment_mode', '=', $testMode ? SubscriptionMode::TEST : SubscriptionMode::LIVE);
+        } else {
+            $query->where('payment_mode', $testMode ? SubscriptionMode::TEST : SubscriptionMode::LIVE);
+        }
 
         return $query;
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

The current PR is a continuation of https://github.com/impress-org/givewp/pull/6631

## Description

- We discovered that attaching all meta to the count query damages its performance. So, we created the concept of dependencies, that only attach the meta fields required for performing the filtering, if some;
- Also, using the `having` clause is not the best option for every scenario. So, we are now checking if a filter is being applied to decide if the best option is a `having` or a `where` clause for the `mode` column;

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

