### PR TITLE
fix: Prevent fatal errors when redirecting form IDs

### DIFF
--- a/blocks/donation-form-grid/class-give-donation-form-grid-block.php
+++ b/blocks/donation-form-grid/class-give-donation-form-grid-block.php
@@ -207,7 +207,9 @@ class Give_Donation_Form_Grid_Block {
 	public function render_block( $attributes ) {
 		$parameters = array(
 			'forms_per_page'      => absint( $attributes['formsPerPage'] ),
-			'ids'                 => implode(',', $this->getAsArray($attributes['formIDs'] ) ),
+			'ids'                 => implode(',',
+                array_map('_give_redirect_form_id', $this->getAsArray($attributes['formIDs']))
+            ),
 			'exclude'             => implode(',', $this->getAsArray($attributes['excludedFormIDs'] ) ),
 			'orderby'             => $attributes['orderBy'],
 			'order'               => $attributes['order'],
@@ -230,8 +232,6 @@ class Give_Donation_Form_Grid_Block {
             'image_height_options' => $attributes['imageHeightOptions'],
             'progress_bar_color'  => $attributes['progressBarColor']
         );
-
-        array_walk($parameters['ids'], '_give_redirect_form_id');
 
 		$html = give_form_grid_shortcode( $parameters );
 		$html = ! empty( $html ) ? $html : $this->blank_slate();

--- a/blocks/donor-wall/class-give-donor-wall.php
+++ b/blocks/donor-wall/class-give-donor-wall.php
@@ -209,7 +209,9 @@ class Give_Donor_Wall_Block {
 
 		$parameters = [
 			'donors_per_page'   => absint( $attributes['donorsPerPage'] ),
-			'form_id'           => implode(',', $this->getAsArray($attributes['formID'] ) ),
+			'form_id'           => implode(',',
+                array_map('_give_redirect_form_id', $this->getAsArray($attributes['formID']))
+            ),
 			'ids'               => implode(',', $this->getAsArray($attributes['ids'] ) ),
             'cats'              => implode(',', $this->getAsArray($attributes['categories'] ) ),
             'tags'              => implode(',', $this->getAsArray($attributes['tags'] ) ),
@@ -233,8 +235,6 @@ class Give_Donor_Wall_Block {
             'color'             => $attributes['color'],
             'show_time'         => $attributes['showTimestamp'],
 		];
-
-        array_walk($parameters['form_id'], '_give_redirect_form_id');
 
 		$html = Give_Donor_Wall::get_instance()->render_shortcode( $parameters );
 		$html = ! empty( $html ) ? $html : $this->blank_slate();

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -901,10 +901,8 @@ function give_form_grid_shortcode( $atts ) {
 
 	// Maybe filter forms by IDs.
 	if ( ! empty( $atts['ids'] ) ) {
-		$form_args['post__in'] = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
+		$form_args['post__in'] = array_map('_give_redirect_form_id', array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) ) );
 	}
-
-    array_walk($form_args['post__in'], '_give_redirect_form_id');
 
 	// Convert comma-separated form IDs into array.
 	if ( ! empty( $atts['exclude'] ) ) {

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -47,11 +47,9 @@ class Shortcode
             'give_multi_form_goal'
         );
 
-        array_walk($attributes['ids'], '_give_redirect_form_id');
-
         $multiFormGoal = new MultiFormGoal(
             [
-                'ids' => $attributes['ids'],
+                'ids' => array_map('_give_redirect_form_id', $attributes['ids']),
                 'tags' => $attributes['tags'],
                 'categories' => $attributes['categories'],
                 'goal' => $attributes['goal'],

--- a/src/MultiFormGoals/ProgressBar/Block.php
+++ b/src/MultiFormGoals/ProgressBar/Block.php
@@ -56,11 +56,9 @@ class Block
      **/
     public function renderCallback($attributes)
     {
-        array_walk($attributes['ids'], '_give_redirect_form_id');
-
         $progressBar = new ProgressBar(
             [
-                'ids' => $attributes['ids'],
+                'ids' => array_map('_give_redirect_form_id', $attributes['ids']),
                 'tags' => $attributes['tags'],
                 'categories' => $attributes['categories'],
                 'goal' => $attributes['goal'],


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates every use of `array_walk` when redirecting Form IDs to avoid fatal errors.

In some cases the `array_walk` was being used incorrectly because arrays were being imploded as comma separated strings.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
 Using PHP 8+ add the Form Grid block to a page

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205502083833544
  - https://app.asana.com/0/0/1205534412601309