### PR TITLE
Fix: Add polyfill for the Mbstring extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "symfony/http-foundation": "^v3.4.47",
         "moneyphp/money": "v3.3.1",
         "stellarwp/validation": "^1.0",
-        "symfony/polyfill-ctype": "^1.19"
+        "symfony/polyfill-ctype": "^1.19",
+        "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -87,11 +88,13 @@
             "constant_prefix": "GIVE_VENDORS_",
             "packages": [
                 "stellarwp/validation",
-                "symfony/polyfill-ctype"
+                "symfony/polyfill-ctype",
+                "symfony/polyfill-mbstring"
             ],
             "delete_vendor_packages": true,
             "override_autoload": {
-                "symfony/polyfill-ctype": {}
+                "symfony/polyfill-ctype": {},
+                "symfony/polyfill-mbstring": {}
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e74eed3d3a1547f86e7732716e34f7f7",
+    "content-hash": "bf5e20f97ea1841fc2a1d47e2dea90ab",
     "packages": [
         {
             "name": "composer/installers",
@@ -868,12 +868,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/src/Framework/Support/Facades/Str.php
+++ b/src/Framework/Support/Facades/Str.php
@@ -557,6 +557,8 @@ class Str
     /**
      * Reverse the given string.
      *
+     * @unreleased Required the symfony/polyfill-mbstring package.
+     *
      * @param  string  $value
      * @return string
      */

--- a/src/Framework/Support/Facades/Str.php
+++ b/src/Framework/Support/Facades/Str.php
@@ -557,8 +557,6 @@ class Str
     /**
      * Reverse the given string.
      *
-     * @unreleased Required the symfony/polyfill-mbstring package.
-     *
      * @param  string  $value
      * @return string
      */


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6772

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR requires the `symphony/polyfill-mbstring` package, which resolves a PHP version compatibility issue related to `Str::reverse()`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
 
The GiveWP plugin should not pass the PHP Compatibility check for `7.0`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204442996207314