### PR TITLE
Fix: default values for conditional fields

### DIFF
--- a/src/DonationForms/resources/app/fields/FieldNode.tsx
+++ b/src/DonationForms/resources/app/fields/FieldNode.tsx
@@ -3,17 +3,34 @@ import {useTemplateWrapper} from '../templates';
 import registerFieldAndBuildProps from '../utilities/registerFieldAndBuildProps';
 import type {FieldProps} from '@givewp/forms/propTypes';
 import memoNode from '@givewp/forms/app/utilities/memoNode';
+import {useEffect} from 'react';
 
 const formTemplates = window.givewp.form.templates;
 
 function FieldNode({node}: {node: Field}) {
-    const {register} = window.givewp.form.hooks.useFormContext();
+    const {register, getValues, setValue} = window.givewp.form.hooks.useFormContext();
     const {errors} = window.givewp.form.hooks.useFormState();
     const Field =
         node.type !== 'hidden'
             ? useTemplateWrapper<FieldProps>(formTemplates.fields[node.type], 'div', node.name)
             : formTemplates.fields[node.type];
     const fieldProps = registerFieldAndBuildProps(node, register, errors);
+
+    /**
+     * Set the default value for the field if it is not already set. This is necessary because the default value is not
+     * applied to the initial form render if it requires conditions to be visible.
+     */
+    useEffect(() => {
+        if (node.defaultValue === undefined) {
+            return;
+        }
+
+        const value = getValues(node.name);
+
+        if (value === undefined || value === null) {
+            setValue(node.name, node.defaultValue);
+        }
+    }, []);
 
     return <Field key={node.name} {...fieldProps} />;
 }


### PR DESCRIPTION
Resolves #6891 

## Description

This addresses an issue where default values weren't working for fields that were displayed conditionally. When the field finally displayed the default value wasn't applied, so it defaulted to a null value.

The underlying issue here is that default values are actually set when the form first renders, but if a field isn't set to display then its default value isn't set. It's important _not_ to include it in the default values as otherwise it will fail validation before it displays.

The strategy taken here is to check if the field has a non-null and non-undefined value the first time a field is rendered. This does mean an unnecessary check is made for all the fields whose default value was applied, but it should simply skip those and call the `setValue` function. When a field is finally rendered and it has a default value, the default value is applied.

## Affects

This adds a side-effect to all fields in the donation form.

## Visuals

![2023-08-21 16 33 33](https://github.com/impress-org/givewp/assets/2024145/8c9a92fe-a44c-4480-bbe7-4c605dabe50b)

## Testing Instructions

The following can be used to add two radio fields to simulate the issue in the `givewp_donation_form_schema` hook:
```php
$form->getNodeByName('section-2')
    ->append(
        \Give\Framework\FieldsAPI\Radio::make('t-shirt-size')
            ->label('T-Shirt Size')
            ->defaultValue('medium')
            ->showInReceipt()
            ->options(
                ['small', 'Small'],
                ['medium', 'Medium'],
                ['large', 'Large'],
                ['x-large', 'X-Large']
            )
            ->required(),
        \Give\Framework\FieldsAPI\Radio::make('favorite-color')
            ->label('Favorite Color')
            ->defaultValue('red')
            ->showInReceipt()
            ->options(
                ['red', 'Red'],
                ['green', 'Green'],
                ['blue', 'Blue']
            )
            ->showIf('t-shirt-size', '=', 'small')
            ->required()
    );
```

## Pre-review Checklist

-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

