### PR TITLE
Fix: render v3 forms in modal display on the form grid

### DIFF
--- a/assets/src/css/frontend/modal.scss
+++ b/assets/src/css/frontend/modal.scss
@@ -9,180 +9,186 @@
 
 // Wrapper for popup
 .give-modal {
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: $mfp-z-index-base + 2147482500;
-	//position: fixed;
-	overflow: hidden;
-	outline: none !important;
-	-webkit-backface-visibility: hidden; // fixes webkit bug that can cause "false" scrollbar
-	-webkit-overflow-scrolling: touch;
-	-webkit-transform: translateZ(0);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: $mfp-z-index-base + 2147482500;
+    //position: fixed;
+    overflow: hidden;
+    outline: none !important;
+    -webkit-backface-visibility: hidden; // fixes webkit bug that can cause "false" scrollbar
+    -webkit-overflow-scrolling: touch;
+    -webkit-transform: translateZ(0);
 
-	form[id*='give-form'] {
-		margin-bottom: 0;
-		.give-submit {
-			margin-bottom: 0;
-		}
-		.give-payment-mode-label {
-			margin-top: 0;
-			padding-top: 0;
-		}
-		@media (max-width: 580px) {
-			.give-input {
-				font-size: 16px; // Prevents mobile zoom to inputs.
-			}
-		}
-	}
+    form[id*='give-form'] {
+        margin-bottom: 0;
 
-	// Popup content holder
-	.mfp-content {
-		box-sizing: border-box;
-		position: relative;
-		background: #fff;
-		padding: 20px;
-		width: auto;
-		max-width: 650px;
-		margin: 40px auto;
-		z-index: $mfp-z-index-base + 2147482600;
+        .give-submit {
+            margin-bottom: 0;
+        }
 
-		[id*='give-form'] #give-payment-mode-select,
-		[id*='give-form'] #give_purchase_form_wrap,
-		[id*='give-form'].give-display-button-only .give-donation-amount,
-		[id*='give-form'].give-display-button-only .give-donation-levels-wrap {
-			display: block;
-		}
+        .give-payment-mode-label {
+            margin-top: 0;
+            padding-top: 0;
+        }
 
-		.mfp-close:hover {
-			background-color: transparent;
-		}
-	}
+        @media (max-width: 580px) {
+            .give-input {
+                font-size: 16px; // Prevents mobile zoom to inputs.
+            }
+        }
+    }
 
-	form.give-form button.mfp-close {
-		position: absolute;
-		display: block !important;
-	}
+    // Popup content holder
+    .mfp-content {
+        box-sizing: border-box;
+        position: relative;
+        background: #fff;
+        padding: 20px;
+        width: auto;
+        max-width: 650px;
+        margin: 40px auto;
+        z-index: $mfp-z-index-base + 2147482600;
 
-	.mfp-container::after {
-		display: none;
-	}
+        [id*='give-form'] #give-payment-mode-select,
+        [id*='give-form'] #give_purchase_form_wrap,
+        [id*='give-form'].give-display-button-only .give-donation-amount,
+        [id*='give-form'].give-display-button-only .give-donation-levels-wrap {
+            display: block;
+        }
+
+        .mfp-close:hover {
+            background-color: transparent;
+        }
+    }
+
+    form.give-form button.mfp-close {
+        position: absolute;
+        display: block !important;
+    }
+
+    .mfp-container::after {
+        display: none;
+    }
 }
 
 // Move-from-top effect.
 
 .give-modal {
-	.mfp-content {
-		vertical-align: middle;
-		opacity: 0;
-		transition: all 0.2s;
-		transform: translateY(-100px);
-	}
+    .mfp-content {
+        vertical-align: middle;
+        opacity: 0;
+        transition: all 0.2s;
+        transform: translateY(-100px);
+    }
 
-	&.mfp-bg {
-		opacity: 0;
-		transition: all 0.2s;
-	}
+    &.mfp-bg {
+        opacity: 0;
+        transition: all 0.2s;
+    }
 
-	/* animate in */
-	&.mfp-ready {
-		.mfp-content {
-			opacity: 1;
-			transform: translateY(0);
-		}
-		&.mfp-bg {
-			opacity: 0.8;
-		}
-	}
+    /* animate in */
+    &.mfp-ready {
+        .mfp-content {
+            opacity: 1;
+            transform: translateY(0);
+        }
 
-	/* animate out */
-	&.mfp-removing {
-		.mfp-content {
-			transform: translateY(-50px);
-			opacity: 0;
-		}
-		&.mfp-bg {
-			opacity: 0;
-		}
-	}
+        &.mfp-bg {
+            opacity: 0.8;
+        }
+    }
+
+    /* animate out */
+    &.mfp-removing {
+        .mfp-content {
+            transform: translateY(-50px);
+            opacity: 0;
+        }
+
+        &.mfp-bg {
+            opacity: 0;
+        }
+    }
 }
 
 /**
  * Form Grid Magnific Popup CSS
  */
 .give-donation-grid-item-form {
-	position: relative;
-	margin: 0 auto;
-	max-width: 600px;
-	background-color: #fff;
-	padding: 1rem 1.5rem;
-	height: 85vh;
-	overflow-y: auto;
+    position: relative;
+    margin: 0 auto;
+    max-width: 100%;
+    width: 720px;
+    background-color: #fff;
+    padding: 1rem 1.5rem;
+    max-height: 85vh;
+    overflow-y: auto;
 
-	#give_purchase_form_wrap {
-		display: block !important;
-	}
+    #give_purchase_form_wrap {
+        display: block !important;
+    }
 
