### PR TITLE
Fix: change how update_plugins transient is invalidated

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2505,7 +2505,7 @@ function give_refresh_licenses( $wp_check_updates = true ) {
 
 	// Tell WordPress to look for updates.
 	if ( $wp_check_updates ) {
-		set_site_transient( 'update_plugins', null );
+		delete_site_transient('update_plugins');
 	}
 
 	return [

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -2407,12 +2407,13 @@ function give_get_addon_readme_url( $plugin_slug, $by_plugin_name = false ) {
 /**
  * Refresh all givewp license.
  *
- * @param bool $wp_check_updates
+ * @unreleased delete update_plugins transient instead of invalidate it
+ * @since  2.5.0
+ *
+ * @param  bool  $wp_check_updates
  *
  * @access public
  * @return array|WP_Error
- *
- * @since  2.5.0
  */
 function give_refresh_licenses( $wp_check_updates = true ) {
 	$give_licenses = get_option( 'give_licenses', [] );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6775 

## Description

This PR addresses an issue in which Give was modifying the `update_plugins` transient to `null`, forcing WordPress to search for new updates. However, WooCommerce has a hook that is triggered when the transient is saved, adding a translations key to it. But since it was receiving a null value instead of an object, it caused a fatal error.

To resolve this, the best solution is to delete the transient rather than invalidate it. This way, WordPress can recreate it, ensuring it's created correctly.

## Affects

Give Licenses page

## Testing Instructions

1. In a fresh WP install, install and activate Give core + WooCommerce 5.2.2 then install any additional Give Add-on.
2. Change WP language to another but English US in Settings > General.
3. Open Donations > Settings > Licenses and see the page loads correctly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

