### PR TITLE
Fix: trigger change event on hidden amount field

### DIFF
--- a/assets/src/js/frontend/give-donations.js
+++ b/assets/src/js/frontend/give-donations.js
@@ -416,8 +416,18 @@ jQuery( function( $ ) {
 			// Auto set give price id.
 			$( 'input[name="give-price-id"]', parent_form ).val( price_id );
 
-			// Update hidden amount field
-			parent_form.find( '.give-amount-hidden' ).val( Give.form.fn.formatAmount( value_now, parent_form, {} ) );
+            // Update hidden amount field
+            const hiddenAmountField = parent_form.find('.give-amount-hidden');
+            if (hiddenAmountField) {
+                hiddenAmountField.val(Give.form.fn.formatAmount(value_now, parent_form, {}));
+                // Trigger change event.
+                // We use amount field classes to trigger change event on input field,
+                // But when custom amount disabled then we use hidden field to store amount and span HTML tag to show amount.
+                // This means, if logic depends on amount change event (field with "give-amount" name) then it will not work.
+                // So, it is required to trigger change event on 'give-amount' hidden field.
+                // For example: Form field manager (feature: conditional field visibility)
+                hiddenAmountField.trigger('change');
+            }
 
 			// Remove old selected class & add class for CSS purposes
 			parent_form.find( '.give-default-level' ).removeClass( 'give-default-level' );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6729 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Conditional field visibility javascript tracks field change events by their field name. As we can see issue occurs with the amount field in the donation form because when the custom amount setting is disabled then, we use a hidden field to store the amount value and span the HTML tag to display the amount, which means the change event does not trigger. Donation form logic triggers a change event on for amount by classes. For this reason, the field does not display.

I trigger a change event on the amount hidden field to resolve the issue.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects the donation form the front end and conditional field visibility with the FFM add-on.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] FFM field, which depends upon the amount field, should display regardless of the custom amount setting status.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204172169652914