### PR TITLE
fix: update broken link to WP codex article on PHP memory

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -94,7 +94,7 @@ $give_updates = Give_Updates::get_instance();
 			}
 
 			if ( $memory < 67108864 ) {
-				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend setting memory to at least 64 MB. See: %2$s', 'give' ), size_format( $memory ), '<a href="https://codex.wordpress.org/Editing_wp-config.php#Increasing_memory_allocated_to_PHP" target="_blank">' . __( 'Increasing memory allocated to PHP', 'give' ) . '</a>' ) . '</mark>';
+				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend setting memory to at least 64 MB. See: %2$s', 'give' ), size_format( $memory ), '<a href="https://developer.wordpress.org/apis/wp-config-php/#increasing-memory-allocated-to-php" target="_blank">' . __( 'Increasing memory allocated to PHP', 'give' ) . '</a>' ) . '</mark>';
 			} else {
 				echo '<mark class="yes">' . size_format( $memory ) . '</mark>';
 			}


### PR DESCRIPTION
Resolves #6869

## Description

This PR addresses a broken link which appears in System Info when viewed from a site with less than 64MB of memory available to WordPress.

It updates the link target to the most current and most relevant URL which replaces the documentation that previously existed in the WordPress Codex. I chose this URL to help users navigate to the needed information, as any user following the "This page was moved to..." link on the deprecated Codex article will end up in a Documentation area that does not address their needs. Users will then be forced to search for relevant information.

## Affects

System Info 

## Testing Instructions

1. From a WordPress install with WP memory less than 64MB, go to Donations -> Tools -> System Info
2. Scroll down to WP Memory Limit
3. Click "Increasing memory allocated to PHP"
4. View the content at the URL visited, verify that it shows reference material for "Increasing memory allocated to PHP

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

