### PR TITLE
Fix: form data converter

### DIFF
--- a/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
+++ b/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
@@ -6,7 +6,7 @@ export default function convertValuesToFormData(values: object): FormData {
     for (const valueKey in values) {
         const value = values[valueKey];
 
-        if (value === 'object') {
+        if (value !== null && value === 'object') {
             for (const objKey in value) {
                 formData.append(`${valueKey}[${objKey}]`, value[objKey]);
             }

--- a/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
+++ b/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
@@ -6,7 +6,7 @@ export default function convertValuesToFormData(values: object): FormData {
     for (const valueKey in values) {
         const value = values[valueKey];
 
-        if (value !== null && value === 'object') {
+        if (value !== null && typeof value === 'object') {
             for (const objKey in value) {
                 formData.append(`${valueKey}[${objKey}]`, value[objKey]);
             }

--- a/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
+++ b/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
@@ -3,9 +3,16 @@
  */
 export default function convertValuesToFormData(values: object): FormData {
     const formData = new FormData();
+    for (const valueKey in values) {
+        const value = values[valueKey];
 
-    for (const key in values) {
-        formData.append(key, values[key]);
+        if (value === 'object') {
+            for (const objKey in value) {
+                formData.append(`${valueKey}[${objKey}]`, value[objKey]);
+            }
+        } else {
+            formData.append(valueKey, value);
+        }
     }
 
     return formData;


### PR DESCRIPTION
## Description

When we pass values to the backend using a `FormData` structure, the ability to send arrays/objects is lost because they are converted to strings. This pull request resolves that issue by preserving arrays/objects in their original form when they are sent to the backend.

![CleanShot 2023-08-29 at 11 46 28](https://github.com/impress-org/givewp/assets/3921017/4b289af7-d807-4e0e-8056-3d5d723b8c3c)
_before_

![CleanShot 2023-08-29 at 11 45 15](https://github.com/impress-org/givewp/assets/3921017/4c662d8a-82db-4064-8721-5094b568dd57)
_after_

## Testing Instructions
- Add a MultiSelect field from FFM to your form
- Open that form on the client side
- Select one or two options in that MultiSelect dropdown
- When you submit the form, you must be able to see the selected options in the receipt page.

```php
add_action('givewp_donation_form_schema', static function (DonationForm $form) {
    $field = MultiSelect::make('custom_multiselect')
        ->fieldType('dropdown')
        ->required(true)
        ->showInAdmin(true)
        ->showInReceipt(true)
        ->label('Custom MultiSelect')
        ->rules(new ArrayRule(true))
        ->tap(function ($field) {
            $options = [
                ["Option one", "Option one", false],
                ["Option two", "Option two", false],
                ["Option three", "Option three", false],
            ];
            $field->options(...$options);
        });

    $form->insertAfter('email', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

