### PR TITLE
Fix: address minor form migration issues that could result in fatal errors

### DIFF
--- a/src/FormMigration/Steps/DonationOptions.php
+++ b/src/FormMigration/Steps/DonationOptions.php
@@ -25,14 +25,20 @@ class DonationOptions extends FormMigrationStep
                 array_map([$this, 'roundAmount'], wp_list_pluck($donationLevels, '_give_amount')));
         }
 
-        if($this->formV2->isCustomAmountOptionEnabled()) {
-            $amountField->setAttribute('customAmount', true);
-            $amountField->setAttribute('customAmountMin',
-                $this->roundAmount($this->getMetaV2('_give_custom_amount_range_minimum')));
-            $amountField->setAttribute('customAmountMax',
-                $this->roundAmount($this->getMetaV2('_give_custom_amount_range_maximum')));
-        } else {
-            $amountField->setAttribute('customAmount', false);
+        $isCustomAmountEnabled = $this->formV2->isCustomAmountOptionEnabled();
+        $amountField->setAttribute('customAmount', $isCustomAmountEnabled);
+
+        if ($isCustomAmountEnabled) {
+            $customAmountMin = $this->getMetaV2('_give_custom_amount_range_minimum');
+            $customAmountMax = $this->getMetaV2('_give_custom_amount_range_maximum');
+
+            if ($customAmountMin) {
+                $amountField->setAttribute('customAmountMin', $this->roundAmount($customAmountMin));
+            }
+
+            if ($customAmountMax) {
+                $amountField->setAttribute('customAmountMax', $this->roundAmount($customAmountMax));
+            }
         }
 
         // @note No corresponding setting in v3 for "Custom Amount Text"

--- a/src/FormMigration/Steps/EmailSettings.php
+++ b/src/FormMigration/Steps/EmailSettings.php
@@ -21,7 +21,7 @@ class EmailSettings extends FormMigrationStep
                 'email_subject' => $notification->get_email_subject($this->formV2->id),
                 'email_header' => $notification->get_email_header($this->formV2->id),
                 'email_message' => str_replace(
-                    ['"“', '“"', '“'],
+                    ['"“', '"”', '“"', '”"', '“', '”'],
                     '"',
                     $notification->get_email_message($this->formV2->id)
                 ),

--- a/src/FormMigration/Steps/EmailSettings.php
+++ b/src/FormMigration/Steps/EmailSettings.php
@@ -20,7 +20,11 @@ class EmailSettings extends FormMigrationStep
                 'status' => $notification->get_notification_status($this->formV2->id),
                 'email_subject' => $notification->get_email_subject($this->formV2->id),
                 'email_header' => $notification->get_email_header($this->formV2->id),
-                'email_message' => $notification->get_email_message($this->formV2->id),
+                'email_message' => str_replace(
+                    '”',
+                    '"',
+                    $notification->get_email_message($this->formV2->id)
+                ),
                 'email_content_type' => $notification->get_email_content_type($this->formV2->id),
                 'recipient' => (array) $notification->get_recipient($this->formV2->id)
             ];

--- a/src/FormMigration/Steps/EmailSettings.php
+++ b/src/FormMigration/Steps/EmailSettings.php
@@ -21,7 +21,7 @@ class EmailSettings extends FormMigrationStep
                 'email_subject' => $notification->get_email_subject($this->formV2->id),
                 'email_header' => $notification->get_email_header($this->formV2->id),
                 'email_message' => str_replace(
-                    '”',
+                    ['"“', '“"', '“'],
                     '"',
                     $notification->get_email_message($this->formV2->id)
                 ),

--- a/src/FormMigration/Steps/PdfSettings.php
+++ b/src/FormMigration/Steps/PdfSettings.php
@@ -39,7 +39,6 @@ class PdfSettings extends FormMigrationStep
         ];
 
         $newForm->settings->pdfSettings = $pdfSettings;
-        $newForm->save();
     }
 
     /**


### PR DESCRIPTION
## Description

During the testing of Form Migrations, we encountered errors caused by minor code details. This pull request aims to resolve those issues and ensure smooth Form Migrations.

This is a summary of the changes:
- Previously, if the attributes `customAmountMin` and `customAmountMax` were empty, they were saved as `0.0` post rounding implementation. Now, a validity check is performed on these attributes before rounding and saving them to ensure accurate data storage.
- Identified an issue where email notifications in P2P contained open-quotes, which interfered with form settings while extracting JSON content. This has been resolved by replacing open-quotes with double-quotes before setting the notifications in the migrated form.
- Noticed a migration step that saved the form prematurely before the migration was fully completed. This was unnecessary and had the potential to trigger unexpected side effects. This step has been rectified to ensure the form is saved only after the migration process is entirely finalized.

## Affects

Form Migrations

## Testing Instructions

1. Create a new P2P campaign that creates a new form for you.
2. Open that recently created form and migrate it to v3.
3. The form is migrated with no errors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205692499999974