### PR TITLE
Fix: set read more link and wrap text in a p tag on Feature Notice modal

### DIFF
--- a/src/DonationForms/V2/resources/components/Onboarding/Dialogs/FeatureNoticeDialog.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Dialogs/FeatureNoticeDialog.tsx
@@ -38,7 +38,12 @@ export default function FeatureNoticeDialog({isUpgrading, isEditing, handleClose
                     <StarsIcon /> {__("What's new", 'give')}
                 </div>
 
-                {__('GiveWP 3.0 introduces an enhanced forms experience powered by the new Visual Donation Form Builder. The team is still working on add-on and gateway compatibility. If you need to use an add-on or gateway that isn\'t listed, use the "Add form" option for now.', 'give')}
+                <p className={styles.message}>
+                    {__(
+                        'GiveWP 3.0 introduces an enhanced forms experience powered by the new Visual Donation Form Builder. The team is still working on add-on and gateway compatibility. If you need to use an add-on or gateway that isn\'t listed, use the "Add form" option for now.',
+                        'give'
+                    )}
+                </p>
 
                 {supportedAddons.length > 0 && (
                     <>

--- a/src/DonationForms/V2/resources/components/Onboarding/Dialogs/FeatureNoticeDialog.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Dialogs/FeatureNoticeDialog.tsx
@@ -93,7 +93,7 @@ export default function FeatureNoticeDialog({isUpgrading, isEditing, handleClose
 
                 <br />
 
-                <a href="#">
+                <a href="https://docs.givewp.com/compat-guide" rel="noopener noreferrer" target="_blank">
                     {__('Read more on Add-ons and Gateways compatibility', 'give')}
                 </a>
             </>

--- a/src/DonationForms/V2/resources/components/Onboarding/style.module.scss
+++ b/src/DonationForms/V2/resources/components/Onboarding/style.module.scss
@@ -40,6 +40,9 @@
     }
 }
 
+.message {
+    margin: 0 0 var(--givewp-spacing-5);
+}
 
 .title {
     font-size: 0.875rem;

--- a/src/Views/Components/AdminUI/ModalDialog/style.scss
+++ b/src/Views/Components/AdminUI/ModalDialog/style.scss
@@ -74,10 +74,6 @@
             font-size: 0.875rem;
             padding: var(--givewp-spacing-5);
         }
-
-        a {
-            text-decoration: none;
-        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR replaces the "read more" link with the actual value. Additionally, it wraps the text in a paragraph tag to allow for the application of margins. Previously, the text would collapse into the button when there were no addons or gateways to list.

## Visuals

![CleanShot 2023-09-13 at 17 57 27](https://github.com/impress-org/givewp/assets/3921017/7e0fa077-8663-435a-a8e9-5e02a789a01c)
![CleanShot 2023-09-13 at 17 56 56](https://github.com/impress-org/givewp/assets/3921017/5d5be744-934f-49ef-b600-00dde6995b21)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed