### PR TITLE
Fix: correct race condition when unit testing donations

### DIFF
--- a/includes/payments/class-give-sequential-donation-number.php
+++ b/includes/payments/class-give-sequential-donation-number.php
@@ -66,6 +66,7 @@ class Give_Sequential_Donation_Number {
 	 * Set serialize donation number as donation title.
 	 * Note: only for internal use
 	 *
+     * @unreleased replace wp_update_post with DB::update
 	 * @since  2.1.0
 	 * @access public
 	 *

--- a/includes/payments/class-give-sequential-donation-number.php
+++ b/includes/payments/class-give-sequential-donation-number.php
@@ -1,5 +1,7 @@
 <?php
 // Exit if access directly.
+use Give\Framework\Database\DB;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -115,18 +117,12 @@ class Give_Sequential_Donation_Number {
 		);
 
 		try {
-			/* @var WP_Error $wp_error */
-			$wp_error = wp_update_post(
-				array(
-					'ID'         => $donation_id,
-					'post_name'  => "{$this->donation_title_prefix}-{$serial_number}",
-					'post_title' => trim( $serial_code ),
-				)
-			);
-
-			if ( is_wp_error( $wp_error ) ) {
-				throw new Exception( $wp_error->get_error_message() );
-			}
+            DB::table('posts')
+                ->where('ID', $donation_id)
+                ->update([
+                    'post_title' => $serial_code,
+                    'post_name' => "{$this->donation_title_prefix}-{$serial_number}",
+                ]);
 
 			give_update_option( 'sequential-ordering_number', ( $serial_number + 1 ) );
 		} catch ( Exception $e ) {

--- a/includes/payments/class-give-sequential-donation-number.php
+++ b/includes/payments/class-give-sequential-donation-number.php
@@ -66,7 +66,7 @@ class Give_Sequential_Donation_Number {
 	 * Set serialize donation number as donation title.
 	 * Note: only for internal use
 	 *
-     * @unreleased replace wp_update_post with DB::update
+     * @unreleased replace wp_update_post with DB::update to avoid affecting the post update date and invalidating the donation model's updatedAt date
 	 * @since  2.1.0
 	 * @access public
 	 *

--- a/includes/payments/class-give-sequential-donation-number.php
+++ b/includes/payments/class-give-sequential-donation-number.php
@@ -121,9 +121,10 @@ class Give_Sequential_Donation_Number {
             DB::table('posts')
                 ->where('ID', $donation_id)
                 ->update([
-                    'post_title' => $serial_code,
+                    'post_title' => trim($serial_code),
                     'post_name' => "{$this->donation_title_prefix}-{$serial_number}",
                 ]);
+            clean_post_cache($donation_id);
 
 			give_update_option( 'sequential-ordering_number', ( $serial_number + 1 ) );
 		} catch ( Exception $e ) {


### PR DESCRIPTION
## Description
This pull request addresses a race condition issue occurring in the `testCreateShouldInsertDonation` unit test. The issue originated when creating a new donation. The creation process triggers a method related to sequential order id (`Give_Sequential_Donation_Number->__save_donation_title()`). This method used the `wp_update_post` function to update the `post_title` and `post_name` fields of the donation, which had the side effect of altering the `post_modified` column in the original donation post. This unintended change led to mismatches during unit testing.

#### Changes

- Replaced the `wp_update_post` function with `DB::update` in the `Give_Sequential_Donation_Number->__save_donation_title()` method.
- Manually cleared the WordPress cache for the donation, ensuring other parts of the code recognize the update.

By switching to `DB::update`, we eliminate the issue of updating the `post_modified` column in the original donation post, effectively resolving the race condition problem.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205573516749464