### PR TITLE
Fix: gateway api subscription dashboard link

### DIFF
--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -34,7 +34,6 @@ use Give\Framework\Support\ValueObjects\Money;
 use Give\Helpers\Call;
 use Give\PaymentGateways\Actions\GetGatewayDataFromRequest;
 use Give\Subscriptions\Models\Subscription;
-use ReflectionException;
 use ReflectionMethod;
 
 use function Give\Framework\Http\Response\response;
@@ -227,9 +226,8 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
     }
 
     /**
+     * @unreleased update return logic
      * @since 2.21.2
-     * @since 2.21.2
-     * @throws Exception
      */
     public function hasGatewayDashboardSubscriptionUrl(): bool
     {
@@ -237,7 +235,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
             return $this->subscriptionModule->hasGatewayDashboardSubscriptionUrl();
         }
 
-        throw new Exception('Method has not been implemented yet.');
+        return $this->isFunctionImplementedInGatewayClass('gatewayDashboardSubscriptionUrl');
     }
 
     /**
@@ -291,7 +289,6 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
     /**
      * @since 2.21.2
      * @inheritDoc
-     * @throws Exception
      */
     public function gatewayDashboardSubscriptionUrl(Subscription $subscription): string
     {
@@ -299,7 +296,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
             return $this->subscriptionModule->gatewayDashboardSubscriptionUrl($subscription);
         }
 
-        throw new Exception('Gateway does not support providing a dashboard link.');
+        return false;
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

If subscription logic was added to a gateway directly (without a subscription module) - there was a fatal error from an exception being thrown for not having a `gatewayDashboardSubscriptionUrl()` method implemented.  This is something that should really be optional based on the gateway.  Therefore ,the logic for determining if the url exists checks if it's implemented by the child gateway class - otherwise return false and don't create a link. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The subscription details page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Test a subscription using stripe and make sure the subscription link exists on the details page.
- Then test using test gateway and make sure there are no fatal errors & the subscription profile ID on the details page is just a string / not a link

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

