### PR TITLE
Chore: replace tests since tags

### DIFF
--- a/tests/Feature/Actions/StoreCustomFieldsTest.php
+++ b/tests/Feature/Actions/StoreCustomFieldsTest.php
@@ -17,7 +17,7 @@ class StoreCustomFieldsTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception
@@ -66,7 +66,7 @@ class StoreCustomFieldsTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception

--- a/tests/Feature/Controllers/BlockRenderControllerTest.php
+++ b/tests/Feature/Controllers/BlockRenderControllerTest.php
@@ -14,7 +14,7 @@ class BlockRenderControllerTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Feature/Controllers/DonateControllerTest.php
+++ b/tests/Feature/Controllers/DonateControllerTest.php
@@ -19,7 +19,7 @@ class DonateControllerTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      * @return void
      * @throws Exception|DonationFormFieldErrorsException
      */

--- a/tests/Feature/Controllers/FormBuilderResourceControllerTest.php
+++ b/tests/Feature/Controllers/FormBuilderResourceControllerTest.php
@@ -23,7 +23,7 @@ class FormBuilderResourceControllerTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception
@@ -51,7 +51,7 @@ class FormBuilderResourceControllerTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception
@@ -91,7 +91,7 @@ class FormBuilderResourceControllerTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testUpdateShouldFailIfFormDoesNotExist()
     {
@@ -108,7 +108,7 @@ class FormBuilderResourceControllerTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShowShouldFailIfFormDoesNotExist()
     {
@@ -230,7 +230,7 @@ class FormBuilderResourceControllerTest extends TestCase
 
     /**
      *
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function getMockRequest(string $method): WP_REST_Request
     {

--- a/tests/Feature/Gateways/Stripe/TestStripePaymentElementGateway.php
+++ b/tests/Feature/Gateways/Stripe/TestStripePaymentElementGateway.php
@@ -25,7 +25,7 @@ class TestStripePaymentElementGateway extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @throws ApiErrorException
      * @throws Exception
@@ -56,7 +56,7 @@ class TestStripePaymentElementGateway extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @throws \Give\Framework\Exceptions\Primitives\Exception
      * @throws PaymentGatewayException
@@ -146,7 +146,7 @@ class TestStripePaymentElementGateway extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     protected function getMockGateway(array $methods = [])
     {
@@ -167,7 +167,7 @@ class TestStripePaymentElementGateway extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     protected function getMockIntent(Money $amount, string $stripePublishableKey): PaymentIntent
     {

--- a/tests/Feature/Gateways/Stripe/TestTraits/HasMockStripeAccounts.php
+++ b/tests/Feature/Gateways/Stripe/TestTraits/HasMockStripeAccounts.php
@@ -4,7 +4,7 @@ namespace Give\Tests\Feature\Gateways\Stripe\TestTraits;
 
 trait HasMockStripeAccounts {
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      */
     public function addMockStripeAccounts()
     {

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/ChargeRefundedTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/ChargeRefundedTest.php
@@ -18,7 +18,7 @@ class ChargeRefundedTest extends TestCase
     use RefreshDatabase, HasMockStripeAccounts;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/CustomerSubscriptionDeletedTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/CustomerSubscriptionDeletedTest.php
@@ -19,7 +19,7 @@ class CustomerSubscriptionDeletedTest extends TestCase
     use RefreshDatabase, HasMockStripeAccounts;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/InvoicePaymentFailedTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/InvoicePaymentFailedTest.php
@@ -22,7 +22,7 @@ class InvoicePaymentFailedTest extends TestCase
     use RefreshDatabase, HasMockStripeAccounts;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/InvoicePaymentSucceededTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/InvoicePaymentSucceededTest.php
@@ -24,7 +24,7 @@ class InvoicePaymentSucceededTest extends TestCase
     use RefreshDatabase, HasMockStripeAccounts;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */
@@ -66,7 +66,7 @@ class InvoicePaymentSucceededTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */
@@ -115,7 +115,7 @@ class InvoicePaymentSucceededTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */
@@ -183,7 +183,7 @@ class InvoicePaymentSucceededTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/PaymentIntentFailedTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/PaymentIntentFailedTest.php
@@ -18,7 +18,7 @@ class PaymentIntentFailedTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Feature/Gateways/Stripe/Webhooks/Listeners/PaymentIntentSucceededTest.php
+++ b/tests/Feature/Gateways/Stripe/Webhooks/Listeners/PaymentIntentSucceededTest.php
@@ -18,7 +18,7 @@ class PaymentIntentSucceededTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @throws Exception
      */

--- a/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
+++ b/tests/Unit/Actions/ConvertQueryDataToDonationFormTest.php
@@ -18,7 +18,7 @@ class ConvertQueryDataToDonationFormTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Actions/GenerateDonateRouteUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonateRouteUrlTest.php
@@ -9,7 +9,7 @@ use Give\Tests\TestCase;
 class GenerateDonateRouteUrlTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Actions/GenerateDonationConfirmationReceiptUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonationConfirmationReceiptUrlTest.php
@@ -12,7 +12,7 @@ class GenerateDonationConfirmationReceiptUrlTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Actions/GenerateDonationConfirmationReceiptViewRouteUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonationConfirmationReceiptViewRouteUrlTest.php
@@ -9,7 +9,7 @@ use Give\Tests\TestCase;
 class GenerateDonationConfirmationReceiptViewRouteUrlTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Actions/GenerateDonationFormPreviewRouteUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonationFormPreviewRouteUrlTest.php
@@ -6,12 +6,12 @@ use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class GenerateDonationFormPreviewRouteUrlTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Actions/GenerateDonationFormViewRouteUrlTest.php
+++ b/tests/Unit/Actions/GenerateDonationFormViewRouteUrlTest.php
@@ -6,12 +6,12 @@ use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class GenerateDonationFormViewRouteUrlTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/CustomFields/Controllers/TestDonationDetailsController.php
+++ b/tests/Unit/CustomFields/Controllers/TestDonationDetailsController.php
@@ -15,7 +15,7 @@ class TestDonationDetailsController extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShowShouldReturnDonationDetailsViewRendered()
     {
@@ -37,7 +37,7 @@ class TestDonationDetailsController extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShowShouldReturnEmptyStringIfDonationFormIsLegacy() {
 

--- a/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
+++ b/tests/Unit/CustomFields/Controllers/TestDonorDetailsController.php
@@ -42,7 +42,7 @@ class TestDonorDetailsController extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShowShouldReturnEmptyIfIsLegacyForm()
     {

--- a/tests/Unit/DataTransferObjects/BlockAttributesTest.php
+++ b/tests/Unit/DataTransferObjects/BlockAttributesTest.php
@@ -6,13 +6,13 @@ use Give\DonationForms\Blocks\DonationFormBlock\DataTransferObjects\BlockAttribu
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class BlockAttributesTest extends TestCase
 {
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -31,7 +31,7 @@ class BlockAttributesTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/DataTransferObjects/DonateControllerDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonateControllerDataTest.php
@@ -18,13 +18,13 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonateControllerDataTest extends TestCase
 {
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToDonationShouldReturnDonationModel()
     {
@@ -79,7 +79,7 @@ class DonateControllerDataTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      * @throws Exception
      */
     public function testToSubscriptionShouldReturnSubscriptionModel()
@@ -149,7 +149,7 @@ class DonateControllerDataTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      * @throws Exception
      */
     public function testToInitialSubscriptionDonationShouldReturnDonationModel()
@@ -220,7 +220,7 @@ class DonateControllerDataTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testGetCustomFieldsShouldReturnCustomFieldsArray()
     {

--- a/tests/Unit/DataTransferObjects/DonateFormDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonateFormDataTest.php
@@ -19,14 +19,14 @@ use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonateFormDataTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception
@@ -88,7 +88,7 @@ class DonateFormDataTest extends TestCase
     }
 
     /**
-     * @since 0.3.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception

--- a/tests/Unit/DataTransferObjects/DonateFormRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonateFormRouteDataTest.php
@@ -13,13 +13,13 @@ use Give\Subscriptions\ValueObjects\SubscriptionPeriod;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonateFormRouteDataTest extends TestCase
 {
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testValidatedShouldReturnValidatedData()
     {
@@ -92,7 +92,7 @@ class DonateFormRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testValidatedShouldReturnValidatedDataWithSubscriptionData()
     {

--- a/tests/Unit/DataTransferObjects/DonationConfirmationReceiptViewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationConfirmationReceiptViewRouteDataTest.php
@@ -6,12 +6,12 @@ use Give\DonationForms\DataTransferObjects\DonationConfirmationReceiptViewRouteD
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonationConfirmationReceiptViewRouteDataTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -27,7 +27,7 @@ class DonationConfirmationReceiptViewRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationFormPreviewRouteDataTest.php
@@ -7,12 +7,12 @@ use Give\DonationForms\Models\DonationForm;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonationFormPreviewRouteDataTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -27,7 +27,7 @@ class DonationFormPreviewRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -44,7 +44,7 @@ class DonationFormPreviewRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/DataTransferObjects/DonationFormViewRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonationFormViewRouteDataTest.php
@@ -6,12 +6,12 @@ use Give\DonationForms\DataTransferObjects\DonationFormViewRouteData;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class DonationFormViewRouteDataTest extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/DataTransferObjects/ValidationRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/ValidationRouteDataTest.php
@@ -16,14 +16,14 @@ use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
 /**
- * @since 0.4.0
+ * @since 3.0.0
  */
 class ValidationRouteDataTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      * @throws DonationFormFieldErrorsException
      */
     public function testValidateShouldReturnValidJsonResponse()
@@ -61,7 +61,7 @@ class ValidationRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      * @throws DonationFormFieldErrorsException|Exception
      */
     public function testValidateShouldThrowDonationFormFieldErrorsException()
@@ -104,7 +104,7 @@ class ValidationRouteDataTest extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      *
      * @throws DonationFormFieldErrorsException|Exception
      */

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
@@ -18,7 +18,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception
@@ -70,7 +70,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception

--- a/tests/Unit/DonationForms/Actions/TestGenerateDonateRouteSignatureArgs.php
+++ b/tests/Unit/DonationForms/Actions/TestGenerateDonateRouteSignatureArgs.php
@@ -9,7 +9,7 @@ use Give\Tests\TestCase;
 final class TestGenerateDonateRouteSignatureArgs extends TestCase
 {
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      */
     public function testShouldReturnArrayOfQueryArgs()
     {

--- a/tests/Unit/DonationForms/DataTransferObjects/DonationFormGoalDataTest.php
+++ b/tests/Unit/DonationForms/DataTransferObjects/DonationFormGoalDataTest.php
@@ -13,7 +13,7 @@ class DonationFormGoalDataTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToArrayShouldReturnExpectedArrayOfData()
     {

--- a/tests/Unit/DonationForms/Models/TestDonationForm.php
+++ b/tests/Unit/DonationForms/Models/TestDonationForm.php
@@ -8,14 +8,14 @@ use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class TestDonationForm extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -31,7 +31,7 @@ class TestDonationForm extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
+++ b/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
@@ -44,7 +44,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -61,7 +61,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -80,7 +80,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -98,7 +98,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -116,7 +116,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -136,7 +136,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      *
@@ -159,7 +159,7 @@ final class TestDonationFormRepository extends TestCase
 
     /**
      *
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGetTotalNumberOfDonors()
     {
@@ -173,7 +173,7 @@ final class TestDonationFormRepository extends TestCase
 
     /**
      *
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGetTotalNumberOfDonations()
     {
@@ -188,7 +188,7 @@ final class TestDonationFormRepository extends TestCase
     /**
      * TODO: Notice in this test how we need to simulate a status update on the donation to trigger the legacy listener that update '_give_form_earnings' meta.  This should be resolved up the chain in our donation repository and/or factory so we don't have to do this.
      *
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGetTotalRevenue()
     {
@@ -214,7 +214,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGetFormDataGateways()
     {
@@ -222,7 +222,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testIsLegacyFormShouldReturnTrueWhenFormIsLegacy()
     {
@@ -238,7 +238,7 @@ final class TestDonationFormRepository extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testIsLegacyFormShouldReturnFalseIfNotLegacy()
     {
@@ -250,7 +250,7 @@ final class TestDonationFormRepository extends TestCase
 
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception

--- a/tests/Unit/DonationForms/ViewModels/DonationConfirmationReceiptViewModelTest.php
+++ b/tests/Unit/DonationForms/ViewModels/DonationConfirmationReceiptViewModelTest.php
@@ -17,7 +17,7 @@ class DonationConfirmationReceiptViewModelTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testFormExportsShouldReturnExpectedArrayOfData()
     {
@@ -43,7 +43,7 @@ class DonationConfirmationReceiptViewModelTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testExportsShouldReturnExpectedArrayOfData()
     {
@@ -75,7 +75,7 @@ class DonationConfirmationReceiptViewModelTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testGetReceiptShouldReturnConfirmationReceipt()
     {
@@ -105,7 +105,7 @@ class DonationConfirmationReceiptViewModelTest extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testGetDonationFormShouldReturnModel()
     {

--- a/tests/Unit/DonationForms/ViewModels/DonationFormViewModelTest.php
+++ b/tests/Unit/DonationForms/ViewModels/DonationFormViewModelTest.php
@@ -21,8 +21,8 @@ class DonationFormViewModelTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.6.0 update form export data
-     * @since 0.1.0
+     * @since 3.0.0 update form export data
+     * @since 3.0.0
      */
     public function testExportsShouldReturnExpectedArrayOfData()
     {

--- a/tests/Unit/Framework/Blocks/TestBlockCollection.php
+++ b/tests/Unit/Framework/Blocks/TestBlockCollection.php
@@ -7,7 +7,7 @@ use Give\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class TestBlockCollection extends TestCase
 {
@@ -15,7 +15,7 @@ class TestBlockCollection extends TestCase
     protected $blockCollection;
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -37,9 +37,9 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @return void
-     * @since 0.1.0
+     * @since 3.0.0
      *
+     * @return void
      */
     public function testMakesCollectionFromArray()
     {
@@ -52,7 +52,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -64,7 +64,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */
@@ -83,7 +83,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      */
     public function testInsertBeforeAddsNewBlockBeforeReference()
     {
@@ -103,7 +103,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      */
     public function testInsertAfterAddsNewBlockAfterReference()
     {
@@ -123,7 +123,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      */
     public function testPrependAddsNewBlockAsFirstChild()
     {
@@ -138,7 +138,7 @@ class TestBlockCollection extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      */
     public function testAppendAddsNewBlockAsLastChild()
     {

--- a/tests/Unit/Framework/Blocks/TestBlockModel.php
+++ b/tests/Unit/Framework/Blocks/TestBlockModel.php
@@ -7,12 +7,12 @@ use Give\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class TestBlockModel extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      * @return void
      */
     public function testHasName()
@@ -26,7 +26,7 @@ class TestBlockModel extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      * @return void
      */
     public function testHasAttributes()
@@ -43,7 +43,7 @@ class TestBlockModel extends TestCase
     }
 
     /**
-     * @since 0.4.0
+     * @since 3.0.0
      * @return void
      */
     public function testSetAttributes()
@@ -61,7 +61,7 @@ class TestBlockModel extends TestCase
 
     /**
      * @return void
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testHasInnerBlocksCollection()
     {
@@ -78,7 +78,7 @@ class TestBlockModel extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      */

--- a/tests/Unit/Framework/FormTemplates/Registrars/TestFormTemplateRegistrar.php
+++ b/tests/Unit/Framework/FormTemplates/Registrars/TestFormTemplateRegistrar.php
@@ -9,7 +9,7 @@ use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class TestFormDesignRegistrar extends TestCase
 {
@@ -17,7 +17,7 @@ class TestFormDesignRegistrar extends TestCase
     public $registrar;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function setUp()
     {
@@ -26,7 +26,7 @@ class TestFormDesignRegistrar extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testRegisterFormDesignShouldAddTemplate()
     {
@@ -36,7 +36,7 @@ class TestFormDesignRegistrar extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testUnRegisterFormDesignShouldRemoveTemplate()
     {
@@ -47,7 +47,7 @@ class TestFormDesignRegistrar extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldThrowInvalidArgumentExceptionIfNotExtendingFormDesignClass()
     {
@@ -56,7 +56,7 @@ class TestFormDesignRegistrar extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldThrowOverFlowExceptionIfFormDesignIdIsTaken()
     {
@@ -66,7 +66,7 @@ class TestFormDesignRegistrar extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testGetFormDesignsShouldReturnArrayOfRegisteredTemplates()
     {

--- a/tests/Unit/Framework/FormTemplates/TestFormTemplate.php
+++ b/tests/Unit/Framework/FormTemplates/TestFormTemplate.php
@@ -7,12 +7,12 @@ use Give\Framework\FormDesigns\FormDesign;
 use Give\Tests\TestCase;
 
 /**
- * @since 0.1.0
+ * @since 3.0.0
  */
 class TestFormDesign extends TestCase
 {
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testFormDesignImplementsInterface()
     {

--- a/tests/Unit/Framework/Receipts/TestDonationReceipt.php
+++ b/tests/Unit/Framework/Receipts/TestDonationReceipt.php
@@ -20,7 +20,7 @@ class TestDonationReceipt extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToArrayReturnsExpectedArrayShape()
     {
@@ -81,7 +81,7 @@ class TestDonationReceipt extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToArrayShouldBeEmptyWithoutGenerate()
     {
@@ -103,7 +103,7 @@ class TestDonationReceipt extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToArrayReturnsExpectedArrayShapeWithSubscriptionDetails()
     {
@@ -187,7 +187,7 @@ class TestDonationReceipt extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testAddAdditionalDetailWithToArrayReturnsExpectedArrayShape()
     {
@@ -212,7 +212,7 @@ class TestDonationReceipt extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToArrayReturnsExpectedArrayShapeWithCustomFields()
     {

--- a/tests/Unit/Framework/Receipts/TestDonationReceiptBuilder.php
+++ b/tests/Unit/Framework/Receipts/TestDonationReceiptBuilder.php
@@ -17,7 +17,7 @@ class TestDonationReceiptBuilder extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testToConfirmationPageShouldReturnDonationReceipt()
     {

--- a/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
+++ b/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
@@ -17,7 +17,7 @@ class TestGenerateConfirmationPageReceipt extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGenerateReceiptForOneTimeDonation()
     {
@@ -117,7 +117,7 @@ class TestGenerateConfirmationPageReceipt extends TestCase
     }
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldGenerateReceiptForRecurringDonation()
     {

--- a/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
+++ b/tests/Unit/Framework/TemplateTags/Actions/TestTransformTemplateTags.php
@@ -8,7 +8,7 @@ use Give\Tests\TestCase;
 class TestTransformTemplateTags extends TestCase {
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      * @return void
      */
     public function testShouldTransformTemplateTags() {

--- a/tests/Unit/Framework/TemplateTags/TestDonationTemplateTags.php
+++ b/tests/Unit/Framework/TemplateTags/TestDonationTemplateTags.php
@@ -11,7 +11,7 @@ class TestDonationTemplateTags extends TestCase {
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      */
     public function testShouldTransformDonationTemplateTags() {
 

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -23,7 +23,7 @@ class FormBuilderViewModelTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since 0.1.0
+     * @since 3.0.0
      *
      * @return void
      * @throws Exception


### PR DESCRIPTION
## Description

This PR replaces some leftovers I've found from when we replaced the NextGen since tags with 3.0.0.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

