### PR TITLE
Fix: Prevent donation summary with donor from filtering twice

### DIFF
--- a/src/Framework/PaymentGateways/DonationSummary.php
+++ b/src/Framework/PaymentGateways/DonationSummary.php
@@ -114,13 +114,14 @@ class DonationSummary
     protected function trimAndFilter(string $text): string
     {
         /**
+         * @unreleased Re-use trim method for text.
          * @since 1.8.12
          */
         return apply_filters('give_payment_gateway_donation_summary', $this->trim($text));
     }
     
     /**
-     * @since ...
+     * @unreleased
      *
      * @param string $text
      *

--- a/src/Framework/PaymentGateways/DonationSummary.php
+++ b/src/Framework/PaymentGateways/DonationSummary.php
@@ -116,7 +116,7 @@ class DonationSummary
         /**
          * @since 1.8.12
          */
-        return apply_filters('give_payment_gateway_donation_summary', substr($text, 0, $this->length));
+        return apply_filters('give_payment_gateway_donation_summary', $this->trim($text));
     }
     
     /**

--- a/src/Framework/PaymentGateways/DonationSummary.php
+++ b/src/Framework/PaymentGateways/DonationSummary.php
@@ -40,7 +40,7 @@ class DonationSummary
      */
     public function getSummaryWithDonor(): string
     {
-        return $this->trimAndFilter(
+        return $this->trim(
             implode(' - ', [
                 $this->getSummary(),
                 $this->getDonorLabel(),
@@ -117,5 +117,17 @@ class DonationSummary
          * @since 1.8.12
          */
         return apply_filters('give_payment_gateway_donation_summary', substr($text, 0, $this->length));
+    }
+    
+    /**
+     * @since ...
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    protected function trim(string $text): string
+    {
+        return substr($text, 0, $this->length);
     }
 }


### PR DESCRIPTION
Both functions getSummary() and getSummaryWithDonor() apply the same filter. As getSummaryWithDonor() calls getSummary(), the filter is applied twice. As a result, additional data is added twice.
Here I remove the filter for getSummaryWithDonor() , another solution is to use a different filter or add another parameter to the filter.

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

