### PR TITLE
Feature: Auto-deactivate the feature plugin

### DIFF
--- a/give.php
+++ b/give.php
@@ -533,7 +533,7 @@ final class Give
             add_action('admin_notices', function() {
                 Give()->notices->register_notice([
                     'id' => 'give-visual-donation-form-builder-feature-plugin-deactivated',
-                    'description' => __('The Visual Donation Form Builder is now available with GiveWP v3 and the feature plugin has been deactivated.', 'give'),
+                    'description' => __('The Visual Form Builder Beta plugin is no longer needed, since that functionality has been included in the version of GiveWP you are using. To prevent conflicts, the Beta plugin has been deactivated. You can safely delete that plugin.', 'give'),
                     'type' => 'info',
                 ]);
             });

--- a/give.php
+++ b/give.php
@@ -533,7 +533,7 @@ final class Give
             add_action('admin_notices', function() {
                 Give()->notices->register_notice([
                     'id' => 'give-visual-donation-form-builder-feature-plugin-deactivated',
-                    'description' => __('The Visual Form Builder Beta plugin is no longer needed, since that functionality has been included in the version of GiveWP you are using. To prevent conflicts, the Beta plugin has been deactivated. You can safely delete that plugin.', 'give'),
+                    'description' => __('The Visual Form Builder Beta plugin is no longer needed, since the form builder is included in your current version of GiveWP. To prevent conflicts, the Beta plugin has been deactivated and can be safely deleted.', 'give'),
                     'type' => 'info',
                 ]);
             });

--- a/src/FormMigration/functions.php
+++ b/src/FormMigration/functions.php
@@ -16,7 +16,7 @@ use Give\Framework\Database\DB;
  *
  * @return void Note: $formId is an "output argument" - not a return value.
  */
-function give_redirect_form_id(&$formId, &...$extraReference) {
+function _give_redirect_form_id(&$formId, &...$extraReference) {
     global $wpdb;
 
     $formId = absint(DB::get_var(
@@ -40,7 +40,7 @@ function give_redirect_form_id(&$formId, &...$extraReference) {
  *
  * @return bool
  */
-function give_is_form_migrated($formId) {
+function _give_is_form_migrated($formId) {
     global $wpdb;
 
     return (bool) DB::get_var(
@@ -63,7 +63,7 @@ function give_is_form_migrated($formId) {
  *
  * @return bool
  */
-function give_is_form_donations_transferred($formId) {
+function _give_is_form_donations_transferred($formId) {
     global $wpdb;
 
     return (bool) DB::get_var(

--- a/tests/Unit/FormMigration/FunctionsTest.php
+++ b/tests/Unit/FormMigration/FunctionsTest.php
@@ -20,7 +20,7 @@ class FunctionsTest extends TestCase
 
         $formId = $donationFormV2->id;
 
-        give_redirect_form_id($formId);
+        _give_redirect_form_id($formId);
 
         $this->assertEquals($donationFormV3->id, $formId);
     }
@@ -34,7 +34,7 @@ class FunctionsTest extends TestCase
         $formId = $donationFormV2->id;
         $atts['id'] = $donationFormV2->id;
 
-        give_redirect_form_id($formId, $atts['id']);
+        _give_redirect_form_id($formId, $atts['id']);
 
         $this->assertEquals($donationFormV3->id, $formId);
         $this->assertEquals($donationFormV3->id, $atts['id']);
@@ -46,14 +46,14 @@ class FunctionsTest extends TestCase
         $donationFormV3 = DonationForm::factory()->create();
         give_update_meta($donationFormV3->id, 'migratedFormId', $donationFormV2->id);
 
-        $this->assertTrue(give_is_form_migrated($donationFormV2->id));
+        $this->assertTrue(_give_is_form_migrated($donationFormV2->id));
     }
 
     public function testIsFormNotMigrated()
     {
         $donationFormV2 = $this->createSimpleDonationForm();
 
-        $this->assertFalse(give_is_form_migrated($donationFormV2->id));
+        $this->assertFalse(_give_is_form_migrated($donationFormV2->id));
     }
 
     public function testIsFormDonationsTransferred()
@@ -62,13 +62,13 @@ class FunctionsTest extends TestCase
         $donationFormV3 = DonationForm::factory()->create();
         give_update_meta($donationFormV3->id, 'transferredFormId', $donationFormV2->id);
 
-        $this->assertTrue(give_is_form_donations_transferred($donationFormV2->id));
+        $this->assertTrue(_give_is_form_donations_transferred($donationFormV2->id));
     }
 
     public function testIsFormDonationsNotTransferred()
     {
         $donationFormV2 = $this->createSimpleDonationForm();
 
-        $this->assertFalse(give_is_form_donations_transferred($donationFormV2->id));
+        $this->assertFalse(_give_is_form_donations_transferred($donationFormV2->id));
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR automatically deactivates the Visual Donation Form Builder feature plugin when GiveWP v3 is installed and shows an admin notice with an explanation.

Note: Two other notices are shown which are not controlled by the core plugin and thus cannot be removed by this change.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Renames the `FormMigration` functions to avoid a fatal error conflict with the autoloaded functions in the feature plugin.

Note: These renamed functions are not yet in use, but are included in https://github.com/impress-org/givewp/pull/6832.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/b7312906-12c1-491f-b259-c2bc2bf3c2a6)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Activate the `Give - Donation Plugin` plugin.
- Activate the `Give - Visual Donation Form Builder` plugin.
- Checkout the `feature/deactivate-feature-plugin` branch.
- Refresh the page.