### PR TITLE
Feature: update form field validation rules with optional as default 

### DIFF
--- a/src/Framework/FieldsAPI/Actions/CreateValidatorFromForm.php
+++ b/src/Framework/FieldsAPI/Actions/CreateValidatorFromForm.php
@@ -10,6 +10,7 @@ use Give\Vendors\StellarWP\Validation\Validator;
 class CreateValidatorFromForm
 {
     /**
+     * @since 3.0.0 Update validation rules with optional as default.
      * @since 2.24.0
      */
     public function __invoke(Form $form, array $values): Validator
@@ -18,7 +19,9 @@ class CreateValidatorFromForm
         $rules = [];
 
         foreach ($form->getFields() as $field) {
-            $rules[$field->getName()] = $field->getValidationRules();
+            $rules[$field->getName()] = (new UpdateValidationRulesWithOptionalAsDefault())(
+                $field->getValidationRules()
+            );
 
             if (method_exists($field, 'getLabel')) {
                 $labels[$field->getName()] = $field->getLabel();

--- a/src/Framework/FieldsAPI/Actions/CreateValidatorFromFormFields.php
+++ b/src/Framework/FieldsAPI/Actions/CreateValidatorFromFormFields.php
@@ -23,7 +23,9 @@ class CreateValidatorFromFormFields
         $rules = [];
 
         foreach ($formFields as $field) {
-            $rules[$field->getName()] = $field->getValidationRules();
+            $rules[$field->getName()] = (new UpdateValidationRulesWithOptionalAsDefault())(
+                $field->getValidationRules()
+            );
 
             if (method_exists($field, 'getLabel')) {
                 $labels[$field->getName()] = $field->getLabel();

--- a/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
+++ b/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
@@ -6,6 +6,7 @@ namespace Give\Framework\FieldsAPI\Actions;
 
 use Give\Vendors\StellarWP\Validation\Rules\ExcludeIf;
 use Give\Vendors\StellarWP\Validation\Rules\ExcludeUnless;
+use Give\Vendors\StellarWP\Validation\Rules\Optional;
 use Give\Vendors\StellarWP\Validation\ValidationRuleSet;
 
 class UpdateValidationRulesWithOptionalAsDefault
@@ -23,15 +24,17 @@ class UpdateValidationRulesWithOptionalAsDefault
             return $rules;
         }
 
-        if (!$rules->hasRule('required')) {
+        if (!$rules->hasRule('required') && !$rules->hasRule('optional')) {
             $rules->prependRule('optional');
         }
 
         $excludeRuleIds = [ExcludeIf::id(), ExcludeUnless::id()];
 
         foreach ($excludeRuleIds as $excludeRuleId) {
-            if ($rules->hasRule($excludeRuleId) && $rules->hasRule('optional')) {
+            // If the exclude rule is present, remove it and prepend it to the rules array so that optional comes after.
+            if ($rules->hasRule($excludeRuleId) && $rules->getRules()[0] instanceof Optional) {
                 $excludeRule = $rules->getRule($excludeRuleId);
+
                 $rules->removeRuleWithId($excludeRuleId);
                 $rules->prependRule($excludeRule);
             }

--- a/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
+++ b/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
@@ -20,11 +20,11 @@ class UpdateValidationRulesWithOptionalAsDefault
      */
     public function __invoke(ValidationRuleSet $rules): ValidationRuleSet
     {
-        if (!$rules->hasRules()) {
+        if (!$rules->hasRules() || $rules->hasRule('optional')) {
             return $rules;
         }
 
-        if (!$rules->hasRule('required') && !$rules->hasRule('optional')) {
+        if (!$rules->hasRule('required')) {
             $rules->prependRule('optional');
         }
 

--- a/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
+++ b/src/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefault.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Framework\FieldsAPI\Actions;
+
+use Give\Vendors\StellarWP\Validation\Rules\ExcludeIf;
+use Give\Vendors\StellarWP\Validation\Rules\ExcludeUnless;
+use Give\Vendors\StellarWP\Validation\ValidationRuleSet;
+
+class UpdateValidationRulesWithOptionalAsDefault
+{
+    /**
+     * This adds the "optional" rule to fields that don't have a "required" rule.
+     * This is to ensure that fields that are not required are not validated unless they have a value.
+     * Additionally, this ensures that the "optional" rule is placed before the "exclude" rules to preserve the intended pipeline functionality.
+     *
+     * @unreleased
+     */
+    public function __invoke(ValidationRuleSet $rules): ValidationRuleSet
+    {
+        if (!$rules->hasRules()) {
+            return $rules;
+        }
+
+        if (!$rules->hasRule('required')) {
+            $rules->prependRule('optional');
+        }
+
+        $excludeRuleIds = [ExcludeIf::id(), ExcludeUnless::id()];
+
+        foreach ($excludeRuleIds as $excludeRuleId) {
+            if ($rules->hasRule($excludeRuleId) && $rules->hasRule('optional')) {
+                $excludeRule = $rules->getRule($excludeRuleId);
+                $rules->removeRuleWithId($excludeRuleId);
+                $rules->prependRule($excludeRule);
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
+++ b/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
@@ -27,16 +27,25 @@ class UpdateValidationRulesWithOptionalAsDefaultTest extends TestCase
         $notRequiredField = Text::make('not_required_field')
             ->rules('max:255');
 
+        $alreadyOptionalField = Text::make('not_required_field')
+            ->rules('optional');
+
         $excludeIfField = Text::make('exclude_if_field')
             ->rules('excludeIf:required_field,foo');
 
         $excludeUnlessField = Text::make('excludeUnless_field')
             ->rules('excludeUnless:required_field,foo');
 
+        $excludeUnlessFieldWithAlreadyOptional = Text::make('excludeUnless_field')
+            ->rules('optional', 'excludeUnless:required_field,foo');
+
         $action = new UpdateValidationRulesWithOptionalAsDefault();
 
         $this->assertFalse($action($requiredField->getValidationRules())->hasRule('optional'));
         $this->assertTrue($action($notRequiredField->getValidationRules())->hasRule('optional'));
+
+        $this->assertTrue($action($alreadyOptionalField->getValidationRules())->hasRule('optional'));
+        $this->assertCount(1, $action($alreadyOptionalField->getValidationRules())->getRules());
 
         $excludeUnlessFieldRules = $action($excludeUnlessField->getValidationRules())->getRules();
         $this->assertInstanceOf(ExcludeUnless::class, $excludeUnlessFieldRules[0]);
@@ -45,5 +54,9 @@ class UpdateValidationRulesWithOptionalAsDefaultTest extends TestCase
         $excludeIfFieldRules = $action($excludeIfField->getValidationRules())->getRules();
         $this->assertInstanceOf(ExcludeIf::class, $excludeIfFieldRules[0]);
         $this->assertInstanceOf(Optional::class, $excludeIfFieldRules[1]);
+
+        $excludeUnlessFieldWithAlreadyOptionalRules = $action($excludeUnlessFieldWithAlreadyOptional->getValidationRules())->getRules();
+        $this->assertInstanceOf(ExcludeUnless::class, $excludeUnlessFieldWithAlreadyOptionalRules[0]);
+        $this->assertInstanceOf(Optional::class, $excludeUnlessFieldWithAlreadyOptionalRules[1]);
     }
 }

--- a/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
+++ b/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
@@ -37,7 +37,7 @@ class UpdateValidationRulesWithOptionalAsDefaultTest extends TestCase
             ->rules('excludeUnless:required_field,foo');
 
         $excludeUnlessFieldWithAlreadyOptional = Text::make('excludeUnless_field')
-            ->rules('optional', 'excludeUnless:required_field,foo');
+            ->rules('excludeUnless:required_field,foo', 'optional');
 
         $action = new UpdateValidationRulesWithOptionalAsDefault();
 

--- a/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
+++ b/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
@@ -41,22 +41,36 @@ class UpdateValidationRulesWithOptionalAsDefaultTest extends TestCase
 
         $action = new UpdateValidationRulesWithOptionalAsDefault();
 
-        $this->assertFalse($action($requiredField->getValidationRules())->hasRule('optional'));
-        $this->assertTrue($action($notRequiredField->getValidationRules())->hasRule('optional'));
+        $requiredFieldRules = $action($requiredField->getValidationRules());
+        $this->assertFalse($requiredFieldRules->hasRule('optional'));
+        $this->assertCount(1, $requiredFieldRules->getRules());
 
-        $this->assertTrue($action($alreadyOptionalField->getValidationRules())->hasRule('optional'));
-        $this->assertCount(1, $action($alreadyOptionalField->getValidationRules())->getRules());
+        $notRequiredFieldRules = $action($notRequiredField->getValidationRules());
+        $this->assertTrue($notRequiredFieldRules->hasRule('optional'));
+        $this->assertCount(2, $notRequiredFieldRules->getRules());
+
+        $alreadyOptionalFieldRules = $action($alreadyOptionalField->getValidationRules());
+        $this->assertTrue($alreadyOptionalFieldRules->hasRule('optional'));
+        $this->assertCount(1, $alreadyOptionalFieldRules->getRules());
 
         $excludeUnlessFieldRules = $action($excludeUnlessField->getValidationRules())->getRules();
         $this->assertInstanceOf(ExcludeUnless::class, $excludeUnlessFieldRules[0]);
+        $this->assertEquals($excludeUnlessFieldRules[0], ExcludeUnless::fromString('required_field,foo'));
         $this->assertInstanceOf(Optional::class, $excludeUnlessFieldRules[1]);
+        $this->assertCount(2, $excludeUnlessFieldRules);
 
         $excludeIfFieldRules = $action($excludeIfField->getValidationRules())->getRules();
         $this->assertInstanceOf(ExcludeIf::class, $excludeIfFieldRules[0]);
+        $this->assertEquals($excludeIfFieldRules[0], ExcludeIf::fromString('required_field,foo'));
         $this->assertInstanceOf(Optional::class, $excludeIfFieldRules[1]);
+        $this->assertCount(2, $excludeIfFieldRules);
 
-        $excludeUnlessFieldWithAlreadyOptionalRules = $action($excludeUnlessFieldWithAlreadyOptional->getValidationRules())->getRules();
+        $excludeUnlessFieldWithAlreadyOptionalRules = $action(
+            $excludeUnlessFieldWithAlreadyOptional->getValidationRules()
+        )->getRules();
         $this->assertInstanceOf(ExcludeUnless::class, $excludeUnlessFieldWithAlreadyOptionalRules[0]);
+        $this->assertEquals($excludeUnlessFieldRules[0], ExcludeUnless::fromString('required_field,foo'));
         $this->assertInstanceOf(Optional::class, $excludeUnlessFieldWithAlreadyOptionalRules[1]);
+        $this->assertCount(2, $excludeUnlessFieldWithAlreadyOptionalRules);
     }
 }

--- a/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
+++ b/tests/Unit/Framework/FieldsAPI/Actions/UpdateValidationRulesWithOptionalAsDefaultTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\Framework\FieldsAPI\Actions;
+
+use Give\Framework\FieldsAPI\Actions\UpdateValidationRulesWithOptionalAsDefault;
+use Give\Framework\FieldsAPI\Text;
+use Give\Tests\TestCase;
+use Give\Vendors\StellarWP\Validation\Rules\ExcludeIf;
+use Give\Vendors\StellarWP\Validation\Rules\ExcludeUnless;
+use Give\Vendors\StellarWP\Validation\Rules\Optional;
+
+/**
+ * @covers UpdateValidationRulesWithOptionalAsDefault
+ */
+class UpdateValidationRulesWithOptionalAsDefaultTest extends TestCase
+{
+    /**
+     * @since 3.0.0
+     */
+    public function testShouldUpdateValidationRulesWithOptionalAsDefault()
+    {
+        $requiredField = Text::make('required_field')
+            ->rules('required');
+
+        $notRequiredField = Text::make('not_required_field')
+            ->rules('max:255');
+
+        $excludeIfField = Text::make('exclude_if_field')
+            ->rules('excludeIf:required_field,foo');
+
+        $excludeUnlessField = Text::make('excludeUnless_field')
+            ->rules('excludeUnless:required_field,foo');
+
+        $action = new UpdateValidationRulesWithOptionalAsDefault();
+
+        $this->assertFalse($action($requiredField->getValidationRules())->hasRule('optional'));
+        $this->assertTrue($action($notRequiredField->getValidationRules())->hasRule('optional'));
+
+        $excludeUnlessFieldRules = $action($excludeUnlessField->getValidationRules())->getRules();
+        $this->assertInstanceOf(ExcludeUnless::class, $excludeUnlessFieldRules[0]);
+        $this->assertInstanceOf(Optional::class, $excludeUnlessFieldRules[1]);
+
+        $excludeIfFieldRules = $action($excludeIfField->getValidationRules())->getRules();
+        $this->assertInstanceOf(ExcludeIf::class, $excludeIfFieldRules[0]);
+        $this->assertInstanceOf(Optional::class, $excludeIfFieldRules[1]);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates all the field validation rules used in our donation form with the "optional" rule as the default rule.  This rule will get prepended only if the field is not required.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Form field validation rules

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Currently would have to test this programmatically, make sure this does not validate if empty.

```
add_action('givewp_donation_form_schema', static function (DonationForm $form) {
    $field = \Give\Framework\FieldsAPI\Email::make('custom_email')
        ->showInAdmin()
        ->showInReceipt()
        ->label('Custom Email')
        ->rules('email');

    $form->insertAfter('email', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

