### PR TITLE
Fix: Prevent donation summary with donor from filtering twice

### DIFF
--- a/src/Framework/PaymentGateways/DonationSummary.php
+++ b/src/Framework/PaymentGateways/DonationSummary.php
@@ -40,7 +40,7 @@ class DonationSummary
      */
     public function getSummaryWithDonor(): string
     {
-        return $this->trimAndFilter(
+        return $this->trim(
             implode(' - ', [
                 $this->getSummary(),
                 $this->getDonorLabel(),
@@ -114,8 +114,21 @@ class DonationSummary
     protected function trimAndFilter(string $text): string
     {
         /**
+         * @unreleased Re-use trim method for text.
          * @since 1.8.12
          */
-        return apply_filters('give_payment_gateway_donation_summary', substr($text, 0, $this->length));
+        return apply_filters('give_payment_gateway_donation_summary', $this->trim($text));
+    }
+    
+    /**
+     * @unreleased
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    protected function trim(string $text): string
+    {
+        return substr($text, 0, $this->length);
     }
 }

--- a/tests/Unit/Framework/PaymentGateways/DonationSummaryTest.php
+++ b/tests/Unit/Framework/PaymentGateways/DonationSummaryTest.php
@@ -80,6 +80,23 @@ class DonationSummaryTest extends \Give\Tests\TestCase
     }
 
     /** @test */
+    public function it_summarizes_a_donation_with_donor_filtered_once()
+    {
+        $donationId = Give_Helper_Payment::create_simple_payment();
+        $donation = Donation::find($donationId);
+
+        $count = 0;
+        add_filter('give_payment_gateway_donation_summary', function ($summary) use(&$count) {
+            $count += 1;
+            return $summary;
+        });
+
+        $summary = (new DonationSummary($donation))->getSummaryWithDonor();
+
+        $this->assertEquals(1,$count);
+    }
+
+    /** @test */
     public function it_summarizes_a_simple_donation_truncated()
     {
         $length = 10;


### PR DESCRIPTION
Related #6678.

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Adds a test for #6678, which should fail on `develop`, but pass when #6678 is merged into this branch.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

After the test fails, merge #6678 to re-trigger the tests.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203939212131551