### PR TITLE
Fix: Add user-friendly error messages for Stripe payments

### DIFF
--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -32,16 +32,16 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		}
 
 		/**
-		 * This function is used to create payment intent in Stripe.
-		 *
-		 * @param array $args List of parameters required to create payment intent.
-		 *
-         * @unreleased Stripe payment intent error displays Exception message.
-		 * @since  2.5.0
-		 * @access public
-		 *
-		 * @return bool|\Stripe\PaymentIntent
-		 */
+         * This function is used to create payment intent in Stripe.
+         *
+         * @unreleased Stripe payment intent error sets a more user friendly Exception message.
+         * @since      2.5.0
+         * @access     public
+         *
+         * @param array $args List of parameters required to create payment intent.
+         *
+         * @return bool|\Stripe\PaymentIntent
+         */
 		public function create( $args ) {
 
 			// Add application fee, if the Stripe premium add-on is not active.

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -132,24 +132,25 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 			give_stripe_set_app_info();
 
 			try {
-				return \Stripe\PaymentIntent::update(
-					$client_secret,
-					$args,
-					give_stripe_get_connected_account_options()
-				);
-			} catch ( Exception $e ) {
+                return \Stripe\PaymentIntent::update(
+                    $client_secret,
+                    $args,
+                    give_stripe_get_connected_account_options()
+                );
+            } catch (Exception $e) {
+                give_record_gateway_error(
+                    __('Stripe Payment Intent Error', 'give'),
+                    sprintf(
+                    /* translators: %s Exception Error Message */
+                        __('Unable to update a payment intent. Details: %s', 'give'),
+                        $e->getMessage()
+                    )
+                );
 
-				give_record_gateway_error(
-					__( 'Stripe Payment Intent Error', 'give' ),
-					sprintf(
-						/* translators: %s Exception Error Message */
-						__( 'Unable to update a payment intent. Details: %s', 'give' ),
-						$e->getMessage()
-					)
-				);
-
-				give_set_error( 'stripe_payment_intent_error', __( 'Error updating payment intent with Stripe. Please try again.', 'give' ) );
-			} // End try().
-		}
+                give_set_error('stripe_payment_intent_error',
+                    __('There was an issue with your donation transaction. Please check your payment method or contact your card issuer for assistance. If the issue persists, try a different payment method or contact the site administrators.',
+                        'give'));
+            } // End try().
+        }
 	}
 }

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -56,21 +56,23 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 					$args,
 					give_stripe_get_connected_account_options()
 				);
-			} catch ( Exception $e ) {
+            } catch (Exception $e) {
+                give_record_gateway_error(
+                    __('Stripe Payment Intent Error', 'give'),
+                    sprintf(
+                    /* translators: %s Exception Error Message */
+                        __('Unable to create a payment intent. Details: %s', 'give'),
+                        $e->getMessage()
+                    )
+                );
 
-				give_record_gateway_error(
-					__( 'Stripe Payment Intent Error', 'give' ),
-					sprintf(
-						/* translators: %s Exception Error Message */
-						__( 'Unable to create a payment intent. Details: %s', 'give' ),
-						$e->getMessage()
-					)
-				);
+                give_set_error('stripe_payment_intent_error',
+                    $e->getMessage()
+                );
 
-				give_set_error( 'stripe_payment_intent_error', __( 'Error creating payment intent with Stripe. Please try again.', 'give' ) );
-				return false;
-			} // End try().
-		}
+                return false;
+            } // End try().
+        }
 
 		/**
 		 * This function is used to retrieve payment intent in Stripe.

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -36,6 +36,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
 		 *
 		 * @param array $args List of parameters required to create payment intent.
 		 *
+         * @unreleased Stripe payment intent error displays Exception message.
 		 * @since  2.5.0
 		 * @access public
 		 *

--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -68,8 +68,8 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
                 );
 
                 give_set_error('stripe_payment_intent_error',
-                    $e->getMessage()
-                );
+                    __('There was an issue with your donation transaction. Please check your payment method or contact your card issuer for assistance. If the issue persists, try a different payment method or contact the site administrators.',
+                        'give'));
 
                 return false;
             } // End try().
@@ -148,8 +148,7 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
                 );
 
                 give_set_error('stripe_payment_intent_error',
-                    __('There was an issue with your donation transaction. Please check your payment method or contact your card issuer for assistance. If the issue persists, try a different payment method or contact the site administrators.',
-                        'give'));
+                    __('Error updating payment intent with Stripe. Please try again.', 'give'));
             } // End try().
         }
 	}

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -32,7 +32,10 @@ trait HandlePaymentIntentStatus
                 return new PaymentProcessing($paymentIntent->id());
             default:
                 throw new PaymentIntentException(
-                    sprintf(__('Unhandled payment intent status: %s', 'give'), $paymentIntent->status())
+                    sprintf(__('%s Sorry, there was an issue with your payment. Please check your payment method
+                    or contact your card issuer for assistance. If the issue persists, please try again later or contact our support
+                    team for further assistance.', 'give'),
+                        $paymentIntent->status())
                 );
         }
     }

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -33,11 +33,7 @@ trait HandlePaymentIntentStatus
                 return new PaymentProcessing($paymentIntent->id());
             default:
                 throw new PaymentIntentException(
-                    sprintf(__('%s Sorry, there was an issue with your payment. Please check your payment method
-                    or contact your card issuer for assistance. If the issue persists, please try again later or contact our support
-                    team for further assistance.', 'give'),
-                        $paymentIntent->status())
-                );
+                    sprintf(__('Unhandled payment intent status: %s', 'give'), $paymentIntent->status()));
         }
     }
 }

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -13,6 +13,7 @@ use Give\PaymentGateways\Gateways\Stripe\ValueObjects\PaymentIntent;
 trait HandlePaymentIntentStatus
 {
     /**
+     * @unreleased Update PaymentIntentException message.
      * @since 2.21.0 Update second argument type to Donation model
      * @since 2.19.7 fix param order and only pass donationId
      *


### PR DESCRIPTION
Resolves #6786

## Description
This pull request adds more user-friendly error messages for Stripe payments. When a user faces an error during the payment process, the new error messages provide more context about the issue, which will help them to take appropriate actions to resolve the issue.

## Affects

Stripe Payments

## Visuals
<img width="1727" alt="Screen Shot 2023-05-07 at 10 41 11 AM" src="https://user-images.githubusercontent.com/75056371/236693661-e3fcebda-0887-4031-97ba-17619c0f724c.png">

## Testing Instructions

- Create a form and setup Stripe as a payment option.
- Make a donation that would generally cause a user-facing error. For example, you can use a test card with no balance. The card number is 4000 0000 0000 9995.
- View new error messages.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

