### PR TITLE
Fix: Change the migration to update gateways settings only when data doesn't exist.

### DIFF
--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param int|null $version
  * @return array $gateways All the available gateways
  */
-function give_get_payment_gateways(?int $version = 2): array
+function give_get_payment_gateways($version = 2)
 {
     $suffix = $version === 3 ? '_v3' : '';
 
@@ -67,7 +67,7 @@ function give_get_payment_gateways(?int $version = 2): array
  * @param int|null $version
  * @return array $gateway_list All the available gateways
  */
-function give_get_enabled_payment_gateways(?int $form_id = 0, ?int $version = 2): array
+function give_get_enabled_payment_gateways($form_id = 0, $version = 2)
 {
     $suffix = $version === 3 ? '_v3' : '';
     $gateways = give_get_payment_gateways($version);
@@ -98,7 +98,7 @@ function give_get_enabled_payment_gateways(?int $form_id = 0, ?int $version = 2)
  * @param int|null $version
  * @return bool true if enabled, false otherwise
  */
-function give_is_gateway_active(string $gateway, ?int $version = 2): bool
+function give_is_gateway_active($gateway, $version = 2)
 {
     $gateways = give_get_enabled_payment_gateways(null, $version);
 
@@ -117,7 +117,7 @@ function give_is_gateway_active(string $gateway, ?int $version = 2): bool
  * @param int|null $version
  * @return string Gateway ID
  */
-function give_get_default_gateway(?int $form_id, ?int $version = 2): string
+function give_get_default_gateway($form_id, $version = 2)
 {
     $suffix = $version === 3 ? '_v3' : '';
     $enabled_gateways = array_keys(give_get_enabled_payment_gateways($form_id, $version));
@@ -171,7 +171,7 @@ function give_get_gateway_admin_label($gateway)
  * @param int|null $version
  * @return string Checkout label for the gateway
  */
-function give_get_gateway_checkout_label(string $gateway, ?int $version = 2): string
+function give_get_gateway_checkout_label($gateway, $version = 2)
 {
     $gateways = give_get_payment_gateways($version);
 	$label    = isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ]['checkout_label'] : $gateway;
@@ -352,7 +352,7 @@ function give_count_sales_by_gateway( $gateway_id = 'paypal', $status = 'publish
  * @param int|null $version
  * @return array $gateways All the available gateways
  */
-function give_get_ordered_payment_gateways(array $gateways, ?int $version = 2): array
+function give_get_ordered_payment_gateways($gateways, $version = 2)
 {
     $suffix = $version === 3 ? '_v3' : '';
 

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -294,7 +294,6 @@ class DonationFormRepository
         $gateways = [];
 
         $enabledGateways = give_get_option('gateways_v3', []);
-        $defaultGateway = give_get_default_gateway($formId, 3);
 
         if (!empty($enabledGateways)) {
             foreach ($enabledGateways as $gatewayId => $enabled) {
@@ -311,6 +310,8 @@ class DonationFormRepository
                 $gateways[$gatewayId] = $gateway;
             }
 
+            $defaultGateway = give_get_default_gateway($formId, 3);
+            
             if (array_key_exists($defaultGateway, $gateways)) {
                 $gateways = array_merge([$defaultGateway => $gateways[$defaultGateway]], $gateways);
             }

--- a/src/PaymentGateways/Migrations/CopyV2GatewaysSettingsToV3.php
+++ b/src/PaymentGateways/Migrations/CopyV2GatewaysSettingsToV3.php
@@ -32,20 +32,20 @@ class CopyV2GatewaysSettingsToV3 extends Migration
     public function run()
     {
         $v3Gateways = give_get_option('gateways_v3', null);
-        if ($v3Gateways === null) {
+        if (is_null($v3Gateways)) {
             $v2Gateways = give_get_option('gateways', []);
             $v3Gateways = array_intersect_key($v2Gateways, give()->gateways->getPaymentGateways(3));
             give_update_option('gateways_v3', $v3Gateways);
         }
 
         $v3GatewaysLabels = give_get_option('gateways_label_v3', null);
-        if ($v3GatewaysLabels === null) {
+        if (is_null($v3GatewaysLabels)) {
             $v2GatewaysLabels = give_get_option('gateways_label', []);
             $v3GatewaysLabels = array_intersect_key($v2GatewaysLabels, $v3Gateways);
             give_update_option('gateways_label_v3', $v3GatewaysLabels);
         }
 
-        if (give_get_option('default_gateway_v3', null) === null) {
+        if (is_null(give_get_option('default_gateway_v3', null))) {
             $v2DefaultGateway = give_get_option('default_gateway', '');
             $v3DefaultGateway = array_key_exists($v2DefaultGateway, $v3Gateways) ? $v2DefaultGateway : current(
                 array_keys($v3Gateways)

--- a/src/PaymentGateways/Migrations/CopyV2GatewaysSettingsToV3.php
+++ b/src/PaymentGateways/Migrations/CopyV2GatewaysSettingsToV3.php
@@ -31,19 +31,27 @@ class CopyV2GatewaysSettingsToV3 extends Migration
      */
     public function run()
     {
-        $v2Gateways = give_get_option('gateways', []);
-        $v3Gateways = array_intersect_key($v2Gateways, give()->gateways->getPaymentGateways(3));
-        give_update_option('gateways_v3', $v3Gateways);
+        $v3Gateways = give_get_option('gateways_v3', null);
+        if ($v3Gateways === null) {
+            $v2Gateways = give_get_option('gateways', []);
+            $v3Gateways = array_intersect_key($v2Gateways, give()->gateways->getPaymentGateways(3));
+            give_update_option('gateways_v3', $v3Gateways);
+        }
 
-        $v2GatewaysLabels = give_get_option('gateways_label', []);
-        $v3GatewaysLabels = array_intersect_key($v2GatewaysLabels, $v3Gateways);
-        give_update_option('gateways_label_v3', $v3GatewaysLabels);
+        $v3GatewaysLabels = give_get_option('gateways_label_v3', null);
+        if ($v3GatewaysLabels === null) {
+            $v2GatewaysLabels = give_get_option('gateways_label', []);
+            $v3GatewaysLabels = array_intersect_key($v2GatewaysLabels, $v3Gateways);
+            give_update_option('gateways_label_v3', $v3GatewaysLabels);
+        }
 
-        $v2DefaultGateway = give_get_option('default_gateway', '');
-        $v3DefaultGateway = array_key_exists($v2DefaultGateway, $v3Gateways) ? $v2DefaultGateway : current(
-            array_keys($v3Gateways)
-        );
-        give_update_option('default_gateway_v3', $v3DefaultGateway);
+        if (give_get_option('default_gateway_v3', null) === null) {
+            $v2DefaultGateway = give_get_option('default_gateway', '');
+            $v3DefaultGateway = array_key_exists($v2DefaultGateway, $v3Gateways) ? $v2DefaultGateway : current(
+                array_keys($v3Gateways)
+            );
+            give_update_option('default_gateway_v3', $v3DefaultGateway);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fix an issue where a migration was updating data when they were already saved.

During the installation of GiveWP, the options `gateways_v3` and `default_gateway_v3` are saved. However, a migration process occurred that incorrectly updated these options. In the future, this migration will only run if the options have not been saved yet.

Additionally, recently added types have been removed from legacy functions.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205494192059508