### PR TITLE
Fix: paragraph block safely renders html

### DIFF
--- a/src/DonationForms/resources/registrars/templates/elements/Paragraph.tsx
+++ b/src/DonationForms/resources/registrars/templates/elements/Paragraph.tsx
@@ -1,5 +1,6 @@
+import {Markup} from 'interweave';
 import type {ParagraphProps} from '@givewp/forms/propTypes';
 
 export default function Paragraph({content}: ParagraphProps) {
-    return <p>{content}</p>;
+    return <Markup content={content} tagName={'p'} />;
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
@@ -5,6 +5,7 @@ import Edit from './Edit';
 
 const settings: ElementBlock['settings'] = {
     title: __('Paragraph', 'custom-block-editor'),
+    description: 'Place a styled paragraph in your form.',
     category: 'content',
     supports: {
         html: false,


### PR DESCRIPTION
Blocked/requires: https://github.com/impress-org/givewp/pull/6931
## Description

This PR updates the Paragraph template to use the Markup component from Interweave to safely render html, within the Paragraph block. It also adds a short description to the block.

## Affects

Paragraph block/template

## Visuals

https://github.com/impress-org/givewp/assets/75056371/60b32469-980e-4bb9-91d1-61817b2ea468

## Testing Instructions
- Add a paragraph block 
- Format the text
- View in design mode for formatted changes
- View on page for formatted changes

## Pre-review Checklist
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205483145140328