### PR TITLE
Fix: Resolve Matomo compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,12 +93,18 @@
             "classmap_prefix": "Give_Vendors_",
             "constant_prefix": "GIVE_VENDORS_",
             "packages": [
+                "fakerphp/faker",
                 "stellarwp/validation",
                 "stellarwp/field-conditions",
                 "symfony/polyfill-ctype",
                 "symfony/polyfill-mbstring",
                 "symfony/http-foundation"
             ],
+            "exclude_from_copy": {
+                "packages": [
+                    "symfony/deprecation-contracts"
+                ]
+            },
             "delete_vendor_packages": true,
             "override_autoload": {
                 "symfony/polyfill-ctype": {},

--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.0.0
+ * Version: 3.0.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.0.0');
+            define('GIVE_VERSION', '3.0.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.0.1: October 17th, 2023 =
+* Fix: Resolved a conflict with Matomo plugin that was causing a fatal error
+
 = 3.0.0: October 16th, 2023 =
 * New: Try out the all new Visual Donation Form Builder!
 * New: All new form infrastructure for forms using the Form Builder!

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -3,7 +3,7 @@
 namespace Give\Framework\Models\Factories;
 
 use Exception;
-use Faker\Generator;
+use Give\Vendors\Faker\Generator;
 use Give\Framework\Database\DB;
 use Give\Framework\Models\Contracts\ModelCrud;
 

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -5,7 +5,6 @@ namespace Give\Framework\Models\Factories;
 use Exception;
 use Give\Vendors\Faker\Generator;
 use Give\Framework\Database\DB;
-use Give\Framework\Models\Contracts\ModelCrud;
 
 /**
  * @template M

--- a/src/TestData/Framework/Factory.php
+++ b/src/TestData/Framework/Factory.php
@@ -2,7 +2,7 @@
 
 namespace Give\TestData\Framework;
 
-use Faker\Generator;
+use Give\Vendors\Faker\Generator;
 
 abstract class Factory implements FactoryContract
 {

--- a/src/TestData/Framework/Provider/RandomProvider.php
+++ b/src/TestData/Framework/Provider/RandomProvider.php
@@ -2,7 +2,8 @@
 
 namespace Give\TestData\Framework\Provider;
 
-use Faker\Generator;
+
+use Give\Vendors\Faker\Generator;
 
 abstract class RandomProvider implements ProviderContract
 {

--- a/src/TestData/ServiceProvider.php
+++ b/src/TestData/ServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Give\TestData;
 
-use Faker\Factory as FakerFactory;
-use Faker\Generator as FakerGenerator;
+use Give\Vendors\Faker\Factory as FakerFactory;
+use Give\Vendors\Faker\Generator as FakerGenerator;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\ServiceProviders\ServiceProvider as GiveServiceProvider;
 use Give\TestData\Commands\DonationSeedCommand;

--- a/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/Actions/UpdateStripeFormBuilderSettingsMetaTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/Actions/UpdateStripeFormBuilderSettingsMetaTest.php
@@ -4,7 +4,7 @@ namespace Give\Tests\Unit\PaymentGateways\Stripe\StripePaymentElementGateway\Act
 
 use Closure;
 use Exception;
-use Faker\Factory;
+use Give\Vendors\Faker\Factory;
 use Give\DonationForms\Models\DonationForm;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Actions\UpdateStripeFormBuilderSettingsMeta;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;


### PR DESCRIPTION
## Description

GiveWP 3.0 updated the Faker package, which in turn updated the Psr/Container package. The container interface then conflicts with the [Matomo plugin](https://wordpress.org/plugins/matomo/).

This PR adds Faker to the Strauss list, so it and it's sub-dependencies are prefixed, avoiding conflicts.

In adding Faker to Strauss, I found that the `symfony/deprecation-contracts` package was having issues, as it's a single auto-loaded file. Strauss wasn't updating the file path, so composer was throwing a problem. Since the file is a root-level, conditionally loaded, single function, I decided it was simpler to just have that package excluded from Strauss. That fixed the issue.

## Affects

Faker, which is used by our model factories.

## Testing Instructions

The unit tests should really catch everything here. But we can also use `wp test-give donations` to test making some mock data via the affected factories.

## Pre-review Checklist

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205734884251786