-	.give-btn-reveal,
-	.give-btn-modal {
-		display: none !important;
-	}
+    .give-btn-reveal,
+    .give-btn-modal {
+        display: none !important;
+    }
 }
 
 .modal-fade-slide.give-modal {
-	.mfp-content {
-		padding: 0;
-		max-width: 100%;
-	}
+    .mfp-content {
+        padding: 0;
+        max-width: 100%;
+    }
 }
 
 .modal-fade-slide .give-modal--slide {
-	opacity: 0;
-	transition: all 0.2s ease-out;
-	transform: translateY(-20px) perspective(600px) rotateX(0);
+    opacity: 0;
+    transition: all 0.2s ease-out;
+    transform: translateY(-20px) perspective(600px) rotateX(0);
 }
 
 .modal-fade-slide.mfp-ready .give-modal--slide {
-	opacity: 1;
-	transform: translateY(0) perspective(600px) rotateX(0);
+    opacity: 1;
+    transform: translateY(0) perspective(600px) rotateX(0);
 }
 
 .modal-fade-slide.mfp-removing .give-modal--slide {
-	opacity: 0;
-	transform: translateY(-10px) perspective(600px) rotateX(0);
+    opacity: 0;
+    transform: translateY(-10px) perspective(600px) rotateX(0);
 }
 
 .modal-fade-slide.mfp-bg {
-	opacity: 0;
-	transition: opacity 0.3s ease-out;
+    opacity: 0;
+    transition: opacity 0.3s ease-out;
 }
 
 .modal-fade-slide.mfp-ready.mfp-bg {
-	opacity: 0.8;
+    opacity: 0.8;
 }
 
 .modal-fade-slide.mfp-removing.mfp-bg {
-	opacity: 0;
+    opacity: 0;
 }
 
 .mfp-close:hover {
-	background-color: rgba(0, 0, 0, 0);
+    background-color: rgba(0, 0, 0, 0);
 }
 
 /**
  * Display Style Button
  */
 .mfp-content {
-	.give-display-button-only .give-form-title {
-		display: none;
-	}
+    .give-display-button-only .give-form-title {
+        display: none;
+    }
 
-	.give-display-button-only > *:not(form) {
-		display: block;
-	}
+    .give-display-button-only > *:not(form) {
+        display: block;
+    }
 
-	.give-display-button-only form > *:not(.give-btn-modal) {
-		display: block;
-	}
+    .give-display-button-only form > *:not(.give-btn-modal) {
+        display: block;
+    }
 }

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -7,7 +7,7 @@
 use Give\Helpers\Form\Template;
 use Give\Helpers\Form\Utils as FormUtils;
 
