### PR TITLE
Refactor: Update legacy donation form block title with (v2) suffix

### DIFF
--- a/blocks/donation-form/index.js
+++ b/blocks/donation-form/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n'
-import { registerBlockType } from '@wordpress/blocks';
+import {__} from '@wordpress/i18n';
+import {registerBlockType} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,25 +14,25 @@ import GiveForm from './edit/block';
 
 /**
  * Register Block
-*/
+ */
 
-export default registerBlockType( 'give/donation-form', {
+export default registerBlockType('give/donation-form', {
+    title: __('Donation Form (v2)', 'give'),
+    description: __(
+        "The GiveWP Donation Form block inserts an existing donation form into the page. Each donation form's presentation can be customized below.",
+        'give'
+    ),
+    category: 'give',
+    icon: <GiveIcon color="grey" />,
+    keywords: [__('donation', 'give')],
+    supports: {
+        html: false,
+    },
+    attributes: blockAttributes,
+    edit: GiveForm,
 
-	title: __( 'Donation Form', 'give' ),
-	description: __( 'The GiveWP Donation Form block inserts an existing donation form into the page. Each donation form\'s presentation can be customized below.', 'give' ),
-	category: 'give',
-	icon: <GiveIcon color="grey" />,
-	keywords: [
-		__( 'donation', 'give' ),
-	],
-	supports: {
-		html: false,
-	},
-	attributes: blockAttributes,
-	edit: GiveForm,
-
-	save: () => {
-		// Server side rendering via shortcode
-		return null;
-	},
-} );
+    save: () => {
+        // Server side rendering via shortcode
+        return null;
+    },
+});


### PR DESCRIPTION
## Description

This PR updates the donation form block's title to include the suffix (v2)

## Affects

Donation form block

## Visuals
<img width="1725" alt="Screen Shot 2023-07-03 at 10 29 23 AM" src="https://github.com/impress-org/givewp/assets/75056371/f0560025-da9e-4f6c-883f-07c698612c7a">

## Testing Instructions

- add legacy donation form block
- Verify title is updated and block works as expected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

