### PR TITLE
Fix: Update Last name placeholder

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -61,7 +61,7 @@ export default function Edit({
                     placeholder={lastNamePlaceholder}
                     required={requireLastName}
                     className={`${requireLastName ? 'give-is-required' : ''}`}
-                    value={firstNamePlaceholder}
+                    value={lastNamePlaceholder}
                     onChange={null}
                     readOnly
                 />


### PR DESCRIPTION
## Description

Updates the Last name text control placeholder value to use the correct default value from  'First name' to 'Last name'.

## Visuals

<img width="1727" alt="Screen Shot 2023-08-16 at 7 19 57 PM" src="https://github.com/impress-org/givewp/assets/75056371/d9c6867d-b611-4005-870a-ba80eee44648">

## Testing Instructions

- Add a v3 form 
- Verify the correct placeholder value for the Last name text control
- 
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

