### PR TITLE
Feature: REST API Test Case

### DIFF
--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -26,17 +26,34 @@ class ApiTestCase extends TestCase
     protected $server;
 
     /**
-     * Test admin user account for API authentication
+     * Test user accounts for API authentication
      *
-     * @var WP_User
+     * @var WP_User[] $users
      */
-    protected static $admin_user_id;
+    protected static $users = [
+        'anonymous' => null,
+        'administrator' => null,
+        'editor' => null,
+        'author' => null,
+        'contributor' => null,
+        'subscriber' => null,
+    ];
 
+    /**
+     * Create users for API authentication
+     *
+     * @return void
+     */
     public static function wpSetUpBeforeClass(WP_UnitTest_Factory $factory)
     {
-        self::$admin_user_id = $factory->user->create([
-            'role' => 'administrator',
-        ]);
+        self::$users = [
+            'anonymous' => 0,
+            'administrator' => $factory->user->create(['role' => 'administrator']),
+            'editor' => $factory->user->create(['role' => 'editor']),
+            'author' => $factory->user->create(['role' => 'author']),
+            'contributor' => $factory->user->create(['role' => 'contributor']),
+            'subscriber' => $factory->user->create(['role' => 'subscriber']),
+        ];
     }
 
     /**
@@ -61,7 +78,7 @@ class ApiTestCase extends TestCase
      * @param string $method
      * @param string $route
      * @param array  $attributes
-     * @param bool   $authenticated
+     * @param string $authentication
      *
      * @return WP_REST_Request
      */
@@ -69,13 +86,12 @@ class ApiTestCase extends TestCase
         string $method,
         string $route,
         array $attributes = [],
