### PR TITLE
Fix: text block required asterisk

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
@@ -5,16 +5,10 @@ export default function Edit({attributes}: BlockEditProps<any>) {
     const {label, isRequired, description, placeholder, defaultValue} = attributes;
 
     return (
-        <>
-            <div className={classnames({'give-is-required': isRequired})}>
-                <span
-                    className='components-input-control__label give-text-block__label'
-                >
-                    {label}
-                </span>
-                {description && <p className="give-text-block__description">{description}</p>}
-                <input type="text" placeholder={placeholder} readOnly onChange={null} value={defaultValue} />
-            </div>
-        </>
+        <div className={classnames({'give-is-required': isRequired})}>
+            <span className="components-input-control__label give-text-block__label">{label}</span>
+            {description && <p className="give-text-block__description">{description}</p>}
+            <input type="text" placeholder={placeholder} readOnly onChange={null} value={defaultValue} />
+        </div>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/text/Edit.tsx
@@ -3,13 +3,12 @@ import {BlockEditProps} from '@wordpress/blocks';
 
 export default function Edit({attributes}: BlockEditProps<any>) {
     const {label, isRequired, description, placeholder, defaultValue} = attributes;
-    const requiredClass = isRequired ? 'give-is-required' : '';
 
     return (
         <>
-            <div>
+            <div className={classnames({'give-is-required': isRequired})}>
                 <span
-                    className={classnames('components-input-control__label', 'give-text-block__label', requiredClass)}
+                    className='components-input-control__label give-text-block__label'
                 >
                     {label}
                 </span>

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -85,7 +85,7 @@
     }
 
     .give-is-required .components-base-control__label::after,
-    .give-is-required .components-input-control__label::after, {
+    .give-is-required .components-input-control__label::after {
         content: ' *';
         color: var(--givewp-alert-100);
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This makes the required asterisk show up for custom text blocks

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Custom text block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![2023-10-12 17 38 46](https://github.com/impress-org/givewp/assets/10138447/f1a7fe5c-3aee-4300-94d7-cc6705e4e4d5)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Add a custom field
- Enable required
- Make sure asterisk shows up

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205713285814722