### PR TITLE
Feature: add design system style registration

### DIFF
--- a/give.php
+++ b/give.php
@@ -56,6 +56,7 @@ use Give\Donors\ServiceProvider as DonorsServiceProvider;
 use Give\Form\LegacyConsumer\ServiceProvider as FormLegacyConsumerServiceProvider;
 use Give\Form\Templates;
 use Give\Framework\Database\ServiceProvider as DatabaseServiceProvider;
+use Give\Framework\DesignSystem\DesignSystemServiceProvider;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\Exceptions\UncaughtExceptionLogger;
 use Give\Framework\Http\ServiceProvider as HttpServiceProvider;
@@ -209,6 +210,7 @@ final class Give
         ValidationServiceProvider::class,
         ValidationRulesServiceProvider::class,
         HttpServiceProvider::class,
+        DesignSystemServiceProvider::class,
     ];
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@fortawesome/free-regular-svg-icons": "^5.15.1",
                 "@fortawesome/free-solid-svg-icons": "^5.15.1",
                 "@fortawesome/react-fontawesome": "^0.1.12",
+                "@givewp/design-system-foundation": "^1.1.0",
                 "@paypal/paypal-js": "^1.0.2",
                 "@reach/tabs": "^0.16.1",
                 "@stripe/react-stripe-js": "^1.2.2",
@@ -2229,6 +2230,11 @@
                 "@fortawesome/fontawesome-svg-core": "^1.2.32",
                 "react": ">=16.x"
             }
