### PR TITLE
Refactor: Update multi-select field template with useWatch hook

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/MultiSelect.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/MultiSelect.tsx
@@ -3,45 +3,49 @@ import {Controller} from 'react-hook-form';
 
 import {MultiSelectProps} from '@givewp/forms/propTypes';
 import styles from '../styles.module.scss';
-import {useDonationFormState} from "@givewp/forms/app/store";
 
 export default function MultiSelect({
     Label,
     ErrorMessage,
     fieldError,
-    defaultValue,
     description,
     fieldType,
     options,
     inputProps,
 }: MultiSelectProps) {
-    const {useFormContext} = window.givewp.form.hooks;
+    const {useFormContext, useWatch} = window.givewp.form.hooks;
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
     const {name} = inputProps;
     const {control} = useFormContext();
+    const fieldValue = useWatch({name: inputProps.name});
 
     return (
-        <fieldset className={styles.multiSelectField}>
-            <label>
+        <fieldset
+            className={styles.multiSelectField}
+            {...(fieldType === 'checkbox'
+                ? {
+                      role: 'group',
+                      'aria-required': inputProps.required,
+                      'aria-invalid': !!fieldError,
+                      'aria-describedby': `givewp-field-error-${inputProps.name}`,
+                  }
+                : {})}
+        >
+            <legend>
                 <Label />
                 {description && <FieldDescription description={description} />}
-            </label>
+            </legend>
             {fieldType === 'dropdown' ? (
                 <Controller
                     name={name}
                     control={control}
-                    render={({
-                        field: {onChange, value, ref},
-                        fieldState: {invalid},
-                    }) => (
+                    render={({field: {onChange, value: fieldValue, ref}, fieldState: {invalid}}) => (
                         <Select
                             ref={ref}
                             options={options}
                             defaultValue={
-                                value
-                                    ? options.filter(({value: optionValue}) =>
-                                          Object.values(value)?.includes(optionValue)
-                                      )
+                                fieldValue
+                                    ? options.filter(({value: optionValue}) => fieldValue?.includes(optionValue))
                                     : null
                             }
                             isMulti={true}
@@ -56,12 +60,21 @@ export default function MultiSelect({
                 />
             ) : (
                 <div className="givewp-fields-checkbox__options">
-                    {options.map(({value, label}, index) => (
-                        <div key={index} className="givewp-fields-checkbox__option--container">
-                            <input type="checkbox" value={value} {...inputProps} />
-                            <label htmlFor={inputProps.name}>{label}</label>
-                        </div>
-                    ))}
+                    {options.map(({value: optionValue, label}, index) => {
+                        const optionId = inputProps.name + '_' + index;
+                        return (
+                            <div key={index} className="givewp-fields-checkbox__option-container">
+                                <input
+                                    type="checkbox"
+                                    id={optionId}
+                                    value={optionValue}
+                                    {...inputProps}
+                                    checked={fieldValue?.includes(optionValue)}
+                                />
+                                <label htmlFor={optionId}>{label}</label>
+                            </div>
+                        );
+                    })}
                 </div>
             )}
 

--- a/src/DonationForms/resources/styles/elements/_fields.scss
+++ b/src/DonationForms/resources/styles/elements/_fields.scss
@@ -84,7 +84,8 @@
     }
 }
 
-.givewp-fields-radio {
+.givewp-fields-radio,
+.givewp-fields-checkbox {
     &__options {
         display: flex;
         flex-direction: column;
@@ -95,10 +96,10 @@
         display: flex;
         align-items: flex-end;
         gap: var(--givewp-spacing-2);
-    }
 
-    label {
-        font-weight: 400;
+        label {
+            font-weight: 400;
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR introduces two main changes to the multi-select field template. The issue with `defaultValue` not being applied when using the checkbox template has been fixed by utilizing the field value from `useWatch`. Additionally, the checkboxes now have the styles applied, which are shared with the radio buttons list.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

