### PR TITLE
Hotfix: make donations get finished when Authorize.Net is the default gateway in sites with more than one gateway enabled.

### DIFF
--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -246,10 +246,11 @@ function moveDefaultGatewayDataIntoActiveGatewaySection() {
 
     addSelectedGatewayDetails(createGatewayDetails());
 
-    document.querySelector('#give_purchase_form_wrap').removeChild(document.querySelector('.give-donation-submit'));
-    document.querySelector('.give-gateway-details').append(...document.querySelector('#give_purchase_form_wrap').children);
+    const purchaseFormWrap = document.querySelector('#give_purchase_form_wrap');
+    purchaseFormWrap.removeChild(purchaseFormWrap.querySelector('.give-donation-submit'));
+    document.querySelector('.give-gateway-details').append(...purchaseFormWrap.children);
 
-    removeNode(document.querySelector('#give_purchase_form_wrap'));
+    removeNode(purchaseFormWrap);
 }
 
 function attachRecurringDonationEvents() {

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -246,9 +246,8 @@ function moveDefaultGatewayDataIntoActiveGatewaySection() {
 
     addSelectedGatewayDetails(createGatewayDetails());
 
-    document
-        .querySelector('.give-gateway-details')
-        .append(...jQuery("#give_purchase_form_wrap").children().not('.give-donation-submit').clone(true, true));
+    document.querySelector('#give_purchase_form_wrap').removeChild(document.querySelector('.give-donation-submit'));
+    document.querySelector('.give-gateway-details').append(...document.querySelector('#give_purchase_form_wrap').children);
 
     removeNode(document.querySelector('#give_purchase_form_wrap'));
 }

--- a/src/Views/Form/Templates/Classic/resources/js/form.js
+++ b/src/Views/Form/Templates/Classic/resources/js/form.js
@@ -248,7 +248,7 @@ function moveDefaultGatewayDataIntoActiveGatewaySection() {
 
     document
         .querySelector('.give-gateway-details')
-        .append(...document.querySelectorAll('#give_purchase_form_wrap fieldset:not(.give-donation-submit)'));
+        .append(...jQuery("#give_purchase_form_wrap").children().not('.give-donation-submit').clone(true, true));
 
     removeNode(document.querySelector('#give_purchase_form_wrap'));
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6707

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes the related issue by changing the way how we clone the children nodes from the `#give_purchase_form_wrap` in the `moveDefaultGatewayDataIntoActiveGatewaySection()` method. Now instead of selecting just `fieldset` nodes, we select all nodes, except the `.give-donation-submit` element.

But why does this fix the problem? Because now, we also include the `script` nodes that are necessary to load the Accept.js library required by the Authorize.Net gateway. 

As a note, this problem wasn't happening in situations where Authorize.Net isn't the default gateway because in these cases, the details are loaded through an AJAX call that already was properly loading everything.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Classic Template. 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://user-images.githubusercontent.com/16308864/220739649-39dafb6e-804b-4732-8dc1-ff4d81fc83a3.png)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a form using the classic template
2. Enable the Authorize.Net gateway and set it as the default
3. Enable the test gateway
4. Load the form page, make a donation using Authorize.Net and it should work as expected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204033725468285