### PR TITLE
Refactor: add support to get all gateways on the gateways functions

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.0.1
+ * Version: 3.0.2
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.0.1');
+            define('GIVE_VERSION', '3.0.2');
         }
 
         // Plugin Root File.

--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -368,7 +368,8 @@ if (! class_exists('Give_Settings_Gateways')) :
                         $gateways,
                         give()->gateways->getPaymentGateways(2)
                     )
-                )
+                ),
+                2
             );
 
             // v3 gateways are gateways that are registered with updated gateway registration API.

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -1700,8 +1700,7 @@ add_action( 'give_donation_form_login_fields', 'give_get_login_fields', 10, 1 );
  * @since  1.0
  */
 function give_payment_mode_select( $form_id, $args ) {
-
-	$gateways  = give_get_enabled_payment_gateways( $form_id );
+    $gateways = give_get_enabled_payment_gateways($form_id, 2);
 	$id_prefix = ! empty( $args['id_prefix'] ) ? $args['id_prefix'] : '';
 
 	/**

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -23,10 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param int|null $version
  * @return array $gateways All the available gateways
  */
-function give_get_payment_gateways($version = 2)
+function give_get_payment_gateways($version = null)
 {
-    $suffix = $version === 3 ? '_v3' : '';
-
     // Default, built-in gateways
     $gateways = apply_filters(
         'give_payment_gateways',
@@ -43,7 +41,14 @@ function give_get_payment_gateways($version = 2)
         }
     });
 
