### PR TITLE
Refactor: replace custom block editor text domain with give

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/Edit.tsx
@@ -13,7 +13,7 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<any>) {
                 value={content}
                 allowedFormats={['core/bold', 'core/italic', 'core/link']}
                 onChange={(content) => setAttributes({content})}
-                placeholder={__('Enter some text', 'custom-block-editor')}
+                placeholder={__('Enter some text', 'give')}
             />
             <InspectorControls>
                 <PanelBody title={__('Attributes', 'give')} initialOpen={true}>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/elements/paragraph/settings.tsx
@@ -4,7 +4,7 @@ import {ElementBlock} from '@givewp/form-builder/types/block';
 import Edit from './Edit';
 
 const settings: ElementBlock['settings'] = {
-    title: __('Paragraph', 'custom-block-editor'),
+    title: __('Paragraph', 'give'),
     description: 'Place a styled paragraph in your form.',
     category: 'content',
     supports: {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/settings.tsx
@@ -23,7 +23,7 @@ const {
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Donation Amount and Levels', 'custom-block-editor'),
+    title: __('Donation Amount and Levels', 'give'),
     description: __('The interface for donors to specify the amount they want to donate.', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
@@ -7,7 +7,7 @@ import {Path, SVG} from '@wordpress/components';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Billing Address', 'custom-block-editor'),
+    title: __('Billing Address', 'give'),
     description: __('Collects the donor billing address with display options.', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/company/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/company/settings.tsx
@@ -6,7 +6,7 @@ import {Path, SVG} from '@wordpress/components';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Company', 'custom-block-editor'),
+    title: __('Company', 'give'),
     description: __('Donors can input their company name', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/settings.tsx
@@ -7,7 +7,7 @@ import {Path, SVG} from '@wordpress/components';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Donor Name', 'custom-block-editor'),
+    title: __('Donor Name', 'give'),
     description: __('Collects the donor name with display options.', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
@@ -7,7 +7,7 @@ import {Path, SVG} from '@wordpress/components';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Email', 'custom-block-editor'),
+    title: __('Email', 'give'),
     description: __('The required email field for donors to enter their email address.', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
@@ -12,7 +12,7 @@ const login: FieldBlock = {
     settings: {
         ...defaultSettings,
         icon: BlockIcon,
-        title: __('User Login', 'custom-block-editor'),
+        title: __('User Login', 'give'),
         description: __('...', 'give'),
         supports: {
             multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/settings.tsx
@@ -6,7 +6,7 @@ import Icon from './Icon';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Payment Gateways', 'custom-block-editor'),
+    title: __('Payment Gateways', 'give'),
     description: __('Display payment gateway options for donors to process their donation.', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/index.tsx
@@ -3,7 +3,7 @@ import {BlockAttributes, BlockConfiguration} from '@wordpress/blocks';
 import Edit from './Edit';
 
 const defaultSettings: BlockConfiguration = {
-    title: __('Field', 'custom-block-editor'),
+    title: __('Field', 'give'),
     category: 'input',
     supports: {
         html: false, // Removes support for an HTML mode.

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/settings.tsx
@@ -8,7 +8,7 @@ import defaultSettings from '../settings';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Terms and conditions', 'custom-block-editor'),
+    title: __('Terms and conditions', 'give'),
     description: __('Donors can accept the terms and conditions', 'give'),
     supports: {
         multiple: false,

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/settings.tsx
@@ -7,7 +7,7 @@ import {Path, SVG} from '@wordpress/components';
 
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
-    title: __('Text Field', 'custom-block-editor'),
+    title: __('Text Field', 'give'),
     category: 'custom',
     description: __('A custom text field that donors can use.', 'give'),
     supports: {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This replaces all `'custom-block-editor'` text domains with `'give'`

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

text domains in blocks

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure blocks work

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

