### PR TITLE
Fix: notice message on post publish/update

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -76,9 +76,15 @@ const HeaderContainer = ({
     };
 
     const showOnSaveNotice = formStatus => {
-        const notice = 'publish' === formStatus
-            ? __('Form updated.', 'give')
-            : __('Form published.', 'give')
+        let notice;
+
+        if ('draft' === formStatus) {
+            notice = __('Draft saved.', 'give')
+        } else {
+            notice = 'publish' === formStatus && formSettings.formStatus !== 'draft'
+                ? __('Form updated.', 'give')
+                : __('Form published.', 'give')
+        }
 
         createSuccessNotice(notice, {
             type: 'snackbar',


### PR DESCRIPTION
## Description

This PR resolves the issue with the notice message on post publish/update. 

## Affects

Form builder snackbar notice message

## Visuals
![Screen Capture_select-area_20231011112639](https://github.com/impress-org/givewp/assets/4222590/f0d4daf9-926d-4848-918f-c6e78b2972fc)


## Testing Instructions

1. create form
2. update the form
3. publish the form
4. edit form and hit update
5. save draft



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205606769216054