### PR TITLE
Chore: Redirect transferred form IDs in shortcodes, blocks

### DIFF
--- a/blocks/donation-form-grid/class-give-donation-form-grid-block.php
+++ b/blocks/donation-form-grid/class-give-donation-form-grid-block.php
@@ -231,6 +231,8 @@ class Give_Donation_Form_Grid_Block {
             'progress_bar_color'  => $attributes['progressBarColor']
         );
 
+        array_walk($parameters['ids'], '_give_redirect_form_id');
+
 		$html = give_form_grid_shortcode( $parameters );
 		$html = ! empty( $html ) ? $html : $this->blank_slate();
 

--- a/blocks/donation-form/class-give-donation-form-block.php
+++ b/blocks/donation-form/class-give-donation-form-block.php
@@ -172,6 +172,8 @@ class Give_Donation_Form_Block {
 		$parameters['display_style']         = $attributes['displayStyle'];
 		$parameters['continue_button_title'] = trim( $attributes['continueButtonTitle'] );
 
+        _give_redirect_form_id($parameters['id']);
+
 		return give_form_shortcode( $parameters );
 	}
 

--- a/blocks/donor-wall/class-give-donor-wall.php
+++ b/blocks/donor-wall/class-give-donor-wall.php
@@ -234,6 +234,8 @@ class Give_Donor_Wall_Block {
             'show_time'         => $attributes['showTimestamp'],
 		];
 
