### PR TITLE
Hotfix: make donation get submitted even when a radio or checkbox with conditional visibility based on another field is present

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.29.1
+ * Version: 2.29.2
  * Requires at least: 5.0
  * Requires PHP: 7.0
  * Text Domain: give
@@ -316,7 +316,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.29.1');
+            define('GIVE_VERSION', '2.29.2');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.0
-Stable tag: 2.29.1
+Stable tag: 2.29.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -258,6 +258,10 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.29.2: June 29th, 2023 =
+* Enhancement: PayPal Donations now has separate buttons to connect to PayPal Live and PayPal Sandbox.
+* Fix: Form Field Manager conditional radio and checkbox fields that are not visible no longer prevent donation submission.
+
 = 2.29.1: June 21st, 2023 =
 * Feature: Add Recurring Donations add-on overlay to Reports widget
 

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -68,7 +68,7 @@ class DetermineVisibilityForRequest
     }
 
     /**
-     * @unreleased Return false if the condition's field isn't present in the post data
+     * @since 2.29.2 Return false if the condition's field isn't present in the post data
      * @since      2.27.3 update to use FieldConditions
      * @since      2.21.0
      */

--- a/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
+++ b/src/Form/LegacyConsumer/Actions/DetermineVisibilityForRequest.php
@@ -68,12 +68,19 @@ class DetermineVisibilityForRequest
     }
 
     /**
-     * @since 2.27.3 update to use FieldConditions
-     * @since 2.21.0
+     * @unreleased Return false if the condition's field isn't present in the post data
+     * @since      2.27.3 update to use FieldConditions
+     * @since      2.21.0
      */
     protected function compareConditionWithOperator(Condition $condition): bool
     {
         if (is_a($condition, FieldCondition::class)) {
+            $conditionField = $condition->jsonSerialize()['field'];
+
+            if ( ! isset($this->postData[$conditionField])) {
+                return false;
+            }
+
             return $condition->passes($this->postData);
         }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6833

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR solves the problem by checking if the field used in the condition is present in the form submitted data. If not, we return `false` because if the current field depends on this missing field, it means that the current field can't be visible. If we do not do that, the API will try to access this missing field and throw a fatal error exactly because it is not present in the request.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Form Field Manager Addon

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a form with the following FFM fields: a checkbox OR a radio field with ONLY one option;
- Another field that will show conditionally based on the above;
- Make a donation with the checkbox or radio option empty;
- The donation should be submitted successfully. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204928249570047