### PR TITLE
Fix Modal is not open after an error

### DIFF
--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -2421,7 +2421,7 @@ function give_redirect_and_popup_form( $redirect, $args ) {
 	}
 
 	// Return the modified URL.
-	return esc_url( $redirect );
+	return esc_url_raw( $redirect );
 }
 
 add_filter( 'give_send_back_to_checkout', 'give_redirect_and_popup_form', 10, 2 );


### PR DESCRIPTION
With esc_url() escaping the redirect URL, special characters like &#038; as preserved, and the modal window is not open. As for preview messages, I suggest using esc_url_raw().

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

