### PR TITLE
Fix: Unsupported operand types in PHP v8+ for receipt template 

### DIFF
--- a/src/Views/Form/Templates/Sequoia/views/receipt.php
+++ b/src/Views/Form/Templates/Sequoia/views/receipt.php
@@ -88,7 +88,7 @@ ob_start();
                     $detailRowClass = sanitize_title($lineItem->id) . '-row';
                     // This class is required to highlight total donation amount in receipt.
                     if (DonationReceipt::DONATIONSECTIONID === $section->id) {
-                        $detailRowClass += ('totalAmount' === $lineItem->id ? ' total' : '');
+                        $detailRowClass .= ('totalAmount' === $lineItem->id ? ' total' : '');
                     }
 
                     printf(


### PR DESCRIPTION
Resolves #6711 

## Description

I found that in the [receipt template](https://github.com/impress-org/givewp/blob/develop/src/Views/Form/Templates/Sequoia/views/receipt.php), in line 91, there is an issue between the operation and the operand types. It's trying to use the '+' operation on 2 strings. In older PHP versions (<= 7.0) this will work, in some v7 versions (>7.0, <8.0) it will throw a warning, but in newer versions (>= 8.0) this will fail. You can try this with a [PHP sandbox tools](https://onlinephp.io/). Therefore, to fix it it's enough to change the operation to concatenate strings from "+", to the PHP common of ".".

## Affects

The receipt view when doing an offline donation while using PHP8+.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

