### PR TITLE
Fix: display errors on donation form when checkout validation fails for v2 forms

### DIFF
--- a/assets/src/js/frontend/give-ajax.js
+++ b/assets/src/js/frontend/give-ajax.js
@@ -244,7 +244,7 @@ jQuery( document ).ready( function( $ ) {
 		$.post( Give.fn.getGlobalVar( 'ajaxurl' ), this_form.serialize() + '&action=give_process_donation&give_ajax=true', function( data ) {
 			if ( $.trim( data ) == 'success' ) {
 				//Remove any errors
-				this_form.find( '.give_errors' ).remove();
+                this_form.parent().find( '.give_errors' ).remove();
 				//Submit form for normal processing
 				$( give_purchase_form ).submit();
 
@@ -263,7 +263,7 @@ jQuery( document ).ready( function( $ ) {
                 } else if ($giveFormHeader.length > 0) { // Classic Form
                     $giveFormHeader.after(data);
                 } else { // Legacy Form
-                    this_form.parent().find('.give-form-title').after(data);
+                    this_form.parent().prepend(data);
                 }
 
                 this_form.parent()[0].scrollIntoView({behavior: 'smooth'});

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -305,11 +305,8 @@ class Give_Notices {
             return;
         }
 
-        if ($errors) {
-            self::print_frontend_errors($errors);
-
-            give_clear_errors();
-        }
+        self::print_frontend_errors($errors);
+        give_clear_errors();
     }
 
 	/**

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -282,36 +282,35 @@ class Give_Notices {
 	}
 
 
-	/**
-	 * Render give frontend notices.
-	 *
+    /**
+     * Render give frontend notices.
+     *
+     * @unreleased Render errors on Ajax request (Donation form validation - v2 forms)
      * @since 2.32.0 Display registered error on donation form.
-	 * @since  1.8.9
-	 * @access public
-	 *
-	 * @param int $form_id
-	 */
-	public function render_frontend_notices( $form_id = 0 ) {
-		$errors = give_get_errors();
+     * @since  1.8.9
+     * @access public
+     *
+     * @param int $form_id
+     */
+    public function render_frontend_notices($form_id = 0)
+    {
+        $errors = give_get_errors();
 
-		$request_form_id = isset( $_REQUEST['form-id'] ) ? absint( $_REQUEST['form-id'] ) : 0;
+        $request_form_id = isset($_REQUEST['form-id']) ? absint($_REQUEST['form-id']) : 0;
 
-		// Sanity checks first:
+        // Sanity checks first:
         // - Ensure that gateway returned errors display on the appropriate form.
-        // - Error should not display on AJAX request.
-		if (
-            isset( $_POST['give_ajax'] )
-            || ( $request_form_id && $request_form_id !== $form_id )
-        ) {
-			return;
-		}
+        // - Error should exist.
+        if (! $errors || ($request_form_id && $request_form_id !== $form_id)) {
+            return;
+        }
 
-		if ( $errors ) {
-			self::print_frontend_errors( $errors );
+        if ($errors) {
+            self::print_frontend_errors($errors);
 
-			give_clear_errors();
-		}
-	}
+            give_clear_errors();
+        }
+    }
 
 	/**
 	 * Renders notices for different actions depending on


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The donation form validates on the Ajax request before submission to give immediate feedback to the donor. Client-side code either expects `success` in response or error HTML code. I found that the previous pull request https://github.com/impress-org/givewp/pull/6845 causes a side effect, and the error does not render on v2 donation forms.

https://github.com/impress-org/givewp/blob/e957cbc673bd3bd37297006b556d944316a77755/assets/src/js/frontend/give-ajax.js#L266

[We recently discovered an issue related to this](https://feedback.givewp.com/bug-reports/p/razorpay-should-work-when-requesting-billing-address). I create confusion when the donor does see an error on the v2 donation form.

This pull request resolves this issue.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This pull request affects the V2 donation form.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] Donor must see an error when checkout validation fails on v2 forms with multi-step, classic, and legacy form templates. You can add incorrect zip code/postal code to trigger checkout invalidation.
- [ ] This pull request should not create regression for the previous fix: https://github.com/impress-org/givewp/pull/6845
- [ ] Errors should display correctly on the donor email login form, donation history page, and shortcode login

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205705852739343