### PR TITLE
Refactor: remove donation goal setting from form mode

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Primary/index.tsx
@@ -6,7 +6,6 @@ import TabPanel from '../TabPanel';
 
 import {
     DonationConfirmation,
-    DonationGoalSettings,
     EmailSettings,
     FormGridSettings,
     FormSummarySettings,
@@ -49,7 +48,6 @@ const tabs = [
                     )}
                 />
                 <FormSummarySettings />
-                <DonationGoalSettings />
                 <RegistrationSettings />
                 <DonationConfirmation />
                 <FormGridSettings />


### PR DESCRIPTION
Resolves Asana Task: [Remove Donation Goal from Form Settings](https://app.asana.com/0/1205428662243164/1205722351216728/f)

## Description

Donation Goal should only be available in Design, where people can see the changes as they make them. Currently, Donation Goal is included in both Design and the Form Settings tab of the builder. 

This could potentially cause confusion with users who may wonder which setting actually controls the goal, if they conflict, or if the goal setting appearing in both locations is some kind of bug. 

This PR removes the Donation Goal setting from the Form tab sidebar.

## Affects

Primary Sidebar.

## Visuals

https://github.com/impress-org/givewp/assets/75056371/c2d56096-e936-46d0-b2d3-85b81a0d9bae


## Testing Instructions

- Create or edit a v3 form
- Verify the Donation Goal settings is accessible while in design mode but NOT in form mode.

## Pre-review Checklist

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205734561000499