### PR TITLE
Refactor: optimize form meta migration query

### DIFF
--- a/src/FormMigration/Steps/FormMeta.php
+++ b/src/FormMigration/Steps/FormMeta.php
@@ -21,17 +21,21 @@ class FormMeta extends FormMigrationStep
         $formMetaTable = DB::prefix('give_formmeta');
 
         DB::query(
-            "
-                INSERT INTO $formMetaTable (form_id, meta_key, meta_value)
-                SELECT
-                    $newFormId,
-                    meta_key,
-                    meta_value
-                FROM
-                    $formMetaTable
-                WHERE
-                    form_id = $oldFormId
+            DB::prepare(
                 "
+                    INSERT INTO $formMetaTable (form_id, meta_key, meta_value)
+                    SELECT
+                        %d,
+                        meta_key,
+                        meta_value
+                    FROM
+                        $formMetaTable
+                    WHERE
+                        form_id = %d
+                    ",
+                $newFormId,
+                $oldFormId
+            )
         );
     }
 }

--- a/src/FormMigration/Steps/FormMeta.php
+++ b/src/FormMigration/Steps/FormMeta.php
@@ -32,9 +32,13 @@ class FormMeta extends FormMigrationStep
                         $formMetaTable
                     WHERE
                         form_id = %d
+                        AND meta_key NOT IN (
+                            SELECT meta_key FROM $formMetaTable WHERE form_id = %d
+                        )
                     ",
                 $newFormId,
-                $oldFormId
+                $oldFormId,
+                $newFormId
             )
         );
     }

--- a/src/FormMigration/Steps/FormMeta.php
+++ b/src/FormMigration/Steps/FormMeta.php
@@ -4,8 +4,6 @@ namespace Give\FormMigration\Steps;
 
 use Give\FormMigration\Contracts\FormMigrationStep;
 use Give\Framework\Database\DB;
-use Give\Framework\Exceptions\Primitives\Exception;
-use Give\Log\Log;
 
 /**
  * @since 3.0.0-rc.6
@@ -22,11 +20,8 @@ class FormMeta extends FormMigrationStep
 
         $formMetaTable = DB::prefix('give_formmeta');
 
-        DB::beginTransaction();
-
-        try {
-            $insertQuery = DB::query(
-                "
+        DB::query(
+            "
                 INSERT INTO $formMetaTable (form_id, meta_key, meta_value)
                 SELECT
                     $newFormId,
@@ -37,16 +32,6 @@ class FormMeta extends FormMigrationStep
                 WHERE
                     form_id = $oldFormId
                 "
-            );
-
-            if (!$insertQuery) {
-                throw new Exception('Failed running form meta migration.');
-            }
-        } catch (Exception $exception) {
-            DB::rollback();
-            Log::error($exception->getMessage());
-        }
-
-        DB::commit();
+        );
     }
 }


### PR DESCRIPTION
## Description

While fixing migration bugs, I noticed that the serialized form meta data was being re-serialized during migration, causing fatal errors due to changes in the data structure.

Initially, I considered unserializing the data before inserting it into the database and then serializing it again. However, after discussing it, we decided to completely revamp the way we migrate form metas.

In this Pull Request, we have replaced the previous approach of using a for-loop to store all data in memory and then performing individual insertions. Instead, we now use a single `INSERT INTO` query to streamline the data insertion process, improving both the accuracy and speed of the migration.

## Affects

Form Migration

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205692499999969