### PR TITLE
Feature: Implement shortcode, block redirects

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -133,7 +133,7 @@ add_shortcode( 'donation_history', 'give_donation_history' );
  *
  * @since 2.30.0 Add short-circuit filter to allow for custom output.
  * @since  1.0
- 
+
  * @param array $atts Shortcode attributes
  *
  * @return string
@@ -148,6 +148,8 @@ function give_form_shortcode( $atts ) {
 	// Set form id.
 	$atts['id'] = $atts['id'] ?: FrontendFormTemplateUtils::getFormId();
 	$formId     = absint( $atts['id'] );
+
+    give_redirect_form_id($formId, $atts['id']);
 
     // Short-circuit the shortcode output if the filter returns a non-empty string.
     $output = apply_filters('givewp_form_shortcode_output', '', $atts);
@@ -211,6 +213,8 @@ function give_goal_shortcode( $atts ) {
 	if ( empty( $atts['id'] ) ) {
 		Give_Notices::print_frontend_notice( __( 'The shortcode is missing Donation Form ID attribute.', 'give' ), true );
 	}
+
+    give_redirect_form_id($atts['id']);
 
 	// Sanity check 2: Check the form even has Goals enabled.
 	if ( ! give_is_setting_enabled( give_get_meta( $atts['id'], '_give_goal_option', true ) ) ) {
@@ -607,6 +611,8 @@ function give_totals_shortcode( $atts ) {
 		'give_totals'
 	);
 
+    give_redirect_form_id($atts['ids']);
+
 	// Total Goal.
 	$total_goal = give_maybe_sanitize_amount( $atts['total_goal'] );
 
@@ -845,6 +851,8 @@ function give_form_grid_shortcode( $atts ) {
 		],
 		$atts
 	);
+
+    give_redirect_form_id($atts['ids']);
 
 	// Validate integer attributes.
 	$atts['forms_per_page'] = intval( $atts['forms_per_page'] );

--- a/src/DonationForms/V2/Endpoints/ListDonationForms.php
+++ b/src/DonationForms/V2/Endpoints/ListDonationForms.php
@@ -130,8 +130,8 @@ class ListDonationForms extends Endpoint
 
             foreach ($items as &$item) {
                 $v2form = defined('GIVE_NEXT_GEN_VERSION') && ! get_post_meta($item['id'], 'formBuilderFields');
-                $canMigrate = $v2form && ! give_is_form_migrated($item['id']); // @phpstan-ignore
-                $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($item['id']); // @phpstan-ignore
+                $canMigrate = $v2form && ! give_is_form_migrated($item['id']); // @phpstan-ignore-line
+                $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($item['id']); // @phpstan-ignore-line
 
                 $item['name'] = get_the_title($item['id']);
                 $item['edit'] = get_edit_post_link($item['id'], 'edit');

--- a/src/DonationForms/V2/Endpoints/ListDonationForms.php
+++ b/src/DonationForms/V2/Endpoints/ListDonationForms.php
@@ -130,8 +130,8 @@ class ListDonationForms extends Endpoint
 
             foreach ($items as &$item) {
                 $v2form = defined('GIVE_NEXT_GEN_VERSION') && ! get_post_meta($item['id'], 'formBuilderFields');
-                $canMigrate = $v2form && ! give_is_form_migrated($item['id']);
-                $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($item['id']);
+                $canMigrate = $v2form && ! give_is_form_migrated($item['id']); // @phpstan-ignore
+                $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($item['id']); // @phpstan-ignore
 
                 $item['name'] = get_the_title($item['id']);
                 $item['edit'] = get_edit_post_link($item['id'], 'edit');

--- a/tests/Unit/DonationForms/Endpoints/TestListDonationForms.php
+++ b/tests/Unit/DonationForms/Endpoints/TestListDonationForms.php
@@ -109,8 +109,8 @@ class TestListDonationForms extends TestCase
                 $expectedItem[$column::getId()] = $column->getCellValue($donationForm);
             }
             $v2form = defined('GIVE_NEXT_GEN_VERSION') && ! get_post_meta($donationForm->id, 'formBuilderFields');
-            $canMigrate = $v2form && ! give_is_form_migrated($donationForm->id);
-            $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($donationForm->id);
+            $canMigrate = $v2form && ! give_is_form_migrated($donationForm->id); // @phpstan-ignore
+            $canTransfer = $v2form && ! $canMigrate && ! give_is_form_donations_transferred($donationForm->id); // @phpstan-ignore
 
             $expectedItem['name'] = $donationForm->title;
             $expectedItem['edit'] = get_edit_post_link($donationForm->id, 'edit');


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements the `give_redirect_form_id()` function in each of the relevant `add_shortcode` callback render functions.

Additionally, this covers the Donation Form (v2) block and the Donation Form Grid, which each use the `give_form_shortcode()` function for server-side rendering. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `[give_form]`
- `[give_goal]`
- `[give_totals]`
- `[give_form_grid]`

Note: The "Donation Form (v2)" block uses the `give_form` shortcode under the hood.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Add a v2 form shortcode to a page
- Redirect that v2 form to a v3 form
- View the rendered shortcode - should show the v3 form