### PR TITLE
Fix: Improve error handling for fee recovery product recommendation on Settings page

### DIFF
--- a/src/Promotions/InPluginUpsells/resources/js/payment-gateway.ts
+++ b/src/Promotions/InPluginUpsells/resources/js/payment-gateway.ts
@@ -24,19 +24,16 @@ export interface GiveSettingsData {
 const feeRecoveryProductRecommendation = document.querySelector(
     '.givewp-payment-gateway-fee-recovery-recommendation-row'
 );
-const dismissAction = document.querySelector('.givewp-payment-gateway-fee-recovery-recommendation_close');
-const table = document.querySelector('.give-setting-tab-body-gateways');
-const preceedingContent = table.querySelector('tr');
-
-preceedingContent.insertAdjacentElement('afterend', feeRecoveryProductRecommendation);
 
 if (feeRecoveryProductRecommendation) {
+    const dismissAction = document.querySelector('.givewp-payment-gateway-fee-recovery-recommendation_close');
+    const table = document.querySelector('.give-setting-tab-body-gateways');
+    const preceedingContent = table.querySelector('tr');
+
+    preceedingContent.insertAdjacentElement('afterend', feeRecoveryProductRecommendation);
+
     dismissAction.addEventListener('click', async function (event) {
         feeRecoveryProductRecommendation.remove();
-        await dismissRecommendation(
-            'givewp_payment_gateway_fee_recovery_recommendation',
-            window.GiveSettings.apiNonce
-        );
+        await dismissRecommendation('givewp_payment_gateway_fee_recovery_recommendation', window.GiveSettings.apiNonce);
     });
 }
-


### PR DESCRIPTION
## Description
This pull request resolves the issue of console warnings related to the product recommendation notice on the Settings page. The warning message "Uncaught TypeError: Failed to execute 'insertAdjacentElement' on 'Element': parameter 2 is not of type 'Element'" was appearing because a method was being applied to an element that had been removed from the DOM (product recommendation notice). To fix this, the method and variables targeting the elements necessary for managing the notices have been encapsulated inside an if statement.

## Affects

Settings page

## Visuals
<img width="1718" alt="Screen Shot 2023-05-30 at 7 55 07 PM" src="https://github.com/impress-org/givewp/assets/75056371/5b1ba7ac-48eb-40e5-a76c-81df1fc1b749">


## Testing Instructions
- Visit the Payment Gateway tab in the Settings page. If the product notice is displayed close it out.
- Check the console for no warnings.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