+        },
+        "node_modules/@givewp/design-system-foundation": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@givewp/design-system-foundation/-/design-system-foundation-1.1.0.tgz",
+            "integrity": "sha512-SOAS98QQOytIGsyDX55y4TCS0DeKijjmOPnNaG0YbClTL2u7HFNthqRHk246BXZ0s6U+CUzqZQ8mf/+3NY4Z1g=="
         },
         "node_modules/@hapi/address": {
             "version": "2.1.4",
@@ -27035,6 +27041,11 @@
             "requires": {
                 "prop-types": "^15.7.2"
             }
+        },
+        "@givewp/design-system-foundation": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@givewp/design-system-foundation/-/design-system-foundation-1.1.0.tgz",
+            "integrity": "sha512-SOAS98QQOytIGsyDX55y4TCS0DeKijjmOPnNaG0YbClTL2u7HFNthqRHk246BXZ0s6U+CUzqZQ8mf/+3NY4Z1g=="
         },
         "@hapi/address": {
             "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@fortawesome/free-regular-svg-icons": "^5.15.1",
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/react-fontawesome": "^0.1.12",
+        "@givewp/design-system-foundation": "^1.1.0",
         "@paypal/paypal-js": "^1.0.2",
         "@reach/tabs": "^0.16.1",
         "@stripe/react-stripe-js": "^1.2.2",

--- a/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
+++ b/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
@@ -4,6 +4,9 @@ namespace Give\Framework\DesignSystem\Actions;
 
 class RegisterDesignSystemStyles
 {
+    /**
+     * @unreleased
+     */
     public function __invoke()
     {
         $version = file_get_contents(GIVE_PLUGIN_DIR . 'assets/dist/css/design-system/version');

--- a/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
+++ b/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Give\Framework\DesignSystem\Actions;
+
+class RegisterDesignSystemStyles
+{
+    public function __invoke()
+    {
+        $version = file_get_contents(GIVE_PLUGIN_DIR . 'assets/dist/css/design-system/version');
+
+        wp_register_style(
+            'givewp-design-system-foundation',
+            GIVE_PLUGIN_URL . 'assets/dist/css/design-system/foundation.css',
+            [],
+            $version
+        );
+    }
+}

--- a/src/Framework/DesignSystem/DesignSystemServiceProvider.php
+++ b/src/Framework/DesignSystem/DesignSystemServiceProvider.php
@@ -8,10 +8,16 @@ use Give\ServiceProviders\ServiceProvider;
 
 class DesignSystemServiceProvider implements ServiceProvider
 {
+    /**
+     * @unreleased
+     */
     public function register()
     {
     }
 
+    /**
+     * @unreleased
+     */
     public function boot()
     {
         Hooks::addAction('wp_enqueue_scripts', RegisterDesignSystemStyles::class);

--- a/src/Framework/DesignSystem/DesignSystemServiceProvider.php
+++ b/src/Framework/DesignSystem/DesignSystemServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Give\Framework\DesignSystem;
+
+use Give\Framework\DesignSystem\Actions\RegisterDesignSystemStyles;
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider;
+
+class DesignSystemServiceProvider implements ServiceProvider
+{
+    public function register()
+    {
+    }
+
+    public function boot()
+    {
+        Hooks::addAction('wp_enqueue_scripts', RegisterDesignSystemStyles::class);
+        Hooks::addAction('admin_enqueue_scripts', RegisterDesignSystemStyles::class);
+    }
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,60 +1,70 @@
+const fs = require('fs');
 const mix = require('laravel-mix');
 const path = require('path');
 const WebpackRTLPlugin = require('webpack-rtl-plugin');
 const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
 
 mix.setPublicPath('assets/dist')
-    .sass('assets/src/css/frontend/give-frontend.scss', 'css/give.css')
-    .sass('assets/src/css/admin/block-editor.scss', 'css/admin-block-editor.css')
-    .sass('assets/src/css/admin/give-admin.scss', 'css/admin.css')
-    .sass('assets/src/css/admin/give-admin-global.scss', 'css/admin-global.css')
-    .sass('assets/src/css/admin/setup.scss', 'css/admin-setup.css')
-    .sass('assets/src/css/admin/shortcodes.scss', 'css/admin-shortcode-button.css')
-    .sass('assets/src/css/admin/plugin-deactivation-survey.scss', 'css/')
-    .sass('assets/src/css/admin/widgets.scss', 'css/admin-widgets.css')
-    .sass('assets/src/css/admin/paypal-commerce.scss', 'css/admin-paypal-commerce.css')
-    .sass('src/Views/Form/Templates/Sequoia/assets/css/form.scss', 'css/give-sequoia-template.css')
-    .sass('src/Views/Form/Templates/Classic/resources/css/form.scss', 'css/give-classic-template.css')
-    .sass('src/MultiFormGoals/resources/css/common.scss', 'css/multi-form-goal-block.css')
-    .sass('src/DonationSummary/resources/css/summary.scss', 'css/give-donation-summary.css')
+   .sass('assets/src/css/frontend/give-frontend.scss', 'css/give.css')
+   .sass('assets/src/css/admin/block-editor.scss', 'css/admin-block-editor.css')
+   .sass('assets/src/css/admin/give-admin.scss', 'css/admin.css')
+   .sass('assets/src/css/admin/give-admin-global.scss', 'css/admin-global.css')
+   .sass('assets/src/css/admin/setup.scss', 'css/admin-setup.css')
+   .sass('assets/src/css/admin/shortcodes.scss', 'css/admin-shortcode-button.css')
+   .sass('assets/src/css/admin/plugin-deactivation-survey.scss', 'css/')
+   .sass('assets/src/css/admin/widgets.scss', 'css/admin-widgets.css')
+   .sass('assets/src/css/admin/paypal-commerce.scss', 'css/admin-paypal-commerce.css')
+   .sass('src/Views/Form/Templates/Sequoia/assets/css/form.scss', 'css/give-sequoia-template.css')
+   .sass('src/Views/Form/Templates/Classic/resources/css/form.scss', 'css/give-classic-template.css')
+   .sass('src/MultiFormGoals/resources/css/common.scss', 'css/multi-form-goal-block.css')
+   .sass('src/DonationSummary/resources/css/summary.scss', 'css/give-donation-summary.css')
 
-    .js('assets/src/js/frontend/give.js', 'js/')
-    .js('assets/src/js/frontend/give-stripe.js', 'js/')
-    .js('assets/src/js/frontend/give-stripe-sepa.js', 'js/')
-    .js('assets/src/js/frontend/give-stripe-becs.js', 'js/')
-    .js('assets/src/js/frontend/paypal-commerce/index.js', 'js/paypal-commerce.js')
-    .js('assets/src/js/admin/admin.js', 'js/')
-    .js('assets/src/js/admin/admin-setup.js', 'js/')
-    .js('assets/src/js/admin/plugin-deactivation-survey.js', 'js/')
-    .js('assets/src/js/admin/admin-add-ons.js', 'js/')
-    .js('assets/src/js/admin/admin-widgets.js', 'js/')
-    .js('assets/src/js/admin/reports/app.js', 'js/admin-reports.js')
-    .js('assets/src/js/admin/reports/widget.js', 'js/admin-reports-widget.js')
-    .js('assets/src/js/admin/onboarding-wizard/index.js', 'js/admin-onboarding-wizard.js')
-    .js('includes/admin/shortcodes/admin-shortcodes.js', 'js/')
-    .js('blocks/load.js', 'js/gutenberg.js')
-    .js('src/Views/Form/Templates/Sequoia/assets/js/form.js', 'js/give-sequoia-template.js')
-    .js('src/Views/Form/Templates/Classic/resources/js/form.js', 'js/give-classic-template.js')
-    .js('src/DonorDashboards/resources/js/app/index.js', 'js/donor-dashboards-app.js')
-    .js('src/DonorDashboards/resources/js/block/index.js', 'js/donor-dashboards-block.js')
-    .js('src/Log/Admin/index.js', 'js/give-log-list-table-app.js')
-    .js('src/MigrationLog/Admin/index.js', 'js/give-migrations-list-table-app.js')
-    .js('src/DonationSummary/resources/js/summary.js', 'js/give-donation-summary.js')
-    .js('src/Promotions/InPluginUpsells/resources/js/addons-admin-page.js', 'js/admin-upsell-addons-page.js')
-    .js(
-        'src/Promotions/InPluginUpsells/resources/js/recurring-donations-settings-tab.js',
-        'js/admin-upsell-recurring-donations-settings-tab.js'
-    )
-    .ts('src/DonationForms/resources/admin-donation-forms.tsx', 'js/give-admin-donation-forms.js')
-    .ts('src/Donors/resources/admin-donors.tsx', 'js/give-admin-donors.js')
-    .ts('src/Donations/resources/index.tsx', 'js/give-admin-donations.js')
-    .ts('src/Subscriptions/resources/admin-subscriptions.tsx', 'js/give-admin-subscriptions.js')
-    .js('src/Promotions/InPluginUpsells/resources/js/sale-banner.js', 'js/admin-upsell-sale-banner.js')
-    .react()
-    .sourceMaps(false, 'source-map')
+   .js('assets/src/js/frontend/give.js', 'js/')
+   .js('assets/src/js/frontend/give-stripe.js', 'js/')
+   .js('assets/src/js/frontend/give-stripe-sepa.js', 'js/')
+   .js('assets/src/js/frontend/give-stripe-becs.js', 'js/')
+   .js('assets/src/js/frontend/paypal-commerce/index.js', 'js/paypal-commerce.js')
+   .js('assets/src/js/admin/admin.js', 'js/')
+   .js('assets/src/js/admin/admin-setup.js', 'js/')
+   .js('assets/src/js/admin/plugin-deactivation-survey.js', 'js/')
+   .js('assets/src/js/admin/admin-add-ons.js', 'js/')
+   .js('assets/src/js/admin/admin-widgets.js', 'js/')
+   .js('assets/src/js/admin/reports/app.js', 'js/admin-reports.js')
+   .js('assets/src/js/admin/reports/widget.js', 'js/admin-reports-widget.js')
+   .js('assets/src/js/admin/onboarding-wizard/index.js', 'js/admin-onboarding-wizard.js')
+   .js('includes/admin/shortcodes/admin-shortcodes.js', 'js/')
+   .js('blocks/load.js', 'js/gutenberg.js')
+   .js('src/Views/Form/Templates/Sequoia/assets/js/form.js', 'js/give-sequoia-template.js')
+   .js('src/Views/Form/Templates/Classic/resources/js/form.js', 'js/give-classic-template.js')
+   .js('src/DonorDashboards/resources/js/app/index.js', 'js/donor-dashboards-app.js')
+   .js('src/DonorDashboards/resources/js/block/index.js', 'js/donor-dashboards-block.js')
+   .js('src/Log/Admin/index.js', 'js/give-log-list-table-app.js')
+   .js('src/MigrationLog/Admin/index.js', 'js/give-migrations-list-table-app.js')
+   .js('src/DonationSummary/resources/js/summary.js', 'js/give-donation-summary.js')
+   .js('src/Promotions/InPluginUpsells/resources/js/addons-admin-page.js', 'js/admin-upsell-addons-page.js')
+   .js(
+       'src/Promotions/InPluginUpsells/resources/js/recurring-donations-settings-tab.js',
+       'js/admin-upsell-recurring-donations-settings-tab.js',
+   )
+   .ts('src/DonationForms/resources/admin-donation-forms.tsx', 'js/give-admin-donation-forms.js')
+   .ts('src/Donors/resources/admin-donors.tsx', 'js/give-admin-donors.js')
+   .ts('src/Donations/resources/index.tsx', 'js/give-admin-donations.js')
+   .ts('src/Subscriptions/resources/admin-subscriptions.tsx', 'js/give-admin-subscriptions.js')
+   .js('src/Promotions/InPluginUpsells/resources/js/sale-banner.js', 'js/admin-upsell-sale-banner.js')
+   .react()
+   .sourceMaps(false, 'source-map')
 
-    .copyDirectory('assets/src/images', 'assets/dist/images')
-    .copyDirectory('assets/src/fonts', 'assets/dist/fonts');
+   .css('node_modules/@givewp/design-system-foundation/css/foundation.css', 'css/design-system/foundation.css')
+   .after(() => {
+       // Store the design system version in a file
+       const packageJson = require('./node_modules/@givewp/design-system-foundation/package.json');
+       const version = packageJson.version;
+
+       fs.writeFileSync('./assets/dist/css/design-system/version', version);
+   })
+
+   .copyDirectory('assets/src/images', 'assets/dist/images')
+   .copyDirectory('assets/src/fonts', 'assets/dist/fonts');
 
 mix.webpackConfig({
     resolve: {


### PR DESCRIPTION
## Description

This PR integrates the [GiveWP Design System](https://www.npmjs.com/package/@givewp/design-system-foundation) by registering the script into WP as `givewp-design-system-foundation`. So whenever someone needs to load the design system, they just need to enqueue that handle!

I also got a little clever and store the package version when webpack runs. This version is then used when registering the style, so if the package is ever updated in the future, the version will automatically change and bust the cache. 🪄 

Otherwise, this is pretty simple!

## Affects

Shouldn't affect any existing code!

## Testing Instructions

Just add `wp_enqueue_style('givewp-design-system-foundation')` to some page (admin or front-end), and then check the JS console to make sure the CSS variables are loaded!

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

