### PR TITLE
Fix: Classic form template's donation level tooltip now displays with the labels

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -12,7 +12,6 @@ import {
 import {
     IS_CURRENCY_SWITCHING_ACTIVE,
     IS_DONATION_SUMMARY_ACTIVE,
-    IS_FEE_RECOVERY_ACTIVE,
     IS_RECURRING_ACTIVE,
     IS_STRIPE_ACTIVE,
 } from './is-feature-active.js';
@@ -225,8 +224,13 @@ function splitDonationLevelAmountsIntoParts({
 function addTooltipToLevel(node) {
     const parent = node.parentNode;
     if (!node.getAttribute('has-tooltip')) {
+        const currencySymbol = node.childNodes[0].innerHTML;
+
         const tooltip = nodeFromString(
-            h('span', {className: 'give-tooltip hint--top hint--bounce', 'aria-label': node.innerHTML})
+            h('span', {
+                className: 'give-tooltip hint--top hint--bounce',
+                'aria-label': `${currencySymbol} ${node.value}`,
+            })
         );
         if (node.innerHTML.length < 50) {
             tooltip.classList.add('narrow');

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -229,7 +229,7 @@ function addTooltipToLevel(node) {
         const tooltip = nodeFromString(
             h('span', {
                 className: 'give-tooltip hint--top hint--bounce',
-                'aria-label': `${currencySymbol} ${node.value}`,
+                'aria-label': parent.ariaLabel,
             })
         );
         if (node.innerHTML.length < 50) {
@@ -238,6 +238,7 @@ function addTooltipToLevel(node) {
         parent.replaceChild(tooltip, node);
         tooltip.appendChild(node);
         node.setAttribute('has-tooltip', 'true');
+        console.log(parent.ariaLabel);
     }
 }
 

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -236,7 +236,6 @@ function addTooltipToLevel(node) {
         parent.replaceChild(tooltip, node);
         tooltip.appendChild(node);
         node.setAttribute('has-tooltip', 'true');
-        console.log(parent.ariaLabel);
     }
 }
 

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -227,7 +227,7 @@ function addTooltipToLevel(node) {
         const tooltip = nodeFromString(
             h('span', {
                 className: 'give-tooltip hint--top hint--bounce',
-                'aria-label': parent.ariaLabel,
+                'aria-label': parent.getAttribute('aria-label'),
             })
         );
         if (node.innerHTML.length < 50) {

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -224,8 +224,6 @@ function splitDonationLevelAmountsIntoParts({
 function addTooltipToLevel(node) {
     const parent = node.parentNode;
     if (!node.getAttribute('has-tooltip')) {
-        const currencySymbol = node.childNodes[0].innerHTML;
-
         const tooltip = nodeFromString(
             h('span', {
                 className: 'give-tooltip hint--top hint--bounce',


### PR DESCRIPTION
Resolves #6652

## Description

This PR updates the tool tips aria label to use the parent nodes label as its own value. This is allowing it to update properly while switching between multiple currencies. Previously the passed nodes innerHTML property was being used to set the label and consisted of an HTML element.

## Affects

Classic Form donation level tool tip.

## Visuals

https://user-images.githubusercontent.com/75056371/209094029-03979249-c587-4142-893b-091b1a1b02dd.mov

## Testing Instructions

- Install Currency Switcher.
- Create and visit a Classic form.
- Switch currencies and hover over a donation level.
- Verify tooltips label updates accordingly.
- 
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

