### PR TITLE
Fix: Update asset file path

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/EnqueueStripeFormBuilderScripts.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/EnqueueStripeFormBuilderScripts.php
@@ -17,7 +17,7 @@ class EnqueueStripeFormBuilderScripts
      */
     public function __invoke()
     {
-        $scriptAsset = require GIVE_PLUGIN_DIR . '/build/stripePaymentElementFormBuilder.asset.php';
+        $scriptAsset = require trailingslashit(GIVE_PLUGIN_DIR) . 'build/stripePaymentElementFormBuilder.asset.php';
 
         wp_enqueue_script(
             'givewp-stripe-payment-element-form-builder',


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR enforces a trailing slash on `GIVE_PLUGIN_DIR` instead of adding a leading slash to the relative file path.