### PR TITLE
Fix: Loading animations are immediately visible regardless of page height

### DIFF
--- a/src/Views/Components/ListTable/ListTable/ListTable.module.scss
+++ b/src/Views/Components/ListTable/ListTable/ListTable.module.scss
@@ -129,7 +129,6 @@
 
 .overlay {
     display: flex;
-    display: flex;
     align-items: center;
     justify-content: center;
     position: absolute;

--- a/src/Views/Components/ListTable/ListTable/ListTable.module.scss
+++ b/src/Views/Components/ListTable/ListTable/ListTable.module.scss
@@ -129,6 +129,7 @@
 
 .overlay {
     display: flex;
+    display: flex;
     align-items: center;
     justify-content: center;
     position: absolute;
@@ -138,6 +139,20 @@
     z-index: 10;
     border-radius: inherit;
     overflow: hidden;
+}
+
+.relativeContainer {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    block-size: 100%;
+    inline-size: 100%;
+
+    .fixedContent {
+        position: fixed;
+        top: 50%;
+    }
 }
 
 .appear {

--- a/src/Views/Components/ListTable/ListTable/index.tsx
+++ b/src/Views/Components/ListTable/ListTable/index.tsx
@@ -55,7 +55,7 @@ export const ListTable = ({
     });
     const [errorOverlay, setErrorOverlay] = useState<string | boolean>(false);
     const [initialLoad, setInitialLoad] = useState<boolean>(true);
-    const [loadingOverlay, setLoadingOverlay] = useState<string | boolean>(false);
+    const [loadingOverlay, setLoadingOverlay] = useState<string | boolean>(true);
     const [overlayWidth, setOverlayWidth] = useState(0);
     const tableRef = useRef<null | HTMLTableElement>();
     const isEmpty = !error && data?.items.length === 0;
@@ -103,6 +103,10 @@ export const ListTable = ({
         (column) => column.visible || column.visible === undefined
     );
 
+    const isScrollable = () => {
+        return document.body.scrollHeight > document.body.clientHeight;
+    };
+
     return (
         <>
             {initialLoad && !error ? (
@@ -121,11 +125,12 @@ export const ListTable = ({
                     tabIndex={0}
                 >
                     {loadingOverlay && (
-                        <div
-                            className={cx(styles.overlay, loadingOverlay)}
-                            style={{width: overlayWidth && overlayWidth + 'px'}}
-                        >
-                            <Spinner size={'medium'} />
+                        <div className={cx(styles.overlay, loadingOverlay)}>
+                            <div className={isScrollable() && styles.relativeContainer}>
+                                <div className={styles.fixedContent}>
+                                    <Spinner size={'medium'} />
+                                </div>
+                            </div>
                         </div>
                     )}
                     <table ref={tableRef} className={styles.table}>

--- a/src/Views/Components/ListTable/ListTable/index.tsx
+++ b/src/Views/Components/ListTable/ListTable/index.tsx
@@ -55,7 +55,7 @@ export const ListTable = ({
     });
     const [errorOverlay, setErrorOverlay] = useState<string | boolean>(false);
     const [initialLoad, setInitialLoad] = useState<boolean>(true);
-    const [loadingOverlay, setLoadingOverlay] = useState<string | boolean>(true);
+    const [loadingOverlay, setLoadingOverlay] = useState<string | boolean>(false);
     const [overlayWidth, setOverlayWidth] = useState(0);
     const tableRef = useRef<null | HTMLTableElement>();
     const isEmpty = !error && data?.items.length === 0;


### PR DESCRIPTION
Resolves #6648

## Description

The loading spinner on the react tables are set to display directly in the middle of the table. This styling works well when the table has a limited amount of items to display. As items are added, the page becomes scrollable and the table extends downward causing the animation to display farther down. The spinner is not immediately visible to most users without scrolling downward because most of the table actions that cause the animation reside at the top of the table. I propose adding conditional styling to detect if the documents body is scrollable. If it is scrollable apply a fixed styling to the spinner. This will display a fixed spinner when scrollable and will keep the original styling position in the middle of the table when not. 

## Affects
React list table

## Visuals

https://user-images.githubusercontent.com/75056371/208571706-f7e29bda-2caf-4f5f-950d-1808ee0b8bba.mov




## Testing Instructions

- Go to any new list table.
- Reload page on tables with no pagination or small number of items - you will see the spinner is immediately visible in the middle of the table to users.
- Check any table with a large amount of items or one that includes pagination. The spinner is immediately visible and has a fixed position through scrolling.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

