### PR TITLE
Fix: errors on the legacy forms/templates when Strip is enabled for v3 forms but not for v2 forms

### DIFF
--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -41,42 +41,29 @@ function give_stripe_supported_payment_methods()
 /**
  * This function is used to check whether a payment method supported by Stripe with Give is active or not.
  *
- * @unreleased Use $is_v2_form and $is_v3_form to prevent wrong returns in situations where the form version is known
+ * @unreleased Add filter to the return value
  * @since 2.5.5
  *
  * @return bool
  */
 function give_stripe_is_any_payment_method_active()
 {
-    $is_v2_form = (bool)did_filter('give_form_html_tags');
-    $is_v3_form = isset($_REQUEST['form-id']) && isset($_REQUEST['givewp-route']) && ('donation-form-view' === $_REQUEST['givewp-route'] || 'donation-form-view-preview' === $_REQUEST['givewp-route']);
-
-	// Get settings.
 	$settings             = give_get_settings();
-
-    if ($is_v2_form) {
-        $gateways = $settings['gateways'] ?? [];
-    } elseif ($is_v3_form) {
-        $gateways = $settings['gateways_v3'] ?? [];
-    } else {
-        $gateways = array_merge(
-            $settings['gateways'] ?? [],
-            $settings['gateways_v3'] ?? []
-        );
-    }
-
+    $gateways = $settings['gateways'] ?? [];
     $stripePaymentMethods = give_stripe_supported_payment_methods();
 
-	// Loop through gateways list.
-	foreach ( array_keys( $gateways ) as $gateway ) {
-
+    $active = false;
+    foreach (array_keys($gateways) as $gateway) {
 		// Return true, if even single payment method is active.
 		if ( in_array( $gateway, $stripePaymentMethods, true ) ) {
-			return true;
+            $active = true;
 		}
 	}
 
-	return false;
+    /**
+     * @unreleased
+     */
+    return apply_filters('give_stripe_is_any_payment_method_active', $active, $gateways, $stripePaymentMethods);
 }
 
 /**

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -11,6 +11,7 @@
  */
 
 // Exit, if accessed directly.
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -40,16 +41,31 @@ function give_stripe_supported_payment_methods()
 /**
  * This function is used to check whether a payment method supported by Stripe with Give is active or not.
  *
+ * @unreleased Use $is_v2_form and $is_v3_form to prevent wrong returns in situations where the form version is known
  * @since 2.5.5
  *
  * @return bool
  */
-function give_stripe_is_any_payment_method_active() {
+function give_stripe_is_any_payment_method_active()
+{
+    $is_v2_form = (bool)did_filter('give_form_html_tags');
+    $is_v3_form = isset($_REQUEST['form-id']) && isset($_REQUEST['givewp-route']) && ('donation-form-view' === $_REQUEST['givewp-route'] || 'donation-form-view-preview' === $_REQUEST['givewp-route']);
 
 	// Get settings.
 	$settings             = give_get_settings();
-	$gateways             = isset( $settings['gateways'] ) ? $settings['gateways'] : [];
-	$stripePaymentMethods = give_stripe_supported_payment_methods();
+
+    if ($is_v2_form) {
+        $gateways = $settings['gateways'] ?? [];
+    } elseif ($is_v3_form) {
+        $gateways = $settings['gateways_v3'] ?? [];
+    } else {
+        $gateways = array_merge(
+            $settings['gateways'] ?? [],
+            $settings['gateways_v3'] ?? []
+        );
+    }
+
+    $stripePaymentMethods = give_stripe_supported_payment_methods();
 
 	// Loop through gateways list.
 	foreach ( array_keys( $gateways ) as $gateway ) {

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -41,7 +41,6 @@ function give_stripe_supported_payment_methods()
 /**
  * This function is used to check whether a payment method supported by Stripe with Give is active or not.
  *
- * @unreleased Add filter to the return value
  * @since 2.5.5
  *
  * @return bool

--- a/includes/gateways/stripe/includes/filters.php
+++ b/includes/gateways/stripe/includes/filters.php
@@ -48,18 +48,20 @@ add_filter( 'give_get_payment_transaction_id-stripe_ach', 'give_stripe_get_payme
 /**
  * This function is used to add Stripe credentials to GiveWP form.
  *
- * @param array  $form_html_tags Form HTML tags.
+ * @unreleased Return $form_html_tags instead of false when Stripe gateway isn't enabled
+ * @since 2.7.0
+ *
  * @param object $form           Form Object.
  *
- * @since 2.7.0
+ * @param array  $form_html_tags Form HTML tags.
  *
  * @return array|bool
  */
 function give_stripe_form_add_data_tag_keys( $form_html_tags, $form ) {
 
 	// Must have a Stripe payment gateway active.
-	if ( ! give_stripe_is_any_payment_method_active() ) {
-		return false;
+    if ( ! give_stripe_is_any_payment_method_active()) {
+        return $form_html_tags;
 	}
 
 	$publishable_key = give_stripe_get_publishable_key( $form->ID );

--- a/includes/gateways/stripe/includes/filters.php
+++ b/includes/gateways/stripe/includes/filters.php
@@ -73,4 +73,4 @@ function give_stripe_form_add_data_tag_keys( $form_html_tags, $form ) {
 	return $form_html_tags;
 }
 
-add_filter('give_form_html_tags', 'give_stripe_form_add_data_tag_keys', 1, 2);
+add_filter('give_form_html_tags', 'give_stripe_form_add_data_tag_keys', 0, 2);

--- a/includes/gateways/stripe/includes/filters.php
+++ b/includes/gateways/stripe/includes/filters.php
@@ -73,4 +73,4 @@ function give_stripe_form_add_data_tag_keys( $form_html_tags, $form ) {
 	return $form_html_tags;
 }
 
-add_filter( 'give_form_html_tags', 'give_stripe_form_add_data_tag_keys', 0, 2 );
+add_filter('give_form_html_tags', 'give_stripe_form_add_data_tag_keys', 1, 2);


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

If you enable Stripe gateway for V3 forms and disable it for v2 forms, then try to make donations using legacy forms/templates, you will notice a few strange behaviors that prevent the donations from getting completed. This PR fixes this bug.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Legacy Forms - V2

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/e59231ccf187498da75048cd57751cb9

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

To replicate the bug, you need to follow these steps:

1. In the `Option-Based Form Editor` tab on the gateway settings, disable all Stripe gateways.
2. In the `Visual Form Builder` tab on the gateway settings, enable the Stripe - Payment Element gateway.
3. Try to make a donation with a legacy form using all 3 templates, you'll see that all of them throw exceptions in the console log and the Classic and the Multi-Steps templates do not let you finish the donation.

To test the fix, just pull this branch and repeat step 3 above.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205699277403068