### PR TITLE
Fix: Add missing label to checkbox input

### DIFF
--- a/includes/api/class-give-api.php
+++ b/includes/api/class-give-api.php
@@ -1919,7 +1919,7 @@ class Give_API {
 						?>
 						<?php if ( empty( $user->give_user_public_key ) ) { ?>
 							<input name="give_set_api_key" type="checkbox" id="give_set_api_key" />
-							<span class="description"><?php _e( 'Generate API Key', 'give' ); ?></span>
+							<span class="description"><label for="give_set_api_key"><?php _e( 'Generate API Key', 'give' ); ?></label></span>
 						<?php } else { ?>
 							<strong style="display:inline-block; width: 125px;"><?php _e( 'Public key:', 'give' ); ?>
 								&nbsp;</strong>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6465

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR wraps the description text "Generate API Key" with a `<label/>` so that the checkbox can be toggled by clicking on the label.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Go to `wp-admin/profile.php`.
- Scroll to the setting "GiveWP API Keys".
- Toggle the "Generate API Key" by clicking on the label.
