### PR TITLE
Feature: Add conditional to company name field

### DIFF
--- a/assets/src/css/frontend/_mixins.scss
+++ b/assets/src/css/frontend/_mixins.scss
@@ -93,20 +93,69 @@
 }
 
 @mixin give-input() {
-	border: 1px solid $borders;
-	background: #fff;
-	border-radius: 0;
-	height: 35px;
-	line-height: 35px;
-	padding: 0 12px;
-	margin: 0;
-	font-size: $font-size-medium;
-	@include box-sizing(border-box);
+    border: 1px solid $borders;
+    background: #fff;
+    border-radius: 0;
+    height: 35px;
+    line-height: 35px;
+    padding: 0 12px;
+    margin: 0;
+    font-size: $font-size-medium;
+    @include box-sizing(border-box);
+}
+
+@mixin give-radio() {
+    --size: 1.25em;
+
+    position: relative;
+    appearance: none;
+    margin: 0;
+    content: '';
+    flex-grow: 0;
+    flex-shrink: 0;
+    font-size: 1em;
+    transition: box-shadow 200ms ease-in-out;
+    border-radius: 9999px;
+    background-color: #fff;
+
+    &::before,
+    &::after {
+        content: '';
+        display: block;
+        border-radius: inherit;
+    }
+
+    &::before {
+        width: var(--size);
+        height: var(--size);
+
+        box-shadow: inset 0 0.0625em 0.125em rgba(0, 0, 0, 0.25);
+        border: 0.0625em solid #b4b9be;
+    }
+
+    &::after {
+        width: calc(var(--size) * 0.375);
+        height: calc(var(--size) * 0.375);
+
+        position: absolute;
+        top: 50%;
+        left: calc(var(--size) / 2);
+        transform: translate(-50%, -50%);
+
+        background-color: var(--give-primary-color);
+
+        opacity: 0;
+        transition: opacity 200ms ease-in-out;
+    }
+
+    &:checked::after {
+        opacity: 1;
+    }
 }
 
 @mixin give-img-type-loader {
-	background-image: url('data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA==') !important;
-	background-repeat: no-repeat !important;
-	background-position: center 100px !important;
-	height: 100%;
+    background-image: url('data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA==') !important;
+    background-repeat: no-repeat !important;
+    background-position: center 100px !important;
+    height: 100%;
 }

--- a/assets/src/css/frontend/forms.scss
+++ b/assets/src/css/frontend/forms.scss
@@ -305,25 +305,50 @@ form.give-form {
 	}
 
 	.card-expiration {
-		> select {
-			width: 44%;
-			margin: 0;
-		}
+        > select {
+            width: 44%;
+            margin: 0;
+        }
 
-		> span.exp-divider {
-			display: inline;
-			text-align: center;
-		}
+        > span.exp-divider {
+            display: inline;
+            text-align: center;
+        }
 
-		select.card-expiry-year {
-			float: right;
-		}
-	}
+        select.card-expiry-year {
+            float: right;
+        }
+    }
 
