### PR TITLE
Refactor/list table columns for addons

### DIFF
--- a/src/DonationForms/ListTable/DonationFormsListTable.php
+++ b/src/DonationForms/ListTable/DonationFormsListTable.php
@@ -33,7 +33,7 @@ class DonationFormsListTable extends ListTable
      *
      * @inheritDoc
      */
-    public function getColumns(): array
+    public function getDefaultColumns(): array
     {
         return [
             new IdColumn(),

--- a/src/Donations/ListTable/DonationsListTable.php
+++ b/src/Donations/ListTable/DonationsListTable.php
@@ -32,7 +32,7 @@ class DonationsListTable extends ListTable
      *
      * @inheritDoc
      */
-    public function getColumns(): array
+    public function getDefaultColumns(): array
     {
         return [
             new IdColumn(),

--- a/src/Donors/ListTable/DonorsListTable.php
+++ b/src/Donors/ListTable/DonorsListTable.php
@@ -31,7 +31,7 @@ class DonorsListTable extends ListTable
      *
      * @inheritDoc
      */
-    public function getColumns(): array
+    public function getDefaultColumns(): array
     {
         return [
             new IdColumn(),

--- a/src/Framework/ListTable/Concerns/Columns.php
+++ b/src/Framework/ListTable/Concerns/Columns.php
@@ -179,9 +179,13 @@ trait Columns
      *
      * @return self
      */
-    protected function setColumnVisibility($column)
+    public function setColumnVisibility($columnId, $isVisible = null): self
     {
-        $column->visible(in_array($column->getId(), $this->getDefaultVisibleColumns()));
+        if (is_null($isVisible)) {
+            $isVisible = in_array($columnId, $this->getDefaultVisibleColumns(), true);
+        }
+
+        $this->getColumnById($columnId)->visible($isVisible);
 
         return $this;
     }

--- a/src/Framework/ListTable/Concerns/Columns.php
+++ b/src/Framework/ListTable/Concerns/Columns.php
@@ -23,10 +23,10 @@ trait Columns
      *
      * @param ModelColumn $column
      *
-     * @return void
+     * @return self
      * @throws ColumnIdCollisionException
      */
-    public function addColumn(ModelColumn $column)
+    public function addColumn(ModelColumn $column): self
     {
         $columnId = $column::getId();
 
@@ -34,8 +34,10 @@ trait Columns
             throw new ColumnIdCollisionException($columnId);
         }
 
-        $this->setColumnVisibility($column);
         $this->columns[$columnId] = $column;
+        $this->setColumnVisibility($columnId);
+
+        return $this;
     }
 
     /**
@@ -60,16 +62,18 @@ trait Columns
      *
      * @unreleased
      *
-     * @return void
+     * @return self
      * @throws ReferenceColumnNotFoundException
      */
-    public function removeColumn(string $columnId)
+    public function removeColumn(string $columnId): self
     {
-        if (!isset($this->columns[$columnId])) {
+        if ( ! isset($this->columns[$columnId])) {
             throw new ReferenceColumnNotFoundException($columnId);
         }
 
         unset($this->columns[$columnId]);
+
+        return $this;
     }
 
     /**
@@ -99,14 +103,13 @@ trait Columns
      *
      * @unreleased
      *
-     * @return void
+     * @return self
      * @throws ReferenceColumnNotFoundException
      */
-    public function addColumnBefore(string $columnId, ModelColumn $column)
+    public function addColumnBefore(string $columnId, ModelColumn $column): self
     {
         if (is_int($index = $this->getColumnIndexById($columnId))) {
-            $this->insertAtIndex($index, $column);
-            return;
+            return $this->insertAtIndex($index, $column);
         }
 
         throw new ReferenceColumnNotFoundException($columnId);
@@ -117,14 +120,13 @@ trait Columns
      *
      * @unreleased
      *
-     * @return void
+     * @return self
      * @throws ReferenceColumnNotFoundException
      */
-    public function addColumnAfter(string $columnId, ModelColumn $column)
+    public function addColumnAfter(string $columnId, ModelColumn $column): self
     {
         if (is_int($index = $this->getColumnIndexById($columnId))) {
-            $this->insertAtIndex($index + 1, $column);
-            return;
+            return $this->insertAtIndex($index + 1, $column);
         }
 
         throw new ReferenceColumnNotFoundException($columnId);
@@ -159,25 +161,29 @@ trait Columns
     /**
      * @unreleased
      *
-     * @return void
+     * @return self
      */
-    protected function insertAtIndex(int $index, ModelColumn $column)
+    protected function insertAtIndex(int $index, ModelColumn $column): self
     {
         $this->columns = array_merge(
             array_splice($this->columns, 0, $index),
             [$column::getId() => $column],
             $this->columns
         );
+
+        return $this;
     }
 
     /**
      * @unreleased
      *
-     * @return void
+     * @return self
      */
     protected function setColumnVisibility($column)
     {
         $column->visible(in_array($column->getId(), $this->getDefaultVisibleColumns()));
+
+        return $this;
     }
 
     /**

--- a/src/Framework/ListTable/ListTable.php
+++ b/src/Framework/ListTable/ListTable.php
@@ -25,7 +25,7 @@ abstract class ListTable implements Arrayable
      */
     public function __construct()
     {
-        $this->addColumns(...$this->getColumns());
+        $this->addColumns(...$this->getDefaultColumns());
     }
 
     /**
@@ -42,7 +42,7 @@ abstract class ListTable implements Arrayable
      *
      * @return ModelColumn[]
      */
-    abstract protected function getColumns(): array;
+    abstract protected function getDefaultColumns(): array;
 
     /**
      * Define default visible table columns

--- a/src/Subscriptions/ListTable/SubscriptionsListTable.php
+++ b/src/Subscriptions/ListTable/SubscriptionsListTable.php
@@ -31,7 +31,7 @@ class SubscriptionsListTable extends ListTable
      *
      * @inheritDoc
      */
-    public function getColumns(): array
+    public function getDefaultColumns(): array
     {
         return [
             new IdColumn(),


### PR DESCRIPTION
## Description

In order to add columns to add-ons, these changes have been necessary:
- renamed the method that return columns from a List Table as it was conflicting with the method from the Columns concern. That means once we were trying to get all columns added to the list table instance, we were actually getting the columns registered on the specific list table;
- added self return to the methods that we use to add/remove columns from the list table making them chainable;
- added a new parameter to the `setColumnVisibility` method so we can invoke it, passing a value that is different from its default;

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

