### PR TITLE
Fix: Prevent PHP notice for undefined variable

### DIFF
--- a/src/Form/Template/LegacyFormSettingCompatibility.php
+++ b/src/Form/Template/LegacyFormSettingCompatibility.php
@@ -105,6 +105,8 @@ class LegacyFormSettingCompatibility
      * Note: Only for internal use. This function can be removed or change in future
      *
      * @since 2.7.0
+     *
+     * @unreleased
      */
     public static function migrateExistingFormSettings()
     {
@@ -134,6 +136,7 @@ class LegacyFormSettingCompatibility
             'form_content' => '_give_form_content',
         ];
 
+        $settings = [];
         foreach ($mapToSetting as $newSetting => $oldSetting) {
             if ($value = Give()->form_meta->get_meta($formId, $oldSetting, true)) {
                 $settings['display_settings'][$newSetting] = $value;


### PR DESCRIPTION
Replaces #6925

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR resolves the following PHP Notice:

```
PHP Notice:
Undefined variable: settings
in /src/Form/Template/LegacyFormSettingCompatibility.php
on line 144
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

