### PR TITLE
Fix: missing error notice on form validation error

### DIFF
--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -285,7 +285,7 @@ class Give_Notices {
 	/**
 	 * Render give frontend notices.
 	 *
-     * @since 2.32.0 Display registered error on donation form.
+	 * @since 2.32.0 Display registered error on donation form.
 	 * @since  1.8.9
 	 * @access public
 	 *
@@ -297,12 +297,12 @@ class Give_Notices {
 		$request_form_id = isset( $_REQUEST['form-id'] ) ? absint( $_REQUEST['form-id'] ) : 0;
 
 		// Sanity checks first:
-        // - Ensure that gateway returned errors display on the appropriate form.
-        // - Error should not display on AJAX request.
+		// - Ensure that gateway returned errors display on the appropriate form.
+		// - Error should always display on AJAX request.
 		if (
-            isset( $_POST['give_ajax'] )
-            || ( $request_form_id && $request_form_id !== $form_id )
-        ) {
+			( $request_form_id && $request_form_id !== $form_id )
+			&& !isset( $_POST['give_ajax'] )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

FIX: Missing error notice on form validation rejection

HOW: Change notice displaying condition on AJAX from NEVER to ALWAYS

WHY: It was the originally intention before https://github.com/impress-org/givewp/commit/34ee247a50c78d5fc7d85a0f6fa4d17e922b7f40

## Affects

Form notices displaying

## Testing Instructions

Fill a Give form but skip the Card Number, submit the form.

what should happen : The form validation is rejected, a notice "Card Number missing" should appear.

what does happen (before fix) : The form validation is rejected, no notice displaying

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

