### PR TITLE
Fix: Donors list table should account for sub-directory installs' 

### DIFF
--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -135,7 +135,7 @@ class DonorsAdminPage
                     },
                 })
                     .then((res) => {
-                        window.location.reload();
+                        window.location = window.location.href = '/wp-admin/edit.php?post_type=give_forms&page=give-donors';
                     });
             }
 

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -135,7 +135,7 @@ class DonorsAdminPage
                     },
                 })
                     .then((res) => {
-                        window.location = window.location.href = '/wp-admin/edit.php?post_type=give_forms&page=give-donors';
+                        window.location.href = '/wp-admin/edit.php?post_type=give_forms&page=give-donors';
                     });
             }
 


### PR DESCRIPTION
Feedback: https://feedback.givewp.com/bug-reports/p/donors-list-table-should-account-for-sub-directory-installs

There was the same problem for donations, and it was quickly fixed. One year ago, I reported the problem for donors. I suggest the same correction to set window.location.