### PR TITLE
Fix: Switch the check for strauss.phar for better compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "test": "./vendor/bin/phpunit --colors --stop-on-failure",
         "unreleased": "./vendor/bin/since-unreleased.sh",
         "strauss": [
-            "[[ -f ./bin/strauss.phar ]] || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.13.0/strauss.phar",
+            "test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.13.0/strauss.phar",
             "vendor/stellarwp/validation/bin/set-domain domain=give",
             "@php bin/strauss.phar"
         ],


### PR DESCRIPTION
## Description

I was experiencing an `sh` error when the `strauss.phar` file check was done using the `[[` syntax, which resulted in `strauss.phar` being downloaded every time that I ran `composer install` or `composer update`. This changeset switches to using the `test` command instead.

I ran a test with this `test` check in place on a fresh clone of this repo and the `.phar` file was downloaded and run successfully the first time. The second run of `composer install` avoided downloading the `.phar` and, again, it executed successfully. :man_dancing:

## Affects

This will impact the fetching and execution of `strauss.phar`.

## Visuals

![Screenshot 2023-01-28 173852](https://user-images.githubusercontent.com/430385/215294297-89e6a9ac-569c-4623-bf32-aa84546df894.png)

## Testing Instructions

```bash
rm -rf vendor/vendor-prefixed
composer install
ls vendor/vendor-prefixed/stellarwp/validation/src
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

