### PR TITLE
Fix: Tributes part of [give_donor_wall] shortcode template

### DIFF
--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -184,7 +184,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
             </div>
         </div>
         <?php
-        if ($atts['show_tributes'] && (isset($donation['_give_tributes_first_name']) || isset($donation['_give_tributes_Last_name']))) {
+        if ($atts['show_tributes'] && (isset($donation['_give_tributes_first_name']) || isset($donation['_give_tributes_last_name']))) {
             $tribute_message = esc_html($donation['_give_tributes_type']);
             $honoree_first_name = esc_html($donation['_give_tributes_first_name']);
             $honoree_last_name = esc_html($donation['_give_tributes_last_name']);


### PR DESCRIPTION
Resolves #6720 

## Description

The tribute should show up in one of two cases:
- `show_tributes` attribute and tribute first name are not empty
- `show_tributes` attribute and tribute **last** name are not empty

At this point, the second possibility does not works correctly.
All the needed code is there, only a tiny misprint broke it, this PR fixes this misprint.

## Affects

the `show_tributes` part of [give_donor_wall] shortcode

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

