### PR TITLE
Fix: Fee recovery amount not set in subscriptions

### DIFF
--- a/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
+++ b/src/LegacyPaymentGateways/Adapters/LegacyPaymentGatewayAdapter.php
@@ -75,6 +75,7 @@ class LegacyPaymentGatewayAdapter
 
             $subscription = Subscription::create([
                 'amount' => $donation->amount,
+                'feeAmountRecovered' => $donation->feeAmountRecovered,
                 'period' => new SubscriptionPeriod($subscriptionData->period),
                 'frequency' => (int)$subscriptionData->frequency,
                 'donorId' => $donor->id,


### PR DESCRIPTION
In Give\PaymentGateways\DataTransferObjects\FormData, I define feeAmountRecovered for donations. Here I copy this value for subscriptions. The fee amount is in the model for donations and subscriptions.

See https://github.com/impress-org/givewp/pull/6839