### PR TITLE
Fix: Style modals on classic template

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/css/_modal.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_modal.scss
@@ -1,0 +1,10 @@
+@import '~@givewp/css/plugins/magnific-popup.scss';
+@import '~@givewp/css/frontend/modal.scss';
+
+.give-modal {
+    p {
+        font-size: 1em;
+        line-height: 1.6;
+        margin: 1em 0;
+    }
+}

--- a/src/Views/Form/Templates/Classic/resources/css/_payment-details.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/_payment-details.scss
@@ -294,6 +294,10 @@ $gatewayFontSize: 1rem;
             grid-column: span 12;
         }
 
+        + fieldset {
+            margin-top: 1rem;
+        }
+
         @media screen and (min-width: $desktopMinWidth) {
             > .form-row-responsive {
                 &.form-row-one-third {

--- a/src/Views/Form/Templates/Classic/resources/css/form.scss
+++ b/src/Views/Form/Templates/Classic/resources/css/form.scss
@@ -54,6 +54,7 @@ label.give-hidden {
 @import 'donation-summary';
 @import 'donate-now';
 @import 'errors-notices';
+@import 'modal';
 @import 'terms';
 
 // Receipt


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6700 

## Description

This PR adds styles for the modals importing the legacy stylesheets into the classic template SCSS.

## Affects

Modals on classic template

## Visuals

![CleanShot 2023-02-16 at 12 09 26](https://user-images.githubusercontent.com/3921017/219409485-b82da9dd-bd39-456b-8b9d-a682e75b519c.gif)

## Testing Instructions

1. Go to a donation form using the classic template and have some content using an addon (Gift Aid, for instance)
2. Search for a link that opens the modal
3 . Clicking on that link, the modal must be shown with the content.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

