### PR TITLE
Feature: add migration step for Fee Recovery settings

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -455,7 +455,7 @@ class FormMetaDecorator extends FormModelDecorator
     {
         $feeRecoveryStatus = $this->getMeta('_form_give_fee_recovery');
 
-        if ($feeRecoveryStatus === 'disabled') {
+        if (empty($feeRecoveryStatus) || $feeRecoveryStatus === 'disabled') {
             return [];
         }
 

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -5,6 +5,7 @@ namespace Give\FormMigration;
 use Give\DonationForms\V2\Models\DonationForm;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\FormMigration\Contracts\FormModelDecorator;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
 use Give_Email_Notification_Util;
 
 class FormMetaDecorator extends FormModelDecorator

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -487,7 +487,7 @@ class FormMetaDecorator extends FormModelDecorator
         }
 
         return [
-            'useGlobalSettings' => $feeRecoveryStatus === 'global',
+            'useGlobalSettings' => false,
             'feeSupportForAllGateways' => $this->getMeta('_form_give_fee_configuration') === 'all_gateways',
             'perGatewaySettings' => $perGatewaySettings,
             'feePercentage' => (float)$this->getMeta('_form_give_fee_percentage'),

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -460,23 +460,32 @@ class FormMetaDecorator extends FormModelDecorator
 
         return [
             'useGlobalSettings' => $feeRecoveryStatus === 'global',
-            'feeSupportForAllGateways' => give_get_meta(
-                    $this->form->id,
-                    '_form_give_fee_configuration',
-                    true
-                ) === 'all_gateways',
+            'feeSupportForAllGateways' => $this->getMeta('_form_give_fee_configuration') === 'all_gateways',
             'perGatewaySettings' => [],
-            'feePercentage' => (float)give_get_meta($this->form->id, '_form_give_fee_percentage', true),
-            'feeBaseAmount' => (float)give_get_meta($this->form->id, '_form_give_fee_base_amount', true),
-            'maxFeeAmount' => (float)give_get_meta($this->form->id, '_form_give_fee_maximum_fee_amount', true),
-            'includeInDonationSummary' => give_get_meta(
-                    $this->form->id,
-                    '_form_breakdown',
-                    true
-                ) === 'enabled',
-            'donorOptIn' => give_get_meta($this->form->id, '_form_give_fee_mode', true) === 'donor_opt_in',
-            'feeCheckboxLabel' => give_get_meta($this->form->id, '_form_give_fee_checkbox_label', true),
-            'feeMessage' => give_get_meta($this->form->id, '_form_give_fee_explanation', true),
+            'feePercentage' => (float)$this->getMeta('_form_give_fee_percentage'),
+            'feeBaseAmount' => (float)$this->getMeta('_form_give_fee_base_amount'),
+            'maxFeeAmount' => (float)$this->getMeta('_form_give_fee_maximum_fee_amount'),
+            'includeInDonationSummary' => $this->getMeta('_form_breakdown') === 'enabled',
+            'donorOptIn' => $this->getMeta('_form_give_fee_mode') === 'donor_opt_in',
+            'feeCheckboxLabel' => $this->getMeta('_form_give_fee_checkbox_label'),
+            'feeMessage' => $this->getMeta('_form_give_fee_explanation'),
         ];
+    }
+
+    /**
+     * Retrieves metadata for the current form.
+     *
+     * This method acts as a wrapper for the give_get_meta function, reducing redundancy
+     * and improving code readability when fetching metadata related to the current form.
+     *
+     * @unreleased
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    private function getMeta(string $key, $default = null)
+    {
+        return give_get_meta($this->form->id, $key, true, $default);
     }
 }

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -465,6 +465,10 @@ class FormMetaDecorator extends FormModelDecorator
             ];
         }
 
+        if ($feeRecoveryStatus !== 'enabled') {
+            return [];
+        }
+
         $perGatewaySettings = [];
         $gateways = give_get_ordered_payment_gateways(give_get_enabled_payment_gateways());
         $gatewaysMap = [

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -446,4 +446,37 @@ class FormMetaDecorator extends FormModelDecorator
     {
         return give_get_meta($this->form->id, '_give_ffm_placement', true);
     }
+
+    /**
+     * @unreleased
+     */
+    public function getFeeRecoverySettings(): array
+    {
+        $feeRecoveryStatus = give_get_meta($this->form->id, '_form_give_fee_recovery', true);
+
+        if ($feeRecoveryStatus === 'disabled') {
+            return [];
+        }
+
+        return [
+            'useGlobalSettings' => $feeRecoveryStatus === 'global',
+            'feeSupportForAllGateways' => give_get_meta(
+                    $this->form->id,
+                    '_form_give_fee_configuration',
+                    true
+                ) === 'all_gateways',
+            'perGatewaySettings' => [],
+            'feePercentage' => (float)give_get_meta($this->form->id, '_form_give_fee_percentage', true),
+            'feeBaseAmount' => (float)give_get_meta($this->form->id, '_form_give_fee_base_amount', true),
+            'maxFeeAmount' => (float)give_get_meta($this->form->id, '_form_give_fee_maximum_fee_amount', true),
+            'includeInDonationSummary' => give_get_meta(
+                    $this->form->id,
+                    '_form_breakdown',
+                    true
+                ) === 'enabled',
+            'donorOptIn' => give_get_meta($this->form->id, '_form_give_fee_mode', true) === 'donor_opt_in',
+            'feeCheckboxLabel' => give_get_meta($this->form->id, '_form_give_fee_checkbox_label', true),
+            'feeMessage' => give_get_meta($this->form->id, '_form_give_fee_explanation', true),
+        ];
+    }
 }

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -460,13 +460,16 @@ class FormMetaDecorator extends FormModelDecorator
 
         $perGatewaySettings = [];
         $gateways = give_get_ordered_payment_gateways(give_get_enabled_payment_gateways());
