### PR TITLE
Fix: Use solid background color for custom amount input

### DIFF
--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -1,4 +1,5 @@
 @use '../variables';
+
 $borderColor: #9A9A9A;
 
 .givewp-groups-donationAmount {
@@ -49,6 +50,7 @@ $borderColor: #9A9A9A;
         display: flex;
         align-items: center;
         justify-content: space-between;
+        background: var(--givewp-shades-white);
         border-width: 0.125rem;
         border-style: solid;
         border-color: $borderColor;


### PR DESCRIPTION
## Description

If the amount block is moved into a new section, that sections background color is seen through the custom amount input which makes its background inconsistent. This PR adds a white background to the input.

## Visuals

<img width="1727" alt="Screen Shot 2023-08-16 at 7 18 57 PM" src="https://github.com/impress-org/givewp/assets/75056371/eac515db-5e90-47d1-b435-80ade6821a94">

## Testing Instructions

- Move the amount section down a section and view design on classic template. The custom amount input will now not contain the background of the section but only display var(--givewp-shades-white)
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

