### PR TITLE
Fix: Migrated forms now have a draft status until transferred

### DIFF
--- a/src/FormMigration/Controllers/TransferController.php
+++ b/src/FormMigration/Controllers/TransferController.php
@@ -3,6 +3,7 @@
 namespace Give\FormMigration\Controllers;
 
 use Give\DonationForms\V2\Models\DonationForm;
+use Give\DonationForms\ValueObjects\DonationFormStatus;
 use Give\FormMigration\Actions\GetMigratedFormId;
 use Give\FormMigration\Actions\TransferDonations;
 use Give\FormMigration\Actions\TransferFormUrl;
@@ -38,6 +39,7 @@ class TransferController
                 wp_trash_post($formV2->id);
             }
 
+            wp_update_post(['ID' => $v3FormId, 'post_status' => DonationFormStatus::PUBLISHED()->getValue()]);
             give_update_meta($v3FormId, 'transferredFormId', true);
         });
 

--- a/src/FormMigration/Controllers/TransferController.php
+++ b/src/FormMigration/Controllers/TransferController.php
@@ -39,7 +39,7 @@ class TransferController
                 wp_trash_post($formV2->id);
             }
 
-            wp_update_post(['ID' => $v3FormId, 'post_status' => DonationFormStatus::PUBLISHED()->getValue()]);
+            wp_update_post(['ID' => $v3FormId, 'post_status' => $formV2->status->getValue()]);
             give_update_meta($v3FormId, 'transferredFormId', true);
         });
 

--- a/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
+++ b/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
@@ -4,6 +4,7 @@ namespace Give\FormMigration\DataTransferObjects;
 
 use Give\DonationForms\Models\DonationForm as DonationFormV3;
 use Give\DonationForms\V2\Models\DonationForm as DonationFormV2;
+use Give\DonationForms\ValueObjects\DonationFormStatus;
 
 class FormMigrationPayload
 {
@@ -21,6 +22,8 @@ class FormMigrationPayload
 
     public static function fromFormV2(DonationFormV2 $formV2): self
     {
-        return new self($formV2, DonationFormV3::factory()->create());
+        return new self($formV2, DonationFormV3::factory()->create([
+            'status' => DonationFormStatus::DRAFT(),
+        ]));
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR sets the form status of new forms to be `draft` when first migrated and `publish` once transferred.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/9eca48a6-b2e5-478f-9483-99bff7822af0)

![image](https://github.com/impress-org/givewp/assets/10858303/54159d39-56eb-4085-a89f-6233f896c810)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Migrate a form
2. New form should be draft
3. Transfer the form
4. Form should be publish

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205635546000698