### PR TITLE
New feature : allow third party plugins to add or modify table columns

### DIFF
--- a/src/Framework/ListTable/ListTable.php
+++ b/src/Framework/ListTable/ListTable.php
@@ -25,12 +25,14 @@ abstract class ListTable implements Arrayable
 
     /**
      * @since 2.24.0
+     * @unreleased
      *
      * @throws ColumnIdCollisionException
      */
     public function __construct()
     {
-        $this->addColumns(...$this->getDefaultColumns());
+        $default_columns = apply_filters('list_table_default_columns_'.$this->id(), $this->getDefaultColumns());
+        $this->addColumns(...$default_columns);
     }
 
     /**


### PR DESCRIPTION
## Description

As a third party plugin writer, I want to display some custom value on the Payment Type column of the Donations list table.

With the tiny modification introduced by this plugin, I will be able to make something like

```php
add_filter('list_table_default_columns_donations', 'register_custom_donation_payment_type');

function register_custom_donation_payment_type ($columns) {
    foreach ($columns as $key => $column) {
        if ($column::getId() === 'paymentType') {
            $columns[$key] = new MyCustomPaymentTypeColumn();
            return $columns;
        }
    }
    $columns[] = new MyCustomPaymentTypeColumn();
    return $columns;
}
```

## Affects

No breaking change, affect all ListTable and children

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

