### PR TITLE
Enhancement: Add generics to container functions

### DIFF
--- a/give.php
+++ b/give.php
@@ -523,11 +523,13 @@ final class Give
  * @since 2.8.0 add parameter for quick retrieval from container
  * @since 1.0
  *
- * @param null $abstract Selector for data to retrieve from the service container
+ * @template T
  *
- * @return object|Give
+ * @param class-string<T>|null $abstract Selector for data to retrieve from the service container
+ *
+ * @return Give|T
  */
-function give($abstract = null)
+function give(string $abstract = null)
 {
     static $instance = null;
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -511,10 +511,12 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param string $abstract
+     * @template T
+     *
+     * @param class-string<T> $abstract
      * @param array  $parameters
      *
-     * @return mixed
+     * @return T|mixed
      */
     public function make(string $abstract, array $parameters = [])
     {
@@ -524,9 +526,11 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Finds an entry of the container by its identifier and returns it.
      *
-     * @param string $id Identifier of the entry to look for.
+     * @template T
      *
-     * @return mixed Entry.
+     * @param class-string<T> $id Identifier of the entry to look for.
+     *
+     * @return T|mixed Entry.
      * @throws InvalidArgumentException|BindingResolutionException
      */
     public function get(string $id)
@@ -545,7 +549,11 @@ class Container implements ArrayAccess, ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @return mixed
+     * @template T
+     *
+     * @param class-string<T> $abstract
+     *
+     * @return T|mixed
      * @throws BindingResolutionException
      */
     protected function resolve(string $abstract, array $parameters = [], bool $raiseEvents = true)


### PR DESCRIPTION
## Description

This is a small DX improvement that helps PhpStorm know which class is being returned when the container functions are used. With this, autocomplete will work when doing something like `give(ServiceProvider::class)->register()`.

## Affects

I did change the signature of `give()` to enforce a string, but searched the codebase to make sure all usages of the function are passing strings.

## Visuals

<img width="931" alt="image" src="https://github.com/impress-org/givewp/assets/2024145/a400a993-1d25-498c-b1b4-1b084dd7dd0c">

## Testing Instructions

Autocomplete should work when passing a class, so try that out! Make sure you're using the latest version of PhpStorm.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

