### PR TITLE
Fix: Escape double quotes in emailTemplateOptions

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -257,11 +257,16 @@ class FormSettings implements Arrayable, Jsonable
                 $this->toArray(),
                 [
                     'goalType' => $this->goalType ? $this->goalType->getValue() : null,
-                    'emailTemplateOptions' => array_map(function($emailTemplateOptions) {
-                        return array_map('addslashes', $emailTemplateOptions);
-                    }, $this->emailTemplateOptions),
+                    'emailTemplateOptions' => array_map([$this, 'addSlashesRecursive'], $this->emailTemplateOptions),
                 ]
             )
         );
+    }
+
+    public function addSlashesRecursive($value)
+    {
+        return is_array($value)
+            ? array_map([$this, 'addSlashesRecursive'], $value)
+            : addslashes($value);
     }
 }

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -234,10 +234,9 @@ class FormSettings implements Arrayable, Jsonable
      */
     public static function fromJson(string $json): self
     {
-        $self = new self();
-        $array = json_decode($json, true);
-
-        return $self::fromArray($array);
+        return self::fromArray(
+            json_decode($json, true)
+        );
     }
 
     /**
@@ -258,6 +257,9 @@ class FormSettings implements Arrayable, Jsonable
                 $this->toArray(),
                 [
                     'goalType' => $this->goalType ? $this->goalType->getValue() : null,
+                    'emailTemplateOptions' => array_map(function($emailTemplateOptions) {
+                        return array_map('addslashes', $emailTemplateOptions);
+                    }, $this->emailTemplateOptions),
                 ]
             )
         );

--- a/tests/Unit/DonationForms/Properties/FormSettingsTest.php
+++ b/tests/Unit/DonationForms/Properties/FormSettingsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForms\Properties;
+
+use Give\DonationForms\Properties\FormSettings;
+use Give\Tests\TestCase;
+
+final class FormSettingsTest extends TestCase
+{
+    public function testAddSlashesRecursive()
+    {
+        $array = [
+            'one' => [
+                'aye' => 'This is "a" test',
+                'bee' => [
+                    'see' => 'This is "another" test',
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            [
+                'one' => [
+                    'aye' => 'This is \"a\" test',
+                    'bee' => [
+                        'see' => 'This is \"another\" test',
+                    ]
+                ]
+            ],
+            (new FormSettings)->addSlashesRecursive($array)
+        );
+    }
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR escapes the nested array properties for `FormSettings::$emailTemplateOptions` when converting the form settings to JSON.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Create a v2 form
1. Migrate the form to v3
1. Try to load design mode