### PR TITLE
Feature: add `$nodeNameCollision` property on `NameCollisionException`

### DIFF
--- a/src/Framework/FieldsAPI/Concerns/NameCollision.php
+++ b/src/Framework/FieldsAPI/Concerns/NameCollision.php
@@ -26,14 +26,15 @@ trait NameCollision
     }
 
     /**
+     * @unreleased add existing and incoming nodes to exception
      * @since 2.10.2
      *
      * @throws NameCollisionException
      */
     public function checkNameCollision(Node $node)
     {
-        if ($this->getNodeByName($node->getName())) {
-            throw new NameCollisionException($node->getName());
+        if ($existingNode = $this->getNodeByName($node->getName())) {
+            throw new NameCollisionException($node->getName(), $existingNode, $node);
         }
     }
 }

--- a/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
+++ b/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
@@ -3,8 +3,10 @@
 namespace Give\Framework\FieldsAPI\Exceptions;
 
 use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\FieldsAPI\Contracts\Node;
 
 /**
+ * @unreleased add existing and incoming nodes to exception
  * @since 2.10.2
  */
 class NameCollisionException extends Exception
@@ -13,10 +15,26 @@ class NameCollisionException extends Exception
      * @var string
      */
     protected $nodeNameCollision;
+    /**
+     * @var Node
+     */
+    protected $existingNode;
+    /**
+     * @var Node
+     */
+    protected $incomingNode;
     
-    public function __construct($name, $code = 0, Exception $previous = null)
+    public function __construct(
+        string $name,
+        Node $existingNode,
+        Node $incomingNode,
+        int $code = 0,
+        Exception $previous = null
+    )
     {
         $this->nodeNameCollision = $name;
+        $this->existingNode = $existingNode;
+        $this->incomingNode = $incomingNode;
 
         $message = "Node name collision for $name";
         parent::__construct($message, $code, $previous);
@@ -28,5 +46,21 @@ class NameCollisionException extends Exception
     public function getNodeNameCollision(): string
     {
         return $this->nodeNameCollision;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getIncomingNode(): Node
+    {
+        return $this->incomingNode;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getExistingNode(): Node
+    {
+        return $this->existingNode;
     }
 }

--- a/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
+++ b/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
@@ -9,9 +9,24 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class NameCollisionException extends Exception
 {
+    /**
+     * @var string
+     */
+    protected $nodeNameCollision;
+    
     public function __construct($name, $code = 0, Exception $previous = null)
     {
+        $this->nodeNameCollision = $name;
+
         $message = "Node name collision for $name";
         parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getNodeNameCollision(): string
+    {
+        return $this->nodeNameCollision;
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->
Related: https://github.com/impress-org/givewp-next-gen/pull/243

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a `$nodeNameCollision` property on `NameCollisionException` for flexibility in throwing exception messages.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
- The `NameCollisionException` exception

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```
try {
            $form->schema();
        } catch (NameCollisionException $e) {
            return rest_ensure_response(
                new WP_Error(
                    400,
                    sprintf(
                        __("A field name with meta key '%s' already exists. Please try a new one.", 'give'),
                        $e->getNodeNameCollision()
                    )
                )
            );
        }
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This would have to be done programatically.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

