### PR TITLE
Feature: admin donation details api comment field

### DIFF
--- a/src/Donations/Endpoints/DonationUpdate.php
+++ b/src/Donations/Endpoints/DonationUpdate.php
@@ -7,6 +7,7 @@ use Give\Donations\Endpoints\DonationUpdateAttributes\Address2Attribute;
 use Give\Donations\Endpoints\DonationUpdateAttributes\AmountAttribute;
 use Give\Donations\Endpoints\DonationUpdateAttributes\AttributeUpdatesModel;
 use Give\Donations\Endpoints\DonationUpdateAttributes\CityAttribute;
+use Give\Donations\Endpoints\DonationUpdateAttributes\CommentAttribute;
 use Give\Donations\Endpoints\DonationUpdateAttributes\CountryAttribute;
 use Give\Donations\Endpoints\DonationUpdateAttributes\CreatedAtAttribute;
 use Give\Donations\Endpoints\DonationUpdateAttributes\DonorIdAttribute;
@@ -52,6 +53,7 @@ class DonationUpdate extends Endpoint
         CityAttribute::class,
         StateAttribute::class,
         ZipAttribute::class,
+        CommentAttribute::class,
     ];
 
     /**
@@ -114,7 +116,7 @@ class DonationUpdate extends Endpoint
                 if ( ! $request->has_param($attrId) || ! is_a($attr, AttributeUpdatesModel::class, true)) {
                     continue;
                 }
-                
+
                 $attr::update($request->get_param($attrId), $donation);
                 $updatedFields[] = $attrId;
             }

--- a/src/Donations/Endpoints/DonationUpdateAttributes/CommentAttribute.php
+++ b/src/Donations/Endpoints/DonationUpdateAttributes/CommentAttribute.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Give\Donations\Endpoints\DonationUpdateAttributes;
+
+use Give\Donations\Models\Donation;
+
+/**
+ * Class StateAttribute
+ *
+ * @unreleased
+ */
+class CommentAttribute extends DonationUpdateAttribute implements AttributeUpdatesModel
+{
+    /**
+     * @inheritDoc
+     */
+    public static function getId(): string
+    {
+        return 'comment';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDefinition(): array
+    {
+        return [
+            'type' => 'string',
+            'required' => false,
+            'sanitize_callback' => 'sanitize_textarea_field',
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function update($value, Donation $donation)
+    {
+        $donation->comment = $value;
+    }
+}

--- a/src/Donations/ViewModels/DonationDetailsViewModel.php
+++ b/src/Donations/ViewModels/DonationDetailsViewModel.php
@@ -48,6 +48,11 @@ class DonationDetailsViewModel
             ];
         }
 
+        if ( ! is_null($this->donation->donor->id)) {
+            $userId = $this->donation->donor->userId;
+            $donationArray['donorAvatar'] = get_avatar_url($userId, ['size' => 40]);
+        }
+
         if ( ! is_null($this->donation->feeAmountRecovered)) {
             $donationArray['feeAmountRecovered'] = [
                 'currency' => $this->donation->feeAmountRecovered->getCurrency(),
@@ -55,7 +60,9 @@ class DonationDetailsViewModel
             ];
         }
 
-        $donationArray['gatewayLabel'] = give_get_gateway_checkout_label($this->donation->gatewayId);
+        if ( ! is_null($this->donation->gatewayId)) {
+            $donationArray['gatewayLabel'] = give_get_gateway_checkout_label($this->donation->gatewayId);
+        }
 
         return $donationArray;
     }

--- a/tests/Unit/Donations/Endpoints/TestDonationUpdate.php
+++ b/tests/Unit/Donations/Endpoints/TestDonationUpdate.php
@@ -190,6 +190,35 @@ class TestDonationUpdate extends RestApiTestCase
     }
 
     /**
+     * Test that a valid billing address details update request returns a successful response.
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testValidRequestWithComment()
+    {
+        $donation = Donation::factory()->create();
+        $donationId = $donation->id;
+
+        $comment = $this->faker()->text(144);
+
+        $response = $this->handleRequest($donationId, ['comment' => $comment]);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertEquals(200, $response->get_status());
+
+        $data = $response->get_data();
+        $this->assertArrayHasKey('success', $data);
+        $this->assertTrue($data['success']);
+        $this->assertCount(1, $data['updatedFields']);
+
+        $donation = give()->donations->getById($donationId);
+
+        $this->assertEquals($comment, $donation->comment);
+    }
+
+    /**
      * Test that an invalid donation ID returns an error.
      *
      * @unreleased


### PR DESCRIPTION
Blocked by https://github.com/impress-org/givewp/pull/6765

## Description

This pull request introduces a new `comment` attribute to the Donation Update endpoint.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

