### PR TITLE
Fix: add extra escaping to form grid shortcode attributes

### DIFF
--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -46,15 +46,23 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
 
     $tag_elements = array_map(
         static function($term)use($tag_text_color,$tag_bg_color){
-            return "<span style='color: $tag_text_color; background-color: $tag_bg_color;'>$term->name</span>";
+            $style = sprintf(
+                'color: %s; background-color: %s;',
+                esc_attr($tag_text_color),
+                esc_attr($tag_bg_color)
+            );
+            return "<span style='$style'>$term->name</span>";
         }, $tags
     );
 
     $tag_elements = implode('', $tag_elements);
-    $styles = $apply_styles ? "style='background-color: $tag_container_color;'" : '';
+    $styles = sprintf(
+            "background-color: %s;",
+            $apply_styles ? esc_attr($tag_container_color) : ''
+        );
 
     return "
-         <div class='$wrapper_class' $styles >
+         <div class='$wrapper_class' style='$styles' >
             $tag_elements
          </div>
     ";
@@ -86,7 +94,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
         );
     }
     ?>
-    <div class="give-form-grid" style="flex-direction:<?php echo $flex_direction ?>">
+    <div class="give-form-grid" style="flex-direction:<?php echo esc_attr($flex_direction) ?>">
         <?php
         // Maybe display the featured image.
         if (
@@ -128,7 +136,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
         {
             echo "
                             <div id='row-media' class='give-form-grid-media'>
-                                <img class='give-form-grid-media' src='$imageSrc' alt='' />
+                                <img class='give-form-grid-media' src='". esc_url($imageSrc). "' alt='' />
 
                                 {$renderTags('give-form-grid-media__tags')}
                             </div>
@@ -141,7 +149,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                 <?php
                 if( !$atts['show_featured_image']){
                     echo "
-                                 <div class='give-form-grid-media' >
+                                 <div class='give-form-grid-media'>
                                         {$renderTags('give-form-grid-media__tags_no_image', false)}
                                    </div>
                             ";
@@ -198,9 +206,9 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                         : '#000000';
                     ?>
                     <button style="text-decoration-color: <?php
-                    echo $button_text_color; ?>">
+                    echo esc_attr($button_text_color); ?>">
                                     <span style="color: <?php
-                                    echo $button_text_color; ?>">
+                                    echo esc_attr($button_text_color); ?>">
                                         <?php
                                         echo $button_text ?: __('Donate', 'give'); ?>
                                     </span>
@@ -271,7 +279,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                     echo "
                                             <div class='give-form-grid-progress-bar'>
                                                     <div class='give-progress-bar' role='progressbar' aria-valuemin='0' aria-valuemax='100' aria-valuenow='$progress_bar_value'>
-                                                        <span style='$style'></span>
+                                                        <span style='" . esc_attr($style) . "'></span>
                                                     </div>
                                             </div>
                                         ";

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -210,7 +210,7 @@ $renderTags = static function($wrapper_class, $apply_styles = true) use($form_id
                                     <span style="color: <?php
                                     echo esc_attr($button_text_color); ?>">
                                         <?php
-                                        echo $button_text ?: __('Donate', 'give'); ?>
+                                        echo esc_html($button_text) ?: __('Donate', 'give'); ?>
                                     </span>
                     </button>
                 <?php endif; ?>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds extra escaping to the form grid shortcode attribute rendering to prevent XSS.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form grid shortcode

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the form grid shortcode works as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204137775197143