### PR TITLE
Fix: illegal offset

### DIFF
--- a/src/Form/LoadTemplate.php
+++ b/src/Form/LoadTemplate.php
@@ -13,7 +13,6 @@ use _WP_Dependency;
 use Give\Form\Template\Hookable;
 use Give\Form\Template\Scriptable;
 use Give\Helpers\Form\Template as FormTemplateUtils;
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Helpers\Form\Utils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Session\SessionDonation\DonationAccessor;
@@ -51,8 +50,6 @@ class LoadTemplate
      */
     private function setUpTemplate($formId = null)
     {
-        $formId = (int)($formId ?: FrontendFormTemplateUtils::getFormId());
-
         $templateID = FormTemplateUtils::getActiveID($formId) ?: $this->defaultTemplateID;
 
         $this->template = Give()->templates->getTemplate($templateID);

--- a/src/Helpers/Form/Template.php
+++ b/src/Helpers/Form/Template.php
@@ -21,7 +21,13 @@ class Template
      */
     public static function getActiveID($formId = null)
     {
-        return Give()->form_meta->get_meta($formId ?: Frontend::getFormId(), '_give_form_template', true);
+        /*
+         * Bailout: If neither the parameter nor the Utils\Frontend allows to get a form ID
+         * do not call get_meta.
+         * This method return unpredictable values if called with an invalid ID.
+         */
+        if (!($formId = $formId ?: Frontend::getFormId())) return null;
+        return Give()->form_meta->get_meta($formId, '_give_form_template', true);
     }
 
     /**

--- a/src/Helpers/Form/Utils.php
+++ b/src/Helpers/Form/Utils.php
@@ -226,7 +226,6 @@ class Utils
      */
     public static function isLegacyForm($formID = null)
     {
-        $formID = $formID ?: Frontend::getFormId();
         $formTemplate = Template::getActiveID($formID);
 
         return ! $formTemplate || 'legacy' === Template::getActiveID($formID);


### PR DESCRIPTION
## Description

FIX : If neither `$formId` nor the Utils\Frontend allows getting a form ID, the return value of `Template->getActiveID` becomes unpredictable and error-prone.

HOW : The PR bailout before call of get_meta, returning `null` if no ID found.

WHY : `null` is the most intuitive value to retrieve in such a situation.

## Affects

It's a fix, it not affects any feature, only bugs.

## Testing Instructions

In a context situation where `Frontend::getFormId()` returns `null`.
Call `Give()->form_meta->__add_meta()` with an improbable value (such "I'm not a template") as the only parameter.
Then call `Template::getActiveID()` without any parameters, the return value is the improbable value you provide to `__add_meta`, which should not be the case.

The PR make it returning `null` instead.

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

