### PR TITLE
Fix: Fee recovery amount not set in subscriptions

### DIFF
--- a/src/PaymentGateways/DataTransferObjects/FormData.php
+++ b/src/PaymentGateways/DataTransferObjects/FormData.php
@@ -164,6 +164,10 @@ final class FormData
                 $request['post_data']['give_anonymous_donation']
             );
 
+        $isFeeEnabled = isset($request['post_data']['give-fee-mode-enable']) ? 
+        filter_var( $request['post_data']['give-fee-mode-enable'], FILTER_VALIDATE_BOOLEAN ) : false;
+        $self->feeAmountRecovered = ($isFeeEnabled && !empty($request['post_data']['give-fee-amount'])) ? $request['post_data']['give-fee-amount'] : 0;
+
         $self->company = !empty($request['post_data']['give_company_name']) ? $request['post_data']['give_company_name'] : null;
 
         return $self;
@@ -180,6 +184,7 @@ final class FormData
             'status' => DonationStatus::PENDING(),
             'gatewayId' => $this->paymentGateway,
             'amount' => Money::fromDecimal($this->price, $this->currency),
+            'feeAmountRecovered' => Money::fromDecimal($this->feeAmountRecovered, $this->currency),
             'donorId' => $donorId,
             'firstName' => $this->donorInfo->firstName,
             'lastName' => $this->donorInfo->lastName,


### PR DESCRIPTION
The fee amount for subscriptions was set in update_subscription_args in class-give-fee-recovery-public.php. But the filter give_recurring_subscription_pre_gateway_args is not applied yet.  This code defines feeAmountRecovered for donations.

Another solution is to apply a filter like 'give_recurring_subscription_pre_gateway_args' in FormData. And the plugin Give Fee Recovery can define this element.

For donations, the function 'give_insert_payment' is still used and the action 'give_insert_payment' fired.

