### PR TITLE
Fix: update gateways option key in Stripe adapter for Payment Element Gateway

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
@@ -20,7 +20,7 @@ class LegacyStripeAdapter
     {
         $settings = give_get_settings();
         $gatewaysFromSettings = $settings['gateways'] ?? [];
-        $gatewaysFromOption = give_get_option('gateways');
+        $gatewaysFromOption = give_get_option('gateways_v3', []);
 
         // for some reason, the gateways from the settings are not always in the gateways from the option.
         // this might be a service provider race conditions.


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the Stripe Payment Element gateway to use the `gateway_v3` option when deciding if it needs to load the existing stripe webhooks.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe Payment Element - webhooks

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Connect to Stripe (including webhook) and enable Stripe Elements on the site/form.
- Create v3 form
- Create donation.
- The webhook should respond correctly and mark the donation as complete

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205499836297897
  - https://app.asana.com/0/0/1205522057181508