### PR TITLE
Add loading states to Design Mode

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -42,6 +42,7 @@ const DesignPreview = () => {
                     border: '0',
                     display: isLoading && designUpdated ? 'none' : 'inherit',
                     opacity: isLoading ? 0.5 : 1,
+                    transition: 'opacity 0.3s ease-in-out',
                 }}
                 onInit={iframe => {
                     iframe.iFrameResizer.resize();

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -10,6 +10,7 @@ const DesignPreview = () => {
     const {blocks, settings: formSettings} = useFormState();
     const [isLoading, setLoading] = useState<boolean>(false);
     const [isEditing, setIsEditing] = useState<boolean>(false);
+    const [designUpdated, setDesignUpdated] = useState<boolean>(true);
     const [sourceDocument, setSourceDocument] = useState<string>(null);
     const [previewHTML, setPreviewHTML] = useState<string>(null);
 
@@ -23,9 +24,13 @@ const DesignPreview = () => {
         JSON.stringify(blocks), // stringify to prevent re-renders caused by object as dep
     ]);
 
+    useEffect(() => {
+        setDesignUpdated(true);
+    }, [formSettings.designId]);
+
     return (
         <>
-            {isLoading && <DesignPreviewLoading design={formSettings.designId} editing={isEditing} />}
+            {isLoading && <DesignPreviewLoading design={formSettings.designId} editing={isEditing} designUpdated={designUpdated} />}
             <IframeResizer
                 srcDoc={previewHTML}
                 checkOrigin={
@@ -35,12 +40,14 @@ const DesignPreview = () => {
                     width: '1px',
                     minWidth: '100%',
                     border: '0',
-                    display: isLoading ? 'none' : 'inherit',
+                    display: isLoading && designUpdated ? 'none' : 'inherit',
+                    opacity: isLoading ? 0.5 : 1,
                 }}
                 onInit={iframe => {
                     iframe.iFrameResizer.resize();
                     setLoading(false);
                     setIsEditing(true);
+                    setDesignUpdated(false);
                 }}
             />
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -9,6 +9,7 @@ import DesignPreviewLoading from '@givewp/form-builder/components/canvas/DesignP
 const DesignPreview = () => {
     const {blocks, settings: formSettings} = useFormState();
     const [isLoading, setLoading] = useState<boolean>(false);
+    const [isEditing, setIsEditing] = useState<boolean>(false);
     const [sourceDocument, setSourceDocument] = useState<string>(null);
     const [previewHTML, setPreviewHTML] = useState<string>(null);
 
@@ -24,7 +25,7 @@ const DesignPreview = () => {
 
     return (
         <>
-            {isLoading && <DesignPreviewLoading />}
+            {isLoading && <DesignPreviewLoading design={formSettings.designId} editing={isEditing} />}
             <IframeResizer
                 srcDoc={previewHTML}
                 checkOrigin={
@@ -34,6 +35,13 @@ const DesignPreview = () => {
                     width: '1px',
                     minWidth: '100%',
                     border: '0',
+                    display: isLoading ? 'none' : 'inherit',
+                    // opacity: isLoading ? 0.5 : 1, //todo check with jeffrey
+                    // transition: 'opacity 0.3s'
+                }}
+                onInit={() => {
+                   // setLoading(false);
+                    setIsEditing(true);
                 }}
             />
 
@@ -42,7 +50,6 @@ const DesignPreview = () => {
                 onLoad={(event) => {
                     const target = event.target as HTMLIFrameElement;
                     setPreviewHTML(target.contentWindow.document.documentElement.innerHTML);
-                    setLoading(false);
                 }}
                 srcDoc={sourceDocument}
                 style={{display: 'none'}}

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -37,7 +37,8 @@ const DesignPreview = () => {
                     border: '0',
                     display: isLoading ? 'none' : 'inherit',
                 }}
-                onInit={() => {
+                onInit={iframe => {
+                    iframe.iFrameResizer.resize();
                     setLoading(false);
                     setIsEditing(true);
                 }}

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -36,11 +36,9 @@ const DesignPreview = () => {
                     minWidth: '100%',
                     border: '0',
                     display: isLoading ? 'none' : 'inherit',
-                    // opacity: isLoading ? 0.5 : 1, //todo check with jeffrey
-                    // transition: 'opacity 0.3s'
                 }}
                 onInit={() => {
-                   // setLoading(false);
+                    setLoading(false);
                     setIsEditing(true);
                 }}
             />

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
@@ -3,9 +3,8 @@
     &-DesignPreview {
         position: relative;
         display: flex;
-        flex-basis: 0;
         justify-content: center;
-        align-items: flex-start;
+        align-items: center;
 
         &-spinner {
             position: absolute;
@@ -32,8 +31,7 @@
             background-color: var(--givewp-shades-white);
 
             &-classic {
-                flex-shrink: 0;
-                padding: 1.5rem;
+                width: 720px;
 
                 &-header,
                 &-image,
@@ -43,10 +41,50 @@
                     border-radius: 4px;
                 }
 
+                &-headerwrap {
+                    padding: 2.5rem 4rem;
+                    background-color: var(--givewp-gray-5);
+                }
+
                 &-header {
                     height: 4rem;
-                    margin-bottom: 2rem;
                 }
+
+                &-title {
+                    padding: 1rem;
+                    display: flex;
+                    justify-content: center;
+
+                    div {
+                        height: 1.5rem;
+                        width: 30%;
+                        background-color: var(--givewp-gray-10);
+                    }
+                }
+
+                &-wrap {
+                    padding: 1.5rem 4rem;
+                }
+
+                &-bar {
+                    height: 1.5rem;
+                    background-color: var(--givewp-gray-10);
+                    margin-bottom: 1.5rem;
+                }
+
+                &-doublebar {
+                    height: 2.5rem;
+                    display: flex;
+                    flex-direction: row;
+                    align-content: space-between;
+                    gap: 5px;
+
+                    div {
+                        flex: 1;
+                        background-color: var(--givewp-gray-20);
+                    }
+                }
+
             }
 
             &-multistep {
@@ -70,6 +108,31 @@
                     height: 20rem;
                 }
 
+                &-button {
+                    padding: 1.5rem 2rem;
+
+                    div {
+                        background-color: var(--givewp-gray-10);
+                        height: 4rem;
+                    }
+                }
+
+                &-footer {
+                    padding: 0 1rem;
+                    display: flex;
+                    justify-content: center;
+
+                    div {
+                        background-color: var(--givewp-gray-10);
+                        height: 1rem;
+                        width: 30%;
+                    }
+                }
+            }
+
+
+            &-classic,
+            &-multistep {
                 &-donation-levels {
                     display: flex;
                     flex-direction: row;
@@ -105,27 +168,6 @@
                         background-color: var(--givewp-gray-20);
                         border-radius: 10px;
                         height: 1.5rem;
-                    }
-                }
-
-                &-button {
-                    padding: 1.5rem 2rem;
-
-                    div {
-                        background-color: var(--givewp-gray-10);
-                        height: 4rem;
-                    }
-                }
-
-                &-footer {
-                    padding: 0 1rem;
-                    display: flex;
-                    justify-content: center;
-
-                    div {
-                        background-color: var(--givewp-gray-10);
-                        height: 1rem;
-                        width: 30%;
                     }
                 }
             }

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
@@ -1,17 +1,139 @@
 .givewp__component {
-    &--DesignPreviewLoading {
 
-        position: absolute;
-        margin-top: -48px;
-
-        width: 100%;
+    &-DesignPreview {
+        position: relative;
         display: flex;
-        align-items: flex-start;
+        flex-basis: 0;
         justify-content: center;
+        align-items: flex-start;
 
-        svg {
-            width: 32px;
-            height: 32px;
+        &-spinner {
+            position: absolute;
+            top: -80px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            justify-content: center;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+
+            svg {
+                width: 32px;
+                height: 32px;
+            }
         }
+
+        &-container {
+            margin: 10px;
+            border-radius: 10px;
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+            border: solid 1px var(--givewp-gray-10);
+            background-color: var(--givewp-shades-white);
+
+            &-classic {
+                flex-shrink: 0;
+                padding: 1.5rem;
+
+                &-header,
+                &-image,
+                &-donation-levels,
+                &-progressbar {
+                    background-color: var(--givewp-gray-10);
+                    border-radius: 4px;
+                }
+
+                &-header {
+                    height: 4rem;
+                    margin-bottom: 2rem;
+                }
+            }
+
+            &-multistep {
+                width: 35rem;
+                padding: 1.5rem;
+
+                &-header,
+                &-image,
+                &-donation-levels,
+                &-progressbar {
+                    background-color: var(--givewp-gray-10);
+                    border-radius: 4px;
+                }
+
+                &-header {
+                    height: 4rem;
+                    margin-bottom: 2rem;
+                }
+
+                &-image {
+                    height: 20rem;
+                }
+
+                &-donation-levels {
+                    display: flex;
+                    flex-direction: row;
+                    align-content: space-between;
+                    margin-top: 5px;
+                    border-bottom: solid 1px var(--givewp-gray-20);
+                    border-radius: 4px 4px 0 0;
+
+                    div {
+                        border-radius: 4px 4px 0 0;
+                        flex: 1;
+                        padding: 1.2rem;
+                        background-color: var(--givewp-gray-10);
+                    }
+
+                    div:nth-child(2) {
+                        border-left: solid 1px var(--givewp-gray-20);
+                        border-right: solid 1px var(--givewp-gray-20);
+                    }
+
+                    div > div {
+                        background-color: var(--givewp-gray-20);
+                        border-radius: 4px;
+                        height: 1rem;
+                    }
+                }
+
+                &-progressbar {
+                    border-radius: 0 0 4px 4px;
+                    padding: 1rem 1.5rem;
+
+                    div {
+                        background-color: var(--givewp-gray-20);
+                        border-radius: 10px;
+                        height: 1.5rem;
+                    }
+                }
+
+                &-button {
+                    padding: 1.5rem 2rem;
+
+                    div {
+                        background-color: var(--givewp-gray-10);
+                        height: 4rem;
+                    }
+                }
+
+                &-footer {
+                    padding: 0 1rem;
+                    display: flex;
+                    justify-content: center;
+
+                    div {
+                        background-color: var(--givewp-gray-10);
+                        height: 1rem;
+                        width: 30%;
+                    }
+                }
+            }
+
+
+        }
+
     }
+
+
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.scss
@@ -29,6 +29,7 @@
             box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
             border: solid 1px var(--givewp-gray-10);
             background-color: var(--givewp-shades-white);
+            overflow: hidden;
 
             &-classic {
                 width: 720px;
@@ -72,16 +73,56 @@
                     margin-bottom: 1.5rem;
                 }
 
+                &-barshort {
+                    height: 1.5rem;
+                    background-color: var(--givewp-gray-10);
+                    margin-top: 1.5rem;
+                    margin-bottom: 0.6rem;
+                    width: 40%;
+                }
+
                 &-doublebar {
                     height: 2.5rem;
                     display: flex;
                     flex-direction: row;
                     align-content: space-between;
-                    gap: 5px;
+                    gap: 0.3rem;
 
                     div {
                         flex: 1;
                         background-color: var(--givewp-gray-20);
+                        border-radius: 2px;
+                    }
+                }
+
+                &-doublebar-small {
+                    display: flex;
+                    flex-direction: row;
+
+                    div {
+                        flex: 1;
+                        div {
+                            height: 1.5rem;
+                            width: 7.5rem;
+                            background-color: var(--givewp-gray-10);
+                        }
+                    }
+                }
+
+                &-grid {
+                    display: grid;
+                    gap: 0.6rem;
+                    grid-template-columns: repeat(3, 1fr);
+                    margin-bottom: 4rem;
+
+                    div {
+                        background-color: var(--givewp-gray-10);
+                        height: 4rem;
+                    }
+
+                    div:last-child {
+                        grid-column-start: 1;
+                        grid-column-end: 4;
                     }
                 }
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.tsx
@@ -5,7 +5,7 @@ import MultiStep from './placeholders/MultiStep';
 
 import './index.scss';
 
-export default function DesignPreviewLoading({design, editing}) {
+export default function DesignPreviewLoading({design, editing, designUpdated}) {
     const getDesignPlaceholder = (design: string) => {
         switch (design) {
             case 'classic':
@@ -23,9 +23,11 @@ export default function DesignPreviewLoading({design, editing}) {
                 <Spinner />
                 {editing ? __('Updating your changes', 'give') : __('Preparing your form design', 'give')}...
             </div>
-            <div className="givewp__component-DesignPreview-container">
-                {getDesignPlaceholder(design)}
-            </div>
+            {designUpdated && (
+                <div className="givewp__component-DesignPreview-container">
+                    {getDesignPlaceholder(design)}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/index.tsx
@@ -1,11 +1,31 @@
+import {__} from '@wordpress/i18n';
 import {Spinner} from '@wordpress/components';
+import Classic from './placeholders/Classic';
+import MultiStep from './placeholders/MultiStep';
 
 import './index.scss';
 
-export default function DesignPreviewLoading() {
+export default function DesignPreviewLoading({design, editing}) {
+    const getDesignPlaceholder = (design: string) => {
+        switch (design) {
+            case 'classic':
+                return <Classic />
+            case 'multi-step':
+                return <MultiStep />
+        }
+
+        return null;
+    }
+
     return (
-        <div className="givewp__component--DesignPreviewLoading">
-            <Spinner />
+        <div className="givewp__component-DesignPreview">
+            <div className="givewp__component-DesignPreview-spinner">
+                <Spinner />
+                {editing ? __('Updating your changes', 'give') : __('Preparing your form design', 'give')}...
+            </div>
+            <div className="givewp__component-DesignPreview-container">
+                {getDesignPlaceholder(design)}
+            </div>
         </div>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
@@ -27,6 +27,25 @@ export default function Classic() {
                     <div></div>
                     <div></div>
                 </div>
+                <div className="givewp__component-DesignPreview-container-classic-barshort"></div>
+                <div className="givewp__component-DesignPreview-container-classic-grid">
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                    <div></div>
+                </div>
+                <div className="givewp__component-DesignPreview-container-classic-bar"></div>
+                <div className="givewp__component-DesignPreview-container-classic-doublebar-small">
+                    <div>
+                        <div></div>
+                    </div>
+                    <div>
+                         <div></div>
+                    </div>
+                </div>
             </div>
 
         </div>

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
@@ -1,9 +1,34 @@
 export default function Classic() {
     return (
         <div className="givewp__component-DesignPreview-container-classic">
-            <div className="givewp__component-DesignPreview-container-classic-header">
-
+            <div className="givewp__component-DesignPreview-container-classic-headerwrap">
+                <div className="givewp__component-DesignPreview-container-classic-header"></div>
+                <div className="givewp__component-DesignPreview-container-classic-title">
+                    <div></div>
+                </div>
+                <div className="givewp__component-DesignPreview-container-classic-donation-levels">
+                    <div>
+                        <div></div>
+                    </div>
+                    <div>
+                        <div></div>
+                    </div>
+                    <div>
+                        <div></div>
+                    </div>
+                </div>
+                <div className="givewp__component-DesignPreview-container-classic-progressbar">
+                    <div></div>
+                </div>
             </div>
+            <div className="givewp__component-DesignPreview-container-classic-wrap">
+                <div className="givewp__component-DesignPreview-container-classic-bar"></div>
+                <div className="givewp__component-DesignPreview-container-classic-doublebar">
+                    <div></div>
+                    <div></div>
+                </div>
+            </div>
+
         </div>
     )
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/Classic.tsx
@@ -1,0 +1,9 @@
+export default function Classic() {
+    return (
+        <div className="givewp__component-DesignPreview-container-classic">
+            <div className="givewp__component-DesignPreview-container-classic-header">
+
+            </div>
+        </div>
+    )
+}

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/MultiStep.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreviewLoading/placeholders/MultiStep.tsx
@@ -1,0 +1,28 @@
+export default function MultiStep() {
+    return (
+        <div className="givewp__component-DesignPreview-container-multistep">
+            <div className="givewp__component-DesignPreview-container-multistep-header"></div>
+            <div className="givewp__component-DesignPreview-container-multistep-image"></div>
+            <div className="givewp__component-DesignPreview-container-multistep-donation-levels">
+                <div>
+                    <div></div>
+                </div>
+                <div>
+                    <div></div>
+                </div>
+                <div>
+                    <div></div>
+                </div>
+            </div>
+            <div className="givewp__component-DesignPreview-container-multistep-progressbar">
+                <div></div>
+            </div>
+            <div className="givewp__component-DesignPreview-container-multistep-button">
+                <div></div>
+            </div>
+            <div className="givewp__component-DesignPreview-container-multistep-footer">
+                <div></div>
+            </div>
+        </div>
+    )
+}

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_root.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_root.scss
@@ -26,6 +26,7 @@
     --givewp-primary-800--rgb: 653, 115, 65;
 
     // Gray
+    --givewp-gray-5: #fafafa;
     --givewp-gray-10: #f2f2f2;
     --givewp-gray-20: #e6e6e6;
     --givewp-gray-30: #d9d9d9;


### PR DESCRIPTION
## Description
This PR adds a loading state placeholder for multi-step and classic templates. 

## Affects

Design Mode

## Visuals
![Screen Capture_select-area_20230925135523](https://github.com/impress-org/givewp/assets/4222590/692d607e-1211-48e4-b6e5-289690337f8f)

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions
1. Go to edit form page and enter design mode
2. Make changes to form like switch template, etc. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205367015152177