### PR TITLE
Fix: Patch CSV injection in donation export

### DIFF
--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -681,7 +681,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
      */
     protected function escape_csv_cell_data($cellData) {
         $firstCharacter = substr($cellData, 0, 1);
-        if( in_array($firstCharacter, array('=', '+', '-', '@')) ) {ccq
+        if( in_array($firstCharacter, array('=', '+', '-', '@')) ) {
             $cellData = "'" . $cellData;
         }
         return $cellData;

--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -653,7 +653,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 				foreach ( $row as $col_id => $column ) {
 					// Make sure the column is valid
 					if ( array_key_exists( $col_id, $cols ) ) {
-						$row_data .= '"' . preg_replace( '/"/', "'", $column ) . '"';
+						$row_data .= '"' . $this->escape_csv_cell_data(preg_replace( '/"/', "'", $column )) . '"';
 						$row_data .= $i == count( $cols ) ? '' : ',';
 						$i ++;
 					}
@@ -668,4 +668,22 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 
 		return false;
 	}
+
+    /**
+     * Escapes CSV cell data to protect against CSV injection.
+     * @link https://owasp.org/www-community/attacks/CSV_Injection
+     *
+     * @unreleased
+     *
+     * @param mixed|string $cellData
+     *
+     * @return mixed|string
+     */
+    protected function escape_csv_cell_data($cellData) {
+        $firstCharacter = substr($cellData, 0, 1);
+        if( in_array($firstCharacter, array('=', '+', '-', '@')) ) {ccq
+            $cellData = "'" . $cellData;
+        }
+        return $cellData;
+    }
 }


### PR DESCRIPTION
Re: https://app.asana.com/0/0/1204069668576421/f

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR patches a potential CSV Injection vulnerability by escaping (or 'neutralizing') formula expressions in cells. Cells starting with `=`, `+`, `-`, or `@` are formula expressions in spreadsheets, which may be executed is protections are disabled when opening the file.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `Give_Export_Donations_CSV`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204129686534550