### PR TITLE
Fix: Prevent warnings from displaying in form iframe

### DIFF
--- a/src/DonationForms/Controllers/DonationConfirmationReceiptViewController.php
+++ b/src/DonationForms/Controllers/DonationConfirmationReceiptViewController.php
@@ -27,6 +27,7 @@ class DonationConfirmationReceiptViewController
             return '';
         }
 
+        ob_clean();
         return (new DonationConfirmationReceiptViewModel($donation))->render();
     }
 

--- a/src/DonationForms/Controllers/DonationFormViewController.php
+++ b/src/DonationForms/Controllers/DonationFormViewController.php
@@ -25,6 +25,7 @@ class DonationFormViewController
             $donationForm->settings
         );
 
+        ob_clean();
         return $viewModel->render();
     }
 
@@ -44,6 +45,7 @@ class DonationFormViewController
             $data->formSettings ?: $donationForm->settings
         );
 
+        ob_clean();
         return $viewModel->render(true);
     }
 }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -94,6 +94,7 @@ class ServiceProvider implements ServiceProviderInterface
          * @since 3.0.0
          */
         Route::get('donation-form-view', static function (array $request) {
+            ini_set('display_errors', 0);
             $routeData = DonationFormViewRouteData::fromRequest($request);
 
             return give(DonationFormViewController::class)->show($routeData);
@@ -103,16 +104,17 @@ class ServiceProvider implements ServiceProviderInterface
          * @since 3.0.0
          */
         Route::get('donation-confirmation-receipt-view', static function (array $request) {
+            ini_set('display_errors', 0);
             $routeData = DonationConfirmationReceiptViewRouteData::fromRequest($request);
 
             return give(DonationConfirmationReceiptViewController::class)->show($routeData);
         });
 
-
         /**
          * @since 3.0.0
          */
         Route::post('donation-form-view-preview', static function () {
+            ini_set('display_errors', 0);
             $requestData = (new SanitizeDonationFormPreviewRequest())($_REQUEST);
             $routeData = DonationFormPreviewRouteData::fromRequest($requestData);
 


### PR DESCRIPTION
## Description

This addresses feedback such as: https://feedback.givewp.com/next-gen/p/deprecated-error-notice-when-attempting-to-migrate-a-20-form-to-30

If any kind of deprecation, error, warning, or just plain anything is written to the output buffer, it's currently showing up inside our forms and confirmation receipts. It's fine for things to show up in other places, but we specifically don't want them to show up there, in front of donors.

This clears the output buffer and sets `ini_set('display_errors', 0)` to prevent PHP errors (which supersedes the output buffer). This isn't a perfect system, as any errors/warnings that occur _before_ the `ini_set` will still show up. As such, I put them in the router closures as the earliest point in time we could squelch the errors.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

Without this PR:
![image](https://github.com/impress-org/givewp/assets/2024145/d01421f7-0077-4c12-bb04-229e4619e324)

## Testing Instructions

Use the WordPress Beta Test plugin to update to WP 6.4 beta. Then preview the form in the Form Builder (design mode), and make a donation on the front end.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

