### PR TITLE
Fix: Initialization/handling of nullable values in templates

### DIFF
--- a/src/DonationForms/resources/app/utilities/getDefaultValuesFromSections.ts
+++ b/src/DonationForms/resources/app/utilities/getDefaultValuesFromSections.ts
@@ -13,9 +13,7 @@ export default function getDefaultValuesFromSections(sections: Section[]) {
     return reduceFields(
         sections,
         (values, field) => {
-            if (field.defaultValue !== null) {
-                values[field.name] = field.defaultValue;
-            }
+            values[field.name] = field.defaultValue ?? '';
 
             return values;
         },

--- a/src/DonationForms/resources/registrars/templates/fields/Date.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Date.tsx
@@ -26,9 +26,7 @@ export default function Date({Label, ErrorMessage, description, dateFormat = 'yy
                         ref={ref}
                         dateFormat={dateFormat}
                         selected={value && parse(value, dateFormat, new window.Date())}
-                        onChange={(date) => {
-                            onChange(format(date, dateFormat));
-                        }}
+                        onChange={(date) => onChange(date ? format(date, dateFormat) : '')}
                         onBlur={onBlur}
                     />
                 )}


### PR DESCRIPTION
## Description

This PR addresses two issues associated with nullable values in templates.
- From now on, a template will be initialized with either a `defaultValue` provided through the FieldsAPI or an empty string. Previously, only fields with a `defaultValue` attribute were initialized with that value. This caused other templates to initialize its value attribute as `undefined`.
- I've modified the `onchange` method for the `Date` template, so it now saves the value even when empty. Before this change, the field wouldn't accept an empty string as a valid value, making it impossible to remove a selected date.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

