### PR TITLE
Fix: Prevent header from disapearing

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -13,7 +13,6 @@
 }
 
 .interface-interface-skeleton__body {
-    min-height: 100vh;
     width: 100%;
     background-color: var(--givewp-gray-10);
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR prevents the Editor Skeleton Header component from disappearing.

The underlying issue seems to be that the Editor Skeleton Body has a `min-height` of `100vh`, which was causing the Header to be hidden under certain circumstances.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This remove the `min-height` CSS property from the Editor Skeleton Body.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Set terms and conditions to show in modal.
1. Go to Design tab and click the Show terms link.
1. When the terms and conditions modal opens, the top bar of the builder **should not** disappear.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205502083833595
  - https://app.asana.com/0/0/1205524417076814