### PR TITLE
Fix: update donor deletion functionality in donor list table

### DIFF
--- a/src/Donors/Endpoints/DeleteDonor.php
+++ b/src/Donors/Endpoints/DeleteDonor.php
@@ -52,7 +52,7 @@ class DeleteDonor extends Endpoint
             ]
         );
     }
-    
+
     /**
      * @since 2.25.2
      *
@@ -60,7 +60,9 @@ class DeleteDonor extends Endpoint
      */
     public function permissionsCheck()
     {
-        if ( ! current_user_can('edit_give_donors')) {
+        $donor_edit_role = apply_filters('give_edit_donors_role', 'edit_give_payments');
+
+        if (!current_user_can($donor_edit_role)) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You don\'t have permission to edit Donors', 'give'),

--- a/src/Donors/Endpoints/DeleteDonor.php
+++ b/src/Donors/Endpoints/DeleteDonor.php
@@ -54,7 +54,7 @@ class DeleteDonor extends Endpoint
     }
 
     /**
-     * @unreleased update capability being checked
+     * @unreleased update validation to align with legacy view
      * @since 2.25.2
      *
      * @inheritDoc

--- a/src/Donors/Endpoints/DeleteDonor.php
+++ b/src/Donors/Endpoints/DeleteDonor.php
@@ -54,6 +54,7 @@ class DeleteDonor extends Endpoint
     }
 
     /**
+     * @unreleased update capability being checked
      * @since 2.25.2
      *
      * @inheritDoc


### PR DESCRIPTION
## Description

In the new List Table for Donors, we discovered an issue preventing the deletion of donors. Upon investigation, it was found that the capability being checked to authorize this action was incorrect.

This pull request fix this by aligning the capability validation with that of the legacy view, inclusive of the filter hook. This correction ensures that users who presently have the requisite permissions to delete donors retain this ability.

## Affects

Donors list table

## Visuals

![CleanShot 2023-10-13 at 15 17 41](https://github.com/impress-org/givewp/assets/3921017/a9305695-74ed-4f51-a4b6-62682a9f08a5)

## Testing Instructions

1. Open the Donors list
2. Try to delete a donor either individually or in bulk
3. The donors must be deleted (removed from the list)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205719790108192