### PR TITLE
Fix: add fallback array to option gateways_v3

### DIFF
--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -163,7 +163,7 @@ class FormBuilderViewModel
      */
     public function getGateways(): array
     {
-        $enabledGateways = array_keys(give_get_option('gateways_v3'));
+        $enabledGateways = array_keys(give_get_option('gateways_v3', []));
 
         $builderPaymentGatewayData = array_map(static function ($gatewayClass) use ($enabledGateways) {
             /** @var PaymentGateway $gateway */

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/AddStripeAttributesToNewForms.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/AddStripeAttributesToNewForms.php
@@ -15,7 +15,7 @@ class AddStripeAttributesToNewForms
     {
         $block = $form->blocks->findByName('givewp/payment-gateways');
         if ($block) {
-            $enabledGateways = array_keys(give_get_option('gateways_v3'));
+            $enabledGateways = array_keys(give_get_option('gateways_v3', []));
             $stripeEnabled = in_array('stripe_payment_element', $enabledGateways, true);
 
             if ($stripeEnabled) {

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/EnqueueStripeFormBuilderScripts.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/EnqueueStripeFormBuilderScripts.php
@@ -17,7 +17,7 @@ class EnqueueStripeFormBuilderScripts
      */
     public function __invoke()
     {
-        $enabledGateways = array_keys(give_get_option('gateways_v3'));
+        $enabledGateways = array_keys(give_get_option('gateways_v3', []));
         $stripeEnabled = in_array('stripe_payment_element', $enabledGateways, true);
 
         if (!$stripeEnabled) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a fallback empty array when getting the give option `gateways_v3` to avoid type errors when return false or empty.  

Resolves https://github.com/impress-org/givewp/pull/6923/files#r1321690679

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder when the option is null or not set yet.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Remove the `gateway_v3` option from give settings and make sure you can add a new v3 form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

