### PR TITLE
Fix: Remove locale from PayPal SDK query parameters

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -147,7 +147,6 @@ EOT;
             'client-id' => $merchant->clientId,
             'merchant-id' => $merchant->merchantIdInPayPal,
             'components' => 'hosted-fields,buttons',
-            'locale' => get_locale(),
             'disable-funding' => 'credit',
             'vault' => true,
             'data-partner-attribution-id' => give('PAYPAL_COMMERCE_ATTRIBUTION_ID'),

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -142,6 +142,7 @@ EOT;
 
         /**
          * List of PayPal query parameters: https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters
+         * @unreleased Removes locale from parameters.
          */
         $payPalSdkQueryParameters = [
             'client-id' => $merchant->clientId,

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -142,7 +142,7 @@ EOT;
 
         /**
          * List of PayPal query parameters: https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters
-         * @unreleased Removes locale from parameters.
+         * @unreleased Removed locale query parameter.
          */
         $payPalSdkQueryParameters = [
             'client-id' => $merchant->clientId,


### PR DESCRIPTION
Resolves #6790

## Description

Errors occurred when locale information being sent through Paypals SDK query parameters do not match the expected Paypal format. Per Paypals recommendation this PR removes the local parameter from being sent so that Paypal can automatically set this information.

Reference: https://developer.paypal.com/sdk/js/configuration/#link-queryparameters
<img width="1722" alt="Screen Shot 2023-04-28 at 2 41 48 PM" src="https://user-images.githubusercontent.com/75056371/235260753-cc447f47-3082-41f3-98dc-74d568eb2cd8.png">

## Affects

Paypal Donations

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204525071226798