### PR TITLE
Refactor: Remove migrated form title suffix

### DIFF
--- a/src/FormMigration/Steps/FormTitle.php
+++ b/src/FormMigration/Steps/FormTitle.php
@@ -8,8 +8,7 @@ class FormTitle extends FormMigrationStep
 {
     public function process()
     {
-        $formTitle = sprintf('%s [form builder]', $this->formV2->title);
-        $this->formV3->title = $formTitle;
-        $this->formV3->settings->formTitle = $formTitle;
+        $this->formV3->title = $this->formV2->title;
+        $this->formV3->settings->formTitle = $this->formV2->title;
     }
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the suffix from the migrated form title.