### PR TITLE
Fix: Restore modal component

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/modal/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/modal/index.tsx
@@ -1,10 +1,10 @@
-import {Button, Icon} from '@wordpress/components';
-import GutenbergModal from '@wordpress/components/modal';
+import {Button, Icon, Modal as GutenbergModal} from '@wordpress/components';
+import GutenbergModalProps from './types'
 import {info, warning} from '@wordpress/icons';
 import cx from 'classnames';
 import './styles.scss';
 
-interface ModalProps extends GutenbergModal.Props {
+interface ModalProps extends GutenbergModalProps {
     closeButtonCaption?: string;
 }
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/modal/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/components/modal/types.ts
@@ -1,0 +1,91 @@
+import {
+    ComponentType,
+    HTMLProps,
+    ReactNode,
+    KeyboardEventHandler,
+    MouseEventHandler,
+    FocusEventHandler
+} from 'react';
+
+interface GutenbergModalProps extends HTMLProps<HTMLDivElement> {
+    /**
+     * This property is used as the modal header's title. It is required
+     * for a11y reasons.
+     */
+    title: string;
+    children: ReactNode;
+    aria?: {
+        /**
+         * If this property is added, it will be added to the modal content
+         * div as aria-labelledby. You are encouraged to use this when the
+         * modal is visually labelled.
+         * @defaultValue "modal-heading"
+         */
+        labelledby?: string | undefined;
+        /**
+         * If this property is added, it will be added to the modal content
+         * div as aria-describedby.
+         */
+        describedby?: string | undefined;
+    } | undefined;
+    /**
+     * `className` that is applied to the `document.body` while the modal is open.
+     * @defaultValue "modal-open"
+     */
+    bodyOpenClassName?: string | undefined;
+    /**
+     * Label for the close button.
+     * @defaultValue "Close dialog"
+     */
+    closeButtonLabel?: string | undefined;
+    /**
+     * If this property is true, it will focus the first tabbable element
+     * rendered in the modal.
+     * @defaultValue true
+     */
+    focusOnMount?: boolean | undefined;
+    /**
+     * Icon component to render before the title.
+     */
+    icon?: ReactNode | undefined;
+    /**
+     * If this property is set to false, the modal will not display a close
+     * icon and cannot be dismissed.
+     * @defaultValue true
+     * @deprecated Use isDismissible
+     */
+    isDismissable?: boolean | undefined;
+    /**
+     * If this property is set to false, the modal will not display a close
+     * icon and cannot be dismissed.
+     * @defaultValue true
+     */
+    isDismissible?: boolean | undefined;
+    /**
+     * If this property is added, it will an additional class name to the
+     * modal overlay div.
+     */
+    overlayClassName?: string | undefined;
+    /**
+     * If this property is added, it will determine whether the modal
+     * requests to close when a mouse click occurs outside of the modal
+     * content.
+     * @defaultValue true
+     */
+    shouldCloseOnClickOutside?: boolean | undefined;
+    /**
+     * If this property is added, it will determine whether the modal
+     * requests to close when the escape key is pressed.
+     * @defaultValue true
+     */
+    shouldCloseOnEsc?: boolean | undefined;
+    /**
+     * This function is called to indicate that the modal should be closed.
+     *
+     * The originating event might be different depending on how the modal
+     * is closed.
+     */
+    onRequestClose: KeyboardEventHandler | MouseEventHandler | FocusEventHandler;
+}
+
+export default GutenbergModalProps;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR restores the modal which was broken by https://github.com/impress-org/givewp/pull/6985. I prematurely merged the PR before catching this issues.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/6c136835-39c3-400d-a5df-d3f4064b7aaa)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Delete the Amount Field block
- Publish the changes