### PR TITLE
Chore: Remove redundent composer install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
 
-            -   name: Remove dev dependencies
+            -   name: Install composer dependencies
                 uses: php-actions/composer@v5
                 with:
                     php_version: 7.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
 
-            -   name: Install composer dev dependencies
-                run: composer install --no-progress --no-interaction
-
             -   name: Remove dev dependencies
                 uses: php-actions/composer@v5
                 with:


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The `php-actions/composer` action is a wrapper around the `composer`, with the default command being `composer install`.

Further, it default to no interaction, no progress (output).

By default it does install dev dependencies, but we disable that by passing `dev: no`.