-        bool $authenticated = true
+        string $authentication = 'anonymous'
     ): WP_REST_Request {
-        if ($authenticated) {
-            wp_set_current_user(self::$admin_user_id);
-        } else {
-            wp_set_current_user(0);
+        if ( ! in_array($authentication, array_keys(self::$users), true)) {
+            $authentication = 'anonymous';
         }
+        wp_set_current_user(self::$users[$authentication]);
 
         return new WP_REST_Request($method, $route, $attributes);
     }

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -1,0 +1,80 @@
+<?php
+namespace Give\Tests;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Give Unit API Test Case
+ *
+ * Provides Give-specific setup/tear down/assert methods
+ * and helper functions to be used in API tests.
+ *
+ * @unreleased
+ */
+class ApiTestCase extends TestCase
+{
+    /**
+     * Test REST Server
+     *
+     * @var WP_REST_Server
+     */
+    protected $server;
+
+    /**
+     * Initialize the REST server
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        global $wp_rest_server;
+
+        $wp_rest_server = new WP_REST_Server();
+        $this->server   = $wp_rest_server;
+
+        do_action( 'rest_api_init' );
+    }
+
+    /**
+     * Wrapper for creating a request
+     *
+     * @param string $method
+     * @param string $route
+     * @param array  $attributes
+     *
+     * @return WP_REST_Request
+     */
+    public function createRequest(string $method, string $route, array $attributes = []): WP_REST_Request
+    {
+        return new WP_REST_Request($method, $route, $attributes);
+    }
+
+    /**
+     * Wrapper for dispatching a request
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_REST_Response
+     */
+    public function dispatchRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        return $this->server->dispatch($request);
+    }
+
+    /**
+     * Destroy the REST server
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        global $wp_rest_server;
+        $wp_rest_server = null;
+    }
+}

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -5,6 +5,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 use WP_Roles;
+use WP_UnitTest_Factory;
 use WP_User;
 
 /**
@@ -25,11 +26,18 @@ class ApiTestCase extends TestCase
     protected $server;
 
     /**
-     * Test user account for API authentication
+     * Test admin user account for API authentication
      *
      * @var WP_User
      */
-    protected $user_id;
+    protected static $admin_user_id;
+
+    public static function wpSetUpBeforeClass(WP_UnitTest_Factory $factory)
+    {
+        self::$admin_user_id = $factory->user->create([
+            'role' => 'administrator',
+        ]);
+    }
 
     /**
      * Initialize the REST server
@@ -44,9 +52,6 @@ class ApiTestCase extends TestCase
         $this->server = $wp_rest_server = new WP_REST_Server;
         do_action('rest_api_init');
 
-        $this->user_id = $this->factory->user->create([
-            'role' => 'administrator',
-        ]);
         $this->flush_roles();
     }
 
@@ -67,7 +72,7 @@ class ApiTestCase extends TestCase
         bool $authenticated = true
     ): WP_REST_Request {
         if ($authenticated) {
-            wp_set_current_user($this->user_id);
+            wp_set_current_user(self::$admin_user_id);
         } else {
             wp_set_current_user(0);
         }

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -80,46 +80,6 @@ class RestApiTestCase extends TestCase
     }
 
     /**
-     * Wrapper for creating a request
-     *
-     * @unreleased
-     *
-     * @param string $method
-     * @param string $route
-     * @param array  $attributes
-     * @param string $authentication
-     *
-     * @return WP_REST_Request
-     */
-    public function createRequest(
-        string $method,
-        string $route,
-        array $attributes = [],
-        string $authentication = 'anonymous'
-    ): WP_REST_Request {
-        if ( ! in_array($authentication, array_keys(self::$users), true)) {
-            $authentication = 'anonymous';
-        }
-        wp_set_current_user(self::$users[$authentication]);
-
-        return new WP_REST_Request($method, $route, $attributes);
-    }
-
-    /**
-     * Wrapper for dispatching a request
-     *
-     * @unreleased
-     *
-     * @param WP_REST_Request $request
-     *
-     * @return WP_REST_Response
-     */
-    public function dispatchRequest(WP_REST_Request $request): WP_REST_Response
-    {
-        return $this->server->dispatch($request);
-    }
-
-    /**
      * Flushes the WordPress user roles and reloads them from the database.
      *
      * This function ensures that we are testing against the database data, not just in-memory data.
@@ -151,13 +111,53 @@ class RestApiTestCase extends TestCase
     }
 
     /**
+     * Wrapper for creating a request
+     *
+     * @unreleased
+     *
+     * @param string $method     The HTTP method of the request (e.g. GET, POST, etc.).
+     * @param string $route      The REST API route to access (e.g. /wp/v2/posts).
+     * @param array  $attributes Optional. An array of attributes to set on the request object.
+     * @param string $userRole   Optional. The role of the user to authenticate the request (e.g. anonymous, administrator, etc.).
+     *
+     * @return WP_REST_Request A new WP_REST_Request object with the specified parameters.
+     */
+    public function createRequest(
+        string $method,
+        string $route,
+        array $attributes = [],
+        string $userRole = 'anonymous'
+    ): WP_REST_Request {
+        if ( ! in_array($userRole, array_keys(self::$users), true)) {
+            $userRole = 'anonymous';
+        }
+        wp_set_current_user(self::$users[$userRole]);
+
+        return new WP_REST_Request($method, $route, $attributes);
+    }
+
+    /**
+     * Wrapper for dispatching a request
+     *
+     * @unreleased
+     *
+     * @param WP_REST_Request $request The request object to dispatch to the server.
+     *
+     * @return WP_REST_Response The response object returned by the server.
+     */
+    public function dispatchRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        return $this->server->dispatch($request);
+    }
+
+    /**
      * Asserts that the response is a WP error response with the specified code and status (if provided).
      *
      * @unreleased
      *
-     * @param $code
-     * @param $response
-     * @param $status
+     * @param int|string $code     The expected error code of the WP_Error object.
+     * @param mixed      $response The response object to check (can be a WP_REST_Response or WP_Error object).
+     * @param int|null   $status   Optional. The expected error status of the WP_Error object (if any).
      *
      * @return void
      */

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -6,7 +6,6 @@ use WP_REST_Response;
 use WP_REST_Server;
 use WP_Roles;
 use WP_UnitTest_Factory;