-	.give-disabled,
-	[disabled] {
-		cursor: not-allowed;
-	}
+    .give-disabled,
+    [disabled] {
+        cursor: not-allowed;
+    }
+}
+
+/*---------------------------------
+Form Price & Amount
+-----------------------------------*/
+form[id*='give-form'] {
+    #give-company-radio-list-wrap {
+        ul.give-company-radio-list {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+
+            li {
+                display: inline-block;
+                margin-right: 15px;
+                margin-left: 0;
+
+                label {
+                    cursor: pointer;
+                    display: inline;
+                    margin: 0;
+                }
+            }
+        }
+    }
 }
 
 /*---------------------------------
@@ -331,23 +356,23 @@ Form Price & Amount
 -----------------------------------*/
 
 form[id*='give-form'] {
-	.give-donation-amount {
-		margin: 0 0 15px;
+    .give-donation-amount {
+        margin: 0 0 15px;
 
-		.give-currency-symbol {
-			@include give-currency();
-			float: left;
+        .give-currency-symbol {
+            @include give-currency();
+            float: left;
 
-			&.give-currency-position-before {
-				border-left: 1px solid $borders;
-				border-right: none;
-			}
+            &.give-currency-position-before {
+                border-left: 1px solid $borders;
+                border-right: none;
+            }
 
-			&.give-currency-position-after {
-				border-left: none;
-				border-right: 1px solid $borders;
-			}
-		}
+            &.give-currency-position-after {
+                border-left: none;
+                border-right: 1px solid $borders;
+            }
+        }
 
 		#give-amount,
 		#give-amount-text {

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -874,7 +874,7 @@ function give_user_info_fields( $form_id ) {
                 ?>
                 <div id="give-company-radio-list-wrap" class="form-row form-row-wide">
                     <label><?php
-                        esc_html_e('Are you donating as a company?', 'give'); ?></label>
+                        esc_html_e('Is this donation on behalf of a company?', 'give'); ?></label>
                     <ul id="<?php
                     echo esc_attr('give-company-name-radio-list'); ?>" class="give-company-radio-list">
                         <li>

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -741,12 +741,13 @@ function give_add_button_open_form( $form_id, $args ) {
 /**
  * Shows the User Info fields in the Personal Info box, more fields can be added via the hooks provided.
  *
+ * @unreleased add radio group to conditionally enable/disable company name field
+ * @since      1.0
+ *
  * @param int $form_id The form ID.
  *
  * @return void
- * @see    For Pattern Attribute: https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation
- *
- * @since  1.0
+ * @see        For Pattern Attribute: https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation
  */
 function give_user_info_fields( $form_id ) {
 
@@ -790,130 +791,225 @@ function give_user_info_fields( $form_id ) {
 					type="text"
 					name="give_title"
 					id="give-title"
-					<?php echo( give_field_is_required( 'give_title', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-				>
-					<?php foreach ( $title_prefixes as $key => $value ) { ?>
-						<option
-							value="<?php echo esc_html( $value ); ?>" <?php selected( $value, $title, true ); ?>><?php echo esc_html( $value ); ?></option>
-					<?php } ?>
-				</select>
-			</p>
-		<?php } ?>
+                    <?php
+                    echo(give_field_is_required('give_title', $form_id) ? ' required aria-required="true" ' : ''); ?>
+                >
+                    <?php
+                    foreach ($title_prefixes as $key => $value) { ?>
+                        <option
+                            value="<?php
+                            echo esc_html($value); ?>" <?php
+                        selected($value, $title, true); ?>><?php
+                            echo esc_html($value); ?></option>
+                    <?php
+                    } ?>
+                </select>
+            </p>
+        <?php
+        } ?>
 
-		<p id="give-first-name-wrap" class="form-row form-row-first form-row-responsive">
-			<label class="give-label" for="give-first">
-				<?php esc_attr_e( 'First Name', 'give' ); ?>
-				<?php if ( give_field_is_required( 'give_first', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
-				<?php endif ?>
-				<?php echo Give()->tooltips->render_help( __( 'First Name is used to personalize your donation record.', 'give' ) ); ?>
-			</label>
-			<input
-				class="give-input required"
-				type="text"
-				name="give_first"
-				autocomplete="given-name"
-				placeholder="<?php esc_attr_e( 'First Name', 'give' ); ?>"
-				id="give-first"
-				value="<?php echo esc_html( $first_name ); ?>"
-				<?php echo( give_field_is_required( 'give_first', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+        <p id="give-first-name-wrap" class="form-row form-row-first form-row-responsive">
+            <label class="give-label" for="give-first">
+                <?php
+                esc_attr_e('First Name', 'give'); ?>
+                <?php
+                if (give_field_is_required('give_first', $form_id)) : ?>
+                    <span class="give-required-indicator">*</span>
+                <?php
+                endif ?>
+                <?php
+                echo Give()->tooltips->render_help(__('First Name is used to personalize your donation record.',
+                    'give')); ?>
+            </label>
+            <input
+                class="give-input required"
+                type="text"
+                name="give_first"
+                autocomplete="given-name"
+                placeholder="<?php
+                esc_attr_e('First Name', 'give'); ?>"
+                id="give-first"
+                value="<?php
+                echo esc_html($first_name); ?>"
+                <?php
+                echo(give_field_is_required('give_first', $form_id) ? ' required aria-required="true" ' : ''); ?>
+            />
+        </p>
 
-		<p id="give-last-name-wrap" class="form-row form-row-last form-row-responsive">
-			<label class="give-label" for="give-last">
-				<?php esc_attr_e( 'Last Name', 'give' ); ?>
-				<?php if ( give_field_is_required( 'give_last', $form_id ) ) : ?>
-					<span class="give-required-indicator">*</span>
-				<?php endif ?>
-				<?php echo Give()->tooltips->render_help( __( 'Last Name is used to personalize your donation record.', 'give' ) ); ?>
-			</label>
+        <p id="give-last-name-wrap" class="form-row form-row-last form-row-responsive">
+            <label class="give-label" for="give-last">
+                <?php
+                esc_attr_e('Last Name', 'give'); ?>
+                <?php
+                if (give_field_is_required('give_last', $form_id)) : ?>
+                    <span class="give-required-indicator">*</span>
+                <?php
+                endif ?>
+                <?php
+                echo Give()->tooltips->render_help(__('Last Name is used to personalize your donation record.',
+                    'give')); ?>
+            </label>
 
-			<input
-				class="give-input<?php echo( give_field_is_required( 'give_last', $form_id ) ? ' required' : '' ); ?>"
-				type="text"
-				name="give_last"
-				autocomplete="family-name"
-				id="give-last"
-				placeholder="<?php esc_attr_e( 'Last Name', 'give' ); ?>"
-				value="<?php echo esc_html( $last_name ); ?>"
-				<?php echo( give_field_is_required( 'give_last', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
-		</p>
+            <input
+                class="give-input<?php
+                echo(give_field_is_required('give_last', $form_id) ? ' required' : ''); ?>"
+                type="text"
+                name="give_last"
+                autocomplete="family-name"
+                id="give-last"
+                placeholder="<?php
+                esc_attr_e('Last Name', 'give'); ?>"
+                value="<?php
+                echo esc_html($last_name); ?>"
+                <?php
+                echo(give_field_is_required('give_last', $form_id) ? ' required aria-required="true" ' : ''); ?>
+            />
+        </p>
 
-		<?php if ( give_is_company_field_enabled( $form_id ) ) : ?>
-			<?php $give_company = give_field_is_required( 'give_company_name', $form_id ); ?>
-			<p id="give-company-wrap" class="form-row form-row-wide">
-				<label class="give-label" for="give-company">
-					<?php esc_attr_e( 'Company Name', 'give' ); ?>
-					<?php if ( $give_company ) : ?>
-						<span class="give-required-indicator">*</span>
-					<?php endif; ?>
-					<?php echo Give()->tooltips->render_help( __( 'Donate on behalf of Company', 'give' ) ); ?>
-				</label>
-				<input
-					class="give-input<?php echo( $give_company ? ' required' : '' ); ?>"
-					type="text"
-					name="give_company_name"
-					placeholder="<?php esc_attr_e( 'Company Name', 'give' ); ?>"
-					id="give-company"
-					value="<?php echo esc_html( $company_name ); ?>"
-					<?php echo( $give_company ? ' required aria-required="true" ' : '' ); ?>
-				/>
-			</p>
-		<?php endif ?>
+        <?php
+        if (give_is_company_field_enabled($form_id)) :
+            $give_company = give_field_is_required('give_company_name', $form_id);
 
-		<?php
-		/**
-		 * Fire before user email field
-		 *
-		 * @since 1.7
-		 */
-		do_action( 'give_donation_form_before_email', $form_id );
-		?>
-		<p id="give-email-wrap" class="form-row form-row-wide">
-			<label class="give-label" for="give-email">
-				<?php esc_attr_e( 'Email Address', 'give' ); ?>
-				<?php if ( give_field_is_required( 'give_email', $form_id ) ) { ?>
-					<span class="give-required-indicator">*</span>
-				<?php } ?>
-				<?php echo Give()->tooltips->render_help( __( 'We will send the donation receipt to this address.', 'give' ) ); ?>
-			</label>
-			<input
-				class="give-input required"
-				type="email"
-				name="give_email"
-				autocomplete="email"
-				placeholder="<?php esc_attr_e( 'Email Address', 'give' ); ?>"
-				id="give-email"
-				value="<?php echo esc_html( $email ); ?>"
-				<?php echo( give_field_is_required( 'give_email', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-			/>
+            if ( ! $give_company) :
+                ?>
+                <div id="give-company-radio-list-wrap" class="form-row form-row-wide">
+                    <label><?php
+                        esc_html_e('Are you donating as a company?', 'give'); ?></label>
+                    <ul id="<?php
+                    echo esc_attr('give-company-name-radio-list'); ?>" class="give-company-radio-list">
+                        <li>
+                            <input
+                                checked
+                                type="radio"
+                                id="<?php
+                                echo esc_attr('give-no-company'); ?>"
+                                class="give_company_option"
+                                name="give_company_option"
+                                value="no"
+                            />
+                            <label for="<?php
+                            echo esc_attr('give-no-company'); ?>" class="give-company-option"
+                                   id="<?php
+                                   echo esc_attr('give-no-company'); ?>">
+                                <?php
+                                esc_html_e('No', 'give'); ?>
+                            </label>
+                        </li>
+                        <li>
+                            <input
+                                type="radio"
+                                id="<?php
+                                echo esc_attr('give-has-company'); ?>"
+                                class="give_company_option"
+                                name="give_company_option"
+                                value="yes"
+                            />
+                            <label for="<?php
+                            echo esc_attr('give-has-company'); ?>" class="give-company-option"
+                                   id="<?php
+                                   echo esc_attr('give-has-company'); ?>">
+                                <?php
+                                esc_html_e('Yes', 'give'); ?>
+                            </label>
+                        </li>
+                    </ul>
+                </div>
+            <?php
+            endif; ?>
+            <p id="give-company-wrap" class="form-row form-row-wide">
+                <label class="give-label" for="give-company">
+                    <?php
+                    esc_attr_e('Company Name', 'give'); ?>
+                    <?php
+                    if ($give_company) : ?>
+                        <span class="give-required-indicator">*</span>
+                    <?php
+                    endif; ?>
+                    <?php
+                    echo Give()->tooltips->render_help(__('Donate on behalf of Company', 'give')); ?>
+                </label>
+                <input
+                    class="give-input<?php
+                    echo($give_company ? ' required' : ''); ?>"
+                    type="text"
+                    name="give_company_name"
+                    placeholder="<?php
+                    esc_attr_e('Company Name', 'give'); ?>"
+                    id="give-company"
+                    value="<?php
+                    echo esc_html($company_name); ?>"
+                    <?php
+                    echo($give_company ? ' required aria-required="true" ' : ''); ?>
+                />
+            </p>
+        <?php
+        endif ?>
 
-		</p>
+        <?php
+        /**
+         * Fire before user email field
+         *
+         * @since 1.7
+         */
+        do_action('give_donation_form_before_email', $form_id);
+        ?>
+        <p id="give-email-wrap" class="form-row form-row-wide">
+            <label class="give-label" for="give-email">
+                <?php
+                esc_attr_e('Email Address', 'give'); ?>
+                <?php
+                if (give_field_is_required('give_email', $form_id)) { ?>
+                    <span class="give-required-indicator">*</span>
+                    <?php
+                } ?>
+                <?php
+                echo Give()->tooltips->render_help(__('We will send the donation receipt to this address.', 'give')); ?>
+            </label>
+            <input
+                class="give-input required"
+                type="email"
+                name="give_email"
+                autocomplete="email"
+                placeholder="<?php
+                esc_attr_e('Email Address', 'give'); ?>"
+                id="give-email"
+                value="<?php
+                echo esc_html($email); ?>"
+                <?php
+                echo(give_field_is_required('give_email', $form_id) ? ' required aria-required="true" ' : ''); ?>
+            />
 
-		<?php if ( give_is_anonymous_donation_field_enabled( $form_id ) ) : ?>
-			<?php $is_anonymous_donation = isset( $_POST['give_anonymous_donation'] ) ? absint( $_POST['give_anonymous_donation'] ) : 0; ?>
-			<p id="give-anonymous-donation-wrap" class="form-row form-row-wide">
-				<label class="give-label" for="give-anonymous-donation">
-					<input
-						type="checkbox"
-						class="give-input<?php echo( give_field_is_required( 'give_anonymous_donation', $form_id ) ? ' required' : '' ); ?>"
-						name="give_anonymous_donation"
-						id="give-anonymous-donation"
-						value="1"
-						<?php echo( give_field_is_required( 'give_anonymous_donation', $form_id ) ? ' required aria-required="true" ' : '' ); ?>
-						<?php checked( 1, $is_anonymous_donation ); ?>
-					>
-					<?php
-					/**
-					 * Filters the checkbox label.
-					 *
-					 * @since 2.4.1
-					 */
-					echo apply_filters( 'give_anonymous_donation_checkbox_label', __( 'Make this an anonymous donation.', 'give' ), $form_id );
+        </p>
 
-					if ( give_field_is_required( 'give_comment', $form_id ) ) {
+        <?php
+        if (give_is_anonymous_donation_field_enabled($form_id)) : ?>
+            <?php
+            $is_anonymous_donation = isset($_POST['give_anonymous_donation']) ? absint($_POST['give_anonymous_donation']) : 0; ?>
+            <p id="give-anonymous-donation-wrap" class="form-row form-row-wide">
+                <label class="give-label" for="give-anonymous-donation">
+                    <input
+                        type="checkbox"
+                        class="give-input<?php
+                        echo(give_field_is_required('give_anonymous_donation', $form_id) ? ' required' : ''); ?>"
+                        name="give_anonymous_donation"
+                        id="give-anonymous-donation"
+                        value="1"
+                        <?php
+                        echo(give_field_is_required('give_anonymous_donation',
+                            $form_id) ? ' required aria-required="true" ' : ''); ?>
+                        <?php
+                        checked(1, $is_anonymous_donation); ?>
+                    >
+                    <?php
+                    /**
+                     * Filters the checkbox label.
+                     *
+                     * @since 2.4.1
+                     */
+                    echo apply_filters('give_anonymous_donation_checkbox_label',
+                        __('Make this an anonymous donation.', 'give'), $form_id);
+
+                    if ( give_field_is_required( 'give_comment', $form_id ) ) {
 						?>
 						<span class="give-required-indicator">*</span>
 					<?php } ?>

--- a/src/Views/Form/Templates/Classic/resources/css/_personal-info.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_personal-info.scss
@@ -120,6 +120,35 @@
     content: '\f007';
 }
 
+#give-company-radio-list-wrap {
+    > label {
+        display: block;
+        margin-bottom: 10px;
+    }
+
+    ul.give-company-radio-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+
+        li {
+            display: inline-flex;
+            margin-right: 15px;
+            margin-left: 0;
+
+            input {
+                margin-right: 7px;
+            }
+
+            label {
+                cursor: pointer;
+                display: inline;
+                margin: 0;
+            }
+        }
+    }
+}
+
 #give-email-wrap::before {
     content: '\f0e0';
 }

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -956,6 +956,44 @@ p {
         }
     }
 
+    #give-company-radio-list-wrap {
+        .give-company-option {
+            padding-left: 23px;
+            position: relative;
+
+            &::before {
+                content: ' ';
+                position: absolute;
+                top: calc(50% - 10px);
+                left: 0;
+                width: 16px;
+                height: 16px;
+                border-radius: 50%;
+                border: 1px solid #b4b9be;
+                background-color: #fff;
+                box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+            }
+        }
+
+        input[type='radio']:checked + .give-company-option::after {
+            transform: scale3d(1, 1, 1);
+        }
+
+        input[type='radio'] + .give-company-option::after {
+            transform: scale3d(0, 0, 0);
+            transition: transform 0.2s ease;
+            border-radius: 11px;
+            width: 8px;
+            height: 8px;
+            position: absolute;
+            top: calc(50% - 5px);
+            left: 5px;
+            content: ' ';
+            display: block;
+            background: #333;
+        }
+    }
+
     #give-payment-mode-select {
         .gateway-stripe-google_pay,
         .gateway-stripe-apple_pay {

--- a/src/Views/Form/Templates/Sequoia/assets/css/form.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/form.scss
@@ -957,6 +957,8 @@ p {
     }
 
     #give-company-radio-list-wrap {
+        font-size: 14px;
+
         .give-company-option {
             padding-left: 23px;
             position: relative;
@@ -1004,7 +1006,7 @@ p {
             display: none;
         }
 
-        ul {
+        #give-gateway-radio-list {
             @include before-after-content-none;
             display: grid;
             grid-gap: 10px;
@@ -1065,6 +1067,56 @@ p {
                 content: ' ';
                 display: block;
                 background: #333;
+            }
+
+            ul {
+                input[type='radio'] {
+                    opacity: 0 !important;
+                    position: absolute !important;
+                }
+
+                input[type='radio'] + label:not(.give-tribute-type-button) {
+                    padding: 0 10px 0 28px;
+                    width: 100%;
+                    color: #696969;
+                    font-size: 14px !important;
+                    font-weight: 400 !important;
+                    display: inline-block;
+                    position: relative;
+                    margin: 0 0 5px;
+                    line-height: 1.7;
+
+                    &::before {
+                        content: ' ';
+                        position: absolute;
+                        top: calc(50% - 9px);
+                        left: 0;
+                        width: 16px;
+                        height: 16px;
+                        border-radius: 50%;
+                        border: 1px solid #b4b9be;
+                        background-color: #fff;
+                        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+                    }
+
+                    &::after {
+                        transform: scale3d(0, 0, 0);
+                        transition: transform 0.2s ease;
+                        border-radius: 8px;
+                        width: 8px;
+                        height: 8px;
+                        position: absolute;
+                        top: calc(50% - 4px);
+                        left: 5px;
+                        content: ' ';
+                        display: block;
+                        background: #333;
+                    }
+                }
+
+                input[type='radio']:checked + label:not(.give-tribute-type-button)::after {
+                    transform: scale3d(1, 1, 1);
+                }
             }
         }
     }

--- a/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/tributes.scss
@@ -15,16 +15,23 @@
         }
     }
 
-    legend,
     .give-tributes-legend,
     .give-tributes-label {
-        display: block;
+        display: block !important;
         font-size: 14px !important;
         font-weight: 400 !important;
         border-bottom: none !important;
         padding: 0 !important;
         margin: 0 0 5px !important;
         line-height: 1.7;
+    }
+
+    legend {
+        color: var(--global-palette3);
+        display: block !important;
+        font-size: 14px !important;
+        font-weight: 500 !important;
+        margin-bottom: 5px !important;
     }
 
     .give_tributes_send_ecard_fields > .give-tributes-legend {


### PR DESCRIPTION
This PR is necessary to resolve the major issue of https://github.com/impress-org/give-gift-aid/issues/168.

## Description

The current PR implements a new field in the Personal Info section that controls the visibility of the Company field whenever it's not required. Users will now be able to clearly see when the field is not required.

## Affects

Company field on donation forms.

## Visuals

![CleanShot 2023-01-23 at 11 06 07](https://user-images.githubusercontent.com/3921017/214059471-9c4e6ad6-d265-490f-a68b-3dd43722ec87.gif)
![CleanShot 2023-01-23 at 11 06 45](https://user-images.githubusercontent.com/3921017/214059561-9ec85ba8-5757-4172-8bd3-6ed2114cba5a.gif)
![CleanShot 2023-01-23 at 11 07 18](https://user-images.githubusercontent.com/3921017/214059724-275c84b1-7b13-4731-a22a-a34f40d90a5a.gif)


## Testing Instructions

1. Make sure the Company field is optional on GiveWP Settings > Default Options
2. Open a donation form
3. See the radio list
4. Switch to Yes
5. The company field is shown
6. Change form settings or global settings to make the Company field required
7. Open the donation form
8. The radio list should not be visible but only the Company field

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

