### PR TITLE
Fix: Address StyledPopover component error

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/Edit.tsx
@@ -3,7 +3,6 @@ import {
     Button,
     CheckboxControl,
     Icon,
-    Modal,
     PanelBody,
     PanelRow,
     SelectControl,
@@ -193,20 +192,6 @@ export default function Edit({
                                     onChange={(value) => setAttributes({agreementText: value})}
                                 />
                             </StyledPopover>
-
-                            {showAgreementTextModal && (
-                                <Modal
-                                    title={__('Agreement Text', 'give')}
-                                    onRequestClose={() => setShowAgreementTextModal(false)}
-                                    shouldCloseOnClickOutside={false}
-                                    style={{maxWidth: '35rem'}}
-                                >
-                                    <Editor
-                                        value={agreementText}
-                                        onChange={(value) => setAttributes({agreementText: value})}
-                                    />
-                                </Modal>
-                            )}
                         </>
                     )}
                 </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/Edit.tsx
@@ -77,7 +77,7 @@ export default function Edit({
                     {useGlobalSettings && (
                         <GlobalSettingsLink
                             href={
-                                '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=terms-and-conditions'
+                                '/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=term-and-conditions'
                             }
                         />
                     )}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
@@ -11,13 +11,13 @@ type Props = {
 };
 
 export default function StyledPopover({title, visible, onClose, children}: Props) {
-    if (!visible) {
-        return null;
-    }
-
     useEffect(() => {
         return onClose;
     }, []);
+
+    if (!visible) {
+        return null;
+    }
 
     return (
         <Popover placement="left-end" variant={'unstyled'} focusOnMount={false}>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
@@ -1,4 +1,5 @@
 import {__} from '@wordpress/i18n';
+import {useEffect} from '@wordpress/element';
 import {Button, Popover} from '@wordpress/components';
 import {close} from '@wordpress/icons';
 
@@ -13,6 +14,10 @@ export default function StyledPopover({title, visible, onClose, children}: Props
     if (!visible) {
         return null;
     }
+
+    useEffect(() => {
+        return onClose;
+    }, []);
 
     return (
         <Popover placement="left-end" variant={'unstyled'} focusOnMount={false}>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/StyledPopover.tsx
@@ -1,5 +1,4 @@
 import {__} from '@wordpress/i18n';
-import {useEffect} from '@wordpress/element';
 import {Button, Popover} from '@wordpress/components';
 import {close} from '@wordpress/icons';
 
@@ -14,10 +13,6 @@ export default function StyledPopover({title, visible, onClose, children}: Props
     if (!visible) {
         return null;
     }
-
-    useEffect(() => {
-        return onClose;
-    }, []);
 
     return (
         <Popover placement="left-end" variant={'unstyled'} focusOnMount={false}>


### PR DESCRIPTION
## Description

I noticed the StyledPopover component was not working as expected. It did not open and contained an error. To fix the error we moved the useEffect hook above the conditional check. I also noticed the original Modal was still in the block file. That has been removed as well.


## Affects

StyledPopover component / terms and conditions block

## Visuals

Error:
<img width="1724" alt="Screen Shot 2023-09-01 at 11 15 30 AM" src="https://github.com/impress-org/givewp/assets/75056371/6bef5572-fd51-411a-8d99-800c9400d3c7">


With PR fix:
https://github.com/impress-org/givewp/assets/75056371/f29367cf-f54a-4789-a020-432cc551e8ef


## Testing Instructions

- Add terms and conditions block;
- Open agreement text modal;

## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205399260808640