### PR TITLE
Fix: add error handling for canceling a subscription in donor dashboard

### DIFF
--- a/src/DonorDashboards/Tabs/Contracts/Route.php
+++ b/src/DonorDashboards/Tabs/Contracts/Route.php
@@ -2,9 +2,11 @@
 
 namespace Give\DonorDashboards\Tabs\Contracts;
 
+use Exception;
 use Give\API\RestRoute;
 use Give\DonorDashboards\Helpers as DonorDashboardHelpers;
 use Give\Log\Log;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -69,6 +71,9 @@ abstract class Route implements RestRoute
         );
     }
 
+    /**
+     * @unreleased add try/catch to handleRequest
+     */
     public function handleRequestWithDonorIdCheck(WP_REST_Request $request)
     {
         // Check that the provided donor ID is valid
@@ -102,6 +107,14 @@ abstract class Route implements RestRoute
             );
         }
 
-        return $this->handleRequest($request);
+        try {
+            $response = $this->handleRequest($request);
+
+            return rest_ensure_response($response ?? []);
+        } catch (Exception $exception) {
+            $error = new WP_Error('error', $exception->getMessage());
+
+            return rest_ensure_response($error);
+        }
     }
 }

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
@@ -3,10 +3,26 @@ import {cancelSubscriptionWithAPI} from './utils';
 
 import {__} from '@wordpress/i18n';
 import './style.scss';
+import {useState} from 'react';
+
+const responseIsError = (response) => {
+    return response?.data?.code === 'error';
+};
 
 const SubscriptionCancelModal = ({id, onRequestClose}) => {
+    const [cancelling, setCancelling] = useState(false);
     const handleCancel = async () => {
-        await cancelSubscriptionWithAPI(id);
+        setCancelling(true);
+        const response = await cancelSubscriptionWithAPI(id);
+
+        if (responseIsError(response)) {
+            window.alert(
+                response?.data?.message ?? __('An error occurred while cancelling your subscription.', 'give')
+            );
+        }
+
+        setCancelling(false);
+
         onRequestClose();
     };
 
@@ -16,7 +32,9 @@ const SubscriptionCancelModal = ({id, onRequestClose}) => {
                 <div className="give-donor-dashboard-cancel-modal__header">{__('Cancel Subscription?', 'give')}</div>
                 <div className="give-donor-dashboard-cancel-modal__body">
                     <div className="give-donor-dashboard-cancel-modal__buttons">
-                        <Button onClick={() => handleCancel()}>{__('Yes, cancel', 'give')}</Button>
+                        <Button disabled={cancelling} onClick={() => handleCancel()}>
+                            {!cancelling ? __('Yes, cancel', 'give') : __('Cancelling...', 'give')}
+                        </Button>
                         <a className="give-donor-dashboard-cancel-modal__cancel" onClick={() => onRequestClose()}>
                             {__('Nevermind', 'give')}
                         </a>

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
@@ -6,7 +6,15 @@ import './style.scss';
 import {useState} from 'react';
 
 const responseIsError = (response) => {
-    return response?.data?.code === 'error';
+    return response?.data?.code.includes('error');
+};
+
+const getErrorMessageFromResponse = (response) => {
+    if (response?.data?.code === 'internal_server_error' || !response?.data?.message) {
+        return __('An error occurred while cancelling your subscription.', 'give');
+    }
+
+    return response?.data?.message;
 };
 
 const SubscriptionCancelModal = ({id, onRequestClose}) => {
@@ -16,9 +24,9 @@ const SubscriptionCancelModal = ({id, onRequestClose}) => {
         const response = await cancelSubscriptionWithAPI(id);
 
         if (responseIsError(response)) {
-            window.alert(
-                response?.data?.message ?? __('An error occurred while cancelling your subscription.', 'give')
-            );
+            const errorMessage = getErrorMessageFromResponse(response);
+            
+            window.alert(errorMessage);
         }
 
         setCancelling(false);

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
@@ -1,17 +1,20 @@
 import {donorDashboardApi} from '../../../utils';
 import {fetchSubscriptionsDataFromAPI} from '../../../tabs/recurring-donations/utils';
 
-export const cancelSubscriptionWithAPI = (id) => {
-    return donorDashboardApi
-        .post(
+export const cancelSubscriptionWithAPI = async (id) => {
+    try {
+        const response = await donorDashboardApi.post(
             'recurring-donations/subscription/cancel',
             {
                 id: id,
             },
             {}
-        )
-        .then(async (response) => {
-            await fetchSubscriptionsDataFromAPI();
-            return response;
-        });
+        );
+
+        await fetchSubscriptionsDataFromAPI();
+
+        return await response;
+    } catch (error) {
+        return error.response;
+    }
 };


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I recently discovered there is a lack of error handling in the donor dashboard.  This adds error handling to the endpoint request and the UI for cancelling a subscription.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donor dashboard - cancel subscription functionality.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="787" alt="Screenshot 2023-03-30 at 5 01 00 PM" src="https://user-images.githubusercontent.com/10138447/228963556-21803995-f2ac-48a8-826e-8b3aae6e057f.png">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

You will need something to go wrong with the gateway while cancelling to test this out.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204309736724098