### PR TITLE
Feature: add check for application/json in headers accept

### DIFF
--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -68,9 +68,12 @@ trait HandleHttpResponses
      */
     protected function shouldSendAsJson(): bool
     {
-        return isset($_SERVER['CONTENT_TYPE']) && (str_contains(
-                    $_SERVER['CONTENT_TYPE'],
-                    "application/json"
-                ) || str_contains($_SERVER['CONTENT_TYPE'], "multipart/form-data"));
+        if (!isset($_SERVER['CONTENT_TYPE'])) {
+            return false;
+        }
+        
+        $contentType = isset($_SERVER['CONTENT_TYPE']);
+
+        return str_contains($contentType, "application/json") || str_contains($contentType, "multipart/form-data");
     }
 }

--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -20,7 +20,7 @@ trait HandleHttpResponses
     public function handleResponse($type)
     {
         if ($type instanceof RedirectResponse) {
-            if ($this->shouldSendAsJson()) {
+            if ($this->wantsJson()) {
                 wp_send_json([
                     'type' => 'redirect',
                     'data' => [
@@ -63,23 +63,18 @@ trait HandleHttpResponses
     }
 
     /**
-     * This checks the server content-type to determine how to respond.
-     *
-     * v2 GiveWP forms uses content-type application/x-www-form-urlencoded
-     * v3 GiveWP forms uses content-type application/json and/or multipart/form-data
+     * This checks the server headers for 'application/json' to determine if it should respond with json.
      *
      * @unreleased
      *
      * @return bool
      */
-    protected function shouldSendAsJson(): bool
+    protected function wantsJson(): bool
     {
-        if (!isset($_SERVER['CONTENT_TYPE'])) {
-            return false;
+        if (isset($_SERVER['HTTP_ACCEPT']) && str_contains($_SERVER['HTTP_ACCEPT'], 'application/json')) {
+            return true;
         }
 
-        $contentType = isset($_SERVER['CONTENT_TYPE']);
-
-        return str_contains($contentType, "application/json") || str_contains($contentType, "multipart/form-data");
+        return isset($_SERVER['CONTENT_TYPE']) && str_contains($_SERVER['CONTENT_TYPE'], 'application/json');
     }
 }

--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -11,6 +11,7 @@ trait HandleHttpResponses
     /**
      * Handle Response
      *
+     * @unreleased add support for multipart/form-data content-type
      * @since 2.27.0 add support for json content-type
      * @since 2.18.0
      *
@@ -62,6 +63,11 @@ trait HandleHttpResponses
     }
 
     /**
+     * This checks the server content-type to determine how to respond.
+     *
+     * v2 GiveWP forms uses content-type application/x-www-form-urlencoded
+     * v3 GiveWP forms uses content-type application/json and/or multipart/form-data
+     *
      * @unreleased
      *
      * @return bool
@@ -71,7 +77,7 @@ trait HandleHttpResponses
         if (!isset($_SERVER['CONTENT_TYPE'])) {
             return false;
         }
-        
+
         $contentType = isset($_SERVER['CONTENT_TYPE']);
 
         return str_contains($contentType, "application/json") || str_contains($contentType, "multipart/form-data");

--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -11,7 +11,7 @@ trait HandleHttpResponses
     /**
      * Handle Response
      *
-     * @unreleased add support for multipart/form-data content-type
+     * @unreleased added check for responding with json
      * @since 2.27.0 add support for json content-type
      * @since 2.18.0
      *

--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -19,7 +19,7 @@ trait HandleHttpResponses
     public function handleResponse($type)
     {
         if ($type instanceof RedirectResponse) {
-            if (isset($_SERVER['CONTENT_TYPE']) && str_contains($_SERVER['CONTENT_TYPE'], "application/json")) {
+            if ($this->shouldSendAsJson()) {
                 wp_send_json([
                     'type' => 'redirect',
                     'data' => [
@@ -59,5 +59,18 @@ trait HandleHttpResponses
 
         give_set_error('PaymentGatewayException', $message);
         give_send_back_to_checkout();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return bool
+     */
+    protected function shouldSendAsJson(): bool
+    {
+        return isset($_SERVER['CONTENT_TYPE']) && (str_contains(
+                    $_SERVER['CONTENT_TYPE'],
+                    "application/json"
+                ) || str_contains($_SERVER['CONTENT_TYPE'], "multipart/form-data"));
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds check for `application/json` in the headers accept in handleHttpResponses.

In v3 forms we will explicitly set the accept header as `application/json` in order to tell the server we want it to respond as json.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This is being used in the gateway api and the v3 forms donation related controllers.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This does not affect any existing functionality.  A related PR that used form-data will rely on this so can be tested alongside.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

