### PR TITLE
Fix: Correct the ZIP build process by changing imports

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/modal/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/modal/index.tsx
@@ -1,10 +1,10 @@
-import {Button, Icon, Modal as GutenbergModal} from '@wordpress/components';
+import {Button, Icon} from '@wordpress/components';
+import GutenbergModal from '@wordpress/components/modal';
 import {info, warning} from '@wordpress/icons';
-import GutenbergModalTypes from 'wordpress__components/Modal';
 import cx from 'classnames';
 import './styles.scss';
 
-interface ModalProps extends GutenbergModalTypes.Props {
+interface ModalProps extends GutenbergModal.Props {
     closeButtonCaption?: string;
 }
 


### PR DESCRIPTION
## Description

Our [Generate Plugin Zip](https://github.com/impress-org/givewp/actions/workflows/generate-zip.yml) workflow stopped working at some point. Upon investigating the issue, I discovered that we had imported types in a manner that although works locally, wasn't working in our build process.

This PR modifies the import and usage of those types to ensure they function correctly both locally and during the build process.

## Affects

Modal component

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