-use WP_User;
 
 /**
  * Give Unit API Test Case
@@ -21,6 +20,8 @@ class RestApiTestCase extends TestCase
     /**
      * Test REST Server
      *
+     * @unreleased
+     *
      * @var WP_REST_Server
      */
     protected $server;
@@ -28,7 +29,9 @@ class RestApiTestCase extends TestCase
     /**
      * Test user accounts for API authentication
      *
-     * @var WP_User[] $users
+     * @unreleased
+     *
+     * @var int[] $users
      */
     protected static $users = [
         'anonymous' => null,
@@ -41,6 +44,8 @@ class RestApiTestCase extends TestCase
 
     /**
      * Create users for API authentication
+     *
+     * @unreleased
      *
      * @return void
      */
@@ -59,6 +64,8 @@ class RestApiTestCase extends TestCase
     /**
      * Initialize the REST server
      *
+     * @unreleased
+     *
      * @return void
      */
     public function setUp()
@@ -74,6 +81,8 @@ class RestApiTestCase extends TestCase
 
     /**
      * Wrapper for creating a request
+     *
+     * @unreleased
      *
      * @param string $method
      * @param string $route
@@ -99,6 +108,8 @@ class RestApiTestCase extends TestCase
     /**
      * Wrapper for dispatching a request
      *
+     * @unreleased
+     *
      * @param WP_REST_Request $request
      *
      * @return WP_REST_Response
@@ -108,6 +119,15 @@ class RestApiTestCase extends TestCase
         return $this->server->dispatch($request);
     }
 
+    /**
+     * Flushes the WordPress user roles and reloads them from the database.
+     *
+     * This function ensures that we are testing against the database data, not just in-memory data.
+     *
+     * @unreleased
+     *
+     * @return void
+     */
     private function flushRoles()
     {
         unset($GLOBALS['wp_user_roles']);
@@ -117,6 +137,8 @@ class RestApiTestCase extends TestCase
 
     /**
      * Destroy the REST server
+     *
+     * @unreleased
      *
      * @return void
      */
@@ -128,6 +150,17 @@ class RestApiTestCase extends TestCase
         $wp_rest_server = null;
     }
 
+    /**
+     * Asserts that the response is a WP error response with the specified code and status (if provided).
+     *
+     * @unreleased
+     *
+     * @param $code
+     * @param $response
+     * @param $status
+     *
+     * @return void
+     */
     protected function assertErrorResponse($code, $response, $status = null)
     {
         if (is_a($response, 'WP_REST_Response')) {
@@ -136,7 +169,7 @@ class RestApiTestCase extends TestCase
 
         $this->assertInstanceOf('WP_Error', $response);
         $this->assertEquals($code, $response->get_error_code());
-        
+
         if (null !== $status) {
             $data = $response->get_error_data();
             $this->assertArrayHasKey('status', $data);

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -69,7 +69,7 @@ class RestApiTestCase extends TestCase
         $this->server = $wp_rest_server = new WP_REST_Server;
         do_action('rest_api_init');
 
-        $this->flush_roles();
+        $this->flushRoles();
     }
 
     /**
@@ -108,7 +108,7 @@ class RestApiTestCase extends TestCase
         return $this->server->dispatch($request);
     }
 
-    private function flush_roles()
+    private function flushRoles()
     {
         unset($GLOBALS['wp_user_roles']);
         global $wp_roles;
@@ -126,5 +126,21 @@ class RestApiTestCase extends TestCase
 
         global $wp_rest_server;
         $wp_rest_server = null;
+    }
+
+    protected function assertErrorResponse($code, $response, $status = null)
+    {
+        if (is_a($response, 'WP_REST_Response')) {
+            $response = $response->as_error();
+        }
+
+        $this->assertInstanceOf('WP_Error', $response);
+        $this->assertEquals($code, $response->get_error_code());
+        
+        if (null !== $status) {
+            $data = $response->get_error_data();
+            $this->assertArrayHasKey('status', $data);
+            $this->assertEquals($status, $data['status']);
+        }
     }
 }

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -16,7 +16,7 @@ use WP_User;
  *
  * @unreleased
  */
-class ApiTestCase extends TestCase
+class RestApiTestCase extends TestCase
 {
     /**
      * Test REST Server

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -1,6 +1,8 @@
 <?php
 namespace Give\Tests;
 
+use Give\Tests\TestTraits\HasDefaultGiveWPUsers;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -34,12 +36,7 @@ class RestApiTestCase extends TestCase
      * @var int[] $users
      */
     protected static $users = [
-        'anonymous' => null,
-        'administrator' => null,
-        'editor' => null,
-        'author' => null,
-        'contributor' => null,
-        'subscriber' => null,
+        'anonymous' => 0,
     ];
 
     /**
@@ -51,14 +48,21 @@ class RestApiTestCase extends TestCase
      */
     public static function wpSetUpBeforeClass(WP_UnitTest_Factory $factory)
     {
-        self::$users = [
-            'anonymous' => 0,
-            'administrator' => $factory->user->create(['role' => 'administrator']),
-            'editor' => $factory->user->create(['role' => 'editor']),
-            'author' => $factory->user->create(['role' => 'author']),
-            'contributor' => $factory->user->create(['role' => 'contributor']),
-            'subscriber' => $factory->user->create(['role' => 'subscriber']),
-        ];
+        $uses = array_flip(class_uses(static::class));
+
+        if (isset($uses[HasDefaultWordPressUsers::class])) {
+            self::$users = array_merge(
+                self::$users,
+                static::createDefaultWordPressUsers($factory)
+            );
+        }
+
+        if (isset($uses[HasDefaultGiveWPUsers::class])) {
+            self::$users = array_merge(
+                self::$users,
+                static::createDefaultGiveWPUsers($factory)
+            );
+        }
     }
 
     /**

--- a/tests/RestApiTestCase.php
+++ b/tests/RestApiTestCase.php
@@ -111,6 +111,22 @@ class RestApiTestCase extends TestCase
     }
 
     /**
+     * Delete users after the test class is done
+     *
+     * @unreleased
+     *
+     * @return void
+     */
+    public static function wpTearDownAfterClass()
+    {
+        foreach (self::$users as $user_id) {
+            wp_delete_user($user_id);
+        }
+
+        self::$users = [];
+    }
+
+    /**
      * Wrapper for creating a request
      *
      * @unreleased

--- a/tests/TestTraits/HasDefaultGiveWPUsers.php
+++ b/tests/TestTraits/HasDefaultGiveWPUsers.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Give\Tests\TestTraits;
+
+use WP_UnitTest_Factory;
+
+trait HasDefaultGiveWPUsers
+{
+    /**
+     * Creates a set of default GiveWP users with different roles.
+     *
+     * @unreleased
+     *
+     * @param WP_UnitTest_Factory $factory
+     *
+     * @return array
+     */
+    public static function createDefaultGiveWPUsers(WP_UnitTest_Factory $factory): array
+    {
+        $roles = [
+            'give_manager',
+            'give_accountant',
+            'give_worker',
+            'give_donor',
+            'give_subscriber',
+        ];
+
+        $users = [];
+        foreach ( $roles as $role ) {
+            $users[$role] = $factory->user->create(['role' => $role]);
+        }
+
+        return $users;
+    }
+}

--- a/tests/TestTraits/HasDefaultWordPressUsers.php
+++ b/tests/TestTraits/HasDefaultWordPressUsers.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Give\Tests\TestTraits;
+
+use WP_UnitTest_Factory;
+
+trait HasDefaultWordPressUsers
+{
+    /**
+     * Creates a set of default WordPress users with different roles.
+     *
+     * @unreleased
+     *
+     * @param WP_UnitTest_Factory $factory
+     *
+     * @return array
+     */
+    public static function createDefaultWordPressUsers(WP_UnitTest_Factory $factory): array
+    {
+        $roles = [
+            'administrator',
+            'editor',
+            'author',
+            'contributor',
+            'subscriber',
+        ];
+
+        $users = [];
+        foreach ( $roles as $role ) {
+            $users[$role] = $factory->user->create(['role' => $role]);
+        }
+
+        return $users;
+    }
+}


### PR DESCRIPTION
## Description

This Pull Request adds a new `RestApiTestCase` class. The class provides specific methods and helper functions to be used in API tests. This will make it easier and faster to write tests for the Give REST API.

To use the `RestApiTestCase` class, you just need to extend your test from it instead of the standard `TestCase` class. The `RestApiTestCase` class initializes the REST server, creates user accounts for API authentication, provides wrapper functions for creating and dispatching requests, and includes an assertion method for checking WP error responses.

The reason for extending a class instead of using a trait is to keep the codebase clean and avoid duplication of logic. If we were to use a trait, we would need to implement duplicate logic in the standard `TestCase` class and prefix the methods in the trait to avoid naming conflicts with other traits. By extending the `RestApiTestCase` class, we avoid these issues and can easily access its helper methods without having to add additional prefixes or boilerplate code. This results in cleaner, more readable code that is easier to maintain and understand.

To run authenticated tests, we've now got two traits that whip up the users for it:
```php
use HasDefaultWordPressUsers;
use HasDefaultGiveWPUsers;
```

Below is the method signature for the publicly available methods:
```php
/**
 * Wrapper for creating a request.
 *
 * @param string $method     The HTTP method of the request (e.g. GET, POST, etc.).
 * @param string $route      The REST API route to access (e.g. /wp/v2/posts).
 * @param array  $attributes Optional. An array of attributes to set on the request object.
 * @param string $userRole   Optional. The role of the user to authenticate the request (e.g. anonymous, administrator, etc.).
 * 
 * @return WP_REST_Request A new WP_REST_Request object with the specified parameters.
 */
public function createRequest(string $method, string $route, array $attributes = [], string $userRole = 'anonymous'): WP_REST_Request
```
```php
/**
 * Wrapper for dispatching a request.
 *
 * @param WP_REST_Request $request The request object to dispatch to the server.
 * 
 * @return WP_REST_Response The response object returned by the server.
 */
public function dispatchRequest(WP_REST_Request $request): WP_REST_Response
```
```php
/**
 * Asserts that the response is a WP error response with the specified code and status (if provided).
 *
 * @param int|string $code     The expected error code of the WP_Error object.
 * @param mixed      $response The response object to check (can be a WP_REST_Response or WP_Error object).
 * @param int|null   $status   Optional. The expected error status of the WP_Error object (if any).
 * 
 * @return void
 */
protected function assertErrorResponse($code, $response, $status = null)
```

## Testing Instructions

Unit test class sample:
```php
<?php

namespace Give\Tests\Unit\API\Endpoints;

use Give\Tests\RestApiTestCase;
use Give\Tests\TestTraits\HasDefaultWordPressUsers;
use WP_REST_Response;

class TestExample extends RestApiTestCase
{
    use HasDefaultWordPressUsers;

    public function testValidRequest() {
        $request = $this->createRequest('GET', '/wp/v2/users', [], 'administrator');
        $response = $this->dispatchRequest($request);

        $this->assertInstanceOf(WP_REST_Response::class, $response);
        $this->assertEquals(200, $response->get_status());

        $data = $response->get_data();
        $this->assertIsArray($data);
        $this->assertNotEmpty($data);
    }

    public function testInvalidRequest() {
        $request = $this->createRequest('GET', '/wp/v2/unknown');
        $response = $this->dispatchRequest($request);

        $this->assertErrorResponse('rest_no_route', $response, 404);
    }
}
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203466384450656