### PR TITLE
Fix: New Donation table button added for users with the Manual Donations Add-on

### DIFF
--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -5,7 +5,7 @@ namespace Give\Donations;
 use Give\Donations\ListTable\DonationsListTable;
 use Give\Framework\Database\DB;
 use Give\Helpers\EnqueueScript;
-use WP_REST_Request;
+use Give\Helpers\Utils;
 
 class DonationsAdminPage
 {
@@ -71,6 +71,7 @@ class DonationsAdminPage
             'table' => give(DonationsListTable::class)->toArray(),
             'adminUrl' => $this->adminUrl,
             'paymentMode' => give_is_test_mode(),
+            'manualDonations' => $this->hasManualDonations(),
         ];
 
         EnqueueScript::make('give-admin-donations', 'assets/dist/js/give-admin-donations.js')
@@ -131,7 +132,16 @@ class DonationsAdminPage
             [
                 'value' => '0',
                 'text' => 'Any',
-            ]
+            ],
         ], $options);
+    }
+
+    public function hasManualDonations()
+    {
+        if (Utils::isPluginActive('give-manual-donations/give-manual-donations.php')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -136,6 +136,11 @@ class DonationsAdminPage
         ], $options);
     }
 
+    /**
+     * Checks if manual donations add-on is active
+     *
+     * @return bool
+     */
     public function hasManualDonations()
     {
         if (Utils::isPluginActive('give-manual-donations/give-manual-donations.php')) {

--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -71,7 +71,7 @@ class DonationsAdminPage
             'table' => give(DonationsListTable::class)->toArray(),
             'adminUrl' => $this->adminUrl,
             'paymentMode' => give_is_test_mode(),
-            'manualDonations' => $this->hasManualDonations(),
+            'manualDonations' => Utils::isPluginActive('give-manual-donations/give-manual-donations.php'),
         ];
 
         EnqueueScript::make('give-admin-donations', 'assets/dist/js/give-admin-donations.js')
@@ -134,19 +134,5 @@ class DonationsAdminPage
                 'text' => 'Any',
             ],
         ], $options);
-    }
-
-    /**
-     * Checks if manual donations add-on is active
-     *
-     * @return bool
-     */
-    public function hasManualDonations()
-    {
-        if (Utils::isPluginActive('give-manual-donations/give-manual-donations.php')) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/Donations/resources/components/DonationsListTable.tsx
+++ b/src/Donations/resources/components/DonationsListTable.tsx
@@ -16,6 +16,7 @@ declare global {
             forms: Array<{value: string; text: string}>;
             table: {columns: Array<object>};
             paymentMode: boolean;
+            manualDonations: boolean;
         };
     }
 }
@@ -143,6 +144,14 @@ export default function DonationsListTable() {
             filterSettings={filters}
             paymentMode={!!window.GiveDonations.paymentMode}
         >
+            {!!window.GiveDonations.manualDonations && (
+                <a
+                    className={tableStyles.addFormButton}
+                    href={window.GiveDonations.adminUrl + 'edit.php?post_type=give_forms&page=give-manual-donation'}
+                >
+                    {__('New Donation', 'give')}
+                </a>
+            )}
             <a
                 className={tableStyles.addFormButton}
                 href={

--- a/src/Donations/resources/components/DonationsListTable.tsx
+++ b/src/Donations/resources/components/DonationsListTable.tsx
@@ -147,17 +147,14 @@ export default function DonationsListTable() {
             {!!window.GiveDonations.manualDonations && (
                 <a
                     className={tableStyles.addFormButton}
-                    href={window.GiveDonations.adminUrl + 'edit.php?post_type=give_forms&page=give-manual-donation'}
+                    href={`${window.GiveDonations.adminUrl}edit.php?post_type=give_forms&page=give-manual-donation`}
                 >
                     {__('New Donation', 'give')}
                 </a>
             )}
             <a
                 className={tableStyles.addFormButton}
-                href={
-                    window.GiveDonations.adminUrl +
-                    'edit.php?post_type=give_forms&page=give-tools&tab=import&importer-type=import_donations'
-                }
+                href={` ${window.GiveDonations.adminUrl}edit.php?post_type=give_forms&page=give-tools&tab=import&importer-type=import_donations`}
             >
                 {__('Import Donations', 'give')}
             </a>

--- a/src/Donations/resources/components/DonationsListTable.tsx
+++ b/src/Donations/resources/components/DonationsListTable.tsx
@@ -144,7 +144,7 @@ export default function DonationsListTable() {
             filterSettings={filters}
             paymentMode={!!window.GiveDonations.paymentMode}
         >
-            {!!window.GiveDonations.manualDonations && (
+            {window.GiveDonations.manualDonations && (
                 <a
                     className={tableStyles.addFormButton}
                     href={`${window.GiveDonations.adminUrl}edit.php?post_type=give_forms&page=give-manual-donation`}


### PR DESCRIPTION
Resolves #6637

## Affects
- Donations Table 

## Visuals
<img width="1725" alt="Screen Shot 2022-12-14 at 3 13 03 PM" src="https://user-images.githubusercontent.com/75056371/207526308-82722965-f0cf-4b95-87e5-5075aa6dd058.png">


## Testing Instructions

- Install & activate manual donations add-on.
- Visit donations table and use the new donation button at the top.
- deactivate manual donations add-on.
- Verify new donation button is removed.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

