### PR TITLE
Refactor: update Text/Textarea field and template

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -189,7 +189,8 @@ class ConvertDonationFormBlocksToFieldsApi
                         $block->getShortName() . '-' . $blockIndex
                 )->storeAsDonorMeta(
                     $block->hasAttribute('storeAsDonorMeta') ? $block->getAttribute('storeAsDonorMeta') : false
-                );
+                )->description($block->getAttribute('description'))
+                    ->defaultValue($block->getAttribute('defaultValue'));
 
             case "givewp/terms-and-conditions":
                 return $this->createNodeFromConsentBlock($block, $blockIndex)

--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -35,7 +35,8 @@ export interface CheckboxProps extends FieldProps {
 }
 
 export interface TextareaProps extends FieldProps {
-    helpText?: string;
+    description?: string;
+    rows: number;
 }
 
 export interface FieldHasDescriptionProps extends FieldProps {

--- a/src/DonationForms/resources/registrars/templates/fields/Text.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Text.tsx
@@ -1,9 +1,19 @@
-import type {FieldProps} from '@givewp/forms/propTypes';
+import {FieldHasDescriptionProps} from '@givewp/forms/propTypes';
 
-export default function Text({Label, ErrorMessage, fieldError, placeholder, inputProps}: FieldProps) {
+export default function Text({
+    Label,
+    ErrorMessage,
+    fieldError,
+    description,
+    placeholder,
+    inputProps,
+}: FieldHasDescriptionProps) {
+    const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
+
     return (
         <label>
             <Label />
+            {description && <FieldDescription description={description} />}
             <input type="text" aria-invalid={fieldError ? 'true' : 'false'} placeholder={placeholder} {...inputProps} />
 
             <ErrorMessage />

--- a/src/DonationForms/resources/registrars/templates/fields/TextArea.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/TextArea.tsx
@@ -1,15 +1,26 @@
 import type {TextareaProps} from '@givewp/forms/propTypes';
 
-export default function TextArea({Label, ErrorMessage, placeholder, fieldError, inputProps, helpText}: TextareaProps) {
+export default function TextArea({
+    Label,
+    ErrorMessage,
+    placeholder,
+    fieldError,
+    inputProps,
+    description,
+    rows,
+}: TextareaProps) {
+    const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
+
     return (
         <label>
             <Label />
-            {helpText && (
-                <div className="givewp-fields-textarea__description">
-                    <small>{helpText}</small>
-                </div>
-            )}
-            <textarea aria-invalid={fieldError ? 'true' : 'false'} {...inputProps} placeholder={placeholder} />
+            {description && <FieldDescription description={description} />}
+            <textarea
+                aria-invalid={fieldError ? 'true' : 'false'}
+                {...inputProps}
+                placeholder={placeholder}
+                rows={rows}
+            />
             <ErrorMessage />
         </label>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
@@ -1,22 +1,20 @@
-import {TextControl} from '@wordpress/components';
+import classnames from 'classnames';
 import {BlockEditProps} from '@wordpress/blocks';
 
 export default function Edit({attributes}: BlockEditProps<any>) {
-    const {label, isRequired, placeholder} = attributes;
+    const {label, isRequired, description, placeholder, defaultValue} = attributes;
     const requiredClass = isRequired ? 'give-is-required' : '';
 
     return (
         <>
             <div>
-                <TextControl
-                    label={label}
-                    placeholder={placeholder}
-                    required={isRequired}
-                    className={requiredClass}
-                    readOnly
-                    onChange={null}
-                    value={placeholder}
-                />
+                <span
+                    className={classnames('components-input-control__label', 'give-text-block__label', requiredClass)}
+                >
+                    {label}
+                </span>
+                {description && <p className="give-text-block__description">{description}</p>}
+                <input type="text" placeholder={placeholder} readOnly onChange={null} value={defaultValue} />
             </div>
         </>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/settings.tsx
@@ -17,6 +17,7 @@ const settings: FieldBlock['settings'] = {
                 label: {
                     default: __('Text field', 'give'),
                 },
+                description: true,
                 placeholder: true,
                 defaultValue: true,
                 emailTag: true,

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_blocks.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_blocks.scss
@@ -37,3 +37,19 @@
         }
     }
 }
+
+[data-type="givewp/text"] {
+    .give-text-block {
+        &__label {
+            display: inline-block;
+            margin-bottom: var(--givewp-spacing-2);
+            padding: 0;
+        }
+
+        &__description {
+            font-size: 0.875rem;
+            line-height: 1rem;
+            margin: var(--givewp-spacing-1) 0 var(--givewp-spacing-2);
+        }
+    }
+}

--- a/src/Framework/FieldsAPI/Text.php
+++ b/src/Framework/FieldsAPI/Text.php
@@ -14,6 +14,7 @@ class Text extends Field
     use Concerns\HasMaxLength;
     use Concerns\HasMinLength;
     use Concerns\HasPlaceholder;
+    use Concerns\HasDescription;
 
     const TYPE = 'text';
 }

--- a/src/Framework/FieldsAPI/Textarea.php
+++ b/src/Framework/FieldsAPI/Textarea.php
@@ -18,4 +18,29 @@ class Textarea extends Field
     use Concerns\HasDescription;
 
     const TYPE = 'textarea';
+
+    /** @var int */
+    protected $rows = 5;
+
+    /**
+     * Set the number of rows for the element.
+     *
+     * @since 3.0.0
+     */
+    public function rows(int $rows): self
+    {
+        $this->rows = $rows;
+
+        return $this;
+    }
+
+    /**
+     * Get the number of rows for the element.
+     *
+     * @since 3.0.0
+     */
+    public function getRows(): string
+    {
+        return $this->rows;
+    }
 }

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
@@ -41,6 +41,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
                     'attributes' => [
                         'fieldName' => 'givewp-custom-field-name',
                         'label' => 'GiveWP Custom Block',
+                        'description' => 'GiveWP Custom Block Description',
                     ],
                 ],
             ],
@@ -62,6 +63,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
                 ->append(
                     Text::make('givewp-custom-field-name')
                         ->label('GiveWP Custom Block')
+                        ->description('GiveWP Custom Block Description')
                         ->storeAsDonorMeta(false)
                 )
         );

--- a/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
+++ b/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
@@ -275,6 +275,7 @@ final class TestDonationFormRepository extends TestCase
                     'attributes' => [
                         'fieldName' => 'givewp-custom-field-name',
                         'label' => 'GiveWP Custom Block',
+                        'description' => 'GiveWP Custom Block description',
                     ],
                 ],
             ],
