### PR TITLE
Feature: Reorder donor title prefixes

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -283,7 +283,7 @@ class ConvertDonationFormBlocksToFieldsApi
             if ($block->hasAttribute('showHonorific') && $block->getAttribute('showHonorific') === true) {
                 $group->getNodeByName('honorific')
                     ->label('Title')
-                    ->options(array_values($block->getAttribute('honorifics')));
+                    ->options(...array_values($block->getAttribute('honorifics')));
             } else {
                 $group->remove('honorific');
             }

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -283,7 +283,7 @@ class ConvertDonationFormBlocksToFieldsApi
             if ($block->hasAttribute('showHonorific') && $block->getAttribute('showHonorific') === true) {
                 $group->getNodeByName('honorific')
                     ->label('Title')
-                    ->options(...$block->getAttribute('honorifics'));
+                    ->options(array_values($block->getAttribute('honorifics')));
             } else {
                 $group->remove('honorific');
             }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -1,42 +1,43 @@
 import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
-import {FormTokenField, PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
+import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {useState} from 'react';
-
-const HonorificSelect = ({honorifics}) => {
-    const [selectedTitle, setSelectedTitle] = useState(honorifics[0] ?? '');
-    const honorificOptions = honorifics.map((token) => {
-        return {
-            label: titleLabelTransform(token),
-            value: titleValueTransform(token),
-        };
-    });
-    return (
-        <SelectControl
-            label={__('Title', 'give')}
-            options={honorificOptions}
-            value={selectedTitle}
-            onChange={setSelectedTitle}
-        />
-    );
-};
+import Options from '@givewp/form-builder/components/OptionsPanel';
+import {OptionProps} from '@givewp/form-builder/components/OptionsPanel/types';
 
 const titleLabelTransform = (token = '') => token.charAt(0).toUpperCase() + token.slice(1);
 const titleValueTransform = (token = '') => token.trim().toLowerCase();
 
 export default function Edit({
-    attributes: {
-        showHonorific,
-        honorifics,
-        firstNameLabel,
-        firstNamePlaceholder,
-        lastNameLabel,
-        lastNamePlaceholder,
-        requireLastName,
-    },
-    setAttributes,
-}: BlockEditProps<any>) {
+                                 attributes: {
+                                     showHonorific,
+                                     honorifics,
+                                     firstNameLabel,
+                                     firstNamePlaceholder,
+                                     lastNameLabel,
+                                     lastNamePlaceholder,
+                                     requireLastName,
+                                 },
+                                 setAttributes,
+                             }: BlockEditProps<any>) {
+
+    const [selectedTitle, setSelectedTitle] = useState<string>(Object.values(honorifics)[0] as string ?? '');
+    const [honorificOptions, setHonorificOptions] = useState<OptionProps[]>(Object.keys(honorifics).map((token) => {
+        return {
+            label: titleLabelTransform(token),
+            value: titleValueTransform(token),
+            checked: selectedTitle === token,
+        } as OptionProps;
+    }));
+
+    const setOptions = (options: OptionProps[]) => {
+        setHonorificOptions(options);
+        // Filter options to only include labela so that block can be converted on the server side
+        const filtered = Object.values(options).map((option) => option.label);
+        setAttributes({honorifics: {...filtered}})
+    }
+
     return (
         <>
             <div
@@ -46,7 +47,14 @@ export default function Edit({
                     gap: '15px',
                 }}
             >
-                {!!showHonorific && <HonorificSelect honorifics={honorifics} />}
+                {!!showHonorific && (
+                    <SelectControl
+                        label={__('Title', 'give')}
+                        options={honorificOptions}
+                        value={selectedTitle}
+                        onChange={setSelectedTitle}
+                    />
+                )}
                 <TextControl
                     label={firstNameLabel}
                     placeholder={firstNamePlaceholder}
@@ -84,15 +92,12 @@ export default function Edit({
                                 />
                             </div>
                             {!!showHonorific && (
-                                <FormTokenField
-                                    tokenizeOnSpace={true}
-                                    label={__('Title Prefixes', 'give')}
-                                    value={honorifics}
-                                    suggestions={['Mr', 'Ms', 'Mrs']}
-                                    // placeholder={__('Select some options', 'give')}
-                                    onChange={(tokens) => setAttributes({honorifics: tokens})}
-                                    displayTransform={titleLabelTransform}
-                                    saveTransform={titleValueTransform}
+                                <Options
+                                    currency={false}
+                                    multiple={false}
+                                    options={honorificOptions}
+                                    setOptions={setOptions}
+                                    defaultControlsTooltip={__('Title Prefixes', 'give')}
                                 />
                             )}
                         </div>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -1,6 +1,6 @@
 import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
-import {FormTokenField, PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
+import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {useState} from 'react';
 import Options from '@givewp/form-builder/components/OptionsPanel';

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -1,6 +1,6 @@
 import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
-import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
+import {FormTokenField, PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import {useState} from 'react';
 import Options from '@givewp/form-builder/components/OptionsPanel';
@@ -33,9 +33,14 @@ export default function Edit({
 
     const setOptions = (options: OptionProps[]) => {
         setHonorificOptions(options);
-        // Filter options to only include labela so that block can be converted on the server side
-        const filtered = Object.values(options).map((option) => option.label);
-        setAttributes({honorifics: {...filtered}})
+
+        const filtered = {};
+        // Filter options
+       Object.values(options).forEach((option) => {
+            Object.assign(filtered, {[option.label]: option.label})
+        });
+
+        setAttributes({honorifics: filtered})
     }
 
     return (

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -100,6 +100,7 @@ export default function Edit({
                                 <Options
                                     currency={false}
                                     multiple={false}
+                                    selectable={false}
                                     options={honorificOptions}
                                     setOptions={setOptions}
                                     defaultControlsTooltip={__('Title Prefixes', 'give')}

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsItem.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsItem.tsx
@@ -12,6 +12,7 @@ export default function OptionsItem({
     option,
     showValues,
     multiple,
+    selectable,
     defaultTooltip,
     handleUpdateOptionLabel,
     handleUpdateOptionValue,
@@ -31,12 +32,14 @@ export default function OptionsItem({
             >
                 {/* div is required (for some reason) for the Tooltip to work, do not remove */}
                 <div>
-                    <input
-                        type={multiple ? 'checkbox' : 'radio'}
-                        checked={option.checked}
-                        className={'givewp-options-list--item--checked'}
-                        onClick={() => handleUpdateOptionChecked(!option.checked)}
-                    />
+                    {selectable && (
+                        <input
+                            type={multiple ? 'checkbox' : 'radio'}
+                            checked={option.checked}
+                            className={'givewp-options-list--item--checked'}
+                            onClick={() => handleUpdateOptionChecked(!option.checked)}
+                        />
+                    )}
                 </div>
             </Tooltip>
             <div

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsList.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsList.tsx
@@ -8,6 +8,7 @@ export default function OptionsList({
     options,
     showValues,
     multiple,
+    selectable,
     setOptions,
     defaultControlsTooltip,
 }: OptionsListProps) {
@@ -76,6 +77,7 @@ export default function OptionsList({
                                             index,
                                             showValues,
                                             multiple,
+                                            selectable,
                                             defaultTooltip: defaultControlsTooltip,
                                             handleRemoveOption: handleRemoveOption(index),
                                             handleUpdateOptionLabel: handleUpdateOptionLabel(index),

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/index.tsx
@@ -6,7 +6,7 @@ import OptionsList from './OptionsList';
 
 import {OptionsPanelProps} from './types';
 
-export default function Options({currency, multiple, options, setOptions, defaultControlsTooltip}: OptionsPanelProps) {
+export default function Options({currency, multiple, selectable = true, options, setOptions, defaultControlsTooltip}: OptionsPanelProps) {
     const [showValues, setShowValues] = useState<boolean>(false);
 
     const handleAddOption = (): void => {
@@ -33,6 +33,7 @@ export default function Options({currency, multiple, options, setOptions, defaul
                             options,
                             showValues,
                             multiple,
+                            selectable,
                             setOptions,
                             defaultControlsTooltip,
                         }}

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/types.ts
@@ -1,6 +1,7 @@
 export interface OptionsPanelProps {
     currency: boolean;
     multiple: boolean;
+    selectable?: boolean;
     options: OptionProps[];
     setOptions: (options: OptionProps[]) => void;
     defaultControlsTooltip?: string;
@@ -11,6 +12,7 @@ export interface OptionsListProps {
     options: OptionProps[];
     showValues: boolean;
     multiple: boolean;
+    selectable: boolean;
     setOptions: (options: OptionProps[]) => void;
     defaultControlsTooltip?: string;
 }
@@ -21,6 +23,7 @@ export interface OptionsItemProps {
     option: OptionProps;
     showValues: boolean;
     multiple: boolean;
+    selectable: boolean;
     defaultTooltip?: string;
     handleUpdateOptionLabel: (label: string) => void;
     handleUpdateOptionValue: (value: string) => void;


### PR DESCRIPTION
## Description

This PR changes the way how Donor title prefixes are handled. Instead of using `FormTokenField` component, we now use the `Options` component used by donation levels. This adds flexibility for the site admin to easily add, remove, and reorder the donor title prefixes. Also, this PR resolves the error where the title prefix options UI didn't work at all. 

## Affects

Form Builder -> Donor Name block

## Visuals

![Screen Capture_select-area_20231011114842](https://github.com/impress-org/givewp/assets/4222590/25f74744-00db-41fa-ad56-d5fe2c06faef)



## Testing Instructions

1. Select donor name block
2. Enable title prefixes
3. Add, remove, edit title prefixes
4. Save form and preview the form on frontend

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205710844260100
  - https://app.asana.com/0/0/1205163190191516