### PR TITLE
Refactor: render gateway fields only when it's active

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Gateways.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Gateways.tsx
@@ -182,7 +182,7 @@ function GatewayOption({gateway, defaultChecked, inputProps, isActive}: GatewayO
                         window.location.reload();
                     }}
                 >
-                    <gateway.Fields />
+                    {isActive && <gateway.Fields />}
                 </ErrorBoundary>
             </div>
         </li>


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements a simple change that only renders (on the JS side) the gateway fields of a gateway when it gets selected by the user. This approach improves performance and the initial form load.

After these changes, I did test donations without problems using the following gateways:

- Stripe Element
- PayPal Donations
- PayPal Standard
- Square Credit Card
- Authorize Credit Card
- Authorize eCheck


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

All compatible gateways with v3 forms.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Active all gateways compatible with v3 forms;
2. Make sure the Test Donation is the default gateway;
3. Create test donations using all gateways and make sure everything is working as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205318504721019
  - https://app.asana.com/0/0/1205604772387034