### PR TITLE
Fix: form builder page slug setting

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -1,60 +1,83 @@
-import {Button, Dropdown, ExternalLink, TextControl} from "@wordpress/components";
-import {close, Icon} from "@wordpress/icons";
-import {setFormSettings, useFormState, useFormStateDispatch} from "@givewp/form-builder/stores/form-state";
+import {Button, Dropdown, ExternalLink, TextControl} from '@wordpress/components';
+import {close, Icon} from '@wordpress/icons';
+import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
-import {getWindowData} from "@givewp/form-builder/common";
+import {getWindowData} from '@givewp/form-builder/common';
+import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
+import {useCallback, useState} from '@wordpress/element';
 
-const { formPage: { isEnabled, permalink, rewriteSlug } } = getWindowData();
+const {
+    formPage: {isEnabled, permalink, rewriteSlug},
+} = getWindowData();
 
+/**
+ * @since 3.0.0
+ * @see https://github.com/WordPress/gutenberg/blob/a8c5605f5dd077a601aefce6f58409f54d7d4447/packages/editor/src/components/post-slug/index.js
+ */
 const PageSlugControl = () => {
-
     const {
         settings: {pageSlug},
     } = useFormState();
     const dispatch = useFormStateDispatch();
+  const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
 
-    return !! isEnabled && <Dropdown
-        className="my-container-class-name"
-        contentClassName="givewp-sidebar-dropdown-content"
-        popoverProps={ { placement: 'bottom-start' } }
-        focusOnMount={"container"}
-        renderToggle={ ( { isOpen, onToggle } ) => (
-            <TextControl
-                label={'URL'}
-                value={'/donations/' + pageSlug}
-                onChange={() => null}
-                onClick={ onToggle }
-                aria-expanded={ isOpen }
-            />
-        ) }
-        renderContent={ ({onClose}) => (
-            <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
-                <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                    <strong style={{fontSize: '14px'}}>{'URL'}</strong>
-                    <Button onClick={onClose}>
-                        <Icon icon={close} size={14}></Icon>
-                    </Button>
-                </div>
-                <TextControl
-                    label={'Permalink'}
-                    value={pageSlug}
-                    onChange={(pageSlug) => dispatch(setFormSettings({pageSlug}))}
-                    help={'The last part of the URL.'}
-                />
-                <div>
-                    <strong style={{fontSize: '14px'}}>View Page</strong>
-                </div>
-                <ExternalLink href={permalink} style={{fontSize: '14px'}}>
-                    {sprintf('%s/%s', rewriteSlug, pageSlug)}
-                </ExternalLink>
-            </div>
-        ) }
-    />
-}
+  const updateSlug = useCallback(() => {
+      const cleanEditedSlug = cleanForSlug(editedSlug);
+      setEditedSlug(cleanEditedSlug);
+
+      if (cleanEditedSlug !== pageSlug) {
+          dispatch(setFormSettings({pageSlug: cleanEditedSlug}));
+      }
+  }, [pageSlug, editedSlug, dispatch]);
+
+  return (
+      !!isEnabled && (
+          <Dropdown
+              className="my-container-class-name"
+              contentClassName="givewp-sidebar-dropdown-content"
+              popoverProps={{placement: 'bottom-start'}}
+              focusOnMount={'container'}
+              renderToggle={({isOpen, onToggle}) => (
+                  <TextControl
+                      label={'URL'}
+                      value={'/donations/' + editedSlug}
+                      onChange={() => null}
+                      onClick={onToggle}
+                      aria-expanded={isOpen}
+                  />
+              )}
+              renderContent={({onClose}) => (
+                  <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
+                      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                          <strong style={{fontSize: '14px'}}>{'URL'}</strong>
+                          <Button onClick={onClose}>
+                              <Icon icon={close} size={14}></Icon>
+                          </Button>
+                      </div>
+                      <TextControl
+                          label={'Permalink'}
+                          value={editedSlug}
+                          autoComplete="off"
+                          spellCheck="false"
+                          onChange={(newPageSlug) => {
+                              setEditedSlug(newPageSlug);
+                          }}
+                          help={'The last part of the URL.'}
+                          onBlur={() => updateSlug()}
+                      />
+                      <div>
+                          <strong style={{fontSize: '14px'}}>View Page</strong>
+                      </div>
+                      <ExternalLink href={permalink} style={{fontSize: '14px'}}>
+                          {sprintf('%s/%s', rewriteSlug, editedSlug)}
+                      </ExternalLink>
+                  </div>
+              )}
+          />
+      )
+  );
+};
 
 export default PageSlugControl;
 
-export {
-    isEnabled as isFormPageEnabled,
-    PageSlugControl,
-}
+export {isEnabled as isFormPageEnabled, PageSlugControl};


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes the page slug setting in the form builder to properly clean the permalink before updating the value. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The page slug settings in the form builder

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a new or open an existing form
- Go to the page slug setting and type in something with spaces like `My Awesome Donation Form!`
- Save the form and make sure the slug is properly adjusted like `my-awesome-donation-form`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

