### PR TITLE
Fix: do not need to pass locale when request PayPal javascript SDK

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -147,7 +147,6 @@ EOT;
             'client-id' => $merchant->clientId,
             'merchant-id' => $merchant->merchantIdInPayPal,
             'components' => 'hosted-fields,buttons',
-            'locale' => get_locale(),
             'disable-funding' => 'credit',
             'vault' => true,
             'data-partner-attribution-id' => give('PAYPAL_COMMERCE_ATTRIBUTION_ID'),

--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -128,6 +128,7 @@ EOT;
     /**
      * Load public assets.
      *
+     * @unreleased Remove locale from PayPal SDK.
      * @since 2.9.0
      */
     public function loadPublicAssets()


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://lw.slack.com/archives/C04UT6UPERW/p1682709955254169

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I found that WordPress locale code does not match the PayPal locale code; for this reason, PayPal javascript SDK does not load on fewer websites. To prevent this issue, the team decided not to pass the locale because PayPal localized translation in the client browser language.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects PayPal javascript SDK loading.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
PayPal javascript SDK should load for the following site languages:
1. `English (United States)`
2. `Afrikaans`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

