### PR TITLE
Fix: add design mode video and hover states to the welcome banner

### DIFF
--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Link/styles.scss
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Link/styles.scss
@@ -16,6 +16,8 @@
 
         &:hover {
             color: var(--givewp-green-600);
+            border: 1px solid var(--green-500, #459948);
+            background: var(--green-25, #F2FFF3);
         }
     }
 
@@ -25,6 +27,8 @@
 
         &:hover {
             color: var(--givewp-shades-white);
+            border: 1px solid var(--givewp-green-600, #2D802F);
+            background: var(--givewp-green-600, #2D802F);
         }
     }
 }

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
@@ -22,7 +22,7 @@ export default function RightContentSection({assets}: RightContentSectionProps) 
                         'givewp'
                     )}
                 >
-                    <VideoPlayer src={`${assets}/`} fallbackImage={`${assets}/design-mode.min.png`} />
+                    <VideoPlayer src={`${assets}/design-mode.mp4`} fallbackImage={`${assets}/design-mode.min.png`} />
                 </SpotLight>
 
                 <SpotLight


### PR DESCRIPTION
## Description

This PR includes the design mode video into our assets for display on the 3.0 welcome banner. We have also added hover states to the links on the banner.

## Affects

3.0 welcome banner

## Visuals


https://github.com/impress-org/givewp/assets/75056371/392e0466-84ec-4ecc-a8ae-ce235e0d39f4


## Testing Instructions

If you have previously dismissed the banner, it will reappear by deleting "givewp_welcome_banner_dismiss" from the options table in the database.

- Verify the new design mode video displays.
- Hover over the links to verify hover effects.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205472889752868