### PR TITLE
Fix: Sanitize the donor wall limits

### DIFF
--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -340,6 +340,7 @@ class Give_Donor_Wall {
 	/**
 	 * Get query params
 	 *
+     * @unreleased
 	 * @since 2.3.0
 	 *
 	 * @param  array $atts

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -354,8 +354,8 @@ class Give_Donor_Wall {
 
 		$query_atts['order']         = in_array( $atts['order'], $valid_order ) ? $atts['order'] : 'DESC';
 		$query_atts['orderby']       = in_array( $atts['orderby'], $valid_orderby ) ? $atts['orderby'] : 'post_date';
-		$query_atts['limit']         = $atts['donors_per_page'];
-		$query_atts['offset']        = $atts['donors_per_page'] * ( $atts['paged'] - 1 );
+		$query_atts['limit']         = absint( $atts['donors_per_page'] );
+		$query_atts['offset']        = absint( $atts['donors_per_page'] * ( $atts['paged'] - 1 ) );
         $query_atts['form_id']       = implode( '\',\'', array_map( 'absint', explode( ',', $atts['form_id'] ) ) );
         $query_atts['ids']           = implode( '\',\'', array_map( 'absint', explode( ',', $atts['ids'] ) ) );
 		$query_atts['cats']          = $atts['cats'];


### PR DESCRIPTION
## Description

This adds more on top of https://github.com/impress-org/givewp/pull/6668

The limit and offset are currently being directly injected. This forces the values into an absolute integer before being injected. The reporter mentioned they weren't able to actually exploit anything, but this should be done anyway.

## Affects

The donor wall query

## Testing Instructions

Reach out to me for instructions.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

