### PR TITLE
Hotfix: makes the Square credit card fields be rendered in Safari

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -242,6 +242,7 @@ jQuery( function( $ ) {
 			// Select payment gateway.
 			$( this ).prop( 'checked', true );
 			$( this ).parent().addClass( 'give-gateway-option-selected' );
+			$( this ).focus();
 
 			// Get new payment gateway.
 			new_payment_gateways = Give.form.fn.getGateway( $form );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6644

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR forces the focus on the selected item on the gateways list from the payment form and ensures that this selected item is set as the active element in the DOM.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Makes possible to render Square credit card fields on the Safari browser.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


https://user-images.githubusercontent.com/16308864/208195749-1e38d546-a03f-4fc8-a415-00093d4b8c96.mp4


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Enable Square and any other gateway.
2. Open the form in Safari and switch to Square. If Square is the default gateway, switch to any other gateway and back to Square.

**Important:** If necessary, use a service like [Lambda Test](https://www.lambdatest.com/) to make the test.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203579167893822