### PR TITLE
Fix: set correct gatewayId when migrating Fee Recovery settings for Stripe

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.0.1
+ * Version: 3.0.2
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.0.1');
+            define('GIVE_VERSION', '3.0.2');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,8 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.0.2: October 19th, 2023 =
+* Fix: Stripe per-form settings are included when migrating a form to the Visual Donation Form Builder
 = 3.0.1: October 17th, 2023 =
 * Fix: Resolved a conflict with Matomo plugin that was causing a fatal error
 

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -448,6 +448,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased set correct $gatewayId to be used in getMeta calls
      * @since 3.0.0
      */
     public function getFeeRecoverySettings(): array

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -476,11 +476,12 @@ class FormMetaDecorator extends FormModelDecorator
 
         if ($gateways) {
             foreach (array_keys($gateways) as $gatewayId) {
+                $v3GatewayId = $gatewayId;
                 if (array_key_exists($gatewayId, $gatewaysMap)) {
-                    $gatewayId = $gatewaysMap[$gatewayId];
+                    $v3GatewayId = $gatewaysMap[$gatewayId];
                 }
 
-                $perGatewaySettings[$gatewayId] = [
+                $perGatewaySettings[$v3GatewayId] = [
                     'enabled' => $this->getMeta('_form_gateway_fee_enable_' . $gatewayId) === 'enabled',
                     'feePercentage' => (float)$this->getMeta('_form_gateway_fee_percentage_' . $gatewayId),
                     'feeBaseAmount' => (float)$this->getMeta('_form_gateway_fee_base_amount_' . $gatewayId),

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -448,7 +448,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
-     * @unreleased set correct $gatewayId to be used in getMeta calls
+     * @since 3.0.2 set correct $gatewayId to be used in getMeta calls
      * @since 3.0.0
      */
     public function getFeeRecoverySettings(): array

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -483,9 +483,12 @@ class FormMetaDecorator extends FormModelDecorator
 
                 $perGatewaySettings[$v3GatewayId] = [
                     'enabled' => $this->getMeta('_form_gateway_fee_enable_' . $gatewayId) === 'enabled',
-                    'feePercentage' => (float)$this->getMeta('_form_gateway_fee_percentage_' . $gatewayId),
-                    'feeBaseAmount' => (float)$this->getMeta('_form_gateway_fee_base_amount_' . $gatewayId),
-                    'maxFeeAmount' => (float)$this->getMeta('_form_gateway_fee_maximum_fee_amount_' . $gatewayId),
+                    'feePercentage' => (float)$this->getMeta('_form_gateway_fee_percentage_' . $gatewayId, 2.9),
+                    'feeBaseAmount' => (float)$this->getMeta('_form_gateway_fee_base_amount_' . $gatewayId, 0.30),
+                    'maxFeeAmount' => (float)$this->getMeta(
+                        '_form_gateway_fee_maximum_fee_amount_' . $gatewayId,
+                        give_format_decimal(['amount' => '0.00'])
+                    ),
                 ];
             }
         }


### PR DESCRIPTION
## Description

Currently, when an user migrates a form with Fee Recovery custom settings and has the per-gateway settings option enabled, Stripe options were not being migrated properly.

We have found that the migration script contains an error when mapping gateway ids from v2 to v3: the gateway id for v3 was being used to retrieve the form settings, which obviously will not be found in a v2 form.

This pull request fixes that issue by using the original gateway id to retrieve the settings while using the updated gateway id to set the settings onto the v3 form.

## Affects

Fee Recovery migration

## Testing Instructions

1. Add a v2 form with Fee Recovery
2. Set it to use per-gateway settings
3. Edit Stripe values
4. Migrate the form
5. Confirm that Stripe values were properly migrated to the Fee Recovey block in v3.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205730825400250