### PR TITLE
Doc: remove additional since 3.0.0 tags

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -44,9 +44,6 @@ class ConvertDonationFormBlocksToFieldsApi
     protected $currency;
 
     /**
-     * @since 3.0.0 return DonationForm Node
-     * @since 3.0.0 conditionally append blocks if block has inner blocks. Add blockIndex to inner blocks node converter.
-     * @since 3.0.0 conditionally append blocks if block has inner blocks
      * @since 3.0.0
      *
      * @throws TypeNotSupported|NameCollisionException
@@ -85,7 +82,6 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @since 3.0.0 remove innerBlock appending
      * @since 3.0.0
      */
     protected function convertTopLevelBlockToSection(BlockModel $block, int $blockIndex): Section
@@ -119,9 +115,7 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @since 3.0.0 Add support to billing address field
-     * @since      0.4.0 add blockIndex for unique field names, add filter `givewp_donation_form_block_render` filters
-     * @since      0.1.0
+     * @since 3.0.0
      *
      * @return Node|null
      * @throws NameCollisionException

--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -13,8 +13,7 @@ use Give\Framework\Routes\RouteListener;
 class BlockRenderController
 {
     /**
-     * @since 3.0.0 replace iframe with root element for react
-     * @since      0.1.0
+     * @since 3.0.0
      *
      * @return string|null
      */
@@ -90,8 +89,7 @@ class BlockRenderController
      * Load embed givewp script to resize iframe
      * @see        https://github.com/davidjbradshaw/iframe-resizer
      *
-     * @since 3.0.0 load app scripts
-     * @since      0.1.0
+     * @since 3.0.0
      */
     private function loadEmbedScript()
     {

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
@@ -12,7 +12,6 @@ import BlockPreview from './components/BlockPreview';
 import './styles/index.scss';
 
 /**
- * @since 3.0.0 Render block preview in the editor.
  * @since 3.0.0
  */
 export default function Edit({clientId, attributes, setAttributes}: BlockEditProps<any>) {

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
@@ -4,7 +4,6 @@ import type {Post} from '@wordpress/core-data/src/entity-types';
 import type {Option} from '../types';
 
 /**
- * @since 3.0.0 filter v3 forms by rendered excerpt.
  * @since 3.0.0
  */
 export default function useFormOptions(): {formOptions: Option[] | []; isResolving: boolean} {

--- a/src/DonationForms/Controllers/DonateController.php
+++ b/src/DonationForms/Controllers/DonateController.php
@@ -19,8 +19,6 @@ class DonateController
     /**
      * First we create a donation and/or subscription, then move on to the gateway processing
      *
-     * @since 3.0.0 use gateway controllers
-     * @since 3.0.0 add support for subscriptions
      * @since 3.0.0
      *
      * @return void

--- a/src/DonationForms/DataTransferObjects/DonateControllerData.php
+++ b/src/DonationForms/DataTransferObjects/DonateControllerData.php
@@ -126,10 +126,7 @@ class DonateControllerData
     public $comment;
 
     /**
-     * @since 3.0.0 added support for comment property
-     * @since 3.0.0 added support for anonymous
-     * @since 3.0.0 Add support billing address field
-     * @since      0.1.0
+     * @since 3.0.0
      */
     public function toDonation(int $donorId): Donation
     {
@@ -154,10 +151,7 @@ class DonateControllerData
     }
 
     /**
-     * @since 3.0.0 added support for comment property
-     * @since 3.0.0 added support for anonymous
-     * @since 3.0.0 Add support billing address field
-     * @since      0.3.0
+     * @since 3.0.0
      */
     public function toInitialSubscriptionDonation(int $donorId, int $subscriptionId): Donation
     {

--- a/src/DonationForms/DataTransferObjects/DonateFormRouteData.php
+++ b/src/DonationForms/DataTransferObjects/DonateFormRouteData.php
@@ -61,8 +61,7 @@ class DonateFormRouteData implements Arrayable
      * compares the request against the individual fields,
      * their types and validation rules.
      *
-     * @since 3.0.0 Add support for billing address field
-     * @since      0.1.0
+     * @since 3.0.0
      *
      * @throws DonationFormFieldErrorsException
      */

--- a/src/DonationForms/Listeners/AddRedirectUrlsToGatewayData.php
+++ b/src/DonationForms/Listeners/AddRedirectUrlsToGatewayData.php
@@ -12,7 +12,6 @@ class AddRedirectUrlsToGatewayData
      *
      * This is necessary so gateways can use this value in both legacy and next gen donation forms.
      *
-     * @since 3.0.0 move to an action
      * @since 3.0.0
      *
      * @return void

--- a/src/DonationForms/Listeners/StoreCustomFields.php
+++ b/src/DonationForms/Listeners/StoreCustomFields.php
@@ -17,7 +17,6 @@ class StoreCustomFields
      * schema settings to the request.  Once a field has passed validation, we can determine
      * its storage location from the fields api.  This Action is designed to be triggered post-validation.
      *
-     * @since 3.0.0 added support for field scopes and file uploads
      * @since 3.0.0
      *
      * @return void

--- a/src/DonationForms/Listeners/TemporarilyReplaceLegacySuccessPageUri.php
+++ b/src/DonationForms/Listeners/TemporarilyReplaceLegacySuccessPageUri.php
@@ -15,8 +15,6 @@ class TemporarilyReplaceLegacySuccessPageUri
      *
      * This is a temporary solution until we can update the gateway api to support the new receipt urls.
      *
-     * @since 3.0.0 move logic to an action
-     *
      * @since 3.0.0
      *
      * @return void

--- a/src/DonationForms/Models/DonationForm.php
+++ b/src/DonationForms/Models/DonationForm.php
@@ -132,7 +132,6 @@ class DonationForm extends Model implements ModelCrud, ModelHasFactory
 
     /**
      *
-     * @since 3.0.0 return DonationForm node; throw NameCollisionException
      * @since 3.0.0
      * @throws NameCollisionException
      */

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -401,8 +401,6 @@ class DonationFormRepository
     }
 
     /**
-     * @since 3.0.0 return DonationFormNode; throw NameCollisionException
-     * @since 3.0.0 append formId to first section instead of last with multistep in mind.
      * @since 3.0.0
      * @throws NameCollisionException
      */

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -136,7 +136,6 @@ class DonationFormViewModel
     }
 
     /**
-     * @since 3.0.0 update form object data to use DonationForm Node
      * @since 3.0.0
      */
     public function exports(): array
@@ -234,7 +233,6 @@ class DonationFormViewModel
     /**
      * Loads scripts in order: [Registrars, Designs, Gateways, Block]
      *
-     * @since 3.0.0 Add support for custom form extensions
      * @since 3.0.0
      *
      * @return void

--- a/src/DonationForms/resources/app/DonationFormApp.tsx
+++ b/src/DonationForms/resources/app/DonationFormApp.tsx
@@ -41,7 +41,6 @@ const initialState = {
 const formSettings = {...form.settings, ...getDonationFormNodeSettings(form)};
 
 /**
- * @since 3.0.0 add DonationFormSettingsProvider
  * @since 3.0.0
  */
 function App() {

--- a/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
+++ b/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
@@ -46,7 +46,6 @@ function getJoiRulesForField(field: Field): AnySchema {
 }
 
 /**
- * @since 3.0.0 add support for excludeUnless rule with basic conditions; do not validate fields with no rules
  * @since 3.0.0
  */
 function convertFieldAPIRulesToJoi(rules): AnySchema {

--- a/src/DonationForms/resources/app/utilities/mountWindowData.ts
+++ b/src/DonationForms/resources/app/utilities/mountWindowData.ts
@@ -7,7 +7,6 @@ import {useDonationFormSettings} from '@givewp/forms/app/store/form-settings';
  *
  * This mounts data to the window object, so it can be accessed by form designs and add-ons
  *
- * @since 3.0.0 add useDonationSummary
  * @since 3.0.0
  */
 export default function mountWindowData(): void {

--- a/src/DonationForms/resources/registrars/templates/elements/DonationSummary.tsx
+++ b/src/DonationForms/resources/registrars/templates/elements/DonationSummary.tsx
@@ -17,7 +17,6 @@ const getDonationTotal = (totals: any, amount: any) =>
     );
 
 /**
- * @since 3.0.0 update subscription frequency label
  * @since 3.0.0
  */
 export default function DonationSummary() {
@@ -60,7 +59,7 @@ export default function DonationSummary() {
     };
 
     const donationSummaryItems = [amountItem, frequencyItem, ...Object.values(items)];
-    
+
     const donationTotal = formatter.format(getDonationTotal(totals, amount));
 
     return <DonationSummaryItemsTemplate items={donationSummaryItems} total={donationTotal} />;

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
@@ -3,7 +3,6 @@ import {__} from '@wordpress/i18n';
 import CurrencyInput from 'react-currency-input-field';
 
 /**
- * @since 3.0.0 add value prop
  * @since 3.0.0
  */
 type CustomAmountProps = {
@@ -16,7 +15,6 @@ type CustomAmountProps = {
 };
 
 /**
- * @since 3.0.0 remove forwardRef and use state for value instead
  * @since 3.0.0
  */
 const CustomAmount = (

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -11,7 +11,6 @@ type DonationAmountLevelsProps = {
 };
 
 /**
- * @since 3.0.0 rename to DonationAmountLevels
  * @since 3.0.0
  */
 export default function DonationAmountLevels({

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -7,8 +7,6 @@ import DonationAmountCurrency from './DonationAmountCurrency';
 import DonationAmountLevels from './DonationAmountLevels';
 
 /**
- * @since 3.0.0 add currency settings
- * @since 3.0.0 add display options for multi levels, fixed amount, and custom amount
  * @since 3.0.0
  */
 export default function Amount({

--- a/src/DonationForms/resources/registrars/templates/fields/Checkbox.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Checkbox.tsx
@@ -1,7 +1,6 @@
 import type {CheckboxProps} from '@givewp/forms/propTypes';
 
 /**
- * @since 3.0.0 added helpText
  * @since 3.0.0
  */
 export default function Checkbox({Label, ErrorMessage, value, helpText, fieldError, inputProps}: CheckboxProps) {

--- a/src/DonationForms/resources/registrars/templates/fields/Gateways.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Gateways.tsx
@@ -74,7 +74,6 @@ const TestModeNotice = () => {
 };
 
 /**
- * @since 3.0.0 update to support currency switcher settings and test mode notice
  * @since 3.0.0
  */
 export default function Gateways({isTestMode, defaultValue, inputProps, gateways}: GatewayFieldProps) {
@@ -141,7 +140,6 @@ export default function Gateways({isTestMode, defaultValue, inputProps, gateways
 }
 
 /**
- * @since 3.0.0 replace index prop with defaultChecked
  * @since 3.0.0
  */
 function GatewayOption({gateway, defaultChecked, inputProps}: GatewayOptionProps) {

--- a/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
@@ -36,7 +36,6 @@ const Details = ({id, heading, details}: { id: string; heading: string; details:
         </div>
     );
 /**
- * @since 3.0.0 updated to use Interweave for rich text content
  * @since 3.0.0
  */
 export default function DonationReceipt({

--- a/src/Donations/CustomFields/Views/DonationDetailsView.php
+++ b/src/Donations/CustomFields/Views/DonationDetailsView.php
@@ -53,7 +53,6 @@ class DonationDetailsView
     }
 
     /**
-     * @since 3.0.0 updated to conditionally display value and label
      * @since 3.0.0
      *
      * @return string
@@ -78,7 +77,6 @@ class DonationDetailsView
     }
 
     /**
-     * @since 3.0.0 updated to format file fields
      * @since 3.0.0
      *
      * @param  Field  $field

--- a/src/Donors/CustomFields/Views/DonorDetailsView.php
+++ b/src/Donors/CustomFields/Views/DonorDetailsView.php
@@ -61,7 +61,6 @@ class DonorDetailsView
     }
 
     /**
-     * @since 3.0.0 updated to conditionally display value and label
      * @since 3.0.0
      *
      * @return string
@@ -86,7 +85,6 @@ class DonorDetailsView
     }
 
     /**
-     * @since 3.0.0 updated to format file fields
      * @since 3.0.0
      *
      * @return mixed

--- a/src/FormBuilder/Controllers/FormBuilderResourceController.php
+++ b/src/FormBuilder/Controllers/FormBuilderResourceController.php
@@ -17,7 +17,6 @@ class FormBuilderResourceController
     /**
      * Get the form builder instance
      *
-     * @since 3.0.0 add required block validation
      * @since 3.0.0
      *
      * @param  WP_REST_Request  $request
@@ -47,7 +46,6 @@ class FormBuilderResourceController
     /**
      * Update the form builder
      *
-     * @since 3.0.0 add required block validation
      * @since 3.0.0
      *
      * @return WP_Error|WP_HTTP_Response|WP_REST_Response

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -20,7 +20,6 @@ class RegisterFormBuilderPageRoute
     /**
      * Use add_submenu_page to register page within WP admin
      *
-     * @since 3.0.0 enqueue form builder styles
      * @since 3.0.0
      *
      * @return void
@@ -63,7 +62,6 @@ class RegisterFormBuilderPageRoute
     /**
      * Render page with scripts
      *
-     * @since 3.0.0 Add support for custom form extensions
      * @since 3.0.0
      *
      * @return void

--- a/src/FormBuilder/resources/js/form-builder/src/hooks/useFieldNameValidator.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/hooks/useFieldNameValidator.ts
@@ -20,7 +20,6 @@ export const hasFieldNameConflict = (fieldName: string, fieldNames: string[]) =>
 };
 
 /**
- * @since 3.0.0 switch hyphens to underscores
  * @since 3.0.0
  *
  * @returns {`${*}-${number|number}`}
@@ -73,7 +72,6 @@ const builtInFieldNames = [
  * A hook for validating uniqueness of the 'fieldName' attribute.
  * When a conflict has been found, a new name suggestion will be generated and returned within the array
  *
- * @since 3.0.0 name issue with name uniqueness not being reliable; switch hyphens to underscores
  * @since 3.0.0
  *
  * @return {function(fieldName: string): [isUnique: boolean, suggestedName: string]}

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -30,7 +30,6 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
-     * @since 3.0.0 skip fields with non-existing meta
      * @since 3.0.0
      */
     protected function getCustomFields(Donation $donation): array
@@ -147,7 +146,6 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
-     * @since 3.0.0 added comment field
      * @since 3.0.0
      *
      * @return void
@@ -171,7 +169,7 @@ class GenerateConfirmationPageReceipt
                 )
             );
         }
-      
+
         if ($receipt->donation->anonymous) {
             $receipt->additionalDetails->addDetail(
                 new ReceiptDetail(
@@ -187,7 +185,6 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
-     * @since 3.0.0 update subscription amount label with frequency
      * @since 3.0.0
      *
      * @return void
@@ -270,7 +267,6 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
-     * @since 3.0.0 added backwards compatability for v2 forms tags
      * @since 3.0.0
      */
     protected function getHeading(DonationReceipt $receipt, DonationForm $donationForm = null): string
@@ -288,7 +284,6 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
-     * @since 3.0.0 added backwards compatability for v2 forms tags
      * @since 3.0.0
      */
     protected function getDescription(DonationReceipt $receipt, DonationForm $donationForm = null): string

--- a/src/Framework/Routes/Router.php
+++ b/src/Framework/Routes/Router.php
@@ -56,7 +56,6 @@ class Router
     }
 
     /**
-     * @since 3.0.0 updated to check for "application/json" content-type first before accessing request super globals
      * @since 3.0.0
      */
     protected function getDataFromPostRequest(): array

--- a/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
@@ -14,7 +14,6 @@ class LegacyStripeAdapter
      * This makes it possible to load the files without having to enable a legacy stripe gateway.
      * This also makes it possible to load the files without the use of the give_stripe_supported_payment_methods filter.
      *
-     * @since 3.0.0 Fix reference to Next Gen gateway when loading Stripe (legacy) code.
      * @since 3.0.0
      */
     public function loadLegacyStripeWebhooksAndFilters()

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
@@ -19,7 +19,6 @@ use Stripe\PaymentIntent;
 trait StripePaymentElementRepository
 {
     /**
-     * @since 3.0.0 update params to use StripePaymentIntentData
      * @since 3.0.0
      * @throws ApiErrorException
      */
@@ -128,7 +127,6 @@ trait StripePaymentElementRepository
     }
 
     /**
-     * @since 3.0.0 no longer store the intent secret
      * @since 3.0.0
      *
      * @return void

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -35,7 +35,6 @@ const zeroDecimalCurrencies = [
 /**
  * Takes in an amount value in dollar units and returns the calculated cents amount
  *
- * @since 3.0.0 update conversion to round up to nearest integer
  * @since 3.0.0
  */
 const dollarsToCents = (amount: string, currency: string) => {

--- a/tests/Unit/DonationForms/Actions/StoreBackwardsCompatibleFormMetaTest.php
+++ b/tests/Unit/DonationForms/Actions/StoreBackwardsCompatibleFormMetaTest.php
@@ -15,7 +15,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationLevelMetaIsStoredOnInsert()
     {
@@ -27,7 +27,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationLevelMetaIsStoredOnUpdate()
     {
@@ -43,7 +43,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationGoalMetaIsStoredOnInsert()
     {
@@ -60,7 +60,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      */
     public function testRecurringMetaIsStoredOnUpdate()
     {
@@ -113,7 +113,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      */
     public function testRecurringMetaIsStoredOnInsert()
     {
@@ -161,7 +161,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationGoalMetaIsStoredOnUpdate()
     {
@@ -182,7 +182,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationGoalMetaUsesGoalTypeMetaKeyAmount()
     {
@@ -195,7 +195,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationGoalMetaUsesGoalTypeMetaKeyDonations()
     {
@@ -208,7 +208,7 @@ class StoreBackwardsCompatibleFormMetaTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testDonationGoalMetaUsesGoalTypeMetaKeyDonors()
     {


### PR DESCRIPTION
## Description

This PR removes additional `@since 3.0.0` tags from DocBlocks.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

