### PR TITLE
Fix: Workaround to reset the draggable cursor

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/App.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/App.tsx
@@ -34,6 +34,15 @@ if (ShortcutProvider === undefined) {
     console.error('ShortcutProvider is undefined.');
 }
 
+/**
+ * This is a workaround for a bug in Gutenberg where the drag cursor gets stuck.
+ *
+ * @unreleased
+ */
+document.addEventListener('dragend', () => {
+    document.body.classList.remove('is-dragging-components-draggable')
+});
+
 export default function App() {
     return (
         <FormBuilderErrorBoundary>

--- a/src/FormBuilder/resources/js/form-builder/src/App.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/App.tsx
@@ -9,6 +9,7 @@ import './App.scss';
 import FormBuilderErrorBoundary from '@givewp/form-builder/errors/FormBuilderErrorBounday';
 import Transfer from '@givewp/form-builder/components/onboarding/transfer';
 import {EditorStateProvider} from "@givewp/form-builder/stores/editor-state";
+import scrollIntoView from 'dom-scroll-into-view';
 
 const {blocks: initialBlocks, formSettings: initialFormSettings} = Storage.load();
 
@@ -40,7 +41,11 @@ if (ShortcutProvider === undefined) {
  * @unreleased
  */
 document.addEventListener('dragend', () => {
-    document.body.classList.remove('is-dragging-components-draggable')
+    // Reset the drag cursor.
+    document.body.classList.remove('is-dragging-components-draggable');
+
+    // Scroll the interface down by 1px to force a repaint and reset the popover position.
+    document.getElementsByClassName('interface-interface-skeleton__body')[0].scrollBy(0,1);
 });
 
 export default function App() {


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a workaround for the "stuck" draggable cursor when adding blocks to the form.

In the WordPress Block Editor this doesn't seem to be an issue because the Inserter sidebar is closed on block drop.

Looking at the Gutenberg code base the `draggable` component uses a body class to style the cursor when dragging a block. This should be reset on "cleanup", but does not seem to be working.

See https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/draggable/index.tsx#L230

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Drag and drop a new block/field into the form.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205681679114246