### PR TITLE
Fix: file upload field

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -68,6 +68,27 @@ textarea {
     }
 }
 
+input[type="file"] {
+    --form-element-spacing-horizontal: 0;
+    border: 0.078rem solid transparent;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    height: auto;
+    padding: 0 !important;
+
+    &::file-selector-button {
+        --form-element-spacing-horizontal: 1rem;
+        background-color: var(--givewp-primary-color);
+        border-color: var(--givewp-primary-color);
+        font-size: 0.875rem;
+    }
+
+    &[aria-invalid="true"],
+    &:invalid {
+        border-color: red;
+    }
+}
+
 button[type="submit"] {
     display: flex;
     justify-content: center;

--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -68,27 +68,6 @@ textarea {
     }
 }
 
-input[type="file"] {
-    --form-element-spacing-horizontal: 0;
-    border: 0.078rem solid transparent;
-    border-radius: 0.25rem;
-    font-size: 0.875rem;
-    height: auto;
-    padding: 0 !important;
-
-    &::file-selector-button {
-        --form-element-spacing-horizontal: 1rem;
-        background-color: var(--givewp-primary-color);
-        border-color: var(--givewp-primary-color);
-        font-size: 0.875rem;
-    }
-
-    &[aria-invalid="true"],
-    &:invalid {
-        border-color: red;
-    }
-}
-
 button[type="submit"] {
     display: flex;
     justify-content: center;

--- a/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
+++ b/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
@@ -31,6 +31,7 @@ export default function getJoiRulesForForm(form: Form): ObjectSchema {
         'string.empty': requiredMessage,
         'any.required': requiredMessage,
         'number.base': requiredMessage,
+        'object.base': requiredMessage,
     });
 }
 
@@ -67,6 +68,8 @@ function convertFieldAPIRulesToJoi(rules): AnySchema {
         joiRules = Joi.boolean();
     } else if (rules.hasOwnProperty('array')) {
         joiRules = Joi.array();
+    } else if (rules.hasOwnProperty('file')) {
+        joiRules = Joi.object();
     } else if (rules.hasOwnProperty('dateTime')) {
         joiRules = Joi.date();
     } else {

--- a/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
+++ b/src/DonationForms/resources/app/utilities/convertValuesToFormData.ts
@@ -6,7 +6,7 @@ export default function convertValuesToFormData(values: object): FormData {
     for (const valueKey in values) {
         const value = values[valueKey];
 
-        if (value !== null && typeof value === 'object') {
+        if (value !== null && typeof value === 'object' && !(value instanceof File)) {
             for (const objKey in value) {
                 formData.append(`${valueKey}[${objKey}]`, value[objKey]);
             }

--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -42,6 +42,10 @@ export interface FieldHasDescriptionProps extends FieldProps {
     description: string;
 }
 
+export interface FileProps extends FieldHasDescriptionProps {
+    allowedMimeTypes: string[];
+}
+
 export interface DateProps extends Omit<FieldHasDescriptionProps, 'placeholder'> {
     dateFormat: string;
 }

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,13 +1,13 @@
-import {FieldHasDescriptionProps} from '@givewp/forms/propTypes';
+import {FileProps} from '@givewp/forms/propTypes';
 
 export default function File({
     Label,
+    allowedMimeTypes,
     ErrorMessage,
     fieldError,
-    placeholder,
     description,
     inputProps,
-}: FieldHasDescriptionProps) {
+}: FileProps) {
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
     const {setValue} = window.givewp.form.hooks.useFormContext();
     const {name} = inputProps;
@@ -20,9 +20,7 @@ export default function File({
             <input
                 type="file"
                 aria-invalid={fieldError ? 'true' : 'false'}
-                // TODO: Update with accept prop
-                //accept="image/png, image/jpeg"
-                placeholder={placeholder}
+                accept={allowedMimeTypes.join(',')}
                 onChange={(e) => {
                     setValue(name, e.target.files[0]);
                 }}

--- a/src/DonationForms/resources/styles/elements/_fields.scss
+++ b/src/DonationForms/resources/styles/elements/_fields.scss
@@ -178,3 +178,21 @@ input[type="checkbox"] {
         background-repeat: no-repeat;
     }
 }
+
+input[type="file"] {
+    border: 0.078rem solid transparent;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
+    height: auto;
+
+    &::file-selector-button {
+        background-color: var(--givewp-primary-color);
+        border-color: var(--givewp-primary-color);
+        font-size: 0.875rem;
+    }
+
+    &[aria-invalid="true"],
+    &:invalid {
+        border-color: var(--form-element-invalid-border-color);
+    }
+}

--- a/src/Framework/FieldsAPI/File.php
+++ b/src/Framework/FieldsAPI/File.php
@@ -19,10 +19,11 @@ class File extends Field
     use Concerns\HasEmailTag;
     use Concerns\HasHelpText;
     use Concerns\HasLabel;
-    use Concerns\AllowMultiple;
     use Concerns\HasDescription;
 
     const TYPE = 'file';
+
+    protected $allowedMimeTypes = [];
 
     /**
      * Set the maximum file size.
@@ -113,6 +114,7 @@ class File extends Field
             $this->rules((new FileRule())->allowedMimeTypes($allowedMimeTypes));
         }
 
+        $this->allowedMimeTypes = $allowedMimeTypes;
 
         return $this;
     }

--- a/src/Framework/ValidationRules/Rules/File.php
+++ b/src/Framework/ValidationRules/Rules/File.php
@@ -5,12 +5,13 @@ namespace Give\Framework\ValidationRules\Rules;
 
 use Closure;
 use Give\Framework\Http\Types\UploadedFile;
+use Give\Vendors\StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
 use Give\Vendors\StellarWP\Validation\Contracts\ValidationRule;
 
 /**
  * @since 2.32.0
  */
-class File implements ValidationRule
+class File implements ValidationRule, ValidatesOnFrontEnd
 {
     /**
      * The size, in bytes, of the uploaded file
@@ -109,5 +110,10 @@ class File implements ValidationRule
     public static function fromString(string $options = null): ValidationRule
     {
         return new self();
+    }
+
+    public function serializeOption()
+    {
+        return null;
     }
 }


### PR DESCRIPTION
## Description

This pull request modifies the file upload field to address the issue of it being incorrectly marked as "required" even when a file is selected. It also introduces the "allowed" prop for the file input, which enables filtering of selectable files and applying styles to the file upload input.

## Visuals

![CleanShot 2023-09-06 at 12 39 34](https://github.com/impress-org/givewp/assets/3921017/8b4fef3c-5112-4da8-9732-79d47b8f4737)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

