### PR TITLE
Feature: hide beta menu item

### DIFF
--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -26,14 +26,10 @@ class RegisterFormBuilderPageRoute
      */
     public function __invoke()
     {
-        $pageTitle = __('Visual Donation Form Builder', 'givewp');
-        $menuTitle = __('Add v3 Form', 'givewp');
-        $version = __('Beta', 'givewp');
-
         add_submenu_page(
-            'edit.php?post_type=give_forms',
-            "$pageTitle&nbsp;<span class='awaiting-mod'>$version</span>",
-            "$menuTitle&nbsp;<span class='awaiting-mod'>$version</span>",
+            null, // do not display in menu, just register page
+            'Visual Donation Form Builder', // ignored
+            'Add Form', // ignored
             'manage_options',
             FormBuilderRouteBuilder::SLUG,
             [$this, 'renderPage'],


### PR DESCRIPTION
## Description

This simply hides the v3 beta menu item. This will no longer be a way to add forms.

## Affects

The GiveWP submenu and, in a way, how the form builder page is registered.

## Visuals

<img width="145" alt="image" src="https://github.com/impress-org/givewp/assets/2024145/124b6423-9db0-4a5b-abdd-20da34a97e19">


## Testing Instructions

Just make sure that the "add v3 form" menu item does not show up, but opening up the form builder via the new button (or by editing an existing v3 form) still works.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

