### PR TITLE
Fix: Prevent fatal error for null price option in the Forms Table

### DIFF
--- a/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
@@ -102,19 +102,17 @@ final class DonationFormQueryData
      */
     public function getDonationFormLevels($object): array
     {
-        if ('multi' === $object->{DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase()}) {
-            $levels = [];
-            $array = maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()});
-
-            foreach ($array as $level) {
-                $levels[] = DonationFormLevel::fromArray($level);
-            }
-
-            return $levels;
+        switch( $object->{DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase()} ) {
+            case 'multi':
+                return array_map(function($level) {
+                    return DonationFormLevel::fromArray($level);
+                }, maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()}));
+            case 'simple':
+                return [
+                    DonationFormLevel::fromPrice($object->{DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase()}),
+                ];
+            default:
+                return [];
         }
-
-        return [
-            DonationFormLevel::fromPrice($object->{DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase()}),
-        ];
     }
 }

--- a/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
@@ -104,10 +104,10 @@ final class DonationFormQueryData
     {
         switch( $object->{DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase()} ) {
             case 'multi':
-                return array_map(function($level) {
+                return array_map(function ($level) {
                     return DonationFormLevel::fromArray($level);
                 }, maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()}));
-            case 'simple':
+            case 'set':
                 return [
                     DonationFormLevel::fromPrice($object->{DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase()}),
                 ];

--- a/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
@@ -104,7 +104,7 @@ final class DonationFormQueryData
     {
         switch( $object->{DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase()} ) {
             case 'multi':
-                return array_map(function ($level) {
+                return array_map(static function ($level) {
                     return DonationFormLevel::fromArray($level);
                 }, maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()}));
             case 'set':

--- a/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormQueryData.php
@@ -104,12 +104,24 @@ final class DonationFormQueryData
     {
         switch( $object->{DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase()} ) {
             case 'multi':
+                $levels = maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()});
+
+                if (empty($levels)) {
+                    return [];
+                }
+
                 return array_map(static function ($level) {
                     return DonationFormLevel::fromArray($level);
-                }, maybe_unserialize($object->{DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase()}));
+                }, $levels);
             case 'set':
+                $amount = $object->{DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase()};
+
+                if (empty($amount)) {
+                    return [];
+                }
+
                 return [
-                    DonationFormLevel::fromPrice($object->{DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase()}),
+                    DonationFormLevel::fromPrice($amount),
                 ];
             default:
                 return [];

--- a/src/DonationForms/ListTable/Columns/LevelsColumn.php
+++ b/src/DonationForms/ListTable/Columns/LevelsColumn.php
@@ -44,6 +44,10 @@ class LevelsColumn extends ModelColumn
      */
     public function getCellValue($model, $locale = ''): string
     {
+        if (empty($model->levels)) {
+            return __('No Levels', 'give');
+        }
+
         return sprintf(
             '<div class="amount"><span>%s</span></div>',
             $this->getLevels($model->levels, $locale)
@@ -53,29 +57,25 @@ class LevelsColumn extends ModelColumn
     /**
      * @since 2.24.0
      *
-     * @param array  $levels
+     * @param array $levels
      * @param string $locale
      *
      * @return string
      */
     private function getLevels(array $levels, string $locale): string
     {
-        if ( empty($levels) ) {
-            return __('No Levels', 'give');
-        }
-
-        if ( count($levels) === 1 ) {
+        if (count($levels) === 1) {
             return $levels[0]->amount->formatToLocale($locale);
         }
 
-        $levelsAmount = array_map(function($level) use ($locale) {
+        $levelsAmount = array_map(function ($level) use ($locale) {
             return $level->amount->formatToDecimal();
         }, $levels);
 
-        $min = $levels[ array_search(min($levelsAmount), $levelsAmount) ];
-        $max = $levels[ array_search(max($levelsAmount), $levelsAmount) ];
+        $min = $levels[array_search(min($levelsAmount), $levelsAmount)];
+        $max = $levels[array_search(max($levelsAmount), $levelsAmount)];
 
-        if ( $min === $max ) {
+        if ($min === $max) {
             return $min->amount->formatToLocale($locale);
         }
 

--- a/src/Framework/ListTable/ListTable.php
+++ b/src/Framework/ListTable/ListTable.php
@@ -2,9 +2,12 @@
 
 namespace Give\Framework\ListTable;
 
+use Exception;
 use Give\Framework\ListTable\Concerns\Columns;
 use Give\Framework\ListTable\Exceptions\ColumnIdCollisionException;
+use Give\Framework\Models\Model;
 use Give\Framework\Support\Contracts\Arrayable;
+use Give\Log\Log;
 
 /**
  * @since 2.24.0
@@ -64,7 +67,7 @@ abstract class ListTable implements Arrayable
     {
         return [
             'id' => $this->id(),
-            'columns' => $this->getColumnsArray()
+            'columns' => $this->getColumnsArray(),
         ];
     }
 
@@ -73,7 +76,7 @@ abstract class ListTable implements Arrayable
      *
      * @since 2.24.0
      *
-     * @param array  $items
+     * @param array $items
      * @param string $locale
      *
      * @return void
@@ -88,7 +91,7 @@ abstract class ListTable implements Arrayable
             $row = [];
 
             foreach ($columns as $column) {
-                $row[$column::getId()] = $column->getCellValue($model, $locale);
+                $row[$column::getId()] = $this->safelyGetCellValue($column, $model, $locale);;
             }
 
             $data[] = $row;
@@ -105,6 +108,43 @@ abstract class ListTable implements Arrayable
     public function getItems(): array
     {
         return $this->items;
+    }
+
+    /**
+     * Safely retrieves the cell value for a column. If an exception is thrown, it will be logged and the cell value
+     * will be a human-readable error message. This is to prevent fatal errors from breaking the entire table.
+     *
+     * @unreleased
+     */
+    private function safelyGetCellValue(ModelColumn $column, Model $model, string $locale): string
+    {
+        try {
+            $cellValue = $column->getCellValue($model, $locale);
+        } catch (Exception $exception) {
+            Log::error(
+                sprintf(
+                    'Error while rendering column "%s" for table "%s".',
+                    $column::getId(),
+                    $this->id()
+                ),
+                [
+                    'column' => $column::getId(),
+                    'table' => $this->id(),
+                    'model' => $model->toArray(),
+                    'exception' => $exception->getMessage(),
+                ]
+            );
+
+            $cellValue = __(
+                sprintf(
+                    'Something went wrong, more in detail in <a href="%s">logs</a>',
+                    admin_url('edit.php?post_type=give_forms&page=give-tools&tab=logs')
+                ),
+                'give'
+            );
+        }
+
+        return $cellValue;
     }
 }
 

--- a/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
+++ b/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
@@ -55,6 +55,33 @@ final class DonationFormQueryDataTest extends TestCase
         );
     }
 
+    public function testGetDonationFormLevelsMulti()
+    {
+        $dto = new DonationFormQueryData();
+
+        $this->assertIsArray($dto->getDonationFormLevels(
+            json_decode('{"priceOption":"multi","donationLevels":[]}')
+        ));
+    }
+
+    public function testGetDonationFormLevelsSimple()
+    {
+        $dto = new DonationFormQueryData();
+
+        $this->assertIsArray($dto->getDonationFormLevels(
+            json_decode('{"priceOption":"simple", "setPrice":"100"}')
+        ));
+    }
+
+    public function testGetDonationFormLevelsNull()
+    {
+        $dto = new DonationFormQueryData();
+
+        $this->assertIsArray($dto->getDonationFormLevels(
+            json_decode('{"priceOption":null}')
+        ));
+    }
+
     /**
      * @unreleased
      */
@@ -65,5 +92,4 @@ final class DonationFormQueryDataTest extends TestCase
             ['simple'],
         ];
     }
-
 }

--- a/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
+++ b/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
@@ -98,6 +98,40 @@ final class DonationFormQueryDataTest extends TestCase
     /**
      * @unreleased
      */
+    public function testGetDonationFormLevelsShouldReturnEmptyArrayWhenUsingMultiAndNoLevels()
+    {
+        $dto = new DonationFormQueryData();
+
+        $object = json_encode([
+            DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase() => 'multi',
+            DonationFormMetaKeys::DONATION_LEVELS()->getKeyAsCamelCase() => null
+        ]);
+
+        $levels = $dto->getDonationFormLevels(json_decode($object));
+
+        $this->assertSame([], $levels);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetDonationFormLevelsShouldReturnEmptyArrayWhenUsingSetAndNoAmount()
+    {
+        $dto = new DonationFormQueryData();
+
+        $object = json_encode([
+            DonationFormMetaKeys::PRICE_OPTION()->getKeyAsCamelCase() => 'set',
+            DonationFormMetaKeys::SET_PRICE()->getKeyAsCamelCase() => null
+        ]);
+
+        $levels = $dto->getDonationFormLevels(json_decode($object));
+
+        $this->assertSame([], $levels);
+    }
+
+    /**
+     * @unreleased
+     */
     public function mockFormTypeProvider(): array
     {
         return [

--- a/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
+++ b/tests/Unit/DonationForms/DataTransferObjects/DonationFormQueryDataTest.php
@@ -21,7 +21,8 @@ final class DonationFormQueryDataTest extends TestCase
      */
     public function testToDonationFormShouldReturnDonationForm(string $mockFormType)
     {
-        $mockForm = $mockFormType === 'multi' ? \Give_Helper_Form::create_multilevel_form() : \Give_Helper_Form::create_simple_form();
+        $mockForm = $mockFormType === 'multi' ? $this->createMultiLevelDonationForm() : $this->createSimpleDonationForm(
+        );
 
         // simulate raw query to pass to DTO
         $query = DB::table('posts')
@@ -39,47 +40,59 @@ final class DonationFormQueryDataTest extends TestCase
                 ...DonationFormMetaKeys::getColumnsForAttachMetaQuery()
             )
             ->where('post_type', 'give_forms')
-            ->where('id', $mockForm->get_ID())
+            ->where('id', $mockForm->id)
             ->get();
 
         // create DTO from query object
         $donationFormQueryData = DonationFormQueryData::fromObject($query);
 
-        // create expected donation form model using mock form
-        $expectedDonationFormModel = $this->getDonationFormModelFromLegacyGiveDonateForm($mockForm);
-
         // assert query data returns the donation form we expect.
         $this->assertEquals(
             $donationFormQueryData->toDonationForm(),
-            $expectedDonationFormModel
+            $mockForm
         );
     }
 
+    /**
+     * @unreleased
+     */
     public function testGetDonationFormLevelsMulti()
     {
         $dto = new DonationFormQueryData();
 
-        $this->assertIsArray($dto->getDonationFormLevels(
-            json_decode('{"priceOption":"multi","donationLevels":[]}')
-        ));
+        $this->assertIsArray(
+            $dto->getDonationFormLevels(
+                json_decode('{"priceOption":"multi","donationLevels":[]}')
+            )
+        );
     }
 
+    /**
+     * @unreleased
+     */
     public function testGetDonationFormLevelsSimple()
     {
         $dto = new DonationFormQueryData();
 
-        $this->assertIsArray($dto->getDonationFormLevels(
-            json_decode('{"priceOption":"simple", "setPrice":"100"}')
-        ));
+        $this->assertIsArray(
+            $dto->getDonationFormLevels(
+                json_decode('{"priceOption":"set", "setPrice":"100"}')
+            )
+        );
     }
 
+    /**
+     * @unreleased
+     */
     public function testGetDonationFormLevelsNull()
     {
         $dto = new DonationFormQueryData();
 
-        $this->assertIsArray($dto->getDonationFormLevels(
-            json_decode('{"priceOption":null}')
-        ));
+        $this->assertIsArray(
+            $dto->getDonationFormLevels(
+                json_decode('{"priceOption":null}')
+            )
+        );
     }
 
     /**
@@ -89,7 +102,7 @@ final class DonationFormQueryDataTest extends TestCase
     {
         return [
             ['multi'],
-            ['simple'],
+            ['set'],
         ];
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6674

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR prevents a fatal error caused by donation forms missing the Price Option meta (`_give_price_option`).

Previously, `\Give\DonationForms\DataTransferObjects\DonationFormQueryData::getDonationFormLevels()` would throw a fatal error when the Price Option was `null` because it assumed a non-`mulit` value for the Price Option was the value of `simple` which results in a `TypeError` in `Give\DonationForms\Properties\DonationFormLevel::fromPrice()`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->


1. Checkout `develop`.
2. Delete the `_give_price_option` meta value for a donation form.
3. Navigate to `/wp-admin/admin.php?page=give-forms`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203776617039851