### PR TITLE
Fix: display legacy payment gateway with v2 donation forms

### DIFF
--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Give Settings Page/Tab
  *
@@ -13,92 +14,94 @@ use Give\DonationForms\V2\DonationFormsAdminPage;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 use Give\PaymentGateways\Stripe\Admin\AccountManagerSettingField;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+if (! defined('ABSPATH')) {
+    exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
+if (! class_exists('Give_Settings_Gateways')) :
 
-	/**
-	 * Give_Settings_Gateways.
-	 *
-	 * @sine 1.8
-	 */
-	class Give_Settings_Gateways extends Give_Settings_Page {
+    /**
+     * Give_Settings_Gateways.
+     *
+     * @sine 1.8
+     */
+    class Give_Settings_Gateways extends Give_Settings_Page
+    {
+        /**
+         * Constructor.
+         */
+        public function __construct()
+        {
+            $this->id    = 'gateways';
+            $this->label = esc_html__('Payment Gateways', 'give');
 
-		/**
-		 * Constructor.
-		 */
-		public function __construct() {
-			$this->id    = 'gateways';
-			$this->label = esc_html__( 'Payment Gateways', 'give' );
+            $this->default_tab = 'gateways-settings';
 
-			$this->default_tab = 'gateways-settings';
+            parent::__construct();
 
-			parent::__construct();
-
-			// Do not use main form for this tab.
-			if ( give_get_current_setting_tab() === $this->id ) {
+            // Do not use main form for this tab.
+            if (give_get_current_setting_tab() === $this->id) {
                 add_action('give_admin_field_gateway_notice', [$this, 'render_gateway_notice'], 10, 2);
                 add_action('give_admin_field_enabled_gateways', [$this, 'render_enabled_gateways'], 10, 2);
             }
-		}
+        }
 
-		/**
-		 * Get settings array.
-		 *
-		 * @since  1.8
-		 * @return array
-		 */
-		public function get_settings() {
-			$settings        = [];
-			$current_section = give_get_current_setting_section();
+        /**
+         * Get settings array.
+         *
+         * @since  1.8
+         * @return array
+         */
+        public function get_settings()
+        {
+            $settings        = [];
+            $current_section = give_get_current_setting_section();
 
-			switch ( $current_section ) {
-				case 'offline-donations':
-					$settings = [
-						// Section 3: Offline gateway.
-						[
-							'type' => 'title',
-							'id'   => 'give_title_gateway_settings_3',
-						],
-						[
-							'name'    => __( 'Collect Billing Details', 'give' ),
-							'desc'    => __( 'If enabled, required billing address fields are added to Offline Donation forms. These fields are not required to process the transaction, but you may have a need to collect the data. Billing address details are added to both the donation and donor record in GiveWP. ', 'give' ),
-							'id'      => 'give_offline_donation_enable_billing_fields',
-							'type'    => 'radio_inline',
-							'default' => 'disabled',
-							'options' => [
-								'enabled'  => __( 'Enabled', 'give' ),
-								'disabled' => __( 'Disabled', 'give' ),
-							],
-						],
-						[
-							'name'    => __( 'Offline Donation Instructions', 'give' ),
-							'desc'    => __( 'The Offline Donation Instructions are a chance for you to educate the donor on how to best submit offline donations. These instructions appear directly on the form, and after submission of the form. Note: You may also customize the instructions on individual forms as needed.', 'give' ),
-							'id'      => 'global_offline_donation_content',
-							'default' => give_get_default_offline_donation_content(),
-							'type'    => 'wysiwyg',
-							'options' => [
-								'textarea_rows' => 6,
-							],
-						],
-						[
-							'name'  => esc_html__( 'Offline Donations Settings Docs Link', 'give' ),
-							'id'    => 'offline_gateway_settings_docs_link',
-							'url'   => esc_url( 'http://docs.givewp.com/offlinegateway' ),
-							'title' => __( 'Offline Gateway Settings', 'give' ),
-							'type'  => 'give_docs_link',
-						],
-						[
-							'type' => 'sectionend',
-							'id'   => 'give_title_gateway_settings_3',
-						],
-					];
-					break;
+            switch ($current_section) {
+                case 'offline-donations':
+                    $settings = [
+                        // Section 3: Offline gateway.
+                        [
+                            'type' => 'title',
+                            'id'   => 'give_title_gateway_settings_3',
+                        ],
+                        [
+                            'name'    => __('Collect Billing Details', 'give'),
+                            'desc'    => __('If enabled, required billing address fields are added to Offline Donation forms. These fields are not required to process the transaction, but you may have a need to collect the data. Billing address details are added to both the donation and donor record in GiveWP. ', 'give'),
+                            'id'      => 'give_offline_donation_enable_billing_fields',
+                            'type'    => 'radio_inline',
+                            'default' => 'disabled',
+                            'options' => [
+                                'enabled'  => __('Enabled', 'give'),
+                                'disabled' => __('Disabled', 'give'),
+                            ],
+                        ],
+                        [
+                            'name'    => __('Offline Donation Instructions', 'give'),
+                            'desc'    => __('The Offline Donation Instructions are a chance for you to educate the donor on how to best submit offline donations. These instructions appear directly on the form, and after submission of the form. Note: You may also customize the instructions on individual forms as needed.', 'give'),
+                            'id'      => 'global_offline_donation_content',
+                            'default' => give_get_default_offline_donation_content(),
+                            'type'    => 'wysiwyg',
+                            'options' => [
+                                'textarea_rows' => 6,
+                            ],
+                        ],
+                        [
+                            'name'  => esc_html__('Offline Donations Settings Docs Link', 'give'),
+                            'id'    => 'offline_gateway_settings_docs_link',
+                            'url'   => esc_url('http://docs.givewp.com/offlinegateway'),
+                            'title' => __('Offline Gateway Settings', 'give'),
+                            'type'  => 'give_docs_link',
+                        ],
+                        [
+                            'type' => 'sectionend',
+                            'id'   => 'give_title_gateway_settings_3',
+                        ],
+                    ];
+                    break;
 
-				case 'gateways-settings':
-					$settings = [
+                case 'gateways-settings':
+                    $settings = [
                         // Section 1: Gateways.
                         [
                             'id' => 'give_title_gateway_settings_1',
@@ -263,7 +266,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
          */
         public function render_gateway_notice($field, $settings)
         {
-            if ( ! $this->hasPremiumPaymentGateway() && ! $this->canAcceptCreditCard()) {
+            if (! $this->hasPremiumPaymentGateway() && ! $this->canAcceptCreditCard()) {
                 ?>
                 <div class="give-gateways-notice">
                     <div class="give-gateways-cc-icon">
@@ -323,18 +326,18 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
                 </div>
                 <?php
             }
-		}
+        }
 
-		/**
-		 * Render enabled gateways
-		 *
+        /**
+         * Render enabled gateways
+         *
          * @since 3.0.0 split gateways into separated tabs for v2 and v3 settings
-		 * @since  2.0.5
-		 * @access public
-		 *
-		 * @param $field
-		 * @param $settings
-		 */
+         * @since  2.0.5
+         * @access public
+         *
+         * @param $field
+         * @param $settings
+         */
         public function render_enabled_gateways($field, $settings)
         {
             $id = $field['id'];
@@ -344,14 +347,18 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
             $current_tab = give_get_current_setting_tab();
             $current_section = give_get_current_setting_section();
 
-            $v2Gateways = give_get_ordered_payment_gateways(
-                array_intersect_key($gateways, give()->gateways->getPaymentGateways(2)),
-                2
-            );
+            $v2Gateways = array_intersect_key($gateways, give()->gateways->getPaymentGateways(2));
             $v3Gateways = give_get_ordered_payment_gateways(
                 array_intersect_key($gateways, give()->gateways->getPaymentGateways(3)),
                 3
             );
+
+            // Add legacy payment gateways to v2 gateways if they exists.
+            if ($legacyPaymentGateways = array_diff_key($gateways, $v2Gateways, $v3Gateways)) {
+                $v2Gateways = array_merge($v2Gateways, $legacyPaymentGateways);
+            }
+
+            $v2Gateways = give_get_ordered_payment_gateways($v2Gateways, 2);
 
             $groups = [
                 'v2' => [
@@ -595,10 +602,10 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
                                     <?php
                                     echo $gateway; ?>
                                 </div>
-                            <?php
+                                <?php
                             endforeach; ?>
                         </div>
-                    <?php
+                        <?php
                     endif; ?>
                     <button class="give-payment-gateway-settings-dialog__content-button"><?php
                         esc_html_e('Got it', 'give'); ?></button>
@@ -610,7 +617,7 @@ if ( ! class_exists( 'Give_Settings_Gateways' ) ) :
 
             <?php
         }
-	}
+    }
 
 endif;
 

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -353,7 +353,7 @@ if (! class_exists('Give_Settings_Gateways')) :
                 3
             );
 
-            // Add legacy payment gateways to v2 gateways if they exists.
+            // Add legacy payment gateways to v2 gateways if they exist.
             if ($legacyPaymentGateways = array_diff_key($gateways, $v2Gateways, $v3Gateways)) {
                 $v2Gateways = array_merge($v2Gateways, $legacyPaymentGateways);
             }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
I found that we recently implemented a new feature in GiveWP 3.0.0: https://github.com/impress-org/givewp/pull/6923, which caused a side effect. Payment gateway like Razorpay which registers will legacy payment gateway API, is not displaying in the list. This means plugin users can not toggle legacy payment gateways. This pull request resolves this issue and includes legacy payment gateways under `Enabled Gateways > Option-Based Form Editor`.

<img width="1438" alt="image" src="https://github.com/impress-org/givewp/assets/1784821/ba2e70ac-736e-4d65-b287-da7416c7c59c">


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects the `Enabled Gateways` setting page display.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] Admin should able to activate Razorpay payment gateway.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205659902800058