### PR TITLE
Fix: Explicitly set customAmount setting during form migration

### DIFF
--- a/src/FormMigration/Steps/DonationOptions.php
+++ b/src/FormMigration/Steps/DonationOptions.php
@@ -24,9 +24,12 @@ class DonationOptions extends FormMigrationStep
             $amountField->setAttribute('levels', wp_list_pluck($donationLevels, '_give_amount'));
         }
 
-        if(give_is_setting_enabled($this->getMetaV2('_give_custom_amount'))) {
+        if($this->formV2->isCustomAmountOptionEnabled()) {
+            $amountField->setAttribute('customAmount', true);
             $amountField->setAttribute('customAmountMin', $this->getMetaV2('_give_custom_amount_range_minimum'));
             $amountField->setAttribute('customAmountMax', $this->getMetaV2('_give_custom_amount_range_maximum'));
+        } else {
+            $amountField->setAttribute('customAmount', false);
         }
 
         // @note No corresponding setting in v3 for "Custom Amount Text"


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR explicitly sets the `customAmount` setting during the form migration. Previously only `customAmountMin` and `customAmountMax` were being set - with `customAmount` defaulting to enabled.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a v2 form with Custom Amount disabled.
- Migrate the form.
- Custom Amount should be disabled.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205502083833541
  - https://app.asana.com/0/0/1205557954247356