### PR TITLE
New: Support Slack-bot-based zip packaging requests

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -7,6 +7,21 @@ on:
                 description: 'Git Commit Ref (branch, tag, or hash)'
                 required: true
                 type: string
+            production:
+                description: 'Is this a production build?'
+                default: false
+                type: boolean
+            slack_channel:
+                description: 'Slack channel ID to post to'
+                default: ''
+                required: false
+                type: string
+            slack_thread:
+                description: 'Slack thread to post to'
+                default: ''
+                required: false
+                type: string
+
 
 jobs:
     build:
@@ -14,3 +29,7 @@ jobs:
         with:
             ref: ${{ github.event.inputs.ref }}
             plugin_slug: give
+            production: ${{ github.event.inputs.production }}
+            slack_channel: ${{ github.event.inputs.slack_channel }}
+            slack_thread: ${{ github.event.inputs.slack_thread }}
+        secrets: inherit

--- a/package.json
+++ b/package.json
@@ -19,6 +19,17 @@
         "url": "https://github.com/impress-org/give/issues"
     },
     "homepage": "https://github.com/impress-org/give#readme",
+    "_zipname": "give",
+    "_version_files": [
+        {
+            "file": "give.php",
+            "regex": "(define\\('GIVE_VERSION', ')([^']+)"
+        },
+        {
+            "file": "give.php",
+            "regex": "(Version: )([^\\s]+)"
+        }
+    ],
     "devDependencies": {
         "@babel/core": "^7.13.10",
         "@babel/eslint-parser": "^7.13.10",


### PR DESCRIPTION
## Description

This tweaks the `generate-zip.yml` workflow so that it passes along some extra values to the `givewp-github-actions` zip workflow that enable versioned builds and Slack communication.

To support the versioned builds, a tweak to `package.json` is necessary so that we can read/write version number data in plugin files.

## Affects

This should not impact anything beyond giving the `generate-zip.yml` more values to use.

## Testing Instructions

Run the `Generate Zip` workflow and ensure it continues to build and upload a zip artifact to the workflow.

## Related PRs

* https://github.com/impress-org/givewp-github-actions/pull/8