### PR TITLE
Feature: Show correct notice message on post publish/update

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
@@ -16,7 +16,6 @@ import {Button} from "@wordpress/components";
 import {listView, plus} from "@wordpress/icons";
 import {useEditorState} from "@givewp/form-builder/stores/editor-state";
 import EditorMode from "@givewp/form-builder/types/editorMode";
-import {useFormState} from "@givewp/form-builder/stores/form-state";
 
 export default function BlockEditorInterfaceSkeletonContainer() {
 
@@ -32,10 +31,7 @@ export default function BlockEditorInterfaceSkeletonContainer() {
 }
 
 const DesignEditorSkeleton = () => {
-    const {createSuccessNotice} = useDispatch('core/notices');
-
     const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
-    const {settings: formSettings} = useFormState();
 
     return (
         <InterfaceSkeleton
@@ -43,15 +39,6 @@ const DesignEditorSkeleton = () => {
                 <HeaderContainer
                     showSidebar={showSidebar}
                     toggleShowSidebar={toggleShowSidebar}
-                    onSaveNotice={() => {
-                        const notice = 'publish' === formSettings.formStatus
-                            ? __('Form updated.', 'give')
-                            : __('Form published.', 'give')
-
-                        createSuccessNotice(notice, {
-                            type: 'snackbar',
-                        });
-                    }}
                 />
             }
             content={<DesignPreview />}
@@ -62,12 +49,9 @@ const DesignEditorSkeleton = () => {
 }
 
 const SchemaEditorSkeleton = () => {
-    const {createSuccessNotice} = useDispatch('core/notices');
-
     const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
     const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState('');
     const [selectedTab, setSelectedTab] = useState('form');
-    const {settings: formSettings} = useFormState();
 
     const toggleSelectedSecondarySidebar = (name) => setSelectedSecondarySidebar(name !== selectedSecondarySidebar ? name : false)
 
@@ -107,15 +91,6 @@ const SchemaEditorSkeleton = () => {
                     SecondarySidebarButtons={SecondarySidebarButtons}
                     showSidebar={showSidebar}
                     toggleShowSidebar={toggleShowSidebar}
-                    onSaveNotice={() => {
-                        const notice = 'publish' === formSettings.formStatus
-                            ? __('Form updated.', 'give')
-                            : __('Form published.', 'give')
-
-                        createSuccessNotice(notice, {
-                            type: 'snackbar',
-                        });
-                    }}
                 />
             }
             content={<FormBlocks />}

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
@@ -16,6 +16,7 @@ import {Button} from "@wordpress/components";
 import {listView, plus} from "@wordpress/icons";
 import {useEditorState} from "@givewp/form-builder/stores/editor-state";
 import EditorMode from "@givewp/form-builder/types/editorMode";
+import {useFormState} from "@givewp/form-builder/stores/form-state";
 
 export default function BlockEditorInterfaceSkeletonContainer() {
 
@@ -34,6 +35,7 @@ const DesignEditorSkeleton = () => {
     const {createSuccessNotice} = useDispatch('core/notices');
 
     const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
+    const {settings: formSettings} = useFormState();
 
     return (
         <InterfaceSkeleton
@@ -42,7 +44,11 @@ const DesignEditorSkeleton = () => {
                     showSidebar={showSidebar}
                     toggleShowSidebar={toggleShowSidebar}
                     onSaveNotice={() => {
-                        createSuccessNotice(__('Form updated.', 'give'), {
+                        const notice = 'publish' === formSettings.formStatus
+                            ? __('Form updated.', 'give')
+                            : __('Form published.', 'give')
+
+                        createSuccessNotice(notice, {
                             type: 'snackbar',
                         });
                     }}
@@ -61,6 +67,7 @@ const SchemaEditorSkeleton = () => {
     const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
     const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState('');
     const [selectedTab, setSelectedTab] = useState('form');
+    const {settings: formSettings} = useFormState();
 
     const toggleSelectedSecondarySidebar = (name) => setSelectedSecondarySidebar(name !== selectedSecondarySidebar ? name : false)
 
@@ -101,7 +108,11 @@ const SchemaEditorSkeleton = () => {
                     showSidebar={showSidebar}
                     toggleShowSidebar={toggleShowSidebar}
                     onSaveNotice={() => {
-                        createSuccessNotice(__('Form updated.', 'give'), {
+                        const notice = 'publish' === formSettings.formStatus
+                            ? __('Form updated.', 'give')
+                            : __('Form published.', 'give')
+
+                        createSuccessNotice(notice, {
                             type: 'snackbar',
                         });
                     }}

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -14,6 +14,7 @@ import {Markup} from 'interweave';
 import {InfoModal, ModalType} from '../components/modal';
 import {setEditorMode, useEditorState, useEditorStateDispatch} from "@givewp/form-builder/stores/editor-state";
 import EditorMode from "@givewp/form-builder/types/editorMode";
+import {useDispatch} from "@wordpress/data";
 
 const Logo = () => (
     <div
@@ -41,7 +42,6 @@ const HeaderContainer = ({
                              SecondarySidebarButtons = null,
                              showSidebar,
                              toggleShowSidebar,
-                             onSaveNotice,
                          }) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 
@@ -53,6 +53,7 @@ const HeaderContainer = ({
     const isDraftDisabled = (isSaving || !isDirty) && 'draft' === formSettings.formStatus;
     const isPublishDisabled = (isSaving || !isDirty) && 'publish' === formSettings.formStatus;
     const {isMigratedForm, isTransferredForm} = window.migrationOnboardingData;
+    const {createSuccessNotice} = useDispatch('core/notices');
 
     const onSave = (formStatus: FormStatus) => {
         setSaving(formStatus);
@@ -67,21 +68,31 @@ const HeaderContainer = ({
                 setSaving(null);
                 setErrorMessage(error.message);
             })
-            .then(({pageSlug}: FormSettings) => {
+            .then(({pageSlug, formStatus}: FormSettings) => {
                 dispatch(setFormSettings({pageSlug}));
                 dispatch(setIsDirty(false));
                 setSaving(null);
-                onSaveNotice();
+                showOnSaveNotice(formStatus);
             });
     };
+
+    const showOnSaveNotice = formStatus => {
+        const notice = 'publish' === formStatus
+            ? __('Form updated.', 'give')
+            : __('Form published.', 'give')
+
+        createSuccessNotice(notice, {
+            type: 'snackbar',
+        });
+    }
 
     const {mode} = useEditorState();
     const dispatchEditorState = useEditorStateDispatch();
     const toggleEditorMode = () => {
-        if(EditorMode.schema === mode) {
+        if (EditorMode.schema === mode) {
             dispatchEditorState(setEditorMode(EditorMode.design));
         }
-        if(EditorMode.design === mode) {
+        if (EditorMode.design === mode) {
             dispatchEditorState(setEditorMode(EditorMode.schema));
         }
     }


### PR DESCRIPTION
## Description

This PR adds logic to display a correct snackbar message when saving the form. On form publish it will show "Form published", and on form update, it will show "Form updated" notice.

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

## Affects
Form builder snackbar notice message

## Visuals

![Screen Capture_select-area_20231002163324](https://github.com/impress-org/givewp/assets/4222590/de8b487e-de21-43d8-b4c8-d68434038544)


## Testing Instructions

1. create form
2. update the form
3. publish the form
4. edit form and hit update

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205606769216054