### PR TITLE
Fix: only display promo panel when FFM is not active

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
@@ -3,16 +3,22 @@ import BlockListTree from './panels/BlockListTree';
 import {__experimentalLibrary as Library} from '@wordpress/block-editor';
 import AdditionalFieldsPanel from '@givewp/form-builder/promos/additionalFields';
 import {useSelect} from '@wordpress/data';
+import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 
 const BlockListInserter = () => {
     // @ts-ignore
     const selectedBlock = useSelect((select) => select('core/block-editor').getSelectedBlock(), []);
     const isPrimaryBlockList = !!selectedBlock && selectedBlock.name !== 'givewp/section';
+    const {
+        formFieldManagerData: {isInstalled},
+    } = getFormBuilderWindowData();
+
+    const showAdditionalFieldsPanel = !isInstalled && isPrimaryBlockList;
 
     return (
         <div>
             <Library showInserterHelpPanel={false} />
-            {isPrimaryBlockList && <AdditionalFieldsPanel />}
+            {showAdditionalFieldsPanel && <AdditionalFieldsPanel />}
         </div>
     );
 };


### PR DESCRIPTION
## Description

This PR includes the conditional check needed on the frontend to ensure that the FFM promo panel will only display when FFM is not active.

## Visuals

https://github.com/impress-org/givewp/assets/75056371/6f7926e8-34fb-41f1-ba25-5beebe3583ce


## Testing Instructions
- Visit Formbuilder - select a block
- open primary block list - view FFM promo panel
- Install and activate FFM
- Visit Formbuilder - verify the promo no longer displays

## Pre-review Checklist
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

