### PR TITLE
Refactor: Allow blocks to move freely about the form builder

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
@@ -6,6 +6,7 @@ import {PanelBody, PanelRow, TextareaControl, TextControl} from '@wordpress/comp
 
 import {useSelect} from '@wordpress/data';
 import {BlockEditProps} from '@wordpress/blocks';
+import {getBlockRegistrar} from "@givewp/form-builder/common/getWindowData";
 
 export default function Edit(props: BlockEditProps<any>) {
     const {
@@ -45,7 +46,7 @@ export default function Edit(props: BlockEditProps<any>) {
 
                 <InnerBlocks
                     allowedBlocks={
-                        [] /* This prevents nested sections. Empty array is overwritten by child blocks specifying a parent. */
+                        getBlockRegistrar().getAll().filter((block) => block.name !== 'givewp/section').map((block) => block.name)
                     }
                     template={props.attributes.innerBlocksTemplate}
                     renderAppender={InnerBlocks.DefaultBlockAppender}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/settings.tsx
@@ -34,13 +34,13 @@ const settings: SectionBlock['settings'] = {
             type: 'string',
             source: 'attribute',
             selector: 'h1',
-            default: 'Section Title',
+            default: __('Section Title', 'give'),
         },
         description: {
             type: 'string',
             source: 'attribute',
             selector: 'p',
-            default: 'Section Description',
+            default: __('Section Description', 'give'),
         },
         allowedBlocks: {
             default: true,

--- a/src/FormBuilder/resources/js/form-builder/src/common/registerBlocks.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/common/registerBlocks.ts
@@ -40,16 +40,10 @@ const supportOverrides: BlockSupports = {
 export default function registerBlocks(): void {
     registerMissingBlock();
 
-    const [sectionBlock] = blockRegistrar.getAll();
-
     blockRegistrar.getAll().forEach(({name, settings}) => {
-        // TODO: circle back to parent flexibility
-        const parent = name !== sectionBlock.name ? [sectionBlock.name] : undefined;
-
         // @ts-ignore
         registerBlockType(name, {
             ...settings,
-            parent,
             supports: {
                 ...settings.supports,
                 ...supportOverrides,

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
@@ -6,19 +6,14 @@ import {useSelect} from '@wordpress/data';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 
 const BlockListInserter = () => {
-    // @ts-ignore
-    const selectedBlock = useSelect((select) => select('core/block-editor').getSelectedBlock(), []);
-    const isPrimaryBlockList = !!selectedBlock && selectedBlock.name !== 'givewp/section';
     const {
-        formFieldManagerData: {isInstalled},
+        formFieldManagerData: {isInstalled: isFormFieldManagerInstalled},
     } = getFormBuilderWindowData();
-
-    const showAdditionalFieldsPanel = !isInstalled && isPrimaryBlockList;
 
     return (
         <div>
             <Library showInserterHelpPanel={false} />
-            {showAdditionalFieldsPanel && <AdditionalFieldsPanel />}
+            {!isFormFieldManagerInstalled && <AdditionalFieldsPanel />}
         </div>
     );
 };

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -6,6 +6,7 @@ import BlockEditorInterfaceSkeletonContainer
     from '@givewp/form-builder/containers/BlockEditorInterfaceSkeletonContainer';
 import Onboarding from '@givewp/form-builder/components/onboarding';
 import parseMissingBlocks from '@givewp/form-builder/common/parseMissingBlocks';
+import {__} from "@wordpress/i18n";
 
 
 /**
@@ -22,8 +23,8 @@ export default function BlockEditorContainer() {
                     ...block,
                     name: 'givewp/section',
                     attributes: {
-                        title: 'Dynamically Added Section',
-                        description: 'See what I did there?',
+                        title: __('Section Title', 'give'),
+                        description: __('Section Description', 'give'),
                         innerBlocksTemplate: [[block.name, block.attributes]],
                     }
                 }

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -15,7 +15,19 @@ export default function BlockEditorContainer() {
     const {blocks} = useFormState();
     const dispatch = useFormStateDispatch();
     const dispatchFormBlocks = (blocks) => {
-        dispatch(setFormBlocks(blocks));
+        dispatch(setFormBlocks(blocks.map((block) => {
+            return block.name == 'givewp/section'
+                ? block
+                : {
+                    ...block,
+                    name: 'givewp/section',
+                    attributes: {
+                        title: 'Dynamically Added Section',
+                        description: 'See what I did there?',
+                        innerBlocksTemplate: [[block.name, block.attributes]],
+                    }
+                }
+        })));
     };
 
     parseMissingBlocks(blocks);


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR enables field and element blocks to be inserted between sections - in which case the block will be wrapped in a new section. This supports the quick inserter, drag-and-drop, and moving blocks.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

 The `dispatchFormBlocks` callback now modifies block data to enforce the `form > section > field/element` hierarchy.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2023-09-20 16-18](https://github.com/impress-org/givewp/assets/10858303/7c33d835-b6ea-48f3-b599-9c9c9c6c7cf5)

![Peek 2023-09-20 16-15](https://github.com/impress-org/givewp/assets/10858303/54cd08d0-5080-46ee-a741-1e5ba05af217)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Insert blocks all over the place - no restrictions :sunglasses:



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203980971550726
  - https://app.asana.com/0/0/1205550233964873