### PR TITLE
Fix: Undefined variable: settings in LegacyFormSettingCompatibility.php

### DIFF
--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -105,6 +105,8 @@ class LegacyFormSettingCompatibility
      * Note: Only for internal use. This function can be removed or change in future
      *
      * @since 2.7.0
+     *
+     * @unreleased
      */
     public static function migrateExistingFormSettings()
     {
@@ -140,6 +142,7 @@ class LegacyFormSettingCompatibility
             }
         }
 
+        if (empty($settings)) return;
         Give()->form_meta->update_meta($formId, '_give_form_template', 'legacy');
         Give()->form_meta->update_meta($formId, '_give_legacy_form_template_settings', $settings);
     }


### PR DESCRIPTION
Resolves 

```
PHP Notice:  Undefined variable: settings in /.../wp-content/plugins/give/src/Form/Template/LegacyFormSettingCompatibility.php on line 144
```

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

