### PR TITLE
Feature: handle `RespondToBrowser` command for subscriptions

### DIFF
--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -109,7 +109,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
                 $exception->getMessage(),
                 [
                     'Payment Gateway' => static::id(),
-                    'Donation' => $donation,
+                    'Donation' => $donation->toArray(),
                 ]
             );
 
@@ -150,8 +150,8 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
                 $exception->getMessage(),
                 [
                     'Payment Gateway' => static::id(),
-                    'Donation' => $donation,
-                    'Subscription' => $subscription,
+                    'Donation' => $donation->toArray(),
+                    'Subscription' => $subscription->toArray(),
                 ]
             );
 

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -352,6 +352,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
     /**
      * Handle gateway subscription command
      *
+     * @unreleased add RespondToBrowser command
      * @since 2.21.0 Handle RedirectOffsite response.
      * @since 2.18.0
      *
@@ -386,6 +387,12 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
 
         if ($command instanceof RedirectOffsite) {
             $response = Call::invoke(RedirectOffsiteHandler::class, $command);
+
+            $this->handleResponse($response);
+        }
+
+        if ($command instanceof RespondToBrowser) {
+            $response = (new RespondToBrowserHandler())($command);
 
             $this->handleResponse($response);
         }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds support for using the `RespondToBrowser` command in the gateway api when using `createSubscription()`

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The gateway api 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Would need to use a gateway that supports recurring and returns the `RespondToBrowser` during `createSubscription()`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

