### PR TITLE
Fix: `give_multi_form_goal` shortcode escapes rendering properly

### DIFF
--- a/src/MultiFormGoals/MultiFormGoal/Model.php
+++ b/src/MultiFormGoals/MultiFormGoal/Model.php
@@ -95,9 +95,8 @@ class Model
      * Get Progress Bar output
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getProgressBarOutput()
+    public function getProgressBarOutput(): string
     {
         $progressBar = new ProgressBar(
             [
@@ -123,7 +122,7 @@ class Model
     }
 
     /**
-     * @unreleased 
+     * @unreleased
      *
      * @return false|mixed
      */

--- a/src/MultiFormGoals/MultiFormGoal/Model.php
+++ b/src/MultiFormGoals/MultiFormGoal/Model.php
@@ -122,4 +122,14 @@ class Model
         return GIVE_PLUGIN_DIR . '/src/MultiFormGoals/resources/views/multiformgoal.php';
     }
 
+    /**
+     * @unreleased 
+     *
+     * @return false|mixed
+     */
+    public function getInnerBlocks()
+    {
+        return $this->innerBlocks;
+    }
+
 }

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -39,9 +39,8 @@ class Model
      * Get forms associated with Progress Bar
      *
      * @since 2.9.0
-     **@return array
      */
-    protected function getForms()
+    public function getForms(): array
     {
         if ( ! empty($this->forms)) {
             return $this->forms;
@@ -83,7 +82,10 @@ class Model
         }
     }
 
