### PR TITLE
Fix: `$gatewayData` request supports all native content types

### DIFF
--- a/src/DonationForms/DataTransferObjects/DonateFormRouteData.php
+++ b/src/DonationForms/DataTransferObjects/DonateFormRouteData.php
@@ -5,6 +5,7 @@ namespace Give\DonationForms\DataTransferObjects;
 use Give\DonationForms\Exceptions\DonationFormFieldErrorsException;
 use Give\DonationForms\Models\DonationForm;
 use Give\Framework\FieldsAPI\Actions\CreateValidatorFromForm;
+use Give\Framework\FieldsAPI\Exceptions\NameCollisionException;
 use Give\Framework\Support\Contracts\Arrayable;
 use WP_Error;
 
@@ -49,7 +50,7 @@ class DonateFormRouteData implements Arrayable
         $self->formId = (int)$requestData['formId'];
         $self->gatewayId = $requestData['gatewayId'];
         $self->originUrl = $requestData['originUrl'];
-        $self->isEmbed = $requestData['isEmbed'];
+        $self->isEmbed = filter_var($requestData['isEmbed'], FILTER_VALIDATE_BOOLEAN);
         $self->embedId = $self->isEmbed ? $requestData['embedId'] : null;
         $self->requestData = $requestData;
 
@@ -63,7 +64,7 @@ class DonateFormRouteData implements Arrayable
      *
      * @since 3.0.0
      *
-     * @throws DonationFormFieldErrorsException
+     * @throws DonationFormFieldErrorsException|NameCollisionException
      */
     public function validated(): DonateControllerData
     {

--- a/src/PaymentGateways/Actions/GetGatewayDataFromRequest.php
+++ b/src/PaymentGateways/Actions/GetGatewayDataFromRequest.php
@@ -12,25 +12,16 @@ class GetGatewayDataFromRequest
      * In order for the $gatewayData to be automatically accessible the data will need to come in
      * through a specific key called `gatewayData`.
      *
+     * @since 3.0.0 Updated logic to support all native content types.
      * @since 2.22.0
      */
     public function __invoke(): array
     {
         $gatewayData = [];
 
-        if (!isset($_SERVER['CONTENT_TYPE'])) {
-            return $gatewayData;
-        }
-
-        $contentType = $_SERVER['CONTENT_TYPE'];
-
-        // this content type is typically used throughout legacy with jQuery and wp-ajax
-        if (($contentType === "application/x-www-form-urlencoded") && isset($_REQUEST['gatewayData'])) {
+        if (isset($_REQUEST['gatewayData'])) {
             $gatewayData = give_clean($_REQUEST['gatewayData']);
-        }
-
-        // this content type is typically used with the fetch api and our custom routes
-        if ($contentType === "application/json") {
+        } else if ($this->requestIsJson()) {
             $requestData = file_get_contents('php://input');
             $requestData = json_decode($requestData, true);
 
@@ -40,5 +31,15 @@ class GetGatewayDataFromRequest
         }
 
         return $gatewayData;
+    }
+
+     /**
+     * This checks the server content type for 'application/json' to determine if it is a json request.
+     *
+     * @since 3.0.0
+     */
+    protected function requestIsJson(): bool
+    {
+        return isset($_SERVER['CONTENT_TYPE']) && str_contains($_SERVER['CONTENT_TYPE'], 'application/json');
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The gateway data request was specifically checking for certain content types and json.  This was problematic with our new use of multipart/form-data.  Now this request supports all native content types by simply checking the super global first, then json.

This also fixes a bug related to forms being rendered outside of an iframe and their respected redirects.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- v3 gateways that use the `$gatewayData` will now work properly

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- The easiest way to test this is make sure Stripe Payment Element is working properly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

