### PR TITLE
Fix: conditionally set gateway id default value

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -174,7 +174,7 @@ class ConvertDonationFormBlocksToFieldsApi
                     ->testMode(give_is_test_mode())
                     ->rules(new GatewayRule())
                     ->required()
-                    ->defaultValue($defaultGatewayId);
+                    ->defaultValue(!empty($defaultGatewayId) ? $defaultGatewayId : null);
 
             case "givewp/donation-summary":
                 return DonationSummary::make('donation-summary');


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This conditionally checks sets the donation form's default value for `gatewayId` - making sure it's only set if not empty. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="581" alt="Screenshot 2023-10-12 at 1 34 57 PM" src="https://github.com/impress-org/givewp/assets/10138447/9dde4160-536f-48c2-a9bc-cabaeffd536d">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Step through a multi step form without a default gateway
- You should be able to get to the end but not actually submit.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

