### PR TITLE
Fix: Display errors for PayPal Smart Buttons

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/SmartButtons.js
+++ b/assets/src/js/frontend/paypal-commerce/SmartButtons.js
@@ -126,7 +126,7 @@ class SmartButtons extends PaymentMethod {
 			return actions.resolve();
 		}
 
-		Give.form.fn.addErrors( this.jQueryForm, result );
+		this.showError( result );
 		return actions.reject();
 	}
 


### PR DESCRIPTION
Resolves #6804

### Description

The problem lies in the fact that the function was trying to display errors using the Give.form.fn interface. When looking at Give.form.fn.addErrors, we see that it first looks for an element of id="give-purchase-submit" (see full query) in order to inject the error messages before that element in the DOM. On classic forms, no such element exists to match this query. Errors never get displayed.

Since the handler mentioned in issued #6804 is part of the Smart Buttons frontend code, we can use the DonationForm interface to add the buttons - that is much more appropriate.

### Affects
Classic form front-end, displaying errors on form.

### Testing Instructions

- Navigate to classic form with committed changes of SmartButtons.js
- Enter incomplete user information (first name, e-mail), or an invalid email
- Click PayPal Smart Button to pay via PayPal
- Confirm errors show on form notifying user of incomplete and/or invalid information

### Pre-review Checklist

* [x] Acceptance Criteria satisfied and marked in related issue
* [ ] Relevant `@unreleased` tags included in DocBlocks
* [ ] Includes unit tests
* [ ] Reviewed by the designer (if follows a design)
* [x] [Self-Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204623625528290