### PR TITLE
Feature: Add summer sales banner to plugin page

### DIFF
--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -6,25 +6,6 @@
     & ::after {
         box-sizing: border-box;
     }
-
-    display: grid;
-    row-gap: 1.875rem;
-    font-family: 'Open Sans', system-ui, sans-serif;
-
-    #give-in-plugin-upsells & {
-        margin-top: 2rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .give_forms_page_give-payment-history &,
-    .give_forms_page_give-donors &,
-    .post-type-give_forms.post-new-php &,
-    .post-type-give_forms.edit-php & {
-        background-color: #fff;
-        margin: -10px -20px 30px -20px;
-        border-bottom: 1px solid #dbdbdb;
-        padding: 30px 20px;
-    }
 }
 
 .give-sale-banner {

--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -35,7 +35,7 @@
 
     & * {
         font-size: inherit;
-        font-family: Neurial Grotesk;
+        font-family: 'Neurial Grotesk', Montserrat, sans-serif;
     }
 
     a {
@@ -44,8 +44,6 @@
         text-decoration-thickness: 0.05em;
         transform-style: preserve-3d;
         font-size: 0.875rem;
-        font-family: Inconsolata;
-
 
         &::after {
             content: "";
@@ -88,6 +86,7 @@
 
 
         &-link {
+            font-family: 'Inconsolata', Montserrat, sans-serif;;
             margin-top: 1.125rem;
             display: inline-flex;
             padding: 0.73125rem 1.6714375rem;
@@ -124,20 +123,17 @@
     }
 }
 
-.give-sale-banner-action {
-    margin-top: .25rem;
-
-    &__abstract-icon {
-        position: absolute;
-        bottom: 0;
-        right: 0;
-    }
+.give-sale-banner__abstract-icon {
+    position: absolute;
+    bottom: 0;
+    right: 0;
 }
+
 
 .give-sale-banner-dismiss {
     --size: 1.25rem;
     /* Artificially align this with the sale icon, since we shouldn’t use align-items: center on the banner */
-    margin-top: calc((var(--sale-icon-size) - var(--size)) / 2);
+    //margin-top: calc((var(--sale-icon-size) - var(--size)) / 2);
     appearance: none;
     background: none;
     display: grid;
@@ -146,18 +142,17 @@
     width: var(--size);
     height: var(--size);
     border: 0;
-    border-radius: 9999px;
     outline-offset: 0.25rem;
     color: inherit;
     cursor: pointer;
     font-size: inherit;
     transition: color 0.2s, transform 0.2s;
+    z-index: 999;
 
     & svg {
         width: var(--size);
         height: var(--size);
         transition: fill 200ms ease-in-out;
-
         fill: none;
 
         /* This ensures that the event target is the button when clicked. */
@@ -192,7 +187,7 @@
         display: inline-block;
     }
 
-    .give-sale-banner-action__abstract-icon {
+    .give-sale-banner__abstract-icon {
         max-width: 8.25rem;
         max-height: 9.5rem;
     }

--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -6,6 +6,8 @@
     & ::after {
         box-sizing: border-box;
     }
+
+    overflow: hidden;
 }
 
 .give-sale-banner {

--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -29,7 +29,7 @@
 .give-sale-banner-content {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: center;
     gap: 3rem;
     width: 70%;
 
@@ -179,6 +179,7 @@
     .give-sale-banner {
         padding-left: 1rem;
     }
+
     .give-sale-banner-content__secondary-cta {
         display: none;
     }
@@ -190,5 +191,11 @@
     .give-sale-banner__abstract-icon {
         max-width: 8.25rem;
         max-height: 9.5rem;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .give-sale-banner-content__primary-cta-mobile-link {
+        margin-left: 0;
     }
 }

--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -29,16 +29,16 @@
 .give-sale-banner-content {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    width: 75%;
+    justify-content: flex-start;
+    gap: 3rem;
+    width: 70%;
 
     & * {
         font-size: inherit;
         font-family: Neurial Grotesk;
     }
 
-    & a {
-        display: inline-block;
+    a {
         color: inherit;
         font-weight: 700;
         text-decoration-thickness: 0.05em;
@@ -69,7 +69,7 @@
     }
 
     &__primary-cta {
-        flex: 1;
+        width: fit-content;
 
         > h1 {
             font-size: 1.5rem;
@@ -86,7 +86,8 @@
             line-height: normal;
         }
 
-        > a {
+
+        &-link {
             margin-top: 1.125rem;
             display: inline-flex;
             padding: 0.73125rem 1.6714375rem;
@@ -95,6 +96,14 @@
             background: #62B265;
             border-radius: 9999px;
             text-decoration: none;
+            margin-right: auto;
+        }
+
+        &-mobile-link {
+            display: none;
+            margin: 1rem 0 0 1rem;
+            color: #fff;
+            background: none;
         }
     }
 
@@ -164,27 +173,27 @@
     }
 }
 
-
-@media screen and (max-width: 1200px) {
-    .give-sale-banner-content {
-        gap: 1rem;
-        width: 60%;
-    }
-}
-
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 1100px) {
     .give-sale-banner-content {
         flex-direction: column;
         align-items: flex-start;
     }
 }
 
-@media screen and (max-width: 650px) {
+@media screen and (max-width: 770px) {
+    .give-sale-banner {
+        padding-left: 1rem;
+    }
     .give-sale-banner-content__secondary-cta {
         display: none;
     }
+
+    .give-sale-banner-content__primary-cta-mobile-link {
+        display: inline-block;
+    }
+
     .give-sale-banner-action__abstract-icon {
-        max-width: 6.25rem;
-        max-height: 7.8125rem;
+        max-width: 8.25rem;
+        max-height: 9.5rem;
     }
 }

--- a/assets/src/css/admin/summer-sales-banner.scss
+++ b/assets/src/css/admin/summer-sales-banner.scss
@@ -1,0 +1,207 @@
+.give-sale-banners-container {
+    /* Box-sizing reset */
+    &,
+    & *,
+    & ::before,
+    & ::after {
+        box-sizing: border-box;
+    }
+
+    display: grid;
+    row-gap: 1.875rem;
+    font-family: 'Open Sans', system-ui, sans-serif;
+
+    #give-in-plugin-upsells & {
+        margin-top: 2rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .give_forms_page_give-payment-history &,
+    .give_forms_page_give-donors &,
+    .post-type-give_forms.post-new-php &,
+    .post-type-give_forms.edit-php & {
+        background-color: #fff;
+        margin: -10px -20px 30px -20px;
+        border-bottom: 1px solid #dbdbdb;
+        padding: 30px 20px;
+    }
+}
+
+.give-sale-banner {
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    background: #1D202F;
+    min-height: 180px;
+    --banner-y-pad: 0.6875em;
+    padding-top: var(--banner-y-pad);
+    padding-bottom: var(--banner-y-pad);
+    padding-left: 3.25em;
+    padding-right: 1.3125em;
+    box-shadow: 0 0.0625em 0.25em rgba(0, 0, 0, 0.25);
+    font-size: clamp(max(0.875rem, 14px), 2vw, max(1rem, 16px));
+    color: #F9FAF9;
+}
+
+.give-sale-banner-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 75%;
+
+    & * {
+        font-size: inherit;
+        font-family: Neurial Grotesk;
+    }
+
+    & a {
+        display: inline-block;
+        color: inherit;
+        font-weight: 700;
+        text-decoration-thickness: 0.05em;
+        transform-style: preserve-3d;
+        font-size: 0.875rem;
+        font-family: Inconsolata;
+
+
+        &::after {
+            content: "";
+            position: absolute;
+            transform: translateZ(-1px);
+            display: block;
+            background-color: #fff;
+            height: calc(100% + 0.2em);
+            width: calc(100% + 0.6em);
+            top: -0.1em;
+            left: -0.3em;
+            opacity: 0;
+            box-shadow: 0 0.0625em 0.125em rgba(0, 0, 0, 0.05);
+            transition: opacity 0.2s ease-in-out;
+        }
+
+        &:focus {
+            outline: none;
+            box-shadow: none;
+        }
+    }
+
+    &__primary-cta {
+        flex: 1;
+
+        > h1 {
+            font-size: 1.5rem;
+            font-style: normal;
+            font-weight: 700;
+            line-height: normal;
+            color: #F9FAF9;
+        }
+
+        > p {
+            font-size: 1.375rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: normal;
+        }
+
+        > a {
+            margin-top: 1.125rem;
+            display: inline-flex;
+            padding: 0.73125rem 1.6714375rem;
+            justify-content: center;
+            align-items: center;
+            background: #62B265;
+            border-radius: 9999px;
+            text-decoration: none;
+        }
+    }
+
+    &__secondary-cta {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 1.125rem;
+    }
+
+    & p {
+        display: flex;
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
+        column-gap: 0.9375em;
+        margin: 0;
+        line-height: 1.37;
+    }
+}
+
+.give-sale-banner-action {
+    margin-top: .25rem;
+
+    &__abstract-icon {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+    }
+}
+
+.give-sale-banner-dismiss {
+    --size: 1.25rem;
+    /* Artificially align this with the sale icon, since we shouldn’t use align-items: center on the banner */
+    margin-top: calc((var(--sale-icon-size) - var(--size)) / 2);
+    appearance: none;
+    background: none;
+    display: grid;
+    place-content: center;
+    padding: 0;
+    width: var(--size);
+    height: var(--size);
+    border: 0;
+    border-radius: 9999px;
+    outline-offset: 0.25rem;
+    color: inherit;
+    cursor: pointer;
+    font-size: inherit;
+    transition: color 0.2s, transform 0.2s;
+
+    & svg {
+        width: var(--size);
+        height: var(--size);
+        transition: fill 200ms ease-in-out;
+
+        fill: none;
+
+        /* This ensures that the event target is the button when clicked. */
+        pointer-events: none;
+    }
+
+    &:hover {
+        transform: scale(1.15);
+    }
+
+    &:active {
+        transform: scale(0.95);
+    }
+}
+
+
+@media screen and (max-width: 1200px) {
+    .give-sale-banner-content {
+        gap: 1rem;
+        width: 60%;
+    }
+}
+
+@media screen and (max-width: 900px) {
+    .give-sale-banner-content {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media screen and (max-width: 650px) {
+    .give-sale-banner-content__secondary-cta {
+        display: none;
+    }
+    .give-sale-banner-action__abstract-icon {
+        max-width: 6.25rem;
+        max-height: 7.8125rem;
+    }
+}

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -2,8 +2,6 @@
 
 namespace Give\Promotions\InPluginUpsells;
 
-use Give\Framework\Shims\Shim;
-
 /**
  * @unrleased
  */

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -75,6 +75,7 @@ class SummerSalesBanner extends SaleBanners
         wp_enqueue_style(
             'give-in-plugin-upsells-summer-sales-banner',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-summer-sales-banner.css',
+            [],
         );
 
         wp_enqueue_style('givewp-admin-fonts');

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -31,18 +31,19 @@ class SummerSalesBanner extends SaleBanners
         if ($hasValidLicenses) {
             return [
                 array_merge($commonBannerInfo, [
-                    'id' => 'bfgt2023givewp',
-                    'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
-                    'actionURL' => 'https://go.givewp.com/ss23give',
+                    'id' => 'bfgt2023stellar',
+                    'leadText' => __('Save 30% on all StellarWP products.', 'give'),
+                    'actionURL' => 'https://go.givewp.com/ss23stellar',
                 ]),
             ];
         }
 
         return [
             array_merge($commonBannerInfo, [
-                'id' => 'bfgt2023stellar',
-                'leadText' => __('Save 30% on all StellarWP products.', 'give'),
-                'actionURL' => 'https://go.givewp.com/ss23stellar',
+                'id' => 'bfgt2023givewp',
+                'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
+                'actionURL' => 'https://go.givewp.com/ss23give',
+
             ]),
         ];
     }

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -31,7 +31,7 @@ class SummerSalesBanner extends SaleBanners
         if ($hasValidLicenses) {
             return [
                 array_merge($commonBannerInfo, [
-                    'id' => 'bfgt2023stellar',
+                    'id' => 'bfgt2023givewp',
                     'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
                     'actionURL' => 'https://go.givewp.com/ss23give',
                 ]),
@@ -40,7 +40,7 @@ class SummerSalesBanner extends SaleBanners
 
         return [
             array_merge($commonBannerInfo, [
-                'id' => 'bfgt2023givewp',
+                'id' => 'bfgt2023stellar',
                 'leadText' => __('Save 30% on all StellarWP products.', 'give'),
                 'actionURL' => 'https://go.givewp.com/ss23stellar',
             ]),

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -76,6 +76,7 @@ class SummerSalesBanner extends SaleBanners
             'give-in-plugin-upsells-summer-sales-banner',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-summer-sales-banner.css',
             [],
+            GIVE_VERSION,
         );
 
         wp_enqueue_style('givewp-admin-fonts');

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -15,7 +15,7 @@ class SummerSalesBanner extends SaleBanners
     public function getBanners(): array
     {
         $commonBannerInfo = [
-            'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+            'accessibleLabel' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
             'leadHeader' => __('Make it yours.', 'give'),
             'contentText' => __(
                 'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
@@ -29,9 +29,9 @@ class SummerSalesBanner extends SaleBanners
             'endDate' => '2023-07-19 23:59',
         ];
 
-        $has_valid_license = self::hasValidLicenses();
+        $hasValidLicenses = self::hasValidLicenses();
 
-        if ($has_valid_license) {
+        if ($hasValidLicenses) {
             return [
                 array_merge($commonBannerInfo, [
                     'id' => 'bfgt2023stellar',
@@ -84,9 +84,9 @@ class SummerSalesBanner extends SaleBanners
      */
     public function render()
     {
-        $banners = $this->getVisibleBanners();
+        $banner = $this->getVisibleBanners();
 
-        if ( ! empty($banners)) {
+        if ( ! empty($banner)) {
             include __DIR__ . '/resources/views/summer-sales-banner.php';
         }
     }
@@ -115,14 +115,16 @@ class SummerSalesBanner extends SaleBanners
             'peer_to_peer' => 'give-peer-to-peer',
         ];
 
+        $licensedPluginSlugs = self::getLicensedPluginSlugs();
 
-        return sort($requiredPluginSlugs) === sort(self::getAllExistingLicenseSlugs());
+
+        return sort($requiredPluginSlugs) === sort($licensedPluginSlugs);
     }
 
     /**
      * @unreleased
      */
-    public static function getAllExistingLicenseSlugs(): array
+    public static function getLicensedPluginSlugs(): array
     {
         $pluginSlugs = [];
         $licenses = get_option("give_licenses", []);

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -118,8 +118,10 @@ class SummerSalesBanner extends SaleBanners
 
         $licensedPluginSlugs = self::getLicensedPluginSlugs();
 
+        sort($requiredPluginSlugs);
+        sort($licensedPluginSlugs);
 
-        return sort($requiredPluginSlugs) === sort($licensedPluginSlugs);
+        return $requiredPluginSlugs == $licensedPluginSlugs;
     }
 
     /**

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -23,7 +23,6 @@ class SummerSalesBanner extends SaleBanners
             ),
             'actionText' => __('Shop Now', 'give'),
             'alternateActionText' => __('View all StellarWP Deals', 'give'),
-            'actionURL' => 'https://go.givewp.com/ss23give',
             'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
             'startDate' => '2023-07-16 00:00',
             'endDate' => '2023-07-19 23:59',
@@ -36,6 +35,7 @@ class SummerSalesBanner extends SaleBanners
                 array_merge($commonBannerInfo, [
                     'id' => 'bfgt2023stellar',
                     'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
+                    'actionURL' => 'https://go.givewp.com/ss23give',
                 ]),
             ];
         }
@@ -44,6 +44,7 @@ class SummerSalesBanner extends SaleBanners
             array_merge($commonBannerInfo, [
                 'id' => 'bfgt2023givewp',
                 'leadText' => __('Save 30% on all StellarWP products.', 'give'),
+                'actionURL' => 'https://go.givewp.com/ss23stellar',
             ]),
         ];
     }

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -52,7 +52,7 @@ class SummerSalesBanner extends SaleBanners
     /**
      * @unrleased
      */
-    public function loadScripts(): void
+    public function loadScripts()
     {
         wp_enqueue_script(
             'give-in-plugin-upsells-sale-banners',
@@ -74,7 +74,6 @@ class SummerSalesBanner extends SaleBanners
         wp_enqueue_style(
             'give-in-plugin-upsells-summer-sales-banner',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-summer-sales-banner.css',
-            '1.0.0',
         );
 
         wp_enqueue_style('givewp-admin-fonts');
@@ -83,7 +82,7 @@ class SummerSalesBanner extends SaleBanners
     /**
      * @unreleased
      */
-    public function render(): void
+    public function render()
     {
         $banners = $this->getVisibleBanners();
 

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -24,8 +24,8 @@ class SummerSalesBanner extends SaleBanners
             'actionText' => __('Shop Now', 'give'),
             'alternateActionText' => __('View all StellarWP Deals', 'give'),
             'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
-            'startDate' => '2023-07-16 00:00',
-            'endDate' => '2023-07-19 23:59',
+            'startDate' => '2023-07-24 00:00',
+            'endDate' => '2023-07-31 23:59',
         ];
 
         $hasValidLicenses = self::hasValidLicenses();

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -76,7 +76,7 @@ class SummerSalesBanner extends SaleBanners
             'give-in-plugin-upsells-summer-sales-banner',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-summer-sales-banner.css',
             [],
-            GIVE_VERSION,
+            GIVE_VERSION
         );
 
         wp_enqueue_style('givewp-admin-fonts');

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -14,41 +14,40 @@ class SummerSalesBanner extends SaleBanners
      */
     public function getBanners(): array
     {
+        $commonBannerInfo = [
+            'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+            'leadHeader' => __('Make it yours.', 'give'),
+            'contentText' => __(
+                'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
+                'give'
+            ),
+            'actionText' => __('Shop Now', 'give'),
+            'alternateActionText' => __('View all StellarWP Deals', 'give'),
+            'actionURL' => 'https://go.givewp.com/ss23give',
+            'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
+            'startDate' => '2023-07-16 00:00',
+            'endDate' => '2023-07-19 23:59',
+        ];
+
+        $has_valid_license = self::hasValidLicenses();
+
+        if ($has_valid_license) {
+            return [
+                array_merge($commonBannerInfo, [
+                    'id' => 'bfgt2023stellar',
+                    'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
+                ]),
+            ];
+        }
+
         return [
-            [
-                'id' => 'bfgt2023',
-                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
-                'leadHeader' => __('Make it stellar.', 'give'),
+            array_merge($commonBannerInfo, [
+                'id' => 'bfgt2023givewp',
                 'leadText' => __('Save 30% on all StellarWP products.', 'give'),
-                'contentText' => __(
-                    'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
-                    'give'
-                ),
-                'actionText' => __('Shop Now', 'give'),
-                'alternateActionText' => __('View all StellarWP Deals', 'give'),
-                'actionURL' => 'https://go.givewp.com/ss23give',
-                'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
-                'startDate' => '2023-07-16 00:00',
-                'endDate' => '2023-07-19 23:59',
-            ],
-            [
-                'id' => 'bfgt2023',
-                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
-                'leadHeader' => __('Make it yours.', 'give'),
-                'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
-                'contentText' => __(
-                    'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
-                    'give'
-                ),
-                'actionText' => __('Shop Now', 'give'),
-                'alternateActionText' => __('View all StellarWP Deals', 'give'),
-                'actionURL' => 'https://go.givewp.com/ss23give',
-                'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
-                'startDate' => '2023-07-16 00:00',
-                'endDate' => '2023-07-19 23:59',
-            ],
+            ]),
         ];
     }
+
 
     /**
      * @unrleased
@@ -103,4 +102,42 @@ class SummerSalesBanner extends SaleBanners
 
         return $pagenow === 'plugins.php';
     }
+
+    /**
+     * @unreleased
+     */
+    public static function hasValidLicenses(): bool
+    {
+        $requiredPluginSlugs = [
+            'recurring' => 'give-recurring',
+            'form_field_manager' => 'give-form-field-manager',
+            'fee_recovery' => 'give-fee-recovery',
+            'manual_donations' => 'give-manual-donations',
+            'peer_to_peer' => 'give-peer-to-peer',
+        ];
+
+
+        return sort($requiredPluginSlugs) === sort(self::getAllExistingLicenseSlugs());
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function getAllExistingLicenseSlugs(): array
+    {
+        $pluginSlugs = [];
+        $licenses = get_option("give_licenses", []);
+
+        foreach ($licenses as $license) {
+            if (isset($license['is_all_access_pass']) && $license['is_all_access_pass'] && ! empty($license['download'])) {
+                $slugs = array_column($license['download'], 'plugin_slug');
+                $pluginSlugs = array_merge($pluginSlugs, $slugs);
+            } else {
+                $pluginSlugs[] = $license['plugin_slug'];
+            }
+        }
+
+        return $pluginSlugs;
+    }
 }
+

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -79,6 +79,14 @@ class SummerSalesBanner extends SaleBanners
         );
 
         wp_enqueue_style('givewp-admin-fonts');
+
+        wp_enqueue_style(
+            'Inconsolpata',
+            'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap',
+            [],
+            '1.0',
+            'all'
+        );
     }
 
     /**

--- a/src/Promotions/InPluginUpsells/SummerSalesBanner.php
+++ b/src/Promotions/InPluginUpsells/SummerSalesBanner.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Give\Promotions\InPluginUpsells;
+
+use Give\Framework\Shims\Shim;
+
+/**
+ * @unrleased
+ */
+class SummerSalesBanner extends SaleBanners
+{
+    /**
+     * @unrleased
+     */
+    public function getBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2023',
+                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+                'leadHeader' => __('Make it stellar.', 'give'),
+                'leadText' => __('Save 30% on all StellarWP products.', 'give'),
+                'contentText' => __(
+                    'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
+                    'give'
+                ),
+                'actionText' => __('Shop Now', 'give'),
+                'alternateActionText' => __('View all StellarWP Deals', 'give'),
+                'actionURL' => 'https://go.givewp.com/ss23give',
+                'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
+                'startDate' => '2023-07-16 00:00',
+                'endDate' => '2023-07-19 23:59',
+            ],
+            [
+                'id' => 'bfgt2023',
+                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+                'leadHeader' => __('Make it yours.', 'give'),
+                'leadText' => __('Save 30% on all GiveWP Pricing Plans.', 'give'),
+                'contentText' => __(
+                    'Purchase any StellarWP product during the sale and get 100% off WP Business Reviews and take 40% off all other brands.',
+                    'give'
+                ),
+                'actionText' => __('Shop Now', 'give'),
+                'alternateActionText' => __('View all StellarWP Deals', 'give'),
+                'actionURL' => 'https://go.givewp.com/ss23give',
+                'alternateActionURL' => 'https://go.givewp.com/ss23stellar',
+                'startDate' => '2023-07-16 00:00',
+                'endDate' => '2023-07-19 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * @unrleased
+     */
+    public function loadScripts(): void
+    {
+        wp_enqueue_script(
+            'give-in-plugin-upsells-sale-banners',
+            GIVE_PLUGIN_URL . 'assets/dist/js/admin-upsell-sale-banner.js',
+            [],
+            GIVE_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'give-in-plugin-upsells-sale-banners',
+            'GiveSaleBanners',
+            [
+                'apiRoot' => esc_url_raw(rest_url('give-api/v2/sale-banner')),
+                'apiNonce' => wp_create_nonce('wp_rest'),
+            ]
+        );
+
+        wp_enqueue_style(
+            'give-in-plugin-upsells-summer-sales-banner',
+            GIVE_PLUGIN_URL . 'assets/dist/css/admin-summer-sales-banner.css',
+            '1.0.0',
+        );
+
+        wp_enqueue_style('givewp-admin-fonts');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function render(): void
+    {
+        $banners = $this->getVisibleBanners();
+
+        if ( ! empty($banners)) {
+            include __DIR__ . '/resources/views/summer-sales-banner.php';
+        }
+    }
+
+
+    /**
+     * @unreleased
+     */
+    public static function isShowing(): bool
+    {
+        global $pagenow;
+
+        return $pagenow === 'plugins.php';
+    }
+}

--- a/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
@@ -30,8 +30,8 @@ extract($banner[0])
                 <h1><?= $leadHeader ?></h1>
                 <p><?= $leadText ?></p>
 
-                <a class="give-sale-banner-content__primary-cta-link href="<?= $actionURL ?>" rel="noopener"
-                target="_blank"><?= $actionText ?></a>
+                <a class="give-sale-banner-content__primary-cta-link" href="<?= $actionURL ?>" rel="noopener"
+                   target="_blank"><?= $actionText ?></a>
 
                 <a class="give-sale-banner-content__primary-cta-mobile-link" href="<?= $alternateActionURL ?>"
                    rel="noopener"
@@ -45,35 +45,32 @@ extract($banner[0])
             </div>
         </div>
 
-        <div class="give-sale-banner-action">
-            <div class="give-sale-banner-action__abstract-icon">
-                <svg width="280" height="154" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <g clip-path="url(#clip0_1482_402)">
-                        <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
-                        <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
-                        <path
-                            d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
-                            stroke="#F9FAF9" stroke-width="1.43752" />
-                    </g>
-                    <defs>
-                        <clipPath id="clip0_1482_402">
-                            <rect width="280" height="154" fill="white" />
-                        </clipPath>
-                    </defs>
-                </svg>
-            </div>
-
-            <button type="button" aria-label="<?= __('Dismiss', 'give') ?> <?= $accessibleLabel ?>"
-                    aria-controls="<?= $dismissableElementId ?>" class="give-sale-banner-dismiss"
-                    data-id="<?= $id ?>">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
-                    <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
-                    <line y1="-0.5" x2="25.4558" y2="-0.5"
-                          transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
-                          stroke="#F9FAF9" />
-                </svg>
-            </button>
+        <div class="give-sale-banner__abstract-icon">
+            <svg width="280" height="154" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <g clip-path="url(#clip0_1482_402)">
+                    <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
+                    <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
+                    <path
+                        d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
+                        stroke="#F9FAF9" stroke-width="1.43752" />
+                </g>
+                <defs>
+                    <clipPath id="clip0_1482_402">
+                        <rect width="280" height="154" fill="white" />
+                    </clipPath>
+                </defs>
+            </svg>
         </div>
+        <button type="button" aria-label="<?= __('Dismiss', 'give') ?> <?= $accessibleLabel ?>"
+                aria-controls="<?= $dismissableElementId ?>" class="give-sale-banner-dismiss"
+                data-id="<?= $id ?>">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
+                <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                <line y1="-0.5" x2="25.4558" y2="-0.5"
+                      transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                      stroke="#F9FAF9" />
+            </svg>
+        </button>
     </aside>
     <br>
 </div>

--- a/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
@@ -1,80 +1,71 @@
 <?php
-/** @var array[] $banners */ ?>
+
+/** @var array[] $banner */
+
+extract($banner[0])
+/**
+ * @var string $id
+ * @var string $iconURL
+ * @var string $accessibleLabel
+ * @var string $leadHeader
+ * @var string $leadText
+ * @var string $contentText
+ * @var string $actionText
+ * @var string $alternateActionText
+ * @var string $actionURL
+ * @var string $alternateActionURL
+ * @var string $startDate
+ * @var string $endDate
+ */
+?>
 <div class="give-sale-banners-container" style="display: none;">
+    <aside aria-label="<?= $accessibleLabel ?>" id="<?= $dismissableElementId = "give-sale-banner-{$id}" ?>"
+           class="give-sale-banner">
 
-    <?php
-    foreach (
-        $banners
-
-        as $banner
-    ):
-        extract($banner);
-        /**
-         * @var string $id
-         * @var string $iconURL
-         * @var string $accessibleLabel
-         * @var string $leadHeader
-         * @var string $leadText
-         * @var string $contentText
-         * @var string $actionText
-         * @var string $alternateActionText
-         * @var string $actionURL
-         * @var string $alternateActionURL
-         * @var string $startDate
-         * @var string $endDate
-         */
-        ?>
-
-        <aside aria-label="<?= $accessibleLabel ?>" id="<?= $dismissableElementId = "give-sale-banner-{$id}" ?>"
-               class="give-sale-banner">
-
-            <div class="give-sale-banner-content">
-                <div class="give-sale-banner-content__primary-cta">
-                    <h1><?= $leadHeader ?></h1>
-                    <p><?= $leadText ?></p>
-                    <a href="<?= $actionURL ?>" rel="noopener"
-                       target="_blank"><?= $actionText ?></a>
-                </div>
-
-                <div class="give-sale-banner-content__secondary-cta">
-                    <p><?= $contentText ?></p>
-                    <a href="<?= $alternateActionURL ?>" rel="noopener"
-                       target="_blank"><?= $alternateActionText ?></a>
-                </div>
+        <div class="give-sale-banner-content">
+            <div class="give-sale-banner-content__primary-cta">
+                <h1><?= $leadHeader ?></h1>
+                <p><?= $leadText ?></p>
+                <a href="<?= $actionURL ?>" rel="noopener"
+                   target="_blank"><?= $actionText ?></a>
             </div>
 
-            <div class="give-sale-banner-action">
-                <div class="give-sale-banner-action__abstract-icon">
-                    <svg width="280" height="154" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <g clip-path="url(#clip0_1482_402)">
-                            <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
-                            <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
-                            <path
-                                d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
-                                stroke="#F9FAF9" stroke-width="1.43752" />
-                        </g>
-                        <defs>
-                            <clipPath id="clip0_1482_402">
-                                <rect width="280" height="154" fill="white" />
-                            </clipPath>
-                        </defs>
-                    </svg>
-                </div>
-
-                <button type="button" aria-label="<?= __('Dismiss', 'give') ?> <?= $accessibleLabel ?>"
-                        aria-controls="<?= $dismissableElementId ?>" class="give-sale-banner-dismiss"
-                        data-id="<?= $id ?>">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
-                        <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
-                        <line y1="-0.5" x2="25.4558" y2="-0.5"
-                              transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
-                              stroke="#F9FAF9" />
-                    </svg>
-                </button>
+            <div class="give-sale-banner-content__secondary-cta">
+                <p><?= $contentText ?></p>
+                <a href="<?= $alternateActionURL ?>" rel="noopener"
+                   target="_blank"><?= $alternateActionText ?></a>
             </div>
-        </aside>
+        </div>
 
-    <?php
-    endforeach; ?>
+        <div class="give-sale-banner-action">
+            <div class="give-sale-banner-action__abstract-icon">
+                <svg width="280" height="154" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_1482_402)">
+                        <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
+                        <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
+                        <path
+                            d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
+                            stroke="#F9FAF9" stroke-width="1.43752" />
+                    </g>
+                    <defs>
+                        <clipPath id="clip0_1482_402">
+                            <rect width="280" height="154" fill="white" />
+                        </clipPath>
+                    </defs>
+                </svg>
+            </div>
 
+            <button type="button" aria-label="<?= __('Dismiss', 'give') ?> <?= $accessibleLabel ?>"
+                    aria-controls="<?= $dismissableElementId ?>" class="give-sale-banner-dismiss"
+                    data-id="<?= $id ?>">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
+                    <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                    <line y1="-0.5" x2="25.4558" y2="-0.5"
+                          transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                          stroke="#F9FAF9" />
+                </svg>
+            </button>
+        </div>
+    </aside>
+    <br>
 </div>

--- a/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @unrleased
+ */
 
 /** @var array[] $banner */
 

--- a/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
@@ -29,8 +29,13 @@ extract($banner[0])
             <div class="give-sale-banner-content__primary-cta">
                 <h1><?= $leadHeader ?></h1>
                 <p><?= $leadText ?></p>
-                <a href="<?= $actionURL ?>" rel="noopener"
-                   target="_blank"><?= $actionText ?></a>
+
+                <a class="give-sale-banner-content__primary-cta-link href="<?= $actionURL ?>" rel="noopener"
+                target="_blank"><?= $actionText ?></a>
+
+                <a class="give-sale-banner-content__primary-cta-mobile-link" href="<?= $alternateActionURL ?>"
+                   rel="noopener"
+                   target="_blank"><?= $alternateActionText ?></a>
             </div>
 
             <div class="give-sale-banner-content__secondary-cta">

--- a/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/summer-sales-banner.php
@@ -1,0 +1,80 @@
+<?php
+/** @var array[] $banners */ ?>
+<div class="give-sale-banners-container" style="display: none;">
+
+    <?php
+    foreach (
+        $banners
+
+        as $banner
+    ):
+        extract($banner);
+        /**
+         * @var string $id
+         * @var string $iconURL
+         * @var string $accessibleLabel
+         * @var string $leadHeader
+         * @var string $leadText
+         * @var string $contentText
+         * @var string $actionText
+         * @var string $alternateActionText
+         * @var string $actionURL
+         * @var string $alternateActionURL
+         * @var string $startDate
+         * @var string $endDate
+         */
+        ?>
+
+        <aside aria-label="<?= $accessibleLabel ?>" id="<?= $dismissableElementId = "give-sale-banner-{$id}" ?>"
+               class="give-sale-banner">
+
+            <div class="give-sale-banner-content">
+                <div class="give-sale-banner-content__primary-cta">
+                    <h1><?= $leadHeader ?></h1>
+                    <p><?= $leadText ?></p>
+                    <a href="<?= $actionURL ?>" rel="noopener"
+                       target="_blank"><?= $actionText ?></a>
+                </div>
+
+                <div class="give-sale-banner-content__secondary-cta">
+                    <p><?= $contentText ?></p>
+                    <a href="<?= $alternateActionURL ?>" rel="noopener"
+                       target="_blank"><?= $alternateActionText ?></a>
+                </div>
+            </div>
+
+            <div class="give-sale-banner-action">
+                <div class="give-sale-banner-action__abstract-icon">
+                    <svg width="280" height="154" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <g clip-path="url(#clip0_1482_402)">
+                            <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
+                            <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
+                            <path
+                                d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
+                                stroke="#F9FAF9" stroke-width="1.43752" />
+                        </g>
+                        <defs>
+                            <clipPath id="clip0_1482_402">
+                                <rect width="280" height="154" fill="white" />
+                            </clipPath>
+                        </defs>
+                    </svg>
+                </div>
+
+                <button type="button" aria-label="<?= __('Dismiss', 'give') ?> <?= $accessibleLabel ?>"
+                        aria-controls="<?= $dismissableElementId ?>" class="give-sale-banner-dismiss"
+                        data-id="<?= $id ?>">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
+                        <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                        <line y1="-0.5" x2="25.4558" y2="-0.5"
+                              transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                              stroke="#F9FAF9" />
+                    </svg>
+                </button>
+            </div>
+        </aside>
+
+    <?php
+    endforeach; ?>
+
+</div>

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -14,6 +14,7 @@ use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
 use Give\Promotions\InPluginUpsells\RecurringDonationsTab;
 use Give\Promotions\InPluginUpsells\SaleBanners;
+use Give\Promotions\InPluginUpsells\SummerSalesBanner;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
 
 class ServiceProvider implements ServiceProviderContract
@@ -39,7 +40,7 @@ class ServiceProvider implements ServiceProviderContract
     }
 
     /**
-     * @since 2.27.1 Removed Recurring donations tab app.
+     * @since      2.27.1 Removed Recurring donations tab app.
      *
      * Boots the Plugin Upsell promotional page
      *
@@ -58,6 +59,10 @@ class ServiceProvider implements ServiceProviderContract
         if (SaleBanners::isShowing()) {
             Hooks::addAction('admin_notices', SaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', SaleBanners::class, 'loadScripts');
+        }
+        if (SummerSalesBanner::isShowing()) {
+            Hooks::addAction('admin_notices', SummerSalesBanner::class, 'render');
+            Hooks::addAction('admin_enqueue_scripts', SummerSalesBanner::class, 'loadScripts');
         }
 
         if (PaymentGateways::isShowing()) {

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -4,15 +4,11 @@ namespace Give\Promotions;
 
 use Give\Helpers\Hooks;
 use Give\Promotions\FreeAddonModal\Controllers\CompleteRestApiEndpoint;
-use Give\Promotions\FreeAddonModal\Controllers\DisplaySettingsButton;
-use Give\Promotions\FreeAddonModal\Controllers\EnqueueModal;
-use Give\Promotions\FreeAddonModal\Controllers\PreventFreshInstallPromotion;
 use Give\Promotions\InPluginUpsells\AddonsAdminPage;
 use Give\Promotions\InPluginUpsells\Endpoints\HideSaleBannerRoute;
 use Give\Promotions\InPluginUpsells\Endpoints\ProductRecommendationsRoute;
 use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
-use Give\Promotions\InPluginUpsells\RecurringDonationsTab;
 use Give\Promotions\InPluginUpsells\SaleBanners;
 use Give\Promotions\InPluginUpsells\SummerSalesBanner;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -18,6 +18,7 @@ mix.setPublicPath('assets/dist')
     .sass('src/Views/Form/Templates/Classic/resources/css/form.scss', 'css/give-classic-template.css')
     .sass('src/MultiFormGoals/resources/css/common.scss', 'css/multi-form-goal-block.css')
     .sass('src/DonationSummary/resources/css/summary.scss', 'css/give-donation-summary.css')
+    .sass('assets/src/css/admin/summer-sales-banner.scss', 'css/admin-summer-sales-banner.css')
 
     .js('assets/src/js/frontend/give.js', 'js/')
     .js('assets/src/js/frontend/give-stripe.js', 'js/')


### PR DESCRIPTION
## Description
This PR adds a summer sales banner to the plugin page. There are two different banners designs which can be viewed [here](https://www.figma.com/file/QJRUKnl10E8eFsvSaW5cI4/Stellar%3A-Sale-'23?node-id=1482%3A429&mode=dev). 

The banner populated is determined by the active licenses the user currently has. The licenses being checked for are the add ons listed below : 
- Recurring donations
- Form field manager
-  Fee recovery
-  Manual donations
-  P2P

### Behavior
- The banners has a start date of 07-24-23 and an expiration date of 07-31-23.
- When closed with the icon at the top right. The banner remains closed.
- In mobile view the secondary message is removed from display and the abstract pattern design is moved downward.


## Additional context
The Give links will not be active until day of display.

## Affects

Plugins Page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions
Will require active licenses for the add ons previously mentioned to accurately test. 

- Visit the Plugin page and view the banner. 
- Test closing the banner and ensuring it does not repopulate after.
- Test all links on the banner.
- Change screen size of the banner.
- Active add ons required with licensing and verify the additional banner displays when all licensing requirements are met.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205113834227970