-    $gatewayLabels = give_get_option('gateways_label' . $suffix, []);
+    $gatewayLabels = [];
+    if (!$version || $version === 2) {
+        $gatewayLabels = array_merge($gatewayLabels, (array)give_get_option('gateways_label', []));
+    }
+
+    if (!$version || $version === 3) {
+        $gatewayLabels = array_merge($gatewayLabels, (array)give_get_option('gateways_label_v3', []));
+    }
 
     // Replace payment gateway checkout label with admin defined checkout label.
     if ($gatewayLabels) {
@@ -67,12 +72,18 @@ function give_get_payment_gateways($version = 2)
  * @param int|null $version
  * @return array $gateway_list All the available gateways
  */
-function give_get_enabled_payment_gateways($form_id = 0, $version = 2)
+function give_get_enabled_payment_gateways($form_id = 0, $version = null)
 {
-    $suffix = $version === 3 ? '_v3' : '';
     $gateways = give_get_payment_gateways($version);
 
-    $enabled = $_POST['gateways' . $suffix] ?? give_get_option('gateways' . $suffix);
+    $enabled = [];
+    if (!$version || $version === 2) {
+        $enabled = array_merge($enabled, $_POST['gateways'] ?? (array)give_get_option('gateways', []));
+    }
+
+    if (!$version || $version === 3) {
+        $enabled = array_merge($enabled, $_POST['gateways_v3'] ?? (array)give_get_option('gateways_v3', []));
+    }
 
 	$gateway_list = [];
 
@@ -91,7 +102,7 @@ function give_get_enabled_payment_gateways($form_id = 0, $version = 2)
 /**
  * Checks whether a specified gateway is activated.
  *
- * @unlreased add $version param
+ * @unreleased add $version param
  * @since 1.0
  *
  * @param string $gateway Name of the gateway to check for
@@ -110,7 +121,7 @@ function give_is_gateway_active($gateway, $version = 2)
 /**
  * Gets the default payment gateway selected from the Give Settings
  *
- * @unlreased add $version param
+ * @unreleased add $version param
  * @since 1.0
  *
  * @param int|null $form_id int ID of the Give Form
@@ -345,19 +356,30 @@ function give_count_sales_by_gateway( $gateway_id = 'paypal', $status = 'publish
 /**
  * Returns a ordered list of all available gateways.
  *
- * @unlreased add $version param
+ * @unreleased add $version param
  * @since 1.4.5
  *
  * @param array $gateways List of payment gateways
  * @param int|null $version
  * @return array $gateways All the available gateways
  */
-function give_get_ordered_payment_gateways($gateways, $version = 2)
+function give_get_ordered_payment_gateways($gateways, $version = null)
 {
-    $suffix = $version === 3 ? '_v3' : '';
-
 	// Get gateways setting.
-    $gateways_setting = $_POST['gateways' . $suffix] ?? give_get_option('gateways' . $suffix);
+    $gateways_setting = [];
+    if (!$version || $version === 2) {
+        $gateways_setting = array_merge(
+            $gateways_setting,
+            $_POST['gateways'] ?? (array)give_get_option('gateways', [])
+        );
+    }
+
+    if (!$version || $version === 3) {
+        $gateways_setting = array_merge(
+            $gateways_setting,
+            $_POST['gateways_v3'] ?? (array)give_get_option('gateways_v3', [])
+        );
+    }
 
 	// Return from here if we do not have gateways setting.
 	if ( empty( $gateways_setting ) ) {
@@ -369,8 +391,7 @@ function give_get_ordered_payment_gateways($gateways, $version = 2)
 
 	// Reorder gateways array
 	foreach ( $gateways_setting as $gateway_key => $value ) {
-
-		$new_gateway_value = isset( $gateways[ $gateway_key ] ) ? $gateways[ $gateway_key ] : '';
+        $new_gateway_value = $gateways[$gateway_key] ?? '';
 		unset( $gateways[ $gateway_key ] );
 
 		if ( ! empty( $new_gateway_value ) ) {
@@ -381,9 +402,10 @@ function give_get_ordered_payment_gateways($gateways, $version = 2)
 	/**
 	 * Filter payment gateways order.
 	 *
+     * @unreleased add $version param
 	 * @since 1.7
 	 *
 	 * @param array $gateways All the available gateways
 	 */
-    return apply_filters('give_payment_gateways_order' . $suffix, $gateways);
+    return apply_filters('give_payment_gateways_order', $gateways, $version);
 }

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -78,11 +78,13 @@ function give_get_enabled_payment_gateways($form_id = 0, $version = null)
 
     $enabled = [];
     if (!$version || $version === 2) {
-        $enabled = array_merge($enabled, $_POST['gateways'] ?? (array)give_get_option('gateways', []));
+        $gatewaysFromPostRequest = isset($_POST['gateways']) ? (array)$_POST['gateways'] : null;
+        $enabled = array_merge($enabled, $gatewaysFromPostRequest ?? (array)give_get_option('gateways', []));
     }
 
     if (!$version || $version === 3) {
-        $enabled = array_merge($enabled, $_POST['gateways_v3'] ?? (array)give_get_option('gateways_v3', []));
+        $gatewaysFromPostRequest = isset($_POST['gateways_v3']) ? (array)$_POST['gateways_v3'] : null;
+        $enabled = array_merge($enabled, $gatewaysFromPostRequest ?? (array)give_get_option('gateways_v3', []));
     }
 
 	$gateway_list = [];
@@ -368,16 +370,18 @@ function give_get_ordered_payment_gateways($gateways, $version = null)
 	// Get gateways setting.
     $gateways_setting = [];
     if (!$version || $version === 2) {
+        $gatewaysFromPostRequest = isset($_POST['gateways']) ? (array)$_POST['gateways'] : null;
         $gateways_setting = array_merge(
             $gateways_setting,
-            $_POST['gateways'] ?? (array)give_get_option('gateways', [])
+            $gatewaysFromPostRequest ?? (array)give_get_option('gateways', [])
         );
     }
 
     if (!$version || $version === 3) {
+        $gatewaysFromPostRequest = isset($_POST['gateways_v3']) ? (array)$_POST['gateways_v3'] : null;
         $gateways_setting = array_merge(
             $gateways_setting,
-            $_POST['gateways_v3'] ?? (array)give_get_option('gateways_v3', [])
+            $gatewaysFromPostRequest ?? (array)give_get_option('gateways_v3', [])
         );
     }
 

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -104,7 +104,7 @@ function give_get_enabled_payment_gateways($form_id = 0, $version = null)
 /**
  * Checks whether a specified gateway is activated.
  *
- * @unreleased add $version param
+ * @since 3.0.2 add $version param
  * @since 1.0
  *
  * @param string $gateway Name of the gateway to check for
@@ -123,7 +123,7 @@ function give_is_gateway_active($gateway, $version = 2)
 /**
  * Gets the default payment gateway selected from the Give Settings
  *
- * @unreleased add $version param
+ * @since 3.0.2 add $version param
  * @since 1.0
  *
  * @param int|null $form_id int ID of the Give Form
@@ -358,7 +358,7 @@ function give_count_sales_by_gateway( $gateway_id = 'paypal', $status = 'publish
 /**
  * Returns a ordered list of all available gateways.
  *
- * @unreleased add $version param
+ * @since 3.0.2 add $version param
  * @since 1.4.5
  *
  * @param array $gateways List of payment gateways
@@ -406,7 +406,7 @@ function give_get_ordered_payment_gateways($gateways, $version = null)
 	/**
 	 * Filter payment gateways order.
 	 *
-     * @unreleased add $version param
+     * @since 3.0.2 add $version param
 	 * @since 1.7
 	 *
 	 * @param array $gateways All the available gateways

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.0.2: October 19th, 2023 =
+* Fix: Gateways are properly separated in the settings page and Global Settings for Fee Recovery shows all gateways when you select per gateway
+
 = 3.0.1: October 17th, 2023 =
 * Fix: Resolved a conflict with Matomo plugin that was causing a fatal error
 


### PR DESCRIPTION
## Description

After splitting the gateways based on whether they support v2 or v3 forms, we found that it was not possible to get a complete list of all active gateways in Give. This complete list is important for other features, like setting Fee Recovery options for each gateway.

When we made this split, we chose to make sure the `$version` parameter defaults to `2`. This was done to maintain compatibility with older v2 code, ensuring that it would continue to work seamlessly. However, we recently realized that this might not be the best solution. This is because, aside from the donation forms themselves, most other settings require access to the complete list of gateways.

In this pull request, we've changed the default value of the `$version` parameter to `null`. This allows us to combine the lists of v2 and v3 gateways when this parameter has no value defined.

## Affects

Gateways functions

## Testing Instructions

In general, ensure that all code using `give_get_enabled_payment_gateways`, `give_get_payment_gateways` or `give_get_ordered_payment_gateways` are still working as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205749663675382