### PR TITLE
Fix: prevent meta key conflict on block duplication

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -21,7 +21,7 @@ import MetaKeyTextControl, {slugifyMeta} from '@givewp/form-builder/supports/fie
  */
 const FieldSettingsHOC = createHigherOrderComponent((BlockEdit) => {
     return (props) => {
-        const {name, attributes, setAttributes} = props;
+        const {name, attributes, setAttributes, clientId} = props;
 
         const fieldSettings: FieldSettings = useMemo(() => {
             // @ts-ignore
@@ -41,6 +41,7 @@ const FieldSettingsHOC = createHigherOrderComponent((BlockEdit) => {
                     attributes={attributes}
                     setAttributes={setAttributes}
                     fieldSettings={fieldSettings}
+                    clientId={clientId}
                 />
             </>
         );
@@ -58,10 +59,10 @@ const generateEmailTag = (fieldName, storeAsDonorMeta) => {
  *
  * @since 3.0.0
  */
-function FieldSettingsEdit({attributes, setAttributes, fieldSettings}) {
+function FieldSettingsEdit({attributes, setAttributes, fieldSettings, clientId}) {
     const validateFieldName = useFieldNameValidator();
-    const [hasFieldNameAttribute, setHasFieldNameAttribute] = useState(attributes.hasOwnProperty('fieldName'));
-    const [isNewField] = useState(!hasFieldNameAttribute);
+    const [hasFieldNameAttribute, setHasFieldNameAttribute] = useState<boolean>(attributes.hasOwnProperty('fieldName'));
+    const [isNewField] = useState<boolean>(attributes.metaUUID !== clientId);
 
     const updateFieldName = useCallback(
         (newFieldName = null, bumpUniqueness = false) => {
@@ -109,6 +110,7 @@ function FieldSettingsEdit({attributes, setAttributes, fieldSettings}) {
         if (isNewField) {
             updateFieldName();
             setHasFieldNameAttribute(false);
+            setAttributes({metaUUID: clientId});
         }
     }, []);
 
@@ -224,7 +226,7 @@ function FieldSettingsEdit({attributes, setAttributes, fieldSettings}) {
                                 value={attributes.fieldName}
                                 onChange={(newName) => setAttributes({fieldName: newName})}
                                 onBlur={enforceFieldName}
-                                lockValue={isNewField}
+                                lockValue={!isNewField}
                             />
                         </PanelRow>
                     )}

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/updateBlockTypes.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/updateBlockTypes.ts
@@ -23,6 +23,10 @@ export default function updateBlockTypes(settings) {
     }
 
     if (fieldSettings.metaKey) {
+        fieldAttributes.metaUUID = {
+            type: 'string',
+        };
+
         fieldAttributes.fieldName = {
             type: 'string',
         };


### PR DESCRIPTION
## Description

This PR fixes the issue of duplicate meta keys when duplicating a block. We introduced a `metaUUID` attribute to store the current `clientId` value. This allows us to identify when a block is duplicated and generate a new meta key for it.

## Visuals

https://github.com/impress-org/givewp/assets/3921017/aab848b8-bab8-452e-8b61-8d76b96f2ccc

## Testing Instructions

- Add a custom field block
- Change its label
- Check the current meta key under the Advanced panel
- Duplicate that block
- Confirm the new block has an unique meta key
- Add a new custom field block
- Give it the same label from the previous ones
- Confirm it also has an unique meta key

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205504594681466