### PR TITLE
Fix: Restore focusability of paragraph block/element

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
@@ -1,19 +1,31 @@
 import {BlockEditProps} from '@wordpress/blocks';
-import {RichText} from '@wordpress/block-editor';
+import {RichText, InspectorControls} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
+import {PanelBody, PanelRow, TextareaControl, TextControl} from "@wordpress/components";
 
 export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
     const {content} = attributes;
 
     return (
-        <div>
+        <>
             <RichText
                 tagName="p"
                 value={content}
                 allowedFormats={['core/bold', 'core/italic', 'core/link']}
-                onChange={(value) => setAttributes({content: value})}
+                onChange={(content) => setAttributes({content})}
                 placeholder={__('Enter some text', 'custom-block-editor')}
             />
-        </div>
+            <InspectorControls>
+                <PanelBody title={__('Attributes', 'give')} initialOpen={true}>
+                    <PanelRow>
+                        <TextareaControl
+                            label={__('Content', 'give')}
+                            value={content}
+                            onChange={(content) => setAttributes({content})}
+                        />
+                    </PanelRow>
+                </PanelBody>
+            </InspectorControls>
+        </>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
@@ -17,7 +17,8 @@ const settings: ElementBlock['settings'] = {
     attributes: {
         content: {
             type: 'string',
-            source: 'html',
+            source: 'attribute',
+            selector: 'p',
             default: '',
         },
     },

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -118,18 +118,12 @@
 
     .wp-block {
 
-        &.is-selected:before {
-            border-style: solid;
-            border-width: thin;
-            border-radius: 0.5rem;
-            border-color: var(--wp-admin-theme-color);
-            display: block;
-            content: '';
-            position: absolute;
-            width: calc(100% + 1rem);
-            height: calc(100% + 1rem);
-            left: calc(-1rem / 2);
-            top: calc(-1rem / 2);
+        &.is-selected {
+            // Outline doesn't seem to respect border-radius directly,
+            // but adding a 1px border-radius seems to get it close.
+            border-radius: 1px;
+            outline: 1px solid var(--wp-admin-theme-color);
+            outline-offset: 0.5rem;
         }
     }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #6930

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR replaces the pseudo outline with the native outline property (coupled with outline-offset) to restore focusability of the rich text content editable.

Additionally, a new inspector control was added for a fallback method to edit the content attribute.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205338142988520
  - https://app.asana.com/0/0/1205470381066812