### PR TITLE
Fix: Donor List edit link now supports sub-directory installs

### DIFF
--- a/src/Donors/resources/components/DonorsListTable.tsx
+++ b/src/Donors/resources/components/DonorsListTable.tsx
@@ -15,6 +15,7 @@ declare global {
             apiRoot: string;
             forms: Array<{value: string; text: string}>;
             table: {columns: Array<object>};
+            adminUrl: string;
             pluginUrl: string;
             dissedRecommendations: Array<string>;
         };

--- a/src/Donors/resources/components/DonorsRowActions.tsx
+++ b/src/Donors/resources/components/DonorsRowActions.tsx
@@ -48,7 +48,10 @@ export function DonorsRowActions({item, setUpdateErrors, parameters}) {
         <div className={styles.container}>
             <RowAction
                 className={styles.action}
-                href={`/wp-admin/edit.php?post_type=give_forms&page=give-donors&view=overview&id=${item.id}`}
+                href={
+                    window.GiveDonors.adminUrl +
+                    `edit.php?post_type=give_forms&page=give-donors&view=overview&id=${item.id}`
+                }
                 displayText={__('Edit', 'give')}
             />
             <RowAction


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://feedback.givewp.com/bug-reports/p/donors-list-table-should-account-for-sub-directory-installs

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the URL of the Edit Row Action to use the localize `admin_url()` to build the URL.

This is similar to #6488, but addresses the Donor List Table.

## Testing Instructions

On site with a sub-directory install of WordPress the donor edit link results in a 404 Not Found error.
The donor edit link does not account for the sub-directory in the generated URL.
The workaround is to use the legacy view.

## Todo

- [ ] Mention @Genevieve-K in the squash commit as a co-author.