-    protected function getDonations()
+    /**
+     * @since 2.9.0
+     */
+    public function getDonations(): array
     {
         $query_args = [
             'post_status' => [
@@ -102,17 +104,13 @@ class Model
      * Get output markup for Progress Bar
      *
      * @since 2.9.0
-     **@return string
      */
-    public function getOutput()
+    public function getOutput(): string
     {
         ob_start();
         $output = '';
         require $this->getTemplatePath();
-        $output = ob_get_contents();
-        ob_end_clean();
-
-        return $output;
+        return ob_get_clean();
     }
 
     /**
@@ -120,7 +118,7 @@ class Model
      * @since 2.9.0
      * @return stdClass seem MultiFormGoals/ProgressBar/Query.php
      */
-    protected function getDonationRevenueResults()
+    public function getDonationRevenueResults()
     {
         if ( ! $this->donationRevenueResults) {
             $query = new Query($this->getForms());
@@ -134,9 +132,8 @@ class Model
      * Get raw earnings value for Progress Bar
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getTotal()
+    public function getTotal(): string
     {
         $query = new Query($this->getForms());
         $results = $query->getResults();
@@ -181,9 +178,8 @@ class Model
      * Get goal for Progress Bar
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getGoal()
+    public function getGoal(): string
     {
         return $this->goal;
     }
@@ -192,9 +188,8 @@ class Model
      * Get goal color for Progress Bar
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getColor()
+    public function getColor(): string
     {
         return $this->color;
     }
@@ -208,7 +203,12 @@ class Model
         return GIVE_PLUGIN_DIR . '/src/MultiFormGoals/resources/views/progressbar.php';
     }
 
-    protected function getFormattedTotal()
+    /**
+     * @unreleased
+     *
+     * @return mixed|string
+     */
+    public function getFormattedTotal()
     {
         return give_currency_filter(
             give_format_amount(
@@ -221,7 +221,12 @@ class Model
         );
     }
 
-    protected function getFormattedGoal()
+    /**
+     * @unreleased
+     *
+     * @return mixed|string
+     */
+    public function getFormattedGoal()
     {
         return give_currency_filter(
             give_format_amount(
@@ -238,9 +243,8 @@ class Model
      * Get end date for Progress Bar
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getEndDate()
+    public function getEndDate(): string
     {
         return $this->enddate;
     }
@@ -249,9 +253,8 @@ class Model
      * Get minutes remaining before Progress Bar end date
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getMinutesRemaining()
+    public function getMinutesRemaining(): string
     {
         $enddate = strtotime($this->getEndDate());
         if ($enddate) {
@@ -267,9 +270,8 @@ class Model
      * Get time remaining before Progress Bar end date
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getTimeToGo()
+    public function getTimeToGo(): string
     {
         $minutes = $this->getMinutesRemaining();
         switch ($minutes) {
@@ -292,9 +294,8 @@ class Model
      * Get time remaining before Progress Bar end date
      *
      * @since 2.9.0
-     **@return string
      */
-    protected function getTimeToGoLabel()
+    public function getTimeToGoLabel(): string
     {
         $minutes = $this->getMinutesRemaining();
         switch ($minutes) {
@@ -310,6 +311,8 @@ class Model
             {
                 return _n('minute to go', 'minutes to go', $this->getTimeToGo(), 'give');
             }
+            default:
+                return '';
         }
     }
 }

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -145,9 +145,8 @@ class Model
      * Get number of donations for Progress Bar
      *
      * @since 2.9.0
-     **@return int
      */
-    protected function getDonationCount()
+    public function getDonationCount(): int
     {
         $results = $this->getDonationRevenueResults();
 
@@ -270,10 +269,13 @@ class Model
      * Get time remaining before Progress Bar end date
      *
      * @since 2.9.0
+     *
+     * @return float|int
      */
-    public function getTimeToGo(): string
+    public function getTimeToGo()
     {
         $minutes = $this->getMinutesRemaining();
+
         switch ($minutes) {
             case $minutes > 1440:
             {
@@ -287,6 +289,10 @@ class Model
             {
                 return round($minutes);
             }
+            default:
+            {
+                return 0;
+            }
         }
     }
 
@@ -298,6 +304,7 @@ class Model
     public function getTimeToGoLabel(): string
     {
         $minutes = $this->getMinutesRemaining();
+
         switch ($minutes) {
             case $minutes > 1440:
             {

--- a/src/MultiFormGoals/resources/js/blocks/multi-form-goal/edit/index.js
+++ b/src/MultiFormGoals/resources/js/blocks/multi-form-goal/edit/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n'
+import {__} from '@wordpress/i18n';
+
 const {InnerBlocks} = wp.blockEditor;
 const {useEffect} = wp.element;
 const {select, dispatch} = wp.data;
@@ -17,7 +18,10 @@ const edit = ({isSelected, clientId}) => {
     const selectProgressBar = () => {
         const parentBlock = select('core/editor').getBlocksByClientId(clientId)[0];
         const progressBarBlock = parentBlock.innerBlocks[parentBlock.innerBlocks.length - 1];
-        dispatch('core/block-editor').selectBlock(progressBarBlock.clientId);
+        // prevent error if progressBarBlock is slow to load
+        if (progressBarBlock) {
+            dispatch('core/block-editor').selectBlock(progressBarBlock.clientId);
+        }
     };
 
     const blockTemplate = [

--- a/src/MultiFormGoals/resources/views/multiformgoal.php
+++ b/src/MultiFormGoals/resources/views/multiformgoal.php
@@ -2,9 +2,8 @@
 /**
  * Multi-Form Goals block/shortcode template
  * Styles for this template are defined in 'blocks/multi-form-goals/common.scss'
- *
+ * @var Give\MultiFormGoals\MultiFormGoal\Model $this
  */
-
 ?>
 
 
@@ -16,17 +15,14 @@ if ( ! empty($this->innerBlocks)) {
     <div class="give-multi-form-goal-block">
         <div class="give-multi-form-goal-block__content">
             <div class="give-multi-form-goal-block__image">
-                <img src="<?php
-                echo $this->getImageSrc(); ?>" />
+                <img src="<?= esc_url($this->getImageSrc()) ?>"  alt="goal image"/>
             </div>
             <div class="give-multi-form-goal-block__text">
                 <h2>
-                    <?php
-                    echo $this->getHeading(); ?>
+                    <?= esc_html($this->getHeading()) ?>
                 </h2>
                 <p>
-                    <?php
-                    echo $this->getSummary(); ?>
+                    <?= esc_html($this->getSummary()) ?>
                 </p>
             </div>
         </div>

--- a/src/MultiFormGoals/resources/views/multiformgoal.php
+++ b/src/MultiFormGoals/resources/views/multiformgoal.php
@@ -8,8 +8,8 @@
 
 
 <?php
-if ( ! empty($this->innerBlocks)) {
-    echo $this->innerBlocks;
+if ( ! empty($this->getInnerBlocks())) {
+    echo $this->getInnerBlocks();
 } else {
     ?>
     <div class="give-multi-form-goal-block">

--- a/src/MultiFormGoals/resources/views/progressbar.php
+++ b/src/MultiFormGoals/resources/views/progressbar.php
@@ -2,13 +2,13 @@
 /**
  * Multi-Form Goals block/shortcode template
  * Styles for this template are defined in 'blocks/multi-form-goals/common.scss'
+ * @var Give\MultiFormGoals\ProgressBar\Model $this
  */
 
-$uniqid = uniqid();
+$uniqueId = uniqid('', true);
 ?>
 
-<div id="<?php
-echo $uniqid; ?>" class="give-progress-bar-block">
+<div id="<?= esc_attr($uniqueId) ?>" class="give-progress-bar-block">
     <style>
         <?php echo file_get_contents( GIVE_PLUGIN_DIR . 'assets/dist/css/multi-form-goal-block.css' ); ?>
     </style>
@@ -18,27 +18,27 @@ echo $uniqid; ?>" class="give-progress-bar-block">
             <?php
             $percent = ($this->getTotal() / $this->getGoal()) * 100; ?>
             <div part="progress-bar" class="give-progress-bar-block__progress-bar" style="width: <?php
-            echo min([$percent, 100]); ?>%; background: linear-gradient(180deg, <?php
-            echo $this->getColor(); ?> 0%, <?php
-            echo $this->getColor(); ?> 100%), linear-gradient(180deg, #fff 0%, #ccc 100%);"></div>
+            echo esc_attr(min([$percent, 100])); ?>%; background: linear-gradient(180deg, <?php
+            echo esc_attr($this->getColor()); ?> 0%, <?php
+            echo esc_attr($this->getColor()); ?> 100%), linear-gradient(180deg, #fff 0%, #ccc 100%);"></div>
         </div>
     </div>
     <div part="stats" class="give-progress-bar-block__stats">
         <div part="stat-total" class="give-progress-bar-block__stat">
             <div part="stat-total-value"><?php
-                echo $this->getFormattedTotal(); ?></div>
+                echo esc_html($this->getFormattedTotal()); ?></div>
             <div part="stat-total-label"><?php
                 echo __('raised', 'give'); ?></div>
         </div>
         <div part="stat-count" class="give-progress-bar-block__stat">
             <div part="stat-count-value"><?php
-                echo $this->getDonationCount(); ?></div>
+                echo esc_html($this->getDonationCount()); ?></div>
             <div part="stat-count-label"><?php
                 echo _n('donation', 'donations', $this->getDonationCount(), 'give'); ?></div>
         </div>
         <div part="stat-goal" class="give-progress-bar-block__stat">
             <div part="stat-goal-value"><?php
-                echo $this->getFormattedGoal(); ?></div>
+                echo esc_html($this->getFormattedGoal()); ?></div>
             <div part="stat-goal-label"><?php
                 echo __('goal', 'give'); ?></div>
         </div>
@@ -46,9 +46,9 @@ echo $uniqid; ?>" class="give-progress-bar-block">
         if ( ! empty($this->getEndDate()) && $this->getMinutesRemaining()) : ?>
             <div part="stat-time" class="give-progress-bar-block__stat">
                 <div part="stat-time-value"><?php
-                    echo $this->getTimeToGo(); ?></div>
+                    echo esc_html($this->getTimeToGo()); ?></div>
                 <div part="stat-time-label"><?php
-                    echo $this->getTimeToGoLabel(); ?></div>
+                    echo esc_html($this->getTimeToGoLabel()); ?></div>
             </div>
         <?php
         endif; ?>
@@ -56,7 +56,7 @@ echo $uniqid; ?>" class="give-progress-bar-block">
 </div>
 <script>
     (function() {
-        const container = document.getElementById('<?php echo $uniqid; ?>');
+        const container = document.getElementById('<?php echo $uniqueId; ?>');
         const content = container.innerHTML;
         const shadow = container.attachShadow({mode: 'open'});
         shadow.innerHTML = content;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

It was brought to our attention that the `give_multi_form_goal` shortcode was missing proper data esacping for it's attributes during render.  This PR updates the view and related progress view to escape all dynamic content.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `give_multi_form_goal` shortcode

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**Vulnerability**

Pull the branch and make sure this doesn't trigger an alert: `[give_multi_form_goal image='" onerror="alert(/XSS/)"']`

**General**

Make sure the shortcode and block still work properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203717822928716