### PR TITLE
Fix: insert/update fee amount recovered using the donation model

### DIFF
--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -316,6 +316,7 @@ class DonationRepository
     }
 
     /**
+     * @unreleased update _give_fee_donation_amount meta with donation amount and add the recovered fee to donation total
      * @since 2.20.0 update amount to use new type, and add currency and exchange rate
      * @since 2.19.6
      */
@@ -349,9 +350,15 @@ class DonationRepository
         ];
 
         if ($donation->feeAmountRecovered !== null) {
-            $meta[DonationMetaKeys::FEE_AMOUNT_RECOVERED] = $donation->feeAmountRecovered->formatToDecimal();
-            $meta[DonationMetaKeys::FEE_DONATION_AMOUNT] = $donation->amount->formatToDecimal();
-            $meta[DonationMetaKeys::AMOUNT] = $donation->amount->add($donation->feeAmountRecovered)->formatToDecimal();
+            $meta[DonationMetaKeys::FEE_DONATION_AMOUNT] = $meta[DonationMetaKeys::AMOUNT];
+            $meta[DonationMetaKeys::FEE_AMOUNT_RECOVERED] = give_sanitize_amount_for_db(
+                $donation->feeAmountRecovered->formatToDecimal(),
+                ['currency' => $donation->amount->getCurrency()]
+            );
+            $meta[DonationMetaKeys::AMOUNT] = give_sanitize_amount_for_db(
+                $donation->amount->add($donation->feeAmountRecovered)->formatToDecimal(),
+                ['currency' => $donation->amount->getCurrency()]
+            );
         }
 
         if ($donation->billingAddress !== null) {

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -350,6 +350,8 @@ class DonationRepository
 
         if ($donation->feeAmountRecovered !== null) {
             $meta[DonationMetaKeys::FEE_AMOUNT_RECOVERED] = $donation->feeAmountRecovered->formatToDecimal();
+            $meta[DonationMetaKeys::FEE_DONATION_AMOUNT] = $donation->amount->formatToDecimal();
+            $meta[DonationMetaKeys::AMOUNT] = $donation->amount->add($donation->feeAmountRecovered)->formatToDecimal();
         }
 
         if ($donation->billingAddress !== null) {

--- a/src/Donations/ValueObjects/DonationMetaKeys.php
+++ b/src/Donations/ValueObjects/DonationMetaKeys.php
@@ -36,6 +36,7 @@ use Give\Framework\Support\ValueObjects\EnumInteractsWithQueryBuilder;
  * @method static DonationMetaKeys SUBSCRIPTION_INITIAL_DONATION()
  * @method static DonationMetaKeys IS_RECURRING()
  * @method static DonationMetaKeys FEE_AMOUNT_RECOVERED()
+ * @method static DonationMetaKeys FEE_DONATION_AMOUNT()
  * @method static DonationMetaKeys EXCHANGE_RATE()
  */
 class DonationMetaKeys extends Enum
@@ -47,6 +48,7 @@ class DonationMetaKeys extends Enum
     const CURRENCY = '_give_payment_currency';
     const EXCHANGE_RATE = '_give_cs_exchange_rate';
     const FEE_AMOUNT_RECOVERED = '_give_fee_amount';
+    const FEE_DONATION_AMOUNT = '_give_fee_donation_amount';
     const GATEWAY = '_give_payment_gateway';
     const DONOR_ID = '_give_payment_donor_id';
     const FIRST_NAME = '_give_donor_billing_first_name';


### PR DESCRIPTION
## Description

The Donation Amount value was not correctly displayed when the Fee Amount Recovered property was modified using the Donation model. To fix this issue, this Pull Request updates the `_give_fee_donation_amount` meta with the original value of `_give_payment_total`. Then, it updates the `_give_payment_total` with the sum of `_give_fee_amount` and `_give_fee_donation_amount`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

