### PR TITLE
Refactor: make designId nullable on confirmation receipt

### DIFF
--- a/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -102,10 +102,7 @@ class DonationConfirmationReceiptViewModel
 
         $this->enqueueGlobalStyles($primaryColor, $secondaryColor);
 
-        $this->enqueueFormScripts(
-            $this->donation->formId,
-            $formDesignId
-        );
+        $this->enqueueFormScripts($formDesignId);
 
         ob_start();
         wp_print_styles();
@@ -166,7 +163,7 @@ class DonationConfirmationReceiptViewModel
      *
      * @return void
      */
-    private function enqueueFormScripts(int $formId, string $formDesignId)
+    private function enqueueFormScripts(?string $formDesignId)
     {
         $handle = 'givewp-donation-form-registrars';
         wp_enqueue_script(
@@ -196,7 +193,7 @@ class DonationConfirmationReceiptViewModel
         $formDesignRegistrar = give(FormDesignRegistrar::class);
 
         // silently fail if design is missing for some reason
-        if ($formDesignRegistrar->hasDesign($formDesignId)) {
+        if (!empty($formDesignId) && $formDesignRegistrar->hasDesign($formDesignId)) {
             $design = $formDesignRegistrar->getDesign($formDesignId);
 
             if ($design->css()) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This allows the designId to be null for the donation confirmation page.  This further ensures our forms do not rely on a design.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation confirmation 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a new v3 form and choose a form design on initial load (do not save draft/publish)
- Submit a donation within preview mode and make sure it does not throw an error

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

