### PR TITLE
Fix: correct install routine when activating in a WordPress multisite.

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.33.2
+ * Version: 2.33.3
  * Requires at least: 5.0
  * Requires PHP: 7.0
  * Text Domain: give
@@ -316,7 +316,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.33.2');
+            define('GIVE_VERSION', '2.33.3');
         }
 
         // Plugin Root File.
@@ -409,7 +409,7 @@ final class Give
      *
      * Runs on plugin activation and performs initial setup.
      *
-     * @unreleased set network_wide parameter to true, enabling installing in WP multisite
+     * @since 2.33.3 set network_wide parameter to true, enabling installing in WP multisite
      * @since 1.0.0
      */
     public function install()

--- a/give.php
+++ b/give.php
@@ -407,7 +407,7 @@ final class Give
     public function install()
     {
         $this->loadServiceProviders();
-        give_install();
+        give_install(true);
     }
 
     /**

--- a/give.php
+++ b/give.php
@@ -404,6 +404,14 @@ final class Give
         }
     }
 
+    /**
+     * Install Give
+     *
+     * Runs on plugin activation and performs initial setup.
+     *
+     * @unreleased set network_wide parameter to true, enabling installing in WP multisite
+     * @since 1.0.0
+     */
     public function install()
     {
         $this->loadServiceProviders();

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 7.0
-Stable tag: 2.33.2
+Stable tag: 2.33.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -258,7 +258,10 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
-= 2.33.1: August 31st, 2023 =
+= 2.33.3: September 29th, 2023 =
+* Fix: Multi-site installations no longer produce an error on subsites.
+
+= 2.33.2: September 18th, 2023 =
 * Fix: Add validation for form status to prevent donations to donation forms with the status of "Trash"
 
 = 2.33.1: August 31st, 2023 =


### PR DESCRIPTION
## Description
This PR addresses an error in the installation process of GiveWP on multisite setups. Previously, only the main site was installed, resulting in fatal errors on existing subsites.

Upon investigating the codebase, it was discovered that the installation method for GiveWP had a conditional check for `is_multisite()` and a `$network_wide` parameter. However, this parameter was never set to `true`, causing improper installation on WP multisite.

In this PR, we enable the parameter when the plugin is activated for the first time, ensuring proper installation of GiveWP on all existing subsites.

## Affects

GiveWP install process

## Testing Instructions

1. Fresh WordPress install with Multiste enabled
2. Create one subsite at My Sites > Network Admin > Add New
3. Navigate to My Sites > Network Admin > Plugins, install GiveWP, and activate it
4. Navigate to My Sites > Network Admin > Sites, scroll to subsite, click "Dashboard" link
5. The subsite dashboard must show and the Donations menu must be present, meaning that Give is activated

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205607759526942