### PR TITLE
Fix: add nonces to sendwp functions

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 2.33.3
+ * Version: 2.33.4
  * Requires at least: 5.0
  * Requires PHP: 7.0
  * Text Domain: give
@@ -316,7 +316,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '2.33.3');
+            define('GIVE_VERSION', '2.33.4');
         }
 
         // Plugin Root File.

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -253,9 +253,12 @@ function give_add_ons_feed( $feed_type = '', $echo = true ) {
 /**
  * Handle installation and connection for SendWP via ajax
  *
+ * @unreleased added nonce check
  * @since 2.9.15
  */
 function give_sendwp_remote_install_handler () {
+
+  check_ajax_referer( 'give_sendwp_remote_install');
 
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
 		wp_send_json_error( array(

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -253,7 +253,7 @@ function give_add_ons_feed( $feed_type = '', $echo = true ) {
 /**
  * Handle installation and connection for SendWP via ajax
  *
- * @unreleased added nonce check
+ * @since 2.33.4 added nonce check
  * @since 2.9.15
  */
 function give_sendwp_remote_install_handler () {
@@ -331,7 +331,7 @@ add_action( 'wp_ajax_give_sendwp_remote_install', 'give_sendwp_remote_install_ha
 /**
  * Handle deactivation of SendWP via ajax
  *
- * @unreleased add nonce check
+ * @since 2.33.4 add nonce check
  * @since 2.9.15
  */
 function give_sendwp_disconnect () {

--- a/includes/admin/misc-functions.php
+++ b/includes/admin/misc-functions.php
@@ -328,9 +328,12 @@ add_action( 'wp_ajax_give_sendwp_remote_install', 'give_sendwp_remote_install_ha
 /**
  * Handle deactivation of SendWP via ajax
  *
+ * @unreleased add nonce check
  * @since 2.9.15
  */
 function give_sendwp_disconnect () {
+
+  check_ajax_referer( 'give_sendwp_disconnect');
 
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
 		wp_send_json_error( array(

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
         /**
 		 * Render give_currency_code_preview field type
 		 *
-		 * @unreleased added nonce to give_sendwp_remote_install
+		 * @since 2.33.4 added nonce to give_sendwp_remote_install
 		 * @since  2.3.0
 		 * @access public
 		 *

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
                     function give_sendwp_remote_install() {
                         var data = {
                             'action': 'give_sendwp_remote_install',
-                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_remote_install' ); ?>'
+                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_remote_install'); ?>'
                         };
 
                         // since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
@@ -148,7 +148,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
                     function give_sendwp_disconnect() {
                         var data = {
                             'action': 'give_sendwp_disconnect',
-                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_disconnect' ); ?>
+                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_disconnect' ); ?>'
                         };
 
                         jQuery.post(ajaxurl, data, function( response ) {

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -146,6 +146,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
                     function give_sendwp_disconnect() {
                         var data = {
                             'action': 'give_sendwp_disconnect',
+                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_disconnect' ); ?>
                         };
 
                         jQuery.post(ajaxurl, data, function( response ) {

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -42,6 +42,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
         /**
 		 * Render give_currency_code_preview field type
 		 *
+		 * @unreleased added nonce to give_sendwp_remote_install
 		 * @since  2.3.0
 		 * @access public
 		 *
@@ -120,6 +121,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
                     function give_sendwp_remote_install() {
                         var data = {
                             'action': 'give_sendwp_remote_install',
+                            '_ajax_nonce': '<?php echo wp_create_nonce( 'give_sendwp_remote_install' ); ?>'
                         };
 
                         // since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php

--- a/includes/gateways/stripe/includes/admin/admin-actions.php
+++ b/includes/gateways/stripe/includes/admin/admin-actions.php
@@ -352,26 +352,6 @@ function give_stripe_show_currency_notice() {
 add_action( 'admin_notices', 'give_stripe_show_currency_notice' );
 
 /**
- * Disconnect Stripe Account.
- *
- * @since 2.7.0
- *
- * @return void
- */
-function give_stripe_disconnect_connect_stripe_account() {
-	$get_data = give_clean( $_GET );
-
-	if ( current_user_can( 'manage_options' ) && isset( $get_data['stripe_disconnected'] ) ) {
-		$account_name = ! empty( $get_data['account_name'] ) ? $get_data['account_name'] : false;
-
-		// Disconnect Stripe Account.
-		give_stripe_disconnect_account( $account_name );
-	}
-}
-
-add_action( 'admin_init', 'give_stripe_disconnect_connect_stripe_account' );
-
-/**
  * Show Stripe Account Used under donation details.
  *
  * @param  int  $donationId  Donation ID.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 5.0
 Tested up to: 6.3
 Requires PHP: 7.0
-Stable tag: 2.33.3
+Stable tag: 2.33.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -258,6 +258,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 8. GiveWP has a dedicated support team to help answer any questions you may have and help you through stumbling blocks.
 
 == Changelog ==
+= 2.33.4: October 4th, 2023 =
+* Fix: Update old sendwp buttons and remove unused Stripe disconnect function.
+
 = 2.33.3: September 29th, 2023 =
 * Fix: Multi-site installations no longer produce an error on subsites.
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds nonces to old sendwp functions.  It also removes an unused stripe disconnect function.

## Testing
Make sure sendwp buttons and stripe disconnect buttons work properly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

