### PR TITLE
Fix: post status error

### DIFF
--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -21,7 +21,7 @@ use Give\DonationForms\Routes\AuthenticationRoute;
 use Give\DonationForms\Routes\DonateRoute;
 use Give\DonationForms\Routes\ValidationRoute;
 use Give\DonationForms\Shortcodes\GiveFormShortcode;
-use Give\DonationForms\V2\ValueObjects\DonationFormStatus;
+use Give\DonationForms\ValueObjects\DonationFormStatus;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\Routes\Route;
 use Give\Helpers\Hooks;

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -21,6 +21,7 @@ use Give\DonationForms\Routes\AuthenticationRoute;
 use Give\DonationForms\Routes\DonateRoute;
 use Give\DonationForms\Routes\ValidationRoute;
 use Give\DonationForms\Shortcodes\GiveFormShortcode;
+use Give\DonationForms\V2\ValueObjects\DonationFormStatus;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\Routes\Route;
 use Give\Helpers\Hooks;
@@ -61,6 +62,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerFormDesigns();
         $this->registerSingleFormPage();
         $this->registerShortcodes();
+        $this->registerPostStatus();
 
         Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class);
         Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class);
@@ -172,5 +174,15 @@ class ServiceProvider implements ServiceProviderInterface
     protected function registerShortcodes()
     {
         Hooks::addFilter('givewp_form_shortcode_output', GiveFormShortcode::class, '__invoke', 10, 2);
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function registerPostStatus()
+    {
+        add_action('init', static function () {
+            register_post_status(DonationFormStatus::UPGRADED);
+        });
     }
 }


### PR DESCRIPTION
## Description

This PR resolves the error which was introduced when we added the new post status `upgraded`. The problem with custom statuses in WP is that they have to be registered in order to function properly. The error is resolved by registering the new post status. 


## Testing Instructions

1. Create form
2. Upgrade form
3. Go back to the original form

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205629954321417