### PR TITLE
Fix: keep the same meta key and email tag for custom fields after updating the form

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -61,7 +61,7 @@ const generateEmailTag = (fieldName, storeAsDonorMeta) => {
 function FieldSettingsEdit({attributes, setAttributes, fieldSettings}) {
     const validateFieldName = useFieldNameValidator();
     const [hasFieldNameAttribute, setHasFieldNameAttribute] = useState(attributes.hasOwnProperty('fieldName'));
-    const [isNewField] = useState(hasFieldNameAttribute);
+    const [isNewField] = useState(!hasFieldNameAttribute);
 
     const updateFieldName = useCallback(
         (newFieldName = null, bumpUniqueness = false) => {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that changes the meta key (and tag email) of a custom field when we update the form, even if we not changing anything on the custom field.

For example, if we create a custom field called "Favorite Color", the `meta_donor_favorite_color` displayed on the screen is saved on DB as `favorite_color` the first time. 

After that, when we update the form, the `favorite_color_1` is used instead of the `favorite_color` meta key

But if we use the `meta_donor_favorite_color` as an email tag, the first value set on the `favorite_color` meta key will always be displayed, and the updates stored on `favorite_color_1` will never be displayed on the emails.

For example, if I set my favorite color as BLACK on donation 1, I'll get an email with BLACK in the body message, but if I set my favorite color as RED on donation 2, after a form update, the email will keep saying that my favorite color is  BLACK instead of RED.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Meta keys and email tags.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![different-meta-keys](https://github.com/impress-org/givewp/assets/16308864/674d3e4d-6f3d-467d-85c8-7cb6504d0439)

![colors](https://github.com/impress-org/givewp/assets/16308864/9ecca532-268d-44ca-b685-77068ee4f4a0)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a form with a custom field called "Favorite Color" and set it to be stored as a donor meta key
2. Edit the "New Donation" email and add the meta key created in the previous step as an email tag on the body message - the syntax for that should be something like this: `{meta_donor_favorite_color}`
3. Create a test donation and set the favorite color as BLACK, you should see this same color on the confirmation page and on the "New Donation" email sent to your inbox
4. Update anything on the form created on the first step
5. Repeat step three using another color and **the same user/donor**, then check if the color value changes on the confirmation page and on the "New Donation" email sent to your inbox

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205339263512644
  - https://app.asana.com/0/0/1205198235960347