### PR TITLE
chore: Integrate next gen form button

### DIFF
--- a/src/DonationForms/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/resources/components/DonationFormsListTable.tsx
@@ -13,6 +13,10 @@ declare global {
             authors: Array<{id: string | number; name: string}>;
             table: {columns: Array<object>};
         };
+
+        GiveNextGen?: {
+            newFormUrl: string;
+        }
     }
 }
 
@@ -155,6 +159,11 @@ export default function DonationFormsListTable() {
             apiSettings={window.GiveDonationForms}
             filterSettings={donationFormsFilters}
         >
+            { !! window.GiveNextGen?.newFormUrl && (
+                <a href={window.GiveNextGen.newFormUrl} className={styles.addFormButton}>
+                    {__('Add Next Gen Form', 'give')}
+                </a>
+            )}
             <a href={'post-new.php?post_type=give_forms'} className={styles.addFormButton}>
                 {__('Add Form', 'give')}
             </a>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related https://github.com/impress-org/givewp-next-gen/pull/112

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR checks for a registered Next Gen Form URL and conditionally renders a button.

I tried to keep this simple. The Next Gen feature plugin will register the URL on the window.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/10858303/211891058-43cefd94-14ea-4202-998a-3f920a999427.png)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Install and enable the Next Gen plugin, using https://github.com/impress-org/givewp-next-gen/pull/112, and the "Add Next Gen Form" button should render.

