### PR TITLE
Feature: add filter for `give_stripe_supported_payment_methods`

### DIFF
--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -18,21 +18,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * This function is used to get a list of slug which are supported by payment gateways.
  *
+ * @unreleased add filter for the array of supported stripe gateways.
  * @since 2.5.5
  *
  * @return array
  */
-function give_stripe_supported_payment_methods() {
-	return [
-		'stripe',
-		'stripe_ach',
-		'stripe_ideal',
-		'stripe_google_pay',
-		'stripe_apple_pay',
-		'stripe_checkout',
-		'stripe_sepa',
-		'stripe_becs',
-	];
+function give_stripe_supported_payment_methods()
+{
+    return apply_filters('give_stripe_supported_payment_methods', [
+        'stripe',
+        'stripe_ach',
+        'stripe_ideal',
+        'stripe_google_pay',
+        'stripe_apple_pay',
+        'stripe_checkout',
+        'stripe_sepa',
+        'stripe_becs',
+    ]);
 }
 
 /**

--- a/tests/Unit/PaymentGateways/Stripe/Filters/LegacyStripeFiltersTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/Filters/LegacyStripeFiltersTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Give\Tests\Unit\PaymentGateways\Stripe\Filters;
+
+use Give\Tests\TestCase;
+
+/**
+ * @unreleased
+ */
+class LegacyStripeFiltersTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function test_give_stripe_supported_payment_methods_returns_expected_payment_methods()
+    {
+        add_action('give_stripe_supported_payment_methods', static function ($paymentMethods) {
+            $paymentMethods[] = 'next-gen-stripe';
+
+            return $paymentMethods;
+        });
+
+        $gateways = give_stripe_supported_payment_methods();
+
+        $this->assertContains('next-gen-stripe', $gateways);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related: https://github.com/impress-org/givewp-next-gen/pull/159

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Currently all the stripe gateway id's are hardcoded into a list that gets checked for all things Stripe (like including stripe webhooks).  In Next Gen we need a way to add a new Stripe gateway without hardcoding the id in core.  This filter will allow us to extend this list.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `give_stripe_supported_payment_methods()` function

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure existing Stripe gateways load properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

