### PR TITLE
Fix: replace deprecated get page by title function

### DIFF
--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -45,7 +45,8 @@ function give_import_donation_report_reset() {
 /**
  * Give get form data from csv if not then create and form and return the form value.
  *
- * @since 1.8.13.
+ * @since      1.8.13.
+ * @unreleased Replace deprecated get_page_by_title() with give_get_page_by_title().
  *
  * @param $data .
  *

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -73,7 +73,7 @@ function give_import_get_form_data_from_csv( $data, $import_setting = [] ) {
 	}
 
 	if ( false === $form && ! empty( $data['form_title'] ) ) {
-		$form = get_page_by_title( $data['form_title'], OBJECT, 'give_forms' );
+		$form = give_get_page_by_title($data['form_title'], OBJECT, 'give_forms');
 
 		if ( ! empty( $form->ID ) ) {
 
@@ -96,7 +96,7 @@ function give_import_get_form_data_from_csv( $data, $import_setting = [] ) {
 
 		}
 
-		$form = get_page_by_title( $data['form_title'], OBJECT, 'give_forms' );
+        $form = give_get_page_by_title($data['form_title'], OBJECT, 'give_forms');
 		if ( ! empty( $form->ID ) ) {
 			$form = new Give_Donate_Form( $form->ID );
 		}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2578,3 +2578,26 @@ function give_check_addon_updates( $_transient_data ) {
 
 	return $_transient_data;
 }
+
+function give_get_page_by_title($page_title, $output = OBJECT, $post_type)
+{
+    $args = [
+        'title' => $page_title,
+        'post_type' => $post_type,
+        'post_status' => get_post_stati(),
+        'posts_per_page' => 1,
+        'update_post_term_cache' => false,
+        'update_post_meta_cache' => false,
+        'no_found_rows' => true,
+        'orderby' => 'post_date ID',
+        'order' => 'ASC',
+    ];
+    $query = new WP_Query($args);
+    $pages = $query->posts;
+
+    if (empty($pages)) {
+        return null;
+    }
+
+    return get_post($pages[0], $output);
+}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2579,6 +2579,17 @@ function give_check_addon_updates( $_transient_data ) {
 	return $_transient_data;
 }
 
+/**
+ * Get page by title
+ *
+ * @unreleased
+ *
+ * @param string $page_title
+ * @param string $output
+ * @param string $post_type
+ *
+ * @return null|WP_Post
+ */
 function give_get_page_by_title($page_title, $output = OBJECT, $post_type)
 {
     $args = [

--- a/src/LegacySubscriptions/includes/give-subscriptions-db.php
+++ b/src/LegacySubscriptions/includes/give-subscriptions-db.php
@@ -633,7 +633,7 @@ class Give_Subscriptions_DB extends Give_DB
             $where .= " AND `id` = " . absint($args['search']) . "";
         } else {
             // See if search matches a product name
-            $form = get_page_by_title(trim($args['search']), OBJECT, 'give_forms');
+            $form = give_get_page_by_title(trim($args['search']), OBJECT, 'give_forms');
             if ($form) {
                 $args['search'] = $form->ID;
                 $where .= " AND `product_id` = " . absint($args['search']) . "";

--- a/src/LegacySubscriptions/includes/give-subscriptions-db.php
+++ b/src/LegacySubscriptions/includes/give-subscriptions-db.php
@@ -600,6 +600,8 @@ class Give_Subscriptions_DB extends Give_DB
     }
 
     /**
+     * @unreleased Replace deprecated get_page_by_title() with give_get_page_by_title().
+     *
      * @param $args
      *
      * @return string

--- a/tests/includes/legacy/importer/tests-donations.php
+++ b/tests/includes/legacy/importer/tests-donations.php
@@ -359,26 +359,26 @@ class Tests_Give_Import_Donations extends Give_Unit_Test_Case {
 
 		$this->import_donation_in_live();
 
-		$form = get_page_by_title( 'Make a wish Foundation', OBJECT, 'give_forms' );
-		$this->assertTrue( ! empty( $form->ID ) );
+		$form = give_get_page_by_title('Make a wish Foundation', OBJECT, 'give_forms');
+        $this->assertTrue(! empty($form->ID));
 		$form = new Give_Donate_Form( $form->ID );
 		$id   = $form->get_ID();
 		$this->assertTrue( ! empty( $id ) );
 
-		$form = get_page_by_title( 'Save the Trees', OBJECT, 'give_forms' );
-		$this->assertTrue( ! empty( $form->ID ) );
+        $form = give_get_page_by_title('Save the Trees', OBJECT, 'give_forms');
+        $this->assertTrue(! empty($form->ID));
 		$form = new Give_Donate_Form( $form->ID );
 		$id   = $form->get_ID();
 		$this->assertTrue( ! empty( $id ) );
 
-		$form = get_page_by_title( 'Help a Child', OBJECT, 'give_forms' );
-		$this->assertTrue( ! empty( $form->ID ) );
+        $form = give_get_page_by_title('Help a Child', OBJECT, 'give_forms');
+        $this->assertTrue(! empty($form->ID));
 		$form = new Give_Donate_Form( $form->ID );
 		$id   = $form->get_ID();
 		$this->assertTrue( ! empty( $id ) );
 
-		$form = get_page_by_title( 'No Donation Form', OBJECT, 'give_forms' );
-		$this->assertTrue( empty( $form->ID ) );
+        $form = give_get_page_by_title('No Donation Form', OBJECT, 'give_forms');
+        $this->assertTrue(empty($form->ID));
 	}
 
 

--- a/tests/includes/legacy/importer/tests-donations.php
+++ b/tests/includes/legacy/importer/tests-donations.php
@@ -349,10 +349,11 @@ class Tests_Give_Import_Donations extends Give_Unit_Test_Case {
 	}
 
 	/**
-	 * To test to check is donation form is created or not
-	 *
-	 * @since 2.1
-	 */
+     * To test to check is donation form is created or not
+     *
+     * @since      2.1
+     * @unreleased Replace deprecated get_page_by_title() with give_get_page_by_title().
+     */
 	public function test_to_check_donation_form_is_created() {
 
 		give_import_donation_report_reset();


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6753

## Description

As a replacement for the deprecated `get_page_by_title` function, this PRs adds our own version of that using `WP_Query`. 

## Affects

Import donations tool

## Visuals

![CleanShot 2023-03-29 at 18 25 44](https://user-images.githubusercontent.com/3921017/228671409-1d483e41-b231-40c4-bd3c-3615a303d188.jpg)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