@@ -297,6 +298,7 @@ final class TestDonationFormRepository extends TestCase
                 ->append(
                     Text::make('givewp-custom-field-name')
                         ->label('GiveWP Custom Block')
+                        ->description('GiveWP Custom Block description')
                         ->storeAsDonorMeta(false),
                     Hidden::make('formId')
                         ->defaultValue($formId)


### PR DESCRIPTION
## Description

In the `FieldsAPI`, we had a `Textarea` field and a corresponding template, but they were unused. This pull request adds the `rows` attribute to the field and updates the template to include this attribute in the `textarea` tag. Additionally, support for field description has been added (likewise for `Text` field and template), carrying over from v2 forms.

## Affects
Textarea and Text fields and templates

## Visuals
![CleanShot 2023-10-04 at 19 23 24](https://github.com/impress-org/givewp/assets/3921017/8493e0a8-0d0b-492c-bc31-2c7c857886ad)

![CleanShot 2023-10-04 at 17 53 24](https://github.com/impress-org/givewp/assets/3921017/c2b53683-3cdb-47db-a90d-596fe37a9099)

## Testing Instructions

```php
add_action('_givewp_donation_form_schema', static function (DonationForm $form) {
    $field = Text::make('custom_text')
        ->label('Custom Text')
        ->placeholder('Write something here')
        ->defaultValue('This is the default content');
    
    $form->insertAfter('email');
​
    $field = Textarea::make('custom_textarea')
        ->label('Custom Textarea')
        ->placeholder('Write something here')
        ->defaultValue('This is the default content')
        ->rows(4);
​
    $form->insertAfter('custom_text', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