+        $gatewaysMap = [
+            'stripe' => 'stripe_payment_element',
+        ];
 
         if ($gateways) {
             foreach (array_keys($gateways) as $gatewayId) {
-                if ($gatewayId === 'stripe') {
-                    $gatewayId = 'stripe_payment_element';
+                if (array_key_exists($gatewayId, $gatewaysMap)) {
+                    $gatewayId = $gatewaysMap[$gatewayId];
                 }
-                
+
                 $perGatewaySettings[$gatewayId] = [
                     'enabled' => $this->getMeta('_form_gateway_fee_enable_' . $gatewayId) === 'enabled',
                     'feePercentage' => (float)$this->getMeta('_form_gateway_fee_percentage_' . $gatewayId),

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -459,6 +459,12 @@ class FormMetaDecorator extends FormModelDecorator
             return [];
         }
 
+        if ($feeRecoveryStatus === 'global') {
+            return [
+                'useGlobalSettings' => true,
+            ];
+        }
+
         $perGatewaySettings = [];
         $gateways = give_get_ordered_payment_gateways(give_get_enabled_payment_gateways());
         $gatewaysMap = [

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -461,7 +461,7 @@ class FormMetaDecorator extends FormModelDecorator
         $perGatewaySettings = [];
         $gateways = give_get_ordered_payment_gateways(give_get_enabled_payment_gateways());
         $gatewaysMap = [
-            'stripe' => 'stripe_payment_element',
+            'stripe' => StripePaymentElementGateway::id(),
         ];
 
         if ($gateways) {

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -44,6 +44,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Steps\EmailSettings::class,
                 Steps\FormMeta::class,
                 Steps\PdfSettings::class,
+                Steps\FeeRecovery::class,
             ]);
         });
     }

--- a/src/FormMigration/Steps/FeeRecovery.php
+++ b/src/FormMigration/Steps/FeeRecovery.php
@@ -22,10 +22,48 @@ class FeeRecovery extends FormMigrationStep
             return;
         }
 
+        if ($feeRecoverySettings['useGlobalSettings']) {
+            $feeRecoverySettings = $this->getGlobalSettings();
+        }
+
         $feeRecoveryBlock = BlockModel::make([
             'name' => 'givewp-fee-recovery/fee-recovery',
             'attributes' => $feeRecoverySettings,
         ]);
         $this->fieldBlocks->insertAfter('givewp/donation-amount', $feeRecoveryBlock);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getGlobalSettings(): array
+    {
+        return [
+            'useGlobalSettings' => true,
+            'feeSupportForAllGateways' => give_get_option('give_fee_configuration', 'all_gateways') === 'all_gateways',
+            'perGatewaySettings' => [],
+            'feePercentage' => (float)give_get_option('give_fee_percentage', give_fee_get_default_percentage()),
+            'feeBaseAmount' => (float)give_get_option(
+                'give_fee_base_amount',
+                give_fee_get_default_additional_amount()
+            ),
+            'maxFeeAmount' => (float)give_get_option(
+                'give_fee_maximum_fee_amount',
+                give_format_decimal(['amount' => '0.00'])
+            ),
+            'includeInDonationSummary' => give_get_option('give_fee_breakdown', 'enabled') === 'enabled',
+            'donorOptIn' => give_get_option('give_fee_mode', 'donor_opt_in') === 'donor_opt_in',
+            'feeCheckboxLabel' => give_get_option(
+                'give_fee_checkbox_label',
+                __(
+                    'I\'d like to help cover the transaction fees of {fee_amount} for my donation.',
+                    'give-fee-recovery'
+                )
+            ),
+            'feeMessage' => give_get_option(
+                'give_fee_explanation',
+                __('Plus an additional {fee_amount} to cover gateway fees.', 'give-fee-recovery')
+            ),
+        ];
     }
 }

