### PR TITLE
Fix: Suppress php81 deprecation notices

### DIFF
--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -1085,6 +1085,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->bound($key);
@@ -1097,6 +1098,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->make($key);
@@ -1110,6 +1112,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->bind(
@@ -1127,6 +1130,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);

--- a/src/Framework/FieldsAPI/Contracts/Node.php
+++ b/src/Framework/FieldsAPI/Contracts/Node.php
@@ -26,5 +26,6 @@ interface Node extends JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize();
 }

--- a/src/Framework/PaymentGateways/Contracts/PaymentGatewaysIterator.php
+++ b/src/Framework/PaymentGateways/Contracts/PaymentGatewaysIterator.php
@@ -12,6 +12,7 @@ class PaymentGatewaysIterator implements \Iterator
      * @since 2.18.0
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->gateways);
@@ -20,6 +21,7 @@ class PaymentGatewaysIterator implements \Iterator
     /**
      * @since 2.18.0
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->gateways);
@@ -29,6 +31,7 @@ class PaymentGatewaysIterator implements \Iterator
      * @since 2.18.0
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->gateways);
@@ -38,6 +41,7 @@ class PaymentGatewaysIterator implements \Iterator
      * @since 2.18.0
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return key($this->gateways) !== null;
@@ -46,6 +50,7 @@ class PaymentGatewaysIterator implements \Iterator
     /**
      * @since 2.18.0
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->gateways);


### PR DESCRIPTION
Resolves #6262

## Description

On PHP 8.1 we get flooded with deprecation notices whenever the Give plugin is active. We could fix those by giving funtions the proper return type, but that will cut off support to older PHP versions (e.g. `mixed` keyword is only available in PHP8+). so for now, we just add the recommended `#[\ReturnTypeWillChange]` attribute

## Affects

Servers running PHP8.1 and newer

## Testing Instructions

just open any Give view in PHP8.1 with notices active, and you'll see less of them with this PR

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

