### PR TITLE
Feature: add processing actions to stripe webhook listeners

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/ChargeRefunded.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/ChargeRefunded.php
@@ -20,6 +20,11 @@ class ChargeRefunded extends StripeEventListener
      */
     public function processEvent(Event $event)
     {
+        /**
+         * @unreleased
+         */
+        do_action('give_stripe_processing_charge_refunded', $event);
+
         /* @var Charge $stripeCharge */
         $stripeCharge = $event->data->object;
         $donation = $this->getDonation($event);

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/CheckoutSessionCompleted.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/CheckoutSessionCompleted.php
@@ -2,8 +2,6 @@
 
 namespace Give\PaymentGateways\Gateways\Stripe\Webhooks\Listeners;
 
-use Give\Donations\Models\DonationNote;
-use Give\Donations\Repositories\DonationRepository;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\PaymentGateways\Gateways\Stripe\Webhooks\StripeEventListener;
 use Stripe\Checkout\Session;
@@ -22,6 +20,11 @@ class CheckoutSessionCompleted extends StripeEventListener
      */
     public function processEvent(Event $event)
     {
+        /**
+         * @unreleased
+         */
+        do_action('give_stripe_processing_checkout_session_completed', $event);
+
         /* @var Session $checkoutSession */
         $checkoutSession = $event->data->object;
         $donation = $this->getDonation($event);

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/PaymentIntentPaymentFailed.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/PaymentIntentPaymentFailed.php
@@ -16,6 +16,11 @@ class PaymentIntentPaymentFailed extends StripeEventListener
      */
     public function processEvent(Event $event)
     {
+        /**
+         * @unreleased
+         */
+        do_action('give_stripe_processing_payment_intent_failed', $event);
+
         $donation = $this->getDonation($event);
 
         if (!$donation->status->isFailed()) {

--- a/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/PaymentIntentSucceeded.php
+++ b/src/PaymentGateways/Gateways/Stripe/Webhooks/Listeners/PaymentIntentSucceeded.php
@@ -19,6 +19,11 @@ class PaymentIntentSucceeded extends StripeEventListener
      */
     public function processEvent(Event $event)
     {
+        /**
+         * @unreleased
+         */
+        do_action('give_stripe_processing_payment_intent_succeeded', $event);
+
         /* @var PaymentIntent $paymentIntent */
         $paymentIntent = $event->data->object;
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related: https://github.com/impress-org/givewp-next-gen/pull/141

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds `give_stripe_processing_{stripe_event}` actions to our stripe webhook listeners.  This will specifically give the Next Gen Stripe gateway the opportunity and flexibility of modifying the listener's event processing logic for it's own use cases while not affecting the existing functionality.

Actions added:
- `give_stripe_processing_payment_intent_succeeded`
- `give_stripe_processing_payment_intent_failed`
- `give_stripe_processing_checkout_session_completed`
- `give_stripe_processing_charge_refunded`

Note: we are not using the `givewp` prefix for these because they are still considered legacy at the moment.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Technically the stripe webhook listeners, although they are just added actions so nothing should be affected by this.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Could hook into the added actions and do something.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

