### PR TITLE
Fix: Style additional information section on multi-form receipt page

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
+++ b/src/Views/Form/Templates/Sequoia/assets/css/receipt.scss
@@ -215,6 +215,23 @@
         .details-table:empty {
             display: none !important;
         }
+
+        &.additionalinformation-section {
+            .details-row {
+
+                .value {
+                    white-space: normal;
+                    
+                    p {
+                        margin: 0;
+
+                        + p {
+                            margin-top: 10px;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #give-pdf-receipt-link,

--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -72,7 +72,7 @@ ob_start();
                     continue;
                 }
 
-                echo '<div class="details">';
+                echo '<div class="details ' . sanitize_title($section->id) . '-section">';
                 if ($section->label) {
                     printf('<h3 class="headline">%1$s</h3>', $section->label);
                 }
@@ -85,14 +85,14 @@ ob_start();
                         continue;
                     }
 
+                    $detailRowClass = sanitize_title($lineItem->id) . '-row';
                     // This class is required to highlight total donation amount in receipt.
-                    $detailRowClass = '';
                     if (DonationReceipt::DONATIONSECTIONID === $section->id) {
-                        $detailRowClass = 'totalAmount' === $lineItem->id ? ' total' : '';
+                        $detailRowClass += ('totalAmount' === $lineItem->id ? ' total' : '');
                     }
 
                     printf(
-                        '<div class="details-row%1$s">%2$s<div class="detail">%3$s</div><div class="value">%4$s</div></div>',
+                        '<div class="details-row %1$s">%2$s<div class="detail">%3$s</div><div class="value">%4$s</div></div>',
                         $detailRowClass,
                         $lineItem->icon,
                         $lineItem->label,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6692 

## Description

This PR adds dynamic classes to sections and rows on the multi-form receipt page so we can style them individually then it fixes margins between paragraphs in the Additional Information section.

## Affects

Multi-form receipt page

## Visuals

![CleanShot 2023-02-06 at 10 46 39](https://user-images.githubusercontent.com/3921017/216987678-e4eb5bc2-019d-4927-a677-087211af47dd.jpg)

## Testing Instructions

1. Donate using an addon that includes additional information on the receipt page. Eg: Gift Aid, Tributes etc.
2. See the content in that section.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

