### PR TITLE
Show donor donation comment in donor wall when donate with Stripe credit card

### DIFF
--- a/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
+++ b/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php
@@ -35,12 +35,14 @@ class DispatchGiveInsertPayment
             'purchaseKey' => $donation->purchaseKey,
             'currency' => $donation->amount->getCurrency()->getCode(),
             'paymentGateway' => $donation->gatewayId,
+            'donorId' => $donation->donorId,
             'userInfo' => [
                 'id' => $donor->userId,
                 'firstName' => $donor->firstName,
                 'lastName' => $donor->lastName,
                 'title' => $donor->prefix,
                 'email' => $donor->email,
+                'address' => $donation->billingAddress,
             ],
         ]);
 

--- a/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
+++ b/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
@@ -6,7 +6,7 @@ use Give\Framework\Database\DB;
 use Give\Framework\Migrations\Contracts\Migration;
 
 /**
- * Class GiveWPAddMissingDonorIDInDonationComment
+ * Class AddMissingDonorIdToDonationComment
  *
  * @unreleased
  */

--- a/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
+++ b/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Give\Donations\Migrations;
+
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * Class GiveWPAddMissingDonorIDInDonationComment
+ *
+ * @unreleased
+ */
+class AddMissingDonorIdToDonationComment extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function run()
+    {
+        $commentMetaTable = DB::prefix('give_commentmeta');
+        $commentTable = DB::prefix('give_comments');
+        $donationMetaTable = DB::prefix('give_donationmeta');
+
+        DB::query(
+            "
+            UPDATE
+                 $commentMetaTable AS cm
+                INNER JOIN $commentTable AS c ON c.comment_ID = cm.give_comment_id
+                INNER JOIN $donationMetaTable AS dm ON c.comment_parent = dm.donation_id
+            SET
+                cm.meta_value = dm.meta_value
+            WHERE
+                dm.meta_key = '_give_payment_donor_id'
+                AND cm.meta_key = '_give_donor_id'
+                AND(cm.meta_value IS NULL OR cm.meta_value = '')
+            "
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function id()
+    {
+        return 'ada-missing-donor-id-in-donation-comments';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function title()
+    {
+        return 'Add missing donor id in donation comments';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp()
+    {
+        return strtotime('2022-19-12');
+    }
+}

--- a/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
+++ b/src/Donations/Migrations/AddMissingDonorIdToDonationComment.php
@@ -42,7 +42,7 @@ class AddMissingDonorIdToDonationComment extends Migration
      */
     public static function id()
     {
-        return 'ada-missing-donor-id-in-donation-comments';
+        return 'add-missing-donor-id-in-donation-comments';
     }
 
     /**

--- a/src/Donations/Migrations/AddMissingDonorIdToDonationComments.php
+++ b/src/Donations/Migrations/AddMissingDonorIdToDonationComments.php
@@ -10,7 +10,7 @@ use Give\Framework\Migrations\Contracts\Migration;
  *
  * @unreleased
  */
-class AddMissingDonorIdToDonationComment extends Migration
+class AddMissingDonorIdToDonationComments extends Migration
 {
     /**
      * @inheritdoc

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -10,9 +10,11 @@ use Give\Donations\LegacyListeners\InsertSequentialId;
 use Give\Donations\LegacyListeners\RemoveSequentialId;
 use Give\Donations\LegacyListeners\UpdateDonorPaymentIds;
 use Give\Donations\LegacyListeners\UpdateSequentialId;
+use Give\Donations\Migrations\AddMissingDonorIdToDonationComment;
 use Give\Donations\Models\Donation;
 use Give\Donations\Repositories\DonationNotesRepository;
 use Give\Donations\Repositories\DonationRepository;
+use Give\Framework\Migrations\MigrationsRegister;
 use Give\Helpers\Call;
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
@@ -35,6 +37,8 @@ class ServiceProvider implements ServiceProviderInterface
     {
         $this->bootLegacyListeners();
         $this->registerDonationsAdminPage();
+
+        give(MigrationsRegister::class)->addMigration(AddMissingDonorIdToDonationComment::class);
     }
 
     /**

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -10,7 +10,7 @@ use Give\Donations\LegacyListeners\InsertSequentialId;
 use Give\Donations\LegacyListeners\RemoveSequentialId;
 use Give\Donations\LegacyListeners\UpdateDonorPaymentIds;
 use Give\Donations\LegacyListeners\UpdateSequentialId;
-use Give\Donations\Migrations\AddMissingDonorIdToDonationComment;
+use Give\Donations\Migrations\AddMissingDonorIdToDonationComments;
 use Give\Donations\Models\Donation;
 use Give\Donations\Repositories\DonationNotesRepository;
 use Give\Donations\Repositories\DonationRepository;
@@ -38,7 +38,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->bootLegacyListeners();
         $this->registerDonationsAdminPage();
 
-        give(MigrationsRegister::class)->addMigration(AddMissingDonorIdToDonationComment::class);
+        give(MigrationsRegister::class)->addMigration(AddMissingDonorIdToDonationComments::class);
     }
 
     /**

--- a/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
@@ -2,6 +2,8 @@
 
 namespace Give\PaymentGateways\DataTransferObjects;
 
+use Give\Donations\Properties\BillingAddress;
+
 /**
  * Class GiveInsertPaymentData
  *
@@ -51,6 +53,10 @@ final class GiveInsertPaymentData
      * @var string
      */
     public $paymentGateway;
+    /**
+     * @var int
+     */
+    public $donorId;
 
     /**
      * Convert data from array into DTO
@@ -63,6 +69,7 @@ final class GiveInsertPaymentData
     {
         $self = new static();
 
+        $self->donorId = $array['donorId'];
         $self->price = $array['price'];
         $self->priceId = $array['priceId'];
         $self->formTitle = $array['formTitle'];
@@ -91,8 +98,44 @@ final class GiveInsertPaymentData
             'user_email' => $this->donorEmail,
             'purchase_key' => $this->purchaseKey,
             'currency' => $this->currency,
-            'user_info' => $this->userInfo,
+            'user_info' => [
+                'id' => $this->userInfo['id'],
+                'title' => $this->userInfo['title'],
+                'first_name' => $this->userInfo['firstName'],
+                'last_name' => $this->userInfo['lastName'],
+                'donor_id' => $this->donorId,
+                'address' => $this->getLegacyBillingAddress(),
+            ],
             'status' => 'pending',
         ];
+    }
+
+    /**
+     * Should return donor billing address for donation.
+     *
+     * Check legacy code give_get_donation_form_user:1212
+     *
+     * @unlreased
+     *
+     * @return array|bool
+     */
+    private function getLegacyBillingAddress()
+    {
+        /* @var BillingAddress $donorDonationBillingAddress */
+        $donorDonationBillingAddress = $this->userInfo['address'];
+        $address = [
+            'line1' => $donorDonationBillingAddress->address1,
+            'line2' => $donorDonationBillingAddress->address2,
+            'city' => $donorDonationBillingAddress->city,
+            'state' => $donorDonationBillingAddress->state,
+            'zip' => $donorDonationBillingAddress->zip,
+            'country' => $donorDonationBillingAddress->country,
+        ];
+
+        if (! $donorDonationBillingAddress->country) {
+            $address = false;
+        }
+
+        return $address;
     }
 }

--- a/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
+++ b/src/PaymentGateways/DataTransferObjects/GiveInsertPaymentData.php
@@ -101,6 +101,7 @@ final class GiveInsertPaymentData
             'user_info' => [
                 'id' => $this->userInfo['id'],
                 'title' => $this->userInfo['title'],
+                'email' => $this->userInfo['email'],
                 'first_name' => $this->userInfo['firstName'],
                 'last_name' => $this->userInfo['lastName'],
                 'donor_id' => $this->donorId,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6646

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I find out that `donor_id` is required to add a donation comment, and the legacy adapter does not set it in `user_info`.

https://github.com/impress-org/givewp/blob/bdb780a9124eb3586796612f654bd2a7c09d5900/includes/donors/actions.php#L25

https://github.com/impress-org/givewp/blob/bdb780a9124eb3586796612f654bd2a7c09d5900/src/Donations/LegacyListeners/DispatchGiveInsertPayment.php#L38

I updated the logic set missing user information: `address` and `donor_id`. A correct format of `user_info` is required for most of the legacy code.
I also added a data migration to set the missing donor id in donation comments.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
Donor Comments should appear in donor wall ( if enabled) when processing donations the following:
- Stripe
- Paypal donations
- Test Donation

Note: previous donor comments should also appear on the donor wall.



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203576591035976