### PR TITLE
Feature: add `is_visible` param to legacy adapter gateways list

### DIFF
--- a/src/Framework/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayRegisterAdapter.php
+++ b/src/Framework/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayRegisterAdapter.php
@@ -5,6 +5,8 @@ namespace Give\Framework\LegacyPaymentGateways\Adapters;
 use Give\Framework\PaymentGateways\Contracts\PaymentGatewayInterface;
 use Give\LegacyPaymentGateways\Adapters\LegacyPaymentGatewayAdapter;
 
+use function method_exists;
+
 class LegacyPaymentGatewayRegisterAdapter
 {
     /**
@@ -12,10 +14,8 @@ class LegacyPaymentGatewayRegisterAdapter
      * that prepares data to be sent to each gateway
      *
      * @since 2.19.0
-     *
-     * @param string $gatewayClass
      */
-    public function connectGatewayToLegacyPaymentGatewayAdapter($gatewayClass)
+    public function connectGatewayToLegacyPaymentGatewayAdapter(string $gatewayClass)
     {
         /** @var LegacyPaymentGatewayAdapter $legacyPaymentGatewayAdapter */
         $legacyPaymentGatewayAdapter = give(LegacyPaymentGatewayAdapter::class);
@@ -44,14 +44,10 @@ class LegacyPaymentGatewayRegisterAdapter
     /**
      * Adds new payment gateways to legacy list for settings
      *
+     * @unreleased add is_visible key to $gatewayData
      * @since 2.19.0
-     *
-     * @param array $gatewaysData
-     * @param array $newPaymentGateways
-     *
-     * @return array
      */
-    public function addNewPaymentGatewaysToLegacyListSettings($gatewaysData, $newPaymentGateways)
+    public function addNewPaymentGatewaysToLegacyListSettings(array $gatewaysData, array $newPaymentGateways): array
     {
         foreach ($newPaymentGateways as $gatewayClassName) {
             /* @var PaymentGatewayInterface $paymentGateway */
@@ -60,9 +56,18 @@ class LegacyPaymentGatewayRegisterAdapter
             $gatewaysData[$paymentGateway::id()] = [
                 'admin_label' => $paymentGateway->getName(),
                 'checkout_label' => $paymentGateway->getPaymentMethodLabel(),
+                'is_visible' => $this->supportsLegacyForm($paymentGateway),
             ];
         }
 
         return $gatewaysData;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function supportsLegacyForm(PaymentGatewayInterface $gateway): bool
+    {
+        return method_exists($gateway, 'supportsLegacyForm') ? $gateway->supportsLegacyForm() : true;
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Related: https://github.com/impress-org/givewp-next-gen/pull/115

As we start connecting exiting gateways to our next gen forms, we need a way to know if the gateway supports legacy.  Some gateways like Stripe payment element will only be available in next gen - so they should not be displaying in legacy forms. 

Note: At first the plan was to use the `LegacyPaymentGatewayInterface` to determine if a gateway supports legacy forms.  Unfortunately at the moment, that is tucked away in our main `PaymentGateway` class and would be too much effort to pull it right now.

This PR is a simple & safe solution to accomplish what we need for the time being.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Will only affect next gen forms being displayed on legacy forms.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Just make sure gateways are displaying properly on a form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

