### PR TITLE
Refactor: Remove paragraph content from inspector

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
@@ -1,7 +1,6 @@
 import {BlockEditProps} from '@wordpress/blocks';
-import {RichText, InspectorControls} from '@wordpress/block-editor';
+import {RichText} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
-import {PanelBody, PanelRow, TextareaControl, TextControl} from "@wordpress/components";
 
 export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
     const {content} = attributes;
@@ -15,17 +14,6 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
                 onChange={(content) => setAttributes({content})}
                 placeholder={__('Enter some text', 'custom-block-editor')}
             />
-            <InspectorControls>
-                <PanelBody title={__('Attributes', 'give')} initialOpen={true}>
-                    <PanelRow>
-                        <TextareaControl
-                            label={__('Content', 'give')}
-                            value={content}
-                            onChange={(content) => setAttributes({content})}
-                        />
-                    </PanelRow>
-                </PanelBody>
-            </InspectorControls>
         </>
     );
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the "content" setting inspector control for the paragraph element block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/efc3d14a-9fc3-4118-a0a6-0a16d72da6f1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205502083833606
  - https://app.asana.com/0/0/1205722351216731
  - https://app.asana.com/0/0/1205740516183534