-if ( ! defined('ABSPATH')) {
+if (!defined('ABSPATH')) {
     exit;
 }
 
@@ -32,17 +32,17 @@ $activeTemplate = FormUtils::isLegacyForm($form_id) ? 'legacy' : Template::getAc
 $formTemplate = Give()->templates->getTemplate($activeTemplate);
 
 $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_id, $atts) {
-    if ( ! taxonomy_exists('give_forms_tag')) {
+    if (!taxonomy_exists('give_forms_tag')) {
         return '';
     }
 
     $tags = wp_get_post_terms($form_id, 'give_forms_tag');
 
-    $tag_bg_color = ! empty($atts['tag_background_color'])
+    $tag_bg_color = !empty($atts['tag_background_color'])
         ? $atts['tag_background_color']
         : '#69b86b';
 
-    $tag_text_color = ! empty($atts['tag_text_color'])
+    $tag_text_color = !empty($atts['tag_text_color'])
         ? $atts['tag_text_color']
         : '#ffffff';
 
@@ -75,7 +75,6 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
          </div>
     ";
 };
-
 ?>
 
 <div class="give-grid__item">
@@ -101,7 +100,8 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
         );
     }
     ?>
-    <div class="give-form-grid" style="flex-direction:<?php echo esc_attr($flex_direction) ?>">
+    <div class="give-form-grid" style="flex-direction:<?php
+    echo esc_attr($flex_direction) ?>">
         <?php
         // Maybe display the featured image.
         if (
@@ -153,7 +153,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
         <div class="give-form-grid-container">
             <div class="give-form-grid-content">
                 <?php
-                if ( ! $atts['show_featured_image']) {
+                if (!$atts['show_featured_image']) {
                     echo "
                                  <div class='give-form-grid-media'>
                                         {$renderTags('give-form-grid-media__tags_no_image', false)}
@@ -182,7 +182,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                         // Get content from the form post's content field.
                         $raw_content = give_get_meta($form_id, '_give_form_content', true);
 
-                        if ( ! empty($raw_content)) {
+                        if (!empty($raw_content)) {
                             $stripped_content = wp_strip_all_tags(
                                 strip_shortcodes($raw_content)
                             );
@@ -202,14 +202,14 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 }
 
                 if ($atts['show_donate_button']):
-                    $button_text = ! empty($atts['donate_button_text'])
+                    $button_text = !empty($atts['donate_button_text'])
                         ? $atts['donate_button_text']
                         : give_get_meta($form_id, '_give_form_grid_donate_button_text', true);
 
                     /**
                      * @since 2.23.1 Updated the default text color for the donate button, see #6591.
                      */
-                    $button_text_color = ! empty($atts['donate_button_text_color'])
+                    $button_text_color = !empty($atts['donate_button_text_color'])
                         ? $atts['donate_button_text_color']
                         : '#000000';
                     ?>
@@ -221,7 +221,8 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                                         echo esc_html($button_text) ?: __('Donate', 'give'); ?>
                                     </span>
                     </button>
-                <?php endif; ?>
+                <?php
+                endif; ?>
 
             </div>
             <?php
@@ -229,14 +230,14 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
             $goal_option = give_get_meta($form->ID, '_give_goal_option', true);
 
             // Sanity check - ensure form has pass all condition to show goal.
-            $hide_goal = (isset($atts['show_goal']) && ! filter_var($atts['show_goal'], FILTER_VALIDATE_BOOLEAN))
-                         || empty($form->ID)
-                         || (is_singular('give_forms') && ! give_is_setting_enabled($goal_option))
-                         || ! give_is_setting_enabled($goal_option) || 0 === $form->goal;
+            $hide_goal = (isset($atts['show_goal']) && !filter_var($atts['show_goal'], FILTER_VALIDATE_BOOLEAN))
+                || empty($form->ID)
+                || (is_singular('give_forms') && !give_is_setting_enabled($goal_option))
+                || !give_is_setting_enabled($goal_option) || 0 === $form->goal;
 
             // Maybe display the goal progress bar.
 
-            if ( ! $hide_goal) :
+            if (!$hide_goal) :
                 $goal_progress_stats = give_goal_progress_stats($form);
                 $goal_format = $goal_progress_stats['format'];
                 $color = $atts['progress_bar_color'];
@@ -343,7 +344,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                                  * @since 2.5.4
                                  *
                                  * @param array $amounts List of goal amounts.
-                                 * @param int   $form_id Donation Form ID.
+                                 * @param int $form_id Donation Form ID.
                                  */
                                 $goal_amounts = apply_filters(
                                     'give_goal_amounts',
@@ -359,7 +360,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                                  * @since 2.5.4
                                  *
                                  * @param array $amounts List of goal amounts.
-                                 * @param int   $form_id Donation Form ID.
+                                 * @param int $form_id Donation Form ID.
                                  */
                                 $income_amounts = apply_filters(
                                     'give_goal_raised_amounts',
@@ -420,38 +421,47 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                             elseif ('donation' === $goal_format) :?>
 
                                 <span class="amount">
-                                    <?php echo give_format_amount($form->get_sales(), ['decimal' => false]) ?>
+                                    <?php
+                                    echo give_format_amount($form->get_sales(), ['decimal' => false]) ?>
                                 </span>
 
                                 <span class="goal">
-                                    <?php echo sprintf(
+                                    <?php
+                                    echo sprintf(
                                         _n('of %s donation', 'of %s donations', $goal, 'give'),
                                         give_format_amount($goal, ['decimal' => false])
                                     ); ?>
                                 </span>
 
-                            <?php elseif ('donors' === $goal_format) : ?>
+                            <?php
+                            elseif ('donors' === $goal_format) : ?>
 
-                                <span class="amount"> <?php echo give_get_form_donor_count($form->ID) ?> </span>
+                                <span class="amount"> <?php
+                                    echo give_get_form_donor_count($form->ID) ?> </span>
                                 <span class="goal">
-                                    <?php echo sprintf(
+                                    <?php
+                                    echo sprintf(
                                         _n('of %s donor', 'of %s donors', $goal, 'give'),
                                         give_format_amount($goal, ['decimal' => false])
                                     ); ?>
                                 </span>
-                            <?php endif ?>
+                            <?php
+                            endif ?>
                         </div>
 
                         <div class="form-grid-raised__details">
                             <span class="amount form-grid-raised__details_donations">
-                                <?php echo give_format_amount($form->get_sales(), ['decimal' => false]) ?>
+                                <?php
+                                echo give_format_amount($form->get_sales(), ['decimal' => false]) ?>
                             </span>
                             <span class="goal">
-                                <?php echo _n('donation', 'donations', $goal, 'give') ?> </span>
+                                <?php
+                                echo _n('donation', 'donations', $goal, 'give') ?> </span>
                         </div>
                     </div>
                 </div>
-            <?php endif ?>
+            <?php
+            endif ?>
         </div>
     </div>
     </a>
@@ -459,8 +469,8 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
     // If modal, print form in hidden container until it is time to be revealed.
     if ('modal_reveal' === $atts['display_style']) {
         if (
-            ! isset($_GET['context']) // check if we are in block editor
-            && ! FormUtils::isLegacyForm($form_id)
+            !isset($_GET['context']) // check if we are in block editor
+            && !FormUtils::isLegacyForm($form_id)
         ) {
             echo give_form_shortcode(
                 [
@@ -473,7 +483,14 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 '<div id="give-modal-form-%1$s" class="give-donation-grid-item-form give-modal--slide mfp-hide">',
                 $form_id
             );
-            give_get_donation_form($form_id);
+
+            echo give_form_shortcode(
+                [
+                    'id' => $form_id,
+                    'display_style' => 'button',
+                ]
+            );
+
             echo '</div>';
         }
     }


### PR DESCRIPTION
## Description

This PR updates the rendering function that handles the modal display from the form grid shortcode/block. It replaces 
```give_get_donation_form($form_id); ``` with the ```Donation Form``` block.

The Donation Form Block has already been updated to handle rendering v3 forms.

Also minor styling updates to the modal.

## Affects

Form Grid shortcode

## Visuals

https://github.com/impress-org/givewp/assets/75056371/3ef660fc-ffe5-413f-af9d-ef0365c09ee7


## Testing Instructions

- Create a page using the form grid block
- create a form for each form template v2 and v3
- Update form grid block from ```redirect``` to ```modal```
- Verify each form opens in a modal from the form gird

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

