### PR TITLE
Refactor: hide v3 form block and update v2 block name

### DIFF
--- a/blocks/donation-form/index.js
+++ b/blocks/donation-form/index.js
@@ -17,7 +17,7 @@ import GiveForm from './edit/block';
  */
 
 export default registerBlockType('give/donation-form', {
-    title: __('Donation Form (v2)', 'give'),
+    title: __('Donation Form', 'give'),
     description: __(
         "The GiveWP Donation Form block inserts an existing donation form into the page. Each donation form's presentation can be customized below.",
         'give'

--- a/src/DonationForms/Blocks/DonationFormBlock/block.json
+++ b/src/DonationForms/Blocks/DonationFormBlock/block.json
@@ -8,7 +8,8 @@
     "icon": "superhero",
     "description": "The GiveWP Donation Form block inserts an existing donation form into the page.",
     "supports": {
-        "html": false
+        "html": false,
+        "inserter": false
     },
     "attributes": {
         "formId": {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This hides the v3 donation form block using [this](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#inserter) and remove the `(v2)` suffix on the existing form block.  Now there is only 1 donation form block and it renders both v2 and v3 forms.

In the v2 form block, we have a filter that we hook into and determine if its a v3 form.  If it is, we are using the v3 form block render controller to render the v3 form.

Note: we are still using the v3 form block _under the hood_ to render on the v3 single form template.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The v3 block is hidden.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Go to a page and search for donation form block
- You should not see any mention of v2 or v3
- The existing block should render both v2 and v3 forms.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