--- a/src/FormMigration/Steps/FeeRecovery.php
+++ b/src/FormMigration/Steps/FeeRecovery.php
@@ -42,11 +42,8 @@ class FeeRecovery extends FormMigrationStep
             'useGlobalSettings' => true,
             'feeSupportForAllGateways' => give_get_option('give_fee_configuration', 'all_gateways') === 'all_gateways',
             'perGatewaySettings' => [],
-            'feePercentage' => (float)give_get_option('give_fee_percentage', give_fee_get_default_percentage()),
-            'feeBaseAmount' => (float)give_get_option(
-                'give_fee_base_amount',
-                give_fee_get_default_additional_amount()
-            ),
+            'feePercentage' => (float)give_get_option('give_fee_percentage', 2.9),
+            'feeBaseAmount' => (float)give_get_option('give_fee_base_amount', 0.30),
             'maxFeeAmount' => (float)give_get_option(
                 'give_fee_maximum_fee_amount',
                 give_format_decimal(['amount' => '0.00'])

--- a/src/FormMigration/Steps/FeeRecovery.php
+++ b/src/FormMigration/Steps/FeeRecovery.php
@@ -13,27 +13,16 @@ class FeeRecovery extends FormMigrationStep
      */
     public function process()
     {
-        $feeRecoveryBlock = $this->fieldBlocks->findByName('givewp-fee-recovery/fee-recovery');
         $feeRecoverySettings = $this->formV2->getFeeRecoverySettings();
 
         if (empty($feeRecoverySettings)) {
-            if ($feeRecoveryBlock) {
-                $this->fieldBlocks->remove($feeRecoveryBlock->name);
-            }
-
             return;
         }
 
-        if (!$feeRecoveryBlock) {
-            $feeRecoveryBlock = BlockModel::make([
-                'name' => 'givewp-fee-recovery/fee-recovery',
-                'attributes' => [],
-            ]);
-            $this->fieldBlocks->insertAfter('givewp/donation-amount', $feeRecoveryBlock);
-        }
-
-        foreach ($feeRecoverySettings as $key => $value) {
-            $feeRecoveryBlock->setAttribute($key, $value);
-        }
+        $feeRecoveryBlock = BlockModel::make([
+            'name' => 'givewp-fee-recovery/fee-recovery',
+            'attributes' => $feeRecoverySettings,
+        ]);
+        $this->fieldBlocks->insertAfter('givewp/donation-amount', $feeRecoveryBlock);
     }
 }

--- a/src/FormMigration/Steps/FeeRecovery.php
+++ b/src/FormMigration/Steps/FeeRecovery.php
@@ -15,7 +15,10 @@ class FeeRecovery extends FormMigrationStep
     {
         $feeRecoverySettings = $this->formV2->getFeeRecoverySettings();
 
-        if (empty($feeRecoverySettings)) {
+        if (empty($feeRecoverySettings) || (
+                $feeRecoverySettings['useGlobalSettings'] === true &&
+                !give_is_setting_enabled(give_get_option('give_fee_recovery', 'disabled'))
+            )) {
             return;
         }
 

--- a/src/FormMigration/Steps/FeeRecovery.php
+++ b/src/FormMigration/Steps/FeeRecovery.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Give\FormMigration\Steps;
+
+use Give\FormMigration\Contracts\FormMigrationStep;
+use Give\Framework\Blocks\BlockModel;
+
+class FeeRecovery extends FormMigrationStep
+{
+
+    /**
+     * @unreleased
+     */
+    public function process()
+    {
+        $feeRecoveryBlock = $this->fieldBlocks->findByName('givewp-fee-recovery/fee-recovery');
+        $feeRecoverySettings = $this->formV2->getFeeRecoverySettings();
+
+        if (empty($feeRecoverySettings)) {
+            if ($feeRecoveryBlock) {
+                $this->fieldBlocks->remove($feeRecoveryBlock->name);
+            }
+
+            return;
+        }
+
+        if (!$feeRecoveryBlock) {
+            $feeRecoveryBlock = BlockModel::make([
+                'name' => 'givewp-fee-recovery/fee-recovery',
+                'attributes' => [],
+            ]);
+            $this->fieldBlocks->insertAfter('givewp/donation-amount', $feeRecoveryBlock);
+        }
+
+        foreach ($feeRecoverySettings as $key => $value) {
+            $feeRecoveryBlock->setAttribute($key, $value);
+        }
+    }
+}


### PR DESCRIPTION
## Description

In this pull request, we add a new step to move Fee Recovery settings from a v2 form to the new  v3 form.

## Affects

Form Migrations

## Testing Instructions

1. Create v2 forms
2. Set Fee Recovery in many different combinations
3. Migrate those forms
4. Confirm your choices in v2 are reflected in the recently created v3 form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205703084943466