+        array_walk($parameters['form_id'], '_give_redirect_form_id');
+
 		$html = Give_Donor_Wall::get_instance()->render_shortcode( $parameters );
 		$html = ! empty( $html ) ? $html : $this->blank_slate();
 

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -118,6 +118,9 @@ class Give_Donor_Wall {
 		$give_settings = give_get_settings();
 
 		$atts      = $this->parse_atts( $atts );
+
+        _give_redirect_form_id($atts['form_id']);
+
 		$donations = $this->get_donation_data( $atts );
 		$html      = '';
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -133,7 +133,7 @@ add_shortcode( 'donation_history', 'give_donation_history' );
  *
  * @since 2.30.0 Add short-circuit filter to allow for custom output.
  * @since  1.0
- 
+
  * @param array $atts Shortcode attributes
  *
  * @return string
@@ -148,6 +148,8 @@ function give_form_shortcode( $atts ) {
 	// Set form id.
 	$atts['id'] = $atts['id'] ?: FrontendFormTemplateUtils::getFormId();
 	$formId     = absint( $atts['id'] );
+
+    _give_redirect_form_id($formId, $atts['id']);
 
     // Short-circuit the shortcode output if the filter returns a non-empty string.
     $output = apply_filters('givewp_form_shortcode_output', '', $atts);
@@ -203,6 +205,8 @@ function give_goal_shortcode( $atts ) {
 		$atts,
 		'give_goal'
 	);
+
+    _give_redirect_form_id($atts['id']);
 
 	// get the Give Form.
 	ob_start();
@@ -627,6 +631,8 @@ function give_totals_shortcode( $atts ) {
 			$form_ids = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 		}
 
+        array_walk($form_ids, '_give_redirect_form_id');
+
 		/**
 		 * Filter to modify WP Query for Total Goal.
 		 *
@@ -897,6 +903,8 @@ function give_form_grid_shortcode( $atts ) {
 	if ( ! empty( $atts['ids'] ) ) {
 		$form_args['post__in'] = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 	}
+
+    array_walk($form_args['post__in'], '_give_redirect_form_id');
 
 	// Convert comma-separated form IDs into array.
 	if ( ! empty( $atts['exclude'] ) ) {

--- a/src/FormMigration/Commands/TransferCommand.php
+++ b/src/FormMigration/Commands/TransferCommand.php
@@ -46,9 +46,7 @@ class TransferCommand
 
 
         $options = TransferOptions::fromArray([
-            'changeUrl' => (bool) get_flag_value($assoc_args, 'changeUrl'),
             'delete' => (bool) get_flag_value($assoc_args, 'delete'),
-            'redirect' => (bool) get_flag_value($assoc_args, 'redirect'),
         ]);
 
         $isDryRun = get_flag_value($assoc_args, 'dry-run');
@@ -59,18 +57,11 @@ class TransferCommand
 
         try {
             DB::transaction(function() use ($formIdV3, $sourceId, $options, $isDryRun) {
+                TransferFormUrl::from($sourceId)->to($formIdV3);
                 TransferDonations::from($sourceId)->to($formIdV3);
-
-                if($options->shouldChangeUrl()) {
-                    TransferFormUrl::from($sourceId)->to($formIdV3);
-                }
 
                 if($options->shouldDelete()) {
                     wp_trash_post($sourceId);
-                }
-
-                if($options->shouldRedirect()) {
-                    give_update_meta($formIdV3, 'redirectedFormId', $sourceId);
                 }
 
                 give_update_meta($formIdV3, 'transferredFormId', true);

--- a/src/FormMigration/Controllers/TransferController.php
+++ b/src/FormMigration/Controllers/TransferController.php
@@ -43,18 +43,11 @@ class TransferController
                 )
             );
 
+            TransferFormUrl::from($formV2->id)->to($v3FormId);
             TransferDonations::from($formV2->id)->to($v3FormId);
-
-            if($options->shouldChangeUrl()) {
-                TransferFormUrl::from($formV2->id)->to($v3FormId);
-            }
 
             if($options->shouldDelete()) {
                 wp_trash_post($formV2->id);
-            }
-
-            if($options->shouldRedirect()) {
-                give_update_meta($v3FormId, 'redirectedFormId', $formV2->id);
             }
 
             give_update_meta($v3FormId, 'transferredFormId', true);

--- a/src/FormMigration/DataTransferObjects/TransferOptions.php
+++ b/src/FormMigration/DataTransferObjects/TransferOptions.php
@@ -17,14 +17,14 @@ class TransferOptions
     public static function fromRequest(WP_REST_Request $request): self
     {
         return new self(
-            $request->get_param('changeUrl')
+            $request->get_param('delete')
         );
     }
 
     public static function fromArray($options): self
     {
         return new self(
-            $options['changeUrl']
+            $options['delete']
         );
     }
 

--- a/src/FormMigration/DataTransferObjects/TransferOptions.php
+++ b/src/FormMigration/DataTransferObjects/TransferOptions.php
@@ -6,52 +6,30 @@ use WP_REST_Request;
 
 class TransferOptions
 {
-    /** @var string */
-    protected $changeUrl;
-
     /** @var bool */
     protected $delete;
 
-    /** @var bool */
-    protected $redirect;
-
-    public function __construct(bool $changeUrl, bool $delete, bool $redirect)
+    public function __construct(bool $delete)
     {
-        $this->changeUrl = $changeUrl;
         $this->delete = $delete;
-        $this->redirect = $redirect;
     }
 
     public static function fromRequest(WP_REST_Request $request): self
     {
         return new self(
-            $request->get_param('changeUrl'),
-            $request->get_param('delete'),
-            $request->get_param('redirect')
+            $request->get_param('changeUrl')
         );
     }
 
     public static function fromArray($options): self
     {
         return new self(
-            $options['changeUrl'],
-            $options['delete'],
-            $options['redirect']
+            $options['changeUrl']
         );
-    }
-
-    public function shouldChangeUrl(): bool
-    {
-        return $this->changeUrl;
     }
 
     public function shouldDelete(): bool
     {
         return $this->delete;
-    }
-
-    public function shouldRedirect(): bool
-    {
-        return $this->redirect;
     }
 }

--- a/src/FormMigration/functions.php
+++ b/src/FormMigration/functions.php
@@ -24,7 +24,10 @@ function _give_redirect_form_id(&$formId, &...$extraReference) {
             "
                     SELECT `form_id`
                     FROM `{$wpdb->prefix}give_formmeta`
-                    WHERE `meta_key` = 'redirectedFormId'
+                    JOIN `{$wpdb->posts}`
+                        ON `{$wpdb->posts}`.`ID` = `{$wpdb->prefix}give_formmeta`.`form_id`
+                    WHERE `post_status` != 'trash'
+                      AND `meta_key` = 'transferredFormId'
                       AND `meta_value` = %d",
             $formId
         )
@@ -63,7 +66,7 @@ function _give_is_form_migrated($formId) {
  *
  * @return bool
  */
-function _give_is_form_donations_transferred($formId) {
+function _give_is_form_transferred($formId) {
     global $wpdb;
 
     return (bool) DB::get_var(

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -46,6 +46,9 @@ class Shortcode
             $attributes,
             'give_multi_form_goal'
         );
+
+        array_walk($attributes['ids'], '_give_redirect_form_id');
+
         $multiFormGoal = new MultiFormGoal(
             [
                 'ids' => $attributes['ids'],

--- a/src/MultiFormGoals/ProgressBar/Block.php
+++ b/src/MultiFormGoals/ProgressBar/Block.php
@@ -56,6 +56,8 @@ class Block
      **/
     public function renderCallback($attributes)
     {
+        array_walk($attributes['ids'], '_give_redirect_form_id');
+
         $progressBar = new ProgressBar(
             [
                 'ids' => $attributes['ids'],

--- a/tests/Unit/FormMigration/FunctionsTest.php
+++ b/tests/Unit/FormMigration/FunctionsTest.php
@@ -16,7 +16,7 @@ class FunctionsTest extends TestCase
     {
         $donationFormV2 = $this->createSimpleDonationForm();
         $donationFormV3 = DonationForm::factory()->create();
-        give_update_meta($donationFormV3->id, 'redirectedFormId', $donationFormV2->id);
+        give_update_meta($donationFormV3->id, 'transferredFormId', $donationFormV2->id);
 
         $formId = $donationFormV2->id;
 
@@ -29,7 +29,7 @@ class FunctionsTest extends TestCase
     {
         $donationFormV2 = $this->createSimpleDonationForm();
         $donationFormV3 = DonationForm::factory()->create();
-        give_update_meta($donationFormV3->id, 'redirectedFormId', $donationFormV2->id);
+        give_update_meta($donationFormV3->id, 'transferredFormId', $donationFormV2->id);
 
         $formId = $donationFormV2->id;
         $atts['id'] = $donationFormV2->id;

--- a/tests/Unit/FormMigration/FunctionsTest.php
+++ b/tests/Unit/FormMigration/FunctionsTest.php
@@ -56,19 +56,19 @@ class FunctionsTest extends TestCase
         $this->assertFalse(_give_is_form_migrated($donationFormV2->id));
     }
 
-    public function testIsFormDonationsTransferred()
+    public function testIsFormTransferred()
     {
         $donationFormV2 = $this->createSimpleDonationForm();
         $donationFormV3 = DonationForm::factory()->create();
         give_update_meta($donationFormV3->id, 'transferredFormId', $donationFormV2->id);
 
-        $this->assertTrue(_give_is_form_donations_transferred($donationFormV2->id));
+        $this->assertTrue(_give_is_form_transferred($donationFormV2->id));
     }
 
-    public function testIsFormDonationsNotTransferred()
+    public function testIsFormNotTransferred()
     {
         $donationFormV2 = $this->createSimpleDonationForm();
 
-        $this->assertFalse(_give_is_form_donations_transferred($donationFormV2->id));
+        $this->assertFalse(_give_is_form_transferred($donationFormV2->id));
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR "redirects" v2 form IDs to the respective transferred v3 form ID for shortcode and block attributes.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Updates form ID(s) in block attributes in the render callback.
- Updates form ID(s) in shortcode attributes in the shortcode callback.

Additionally, updates the transfer options to reflect the new workflow.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a v2 form.
- Add the v2 form to a page via a shortcode.
- Migrate the form to a v3 form.
- Transfer the v2 form to the v3 form.
- View the page with the shortcode.