### PR TITLE
fix: prevent javascript error on subscription cancellation from donor dashboard

### DIFF
--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.js
@@ -6,7 +6,7 @@ import './style.scss';
 import {useState} from 'react';
 
 const responseIsError = (response) => {
-    return response?.data?.code.includes('error');
+    return response?.data?.code?.includes('error');
 };
 
 const getErrorMessageFromResponse = (response) => {
@@ -25,7 +25,7 @@ const SubscriptionCancelModal = ({id, onRequestClose}) => {
 
         if (responseIsError(response)) {
             const errorMessage = getErrorMessageFromResponse(response);
-            
+
             window.alert(errorMessage);
         }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://lw.slack.com/archives/C04SLRDD9CK/p1682958076271749

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
On the donor dashboard, I found that the subscription cancellation modal froze because of a javascript error.

![image](https://user-images.githubusercontent.com/1784821/235494964-ff791e55-2c5f-41ce-b441-d648d123a62b.png)

This issue occurs because `CancelSubscriptionRoute` returns `void` while the javascript request handler expects a response in a specific format: `response?.data?.code.includes('error')`

As discussed with @jonwaldstein I made the `code` object key optional to fix the issue.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

