### PR TITLE
Security: remove uses of payment intent secret and remove existing meta

### DIFF
--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -631,36 +631,6 @@ function give_stripe_get_application_fee_amount( $amount ) {
 }
 
 /**
- * This function is used to fetch the donation id by meta key.
- *
- * @param string $id   Any String.
- * @param string $type intent_id/client_secret
- *
- * @since 2.5.0
- *
- * @return void
- */
-function give_stripe_get_donation_id_by( $id, $type ) {
-
-	global $wpdb;
-
-	$donation_id = 0;
-
-	switch ( $type ) {
-		case 'intent_id':
-			$donation_id = $wpdb->get_var( $wpdb->prepare( "SELECT donation_id FROM {$wpdb->donationmeta} WHERE meta_key = '_give_stripe_payment_intent_id' AND meta_value = %s LIMIT 1", $id ) );
-			break;
-
-		case 'client_secret':
-			$donation_id = $wpdb->get_var( $wpdb->prepare( "SELECT donation_id FROM {$wpdb->donationmeta} WHERE meta_key = '_give_stripe_payment_intent_client_secret' AND meta_value = %s LIMIT 1", $id ) );
-			break;
-	}
-
-	return $donation_id;
-
-}
-
-/**
  * This function is used to set Stripe API Key.
  *
  * @param int $form_id Form ID.
@@ -874,10 +844,11 @@ function give_stripe_is_source_type( $id, $type = 'src' ) {
 /**
  * This helper function is used to process Stripe payments.
  *
- * @param array  $donation_data  Donation form data.
- * @param object $stripe_gateway $this data.
- *
+ * @unreleased no longer store the payment intent secret
  * @since 2.5.0
+ *
+ * @param array $donation_data Donation form data.
+ * @param object $stripe_gateway $this data.
  *
  * @return void
  */
@@ -977,10 +948,6 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 			}
 
 			$intent = $stripe_gateway->payment_intent->create( $intent_args );
-
-			// Save Payment Intent Client Secret to donation note and DB.
-			give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );
-			give_update_meta( $donation_id, '_give_stripe_payment_intent_client_secret', $intent->client_secret );
 
 			// Set Payment Intent ID as transaction ID for the donation.
 			give_set_payment_transaction_id( $donation_id, $intent->id );

--- a/includes/gateways/stripe/includes/payment-methods/class-give-stripe-sepa.php
+++ b/includes/gateways/stripe/includes/payment-methods/class-give-stripe-sepa.php
@@ -287,11 +287,6 @@ if ( ! class_exists( 'Give_Stripe_Sepa' ) ) {
 					$intent = $this->payment_intent->create( $intent_args );
 
 					if ( ! empty( $intent->status ) && 'processing' === $intent->status ) {
-
-						// Save Payment Intent Client Secret to donation note and DB.
-						give_insert_payment_note( $donation_id, 'Stripe Payment Intent Client Secret: ' . $intent->client_secret );
-						give_update_meta( $donation_id, '_give_stripe_payment_intent_client_secret', $intent->client_secret );
-
 						// Set Payment Intent ID as transaction ID for the donation.
 						give_set_payment_transaction_id( $donation_id, $intent->id );
 						give_insert_payment_note( $donation_id, 'Stripe Charge/Payment Intent ID: ' . $intent->id );

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
@@ -27,6 +27,7 @@ class CreatePaymentIntent
     }
 
     /**
+     * @unreleased no longer store the payment intent secret
      * @since 2.19.0
      *
      * @throws InvalidPropertyName
@@ -75,12 +76,6 @@ class CreatePaymentIntent
             'donationId' => $donation->id,
             'content' => sprintf(__('Stripe Payment Intent Client Secret: %s', 'give'), $intent->clientSecret())
         ]);
-
-        give_update_meta(
-            $donation->id,
-            '_give_stripe_payment_intent_client_secret',
-            $intent->clientSecret()
-        );
 
         if ('requires_action' === $intent->status()) {
             DonationNote::create([

--- a/src/PaymentGateways/Gateways/Stripe/Migrations/RemovePaymentIntentSecretMeta.php
+++ b/src/PaymentGateways/Gateways/Stripe/Migrations/RemovePaymentIntentSecretMeta.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\Migrations;
+
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * Removes the secret meta that was unnecessarily stored in the database for donations.
+ *
+ * @unreleased
+ */
+class RemovePaymentIntentSecretMeta extends Migration
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'remove_payment_intent_secret_meta';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function title(): string
+    {
+        return __('Remove payment intent secret meta', 'give');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function timestamp()
+    {
+        return strtotime('2020-08-20 00:00:00');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function run()
+    {
+        DB::delete(
+            DB::prefix('give_donationmeta'),
+            ['meta_key' => '_give_stripe_payment_intent_client_secret'],
+            ['%s']
+        );
+    }
+}

--- a/src/PaymentGateways/ServiceProvider.php
+++ b/src/PaymentGateways/ServiceProvider.php
@@ -13,6 +13,7 @@ use Give\PaymentGateways\Gateways\Stripe\CheckoutGateway;
 use Give\PaymentGateways\Gateways\Stripe\Controllers\UpdateStatementDescriptorAjaxRequestController;
 use Give\PaymentGateways\Gateways\Stripe\Migrations\AddMissingTransactionIdForUncompletedDonations;
 use Give\PaymentGateways\Gateways\Stripe\Migrations\AddStatementDescriptorToStripeAccounts;
+use Give\PaymentGateways\Gateways\Stripe\Migrations\RemovePaymentIntentSecretMeta;
 use Give\PaymentGateways\PayPalCommerce\Migrations\RemoveLogWithCardInfo;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
@@ -58,6 +59,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased add RemovePaymentIntentSecretMeta migration
      * @since 2.19.6
      */
     private function registerMigrations()
@@ -66,6 +68,7 @@ class ServiceProvider implements ServiceProviderInterface
             AddStatementDescriptorToStripeAccounts::class,
             AddMissingTransactionIdForUncompletedDonations::class,
             RemoveLogWithCardInfo::class,
+            RemovePaymentIntentSecretMeta::class,
         ]);
     }
 }


### PR DESCRIPTION
## Description

When auditing how API keys are stored within Stripe I found out that we were storing each [Payment Intent's client_secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret). We really shouldn't be storing this as there are better ways of going about the process, and it's not recommended. After further inspection, I realized that it was only being used as a means of identifying a donation (by its secret) within a single function — and that function isn't actually used anywhere! I checked core, Next Gen, and the Stripe add-on.

Therefore, this PR remove that function, all places its being stored, and provides a migration to remove existing secret meta from the database.

## Affects

This is pretty purely a removal, so it shouldn't affect anything. I didn't have to refactor anything to make this possible.

## Testing Instructions

1. Make some donations via Stripe
2. Update to this version of GiveWP
3. Check the DB to make sure there's no donation meta with the `_give_stripe_payment_intent_client_secret` key
4. Make sure Stripe donations still work

## Pre-review Checklist

-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

