### PR TITLE
Feature: Add a starter for new or empty sections

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
@@ -1,24 +1,38 @@
 import {__} from '@wordpress/i18n';
 
-import {InnerBlocks, InspectorControls, RichText} from '@wordpress/block-editor';
-
+import {InnerBlocks, InspectorControls, RichText, store as blockEditorStore} from '@wordpress/block-editor';
 import {PanelBody, PanelRow, TextareaControl, TextControl} from '@wordpress/components';
-
 import {useSelect} from '@wordpress/data';
 import {BlockEditProps} from '@wordpress/blocks';
 import {getBlockRegistrar} from "@givewp/form-builder/common/getWindowData";
+
+import BaseEmptyBlockInserter from './EmptyBlockInserter';
+import './styles.scss';
 
 export default function Edit(props: BlockEditProps<any>) {
     const {
         attributes: {title, description},
         setAttributes,
+        clientId,
     } = props;
 
-    const isParentOfSelectedBlock = useSelect<any>(
-        (select) => select('core/block-editor').hasSelectedInnerBlock(props.clientId, true),
-        []
+    const hasChildBlocks = useSelect(
+        (select) => {
+            const {getBlockOrder} = select(blockEditorStore);
+
+            return getBlockOrder(clientId).length > 0;
+        },
+        [clientId]
     );
-    const isSelectedOrIsInnerBlockSelected = props.isSelected || isParentOfSelectedBlock;
+
+    const EmptyBlockInserter = () => {
+        return (
+            <div className="give-section__empty-block-inserter">
+                {/* @ts-ignore */}
+                <BaseEmptyBlockInserter rootClientId={clientId} />
+            </div>
+        );
+    };
 
     return (
         <>
@@ -45,11 +59,12 @@ export default function Edit(props: BlockEditProps<any>) {
                 </header>
 
                 <InnerBlocks
-                    allowedBlocks={
-                        getBlockRegistrar().getAll().filter((block) => block.name !== 'givewp/section').map((block) => block.name)
-                    }
+                    allowedBlocks={getBlockRegistrar()
+                        .getAll()
+                        .filter((block) => block.name !== 'givewp/section')
+                        .map((block) => block.name)}
                     template={props.attributes.innerBlocksTemplate}
-                    renderAppender={InnerBlocks.DefaultBlockAppender}
+                    renderAppender={hasChildBlocks ? InnerBlocks.DefaultBlockAppender : EmptyBlockInserter}
                     prioritizedInserterBlocks={[
                         'givewp/text',
                         'givewp/paragraph',

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
@@ -18,6 +18,7 @@ export default function Edit(props: BlockEditProps<any>) {
 
     const hasChildBlocks = useSelect(
         (select) => {
+            // @ts-ignore
             const {getBlockOrder} = select(blockEditorStore);
 
             return getBlockOrder(clientId).length > 0;

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
@@ -13,35 +13,22 @@ export default function EmptyBlockInserter({rootClientId}) {
             __experimentalIsQuick
             className="give-section__empty-block-inserter"
             renderToggle={({onToggle, disabled, isOpen, blockTitle, hasSingleBlockType}) => {
-                let label;
-                if (hasSingleBlockType) {
-                    label = sprintf(
-                        // translators: %s: the name of the block when there is only one
-                        _x('Add %s', 'directly add the only allowed block', 'give'),
-                        blockTitle
-                    );
-                } else {
-                    label = _x('Add block', 'Generic label for block inserter button', 'give');
-                }
-                const isToggleButton = !hasSingleBlockType;
+                const label = _x('Add block', 'Generic label for block inserter button', 'give');
 
-                let inserterButton = (
-                    <Button
-                        className="block-editor-button-block-appender"
-                        onClick={onToggle}
-                        aria-haspopup={isToggleButton ? 'true' : undefined}
-                        aria-expanded={isToggleButton ? isOpen : undefined}
-                        disabled={disabled}
-                        label={label}
-                    >
-                        {__('Drag a block here or click to add a block', 'give')}
-                    </Button>
+                return (
+                    <Tooltip text={label}>
+                        <Button
+                            className="block-editor-button-block-appender"
+                            onClick={onToggle}
+                            aria-haspopup="true" // attribute wants a true value, not a boolean
+                            aria-expanded={isOpen}
+                            disabled={disabled}
+                            label={label}
+                        >
+                            {__('Drag a block here or click to add a block', 'give')}
+                        </Button>
+                    </Tooltip>
                 );
-
-                if (isToggleButton || hasSingleBlockType) {
-                    inserterButton = <Tooltip text={label}>{inserterButton}</Tooltip>;
-                }
-                return inserterButton;
             }}
             isAppender
         />

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
@@ -1,6 +1,6 @@
 import {Button, Tooltip} from '@wordpress/components';
 import {Inserter} from '@wordpress/block-editor';
-import {_x, sprintf} from '@wordpress/i18n';
+import {__, _x} from '@wordpress/i18n';
 
 /**
  * The inserter used in sections for dragging and dropping blocks or clicking to add a block.
@@ -12,7 +12,7 @@ export default function EmptyBlockInserter({rootClientId}) {
             rootClientId={rootClientId}
             __experimentalIsQuick
             className="give-section__empty-block-inserter"
-            renderToggle={({onToggle, disabled, isOpen, blockTitle, hasSingleBlockType}) => {
+            renderToggle={({onToggle, disabled, isOpen}) => {
                 const label = _x('Add block', 'Generic label for block inserter button', 'give');
 
                 return (

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
@@ -1,0 +1,56 @@
+import {Button, Tooltip} from '@wordpress/components';
+import {Inserter} from '@wordpress/block-editor';
+import {forwardRef} from '@wordpress/element';
+import {_x, sprintf} from '@wordpress/i18n';
+
+/**
+ * The inserter used in sections for dragging and dropping blocks or clicking to add a block.
+ */
+function EmptyBlockInserter({rootClientId}, ref) {
+    return (
+        <Inserter
+            position="bottom center"
+            rootClientId={rootClientId}
+            __experimentalIsQuick
+            className="give-section__empty-block-inserter"
+            renderToggle={({onToggle, disabled, isOpen, blockTitle, hasSingleBlockType}) => {
+                let label;
+                if (hasSingleBlockType) {
+                    label = sprintf(
+                        // translators: %s: the name of the block when there is only one
+                        _x('Add %s', 'directly add the only allowed block'),
+                        blockTitle
+                    );
+                } else {
+                    label = _x('Add block', 'Generic label for block inserter button');
+                }
+                const isToggleButton = !hasSingleBlockType;
+
+                let inserterButton = (
+                    <Button
+                        ref={ref}
+                        className="block-editor-button-block-appender"
+                        onClick={onToggle}
+                        aria-haspopup={isToggleButton ? 'true' : undefined}
+                        aria-expanded={isToggleButton ? isOpen : undefined}
+                        disabled={disabled}
+                        label={label}
+                    >
+                        Drag a block here or click to add a block
+                    </Button>
+                );
+
+                if (isToggleButton || hasSingleBlockType) {
+                    inserterButton = <Tooltip text={label}>{inserterButton}</Tooltip>;
+                }
+                return inserterButton;
+            }}
+            isAppender
+        />
+    );
+}
+
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/button-block-appender/README.md
+ */
+export default forwardRef(EmptyBlockInserter);

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
@@ -34,7 +34,7 @@ export default function EmptyBlockInserter({rootClientId}) {
                         disabled={disabled}
                         label={label}
                     >
-                        Drag a block here or click to add a block
+                        {__('Drag a block here or click to add a block', 'give')}
                     </Button>
                 );
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/EmptyBlockInserter.tsx
@@ -1,12 +1,11 @@
 import {Button, Tooltip} from '@wordpress/components';
 import {Inserter} from '@wordpress/block-editor';
-import {forwardRef} from '@wordpress/element';
 import {_x, sprintf} from '@wordpress/i18n';
 
 /**
  * The inserter used in sections for dragging and dropping blocks or clicking to add a block.
  */
-function EmptyBlockInserter({rootClientId}, ref) {
+export default function EmptyBlockInserter({rootClientId}) {
     return (
         <Inserter
             position="bottom center"
@@ -18,17 +17,16 @@ function EmptyBlockInserter({rootClientId}, ref) {
                 if (hasSingleBlockType) {
                     label = sprintf(
                         // translators: %s: the name of the block when there is only one
-                        _x('Add %s', 'directly add the only allowed block'),
+                        _x('Add %s', 'directly add the only allowed block', 'give'),
                         blockTitle
                     );
                 } else {
-                    label = _x('Add block', 'Generic label for block inserter button');
+                    label = _x('Add block', 'Generic label for block inserter button', 'give');
                 }
                 const isToggleButton = !hasSingleBlockType;
 
                 let inserterButton = (
                     <Button
-                        ref={ref}
                         className="block-editor-button-block-appender"
                         onClick={onToggle}
                         aria-haspopup={isToggleButton ? 'true' : undefined}
@@ -49,8 +47,3 @@ function EmptyBlockInserter({rootClientId}, ref) {
         />
     );
 }
-
-/**
- * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/button-block-appender/README.md
- */
-export default forwardRef(EmptyBlockInserter);

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/styles.scss
@@ -1,0 +1,17 @@
+.give-section {
+    &__empty-block-inserter {
+        width: 100%;
+
+        .block-editor-inserter {
+            width: 100%;
+        }
+
+        .block-editor-button-block-appender {
+            width: 100%;
+            box-shadow: none;
+            border: dashed var(--givewp-gray-60) 2px;
+            padding: 3rem 0 !important;
+            font-size: var(--givewp-font-weight-paragraph-lg);
+        }
+    }
+}

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -127,7 +127,7 @@
     }
 
     &:not(.is-selected) {
-        .block-list-appender {
+        .block-editor-default-block-appender {
             display: none;
         }
     }


### PR DESCRIPTION
## Description

This PR resolves two problems:
1. There was no way to drag-n-drop a block onto an empty section. Erm. 😬
2. Empty sections were boring and provided no guidance to the user.

This adds a clickable area that the user can also drag blocks into. Check it the video below!

## Affects

Sections that have no child blocks

## Visuals

https://www.loom.com/share/712bb84378544f35ad5f81e01d97a77a?sid=04c3f4fa-eff8-4401-9785-719e8088e9a1

## Pre-review Checklist

-   [x] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205681939046621