### PR TITLE
Feature: save title as pageslug on publish

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -150,9 +150,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                         className={'givewp-form-title'}
                         value={formTitle}
                         onChange={(formTitle) => {
-                            !isPublished &&
-                                formTitle !== 'Donation Form' &&
-                                dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                            !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
                             dispatch(setFormSettings({formTitle}));
                         }}
                     />

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -38,6 +38,9 @@ const Logo = () => (
     </div>
 );
 
+/**
+ * @unreleased dispatch page slug from form title on initial publish.
+ */
 const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleShowSidebar}) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -76,7 +76,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                 dispatch(
                     setFormSettings({
                         formTitle,
-                        pageSlug: pageSlug,
+                        pageSlug,
                     })
                 );
                 dispatch(setIsDirty(false));

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -147,7 +147,9 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                         className={'givewp-form-title'}
                         value={formTitle}
                         onChange={(formTitle) => {
-                            !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                            !isPublished &&
+                                formTitle !== 'Donation Form' &&
+                                dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
                             dispatch(setFormSettings({formTitle}));
                         }}
                     />

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import {EditIcon, GiveIcon} from '../components/icons';
-import {drawerRight, moreVertical, external} from '@wordpress/icons';
+import {drawerRight, external, moreVertical} from '@wordpress/icons';
 import {setFormSettings, setTransferState, useFormState, useFormStateDispatch} from '../stores/form-state';
-import {Button, Dropdown, ExternalLink, Icon, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
+import {Button, Dropdown, ExternalLink, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {Header} from '../components';
 import {getWindowData, Storage} from '../common';
@@ -11,9 +11,10 @@ import {setIsDirty} from '@givewp/form-builder/stores/form-state/reducer';
 import revertMissingBlocks from '@givewp/form-builder/common/revertMissingBlocks';
 import {Markup} from 'interweave';
 import {InfoModal, ModalType} from '../components/modal';
-import {setEditorMode, useEditorState, useEditorStateDispatch} from "@givewp/form-builder/stores/editor-state";
-import EditorMode from "@givewp/form-builder/types/editorMode";
-import {useDispatch} from "@wordpress/data";
+import {setEditorMode, useEditorState, useEditorStateDispatch} from '@givewp/form-builder/stores/editor-state';
+import EditorMode from '@givewp/form-builder/types/editorMode';
+import {useDispatch} from '@wordpress/data';
+import {cleanForSlug} from '@wordpress/url';
 
 const Logo = () => (
     <div
@@ -37,11 +38,7 @@ const Logo = () => (
     </div>
 );
 
-const HeaderContainer = ({
-                             SecondarySidebarButtons = null,
-                             showSidebar,
-                             toggleShowSidebar,
-                         }) => {
+const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleShowSidebar}) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 
     const {formTitle} = formSettings;
@@ -72,7 +69,7 @@ const HeaderContainer = ({
                 setErrorMessage(error.message);
             })
             .then(({formTitle, pageSlug}: FormSettings) => {
-                dispatch(setFormSettings({formTitle, pageSlug}));
+                dispatch(setFormSettings({formTitle, pageSlug: isPublished ? pageSlug : cleanForSlug(formTitle)}));
                 dispatch(setIsDirty(false));
                 setSaving(null);
                 showOnSaveNotice(formStatus);
@@ -82,22 +79,25 @@ const HeaderContainer = ({
     const showOnSaveNotice = (formStatus: string) => {
         if ('draft' === formStatus) {
             createSuccessNotice(__('Draft saved.', 'give'), {
-                type: 'snackbar'
+                type: 'snackbar',
             });
         } else {
-            const notice = 'publish' === formStatus && formSettings.formStatus !== 'draft'
-                ? __('Form updated.', 'give')
-                : __('Form published.', 'give')
+            const notice =
+                'publish' === formStatus && formSettings.formStatus !== 'draft'
+                    ? __('Form updated.', 'give')
+                    : __('Form published.', 'give');
 
             createSuccessNotice(notice, {
                 type: 'snackbar',
-                actions: [{
-                    label: __('View form', 'give'),
-                    url: permalink
-                }]
+                actions: [
+                    {
+                        label: __('View form', 'give'),
+                        url: permalink,
+                    },
+                ],
             });
         }
-    }
+    };
 
     const {mode} = useEditorState();
     const dispatchEditorState = useEditorStateDispatch();
@@ -108,7 +108,7 @@ const HeaderContainer = ({
         if (EditorMode.design === mode) {
             dispatchEditorState(setEditorMode(EditorMode.schema));
         }
-    }
+    };
 
     // @ts-ignore
     return (
@@ -126,7 +126,7 @@ const HeaderContainer = ({
                                 borderRadius: '4px',
                                 display: 'flex',
                                 gap: 'var(--givewp-spacing-2)',
-                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)'
+                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)',
                             }}
                             onClick={() => toggleEditorMode()}
                             icon={EditIcon}
@@ -154,16 +154,11 @@ const HeaderContainer = ({
                             {isSaving && 'draft' === isSaving
                                 ? __('Saving...', 'give')
                                 : 'draft' === formSettings.formStatus
-                                    ? __('Save as Draft', 'give')
-                                    : __('Switch to Draft', 'give')}
+                                ? __('Save as Draft', 'give')
+                                : __('Switch to Draft', 'give')}
                         </Button>
                         {isPublished && (
-                            <Button
-                                label={__('View form', 'give')}
-                                href={permalink}
-                                target="_blank"
-                                icon={external}
-                            />
+                            <Button label={__('View form', 'give')} href={permalink} target="_blank" icon={external} />
                         )}
                         <Button
                             onClick={() => onSave('publish')}
@@ -174,8 +169,8 @@ const HeaderContainer = ({
                             {isSaving && 'publish' === isSaving
                                 ? __('Updating...', 'give')
                                 : 'publish' === formSettings.formStatus
-                                    ? __('Update', 'give')
-                                    : __('Publish', 'give')}
+                                ? __('Update', 'give')
+                                : __('Publish', 'give')}
                         </Button>
                         <Button onClick={toggleShowSidebar} isPressed={showSidebar} icon={drawerRight} />
                         <Dropdown
@@ -189,12 +184,12 @@ const HeaderContainer = ({
                                         icon={moreVertical}
                                         onClick={() => {
                                             if (transfer.showTooltip) {
-                                                dispatch(setTransferState({showTooltip: false}))
+                                                dispatch(setTransferState({showTooltip: false}));
                                             }
                                             onToggle();
                                         }}
                                     />
-                                )
+                                );
                             }}
                             renderContent={({onClose}) => (
                                 <div style={{minWidth: '280px', maxWidth: '400px'}}>
@@ -214,7 +209,9 @@ const HeaderContainer = ({
                                         {isMigratedForm && !isTransferredForm && !transfer.showNotice && (
                                             <>
                                                 <MenuItem
-                                                    className={transfer.showTooltip && 'givewp-transfer-selected-menuitem'}
+                                                    className={
+                                                        transfer.showTooltip && 'givewp-transfer-selected-menuitem'
+                                                    }
                                                     onClick={() => {
                                                         dispatch(setTransferState({showTransferModal: true}));
                                                         onClose();
@@ -225,7 +222,10 @@ const HeaderContainer = ({
 
                                                 {transfer.showTooltip && (
                                                     <div className="givewp-transfer-tooltip">
-                                                        {__('Want to transfer donation data later? Access this option in the three dots menu above at any time.', 'give')}
+                                                        {__(
+                                                            'Want to transfer donation data later? Access this option in the three dots menu above at any time.',
+                                                            'give'
+                                                        )}
                                                     </div>
                                                 )}
                                             </>
@@ -236,9 +236,7 @@ const HeaderContainer = ({
                                         href="https://docs.givewp.com/nextgenfeedback"
                                         rel="noopener noreferrer"
                                     >
-                                        <MenuItem icon={external}>
-                                                {__('Submit Feedback', 'give')}
-                                        </MenuItem>
+                                        <MenuItem icon={external}>{__('Submit Feedback', 'give')}</MenuItem>
                                     </ExternalLink>
                                 </div>
                             )}

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import {EditIcon, GiveIcon} from '../components/icons';
-import {drawerRight, external, moreVertical} from '@wordpress/icons';
+import {drawerRight, moreVertical, external} from '@wordpress/icons';
 import {setFormSettings, setTransferState, useFormState, useFormStateDispatch} from '../stores/form-state';
-import {Button, Dropdown, ExternalLink, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
+import {Button, Dropdown, ExternalLink, Icon, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {Header} from '../components';
 import {getWindowData, Storage} from '../common';
@@ -11,10 +11,9 @@ import {setIsDirty} from '@givewp/form-builder/stores/form-state/reducer';
 import revertMissingBlocks from '@givewp/form-builder/common/revertMissingBlocks';
 import {Markup} from 'interweave';
 import {InfoModal, ModalType} from '../components/modal';
-import {setEditorMode, useEditorState, useEditorStateDispatch} from '@givewp/form-builder/stores/editor-state';
-import EditorMode from '@givewp/form-builder/types/editorMode';
-import {useDispatch} from '@wordpress/data';
-import {cleanForSlug} from '@wordpress/url';
+import {setEditorMode, useEditorState, useEditorStateDispatch} from "@givewp/form-builder/stores/editor-state";
+import EditorMode from "@givewp/form-builder/types/editorMode";
+import {useDispatch} from "@wordpress/data";
 
 const Logo = () => (
     <div
@@ -38,7 +37,11 @@ const Logo = () => (
     </div>
 );
 
-const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleShowSidebar}) => {
+const HeaderContainer = ({
+                             SecondarySidebarButtons = null,
+                             showSidebar,
+                             toggleShowSidebar,
+                         }) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 
     const {formTitle} = formSettings;
@@ -51,7 +54,6 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
     const isPublished = 'publish' === formSettings.formStatus;
     const {isMigratedForm, isTransferredForm} = window.migrationOnboardingData;
     const {createSuccessNotice} = useDispatch('core/notices');
-
     const {
         formPage: {permalink},
     } = getWindowData();
@@ -70,12 +72,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                 setErrorMessage(error.message);
             })
             .then(({formTitle, pageSlug}: FormSettings) => {
-                dispatch(
-                    setFormSettings({
-                        formTitle,
-                        pageSlug: pageSlug,
-                    })
-                );
+                dispatch(setFormSettings({formTitle, pageSlug}));
                 dispatch(setIsDirty(false));
                 setSaving(null);
                 showOnSaveNotice(formStatus);
@@ -85,25 +82,22 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
     const showOnSaveNotice = (formStatus: string) => {
         if ('draft' === formStatus) {
             createSuccessNotice(__('Draft saved.', 'give'), {
-                type: 'snackbar',
+                type: 'snackbar'
             });
         } else {
-            const notice =
-                'publish' === formStatus && formSettings.formStatus !== 'draft'
-                    ? __('Form updated.', 'give')
-                    : __('Form published.', 'give');
+            const notice = 'publish' === formStatus && formSettings.formStatus !== 'draft'
+                ? __('Form updated.', 'give')
+                : __('Form published.', 'give')
 
             createSuccessNotice(notice, {
                 type: 'snackbar',
-                actions: [
-                    {
-                        label: __('View form', 'give'),
-                        url: permalink,
-                    },
-                ],
+                actions: [{
+                    label: __('View form', 'give'),
+                    url: permalink
+                }]
             });
         }
-    };
+    }
 
     const {mode} = useEditorState();
     const dispatchEditorState = useEditorStateDispatch();
@@ -114,7 +108,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
         if (EditorMode.design === mode) {
             dispatchEditorState(setEditorMode(EditorMode.schema));
         }
-    };
+    }
 
     // @ts-ignore
     return (
@@ -132,7 +126,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                 borderRadius: '4px',
                                 display: 'flex',
                                 gap: 'var(--givewp-spacing-2)',
-                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)',
+                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)'
                             }}
                             onClick={() => toggleEditorMode()}
                             icon={EditIcon}
@@ -146,10 +140,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                     <TextControl
                         className={'givewp-form-title'}
                         value={formTitle}
-                        onChange={(formTitle) => {
-                            !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
-                            dispatch(setFormSettings({formTitle}));
-                        }}
+                        onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
                     />
                 }
                 contentRight={
@@ -163,11 +154,16 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                             {isSaving && 'draft' === isSaving
                                 ? __('Saving...', 'give')
                                 : 'draft' === formSettings.formStatus
-                                ? __('Save as Draft', 'give')
-                                : __('Switch to Draft', 'give')}
+                                    ? __('Save as Draft', 'give')
+                                    : __('Switch to Draft', 'give')}
                         </Button>
                         {isPublished && (
-                            <Button label={__('View form', 'give')} href={permalink} target="_blank" icon={external} />
+                            <Button
+                                label={__('View form', 'give')}
+                                href={permalink}
+                                target="_blank"
+                                icon={external}
+                            />
                         )}
                         <Button
                             onClick={() => onSave('publish')}
@@ -178,8 +174,8 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                             {isSaving && 'publish' === isSaving
                                 ? __('Updating...', 'give')
                                 : 'publish' === formSettings.formStatus
-                                ? __('Update', 'give')
-                                : __('Publish', 'give')}
+                                    ? __('Update', 'give')
+                                    : __('Publish', 'give')}
                         </Button>
                         <Button onClick={toggleShowSidebar} isPressed={showSidebar} icon={drawerRight} />
                         <Dropdown
@@ -193,12 +189,12 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         icon={moreVertical}
                                         onClick={() => {
                                             if (transfer.showTooltip) {
-                                                dispatch(setTransferState({showTooltip: false}));
+                                                dispatch(setTransferState({showTooltip: false}))
                                             }
                                             onToggle();
                                         }}
                                     />
-                                );
+                                )
                             }}
                             renderContent={({onClose}) => (
                                 <div style={{minWidth: '280px', maxWidth: '400px'}}>
@@ -218,9 +214,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         {isMigratedForm && !isTransferredForm && !transfer.showNotice && (
                                             <>
                                                 <MenuItem
-                                                    className={
-                                                        transfer.showTooltip && 'givewp-transfer-selected-menuitem'
-                                                    }
+                                                    className={transfer.showTooltip && 'givewp-transfer-selected-menuitem'}
                                                     onClick={() => {
                                                         dispatch(setTransferState({showTransferModal: true}));
                                                         onClose();
@@ -231,10 +225,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
 
                                                 {transfer.showTooltip && (
                                                     <div className="givewp-transfer-tooltip">
-                                                        {__(
-                                                            'Want to transfer donation data later? Access this option in the three dots menu above at any time.',
-                                                            'give'
-                                                        )}
+                                                        {__('Want to transfer donation data later? Access this option in the three dots menu above at any time.', 'give')}
                                                     </div>
                                                 )}
                                             </>
@@ -245,7 +236,9 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         href="https://docs.givewp.com/nextgenfeedback"
                                         rel="noopener noreferrer"
                                     >
-                                        <MenuItem icon={external}>{__('Submit Feedback', 'give')}</MenuItem>
+                                        <MenuItem icon={external}>
+                                                {__('Submit Feedback', 'give')}
+                                        </MenuItem>
                                     </ExternalLink>
                                 </div>
                             )}

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import {EditIcon, GiveIcon} from '../components/icons';
-import {drawerRight, moreVertical, external} from '@wordpress/icons';
+import {drawerRight, external, moreVertical} from '@wordpress/icons';
 import {setFormSettings, setTransferState, useFormState, useFormStateDispatch} from '../stores/form-state';
-import {Button, Dropdown, ExternalLink, Icon, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
+import {Button, Dropdown, ExternalLink, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {Header} from '../components';
 import {getWindowData, Storage} from '../common';
@@ -11,9 +11,10 @@ import {setIsDirty} from '@givewp/form-builder/stores/form-state/reducer';
 import revertMissingBlocks from '@givewp/form-builder/common/revertMissingBlocks';
 import {Markup} from 'interweave';
 import {InfoModal, ModalType} from '../components/modal';
-import {setEditorMode, useEditorState, useEditorStateDispatch} from "@givewp/form-builder/stores/editor-state";
-import EditorMode from "@givewp/form-builder/types/editorMode";
-import {useDispatch} from "@wordpress/data";
+import {setEditorMode, useEditorState, useEditorStateDispatch} from '@givewp/form-builder/stores/editor-state';
+import EditorMode from '@givewp/form-builder/types/editorMode';
+import {useDispatch} from '@wordpress/data';
+import {cleanForSlug} from '@wordpress/url';
 
 const Logo = () => (
     <div
@@ -37,11 +38,7 @@ const Logo = () => (
     </div>
 );
 
-const HeaderContainer = ({
-                             SecondarySidebarButtons = null,
-                             showSidebar,
-                             toggleShowSidebar,
-                         }) => {
+const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleShowSidebar}) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 
     const {formTitle} = formSettings;
@@ -54,6 +51,7 @@ const HeaderContainer = ({
     const isPublished = 'publish' === formSettings.formStatus;
     const {isMigratedForm, isTransferredForm} = window.migrationOnboardingData;
     const {createSuccessNotice} = useDispatch('core/notices');
+
     const {
         formPage: {permalink},
     } = getWindowData();
@@ -72,7 +70,12 @@ const HeaderContainer = ({
                 setErrorMessage(error.message);
             })
             .then(({formTitle, pageSlug}: FormSettings) => {
-                dispatch(setFormSettings({formTitle, pageSlug}));
+                dispatch(
+                    setFormSettings({
+                        formTitle,
+                        pageSlug: pageSlug,
+                    })
+                );
                 dispatch(setIsDirty(false));
                 setSaving(null);
                 showOnSaveNotice(formStatus);
@@ -82,22 +85,25 @@ const HeaderContainer = ({
     const showOnSaveNotice = (formStatus: string) => {
         if ('draft' === formStatus) {
             createSuccessNotice(__('Draft saved.', 'give'), {
-                type: 'snackbar'
+                type: 'snackbar',
             });
         } else {
-            const notice = 'publish' === formStatus && formSettings.formStatus !== 'draft'
-                ? __('Form updated.', 'give')
-                : __('Form published.', 'give')
+            const notice =
+                'publish' === formStatus && formSettings.formStatus !== 'draft'
+                    ? __('Form updated.', 'give')
+                    : __('Form published.', 'give');
 
             createSuccessNotice(notice, {
                 type: 'snackbar',
-                actions: [{
-                    label: __('View form', 'give'),
-                    url: permalink
-                }]
+                actions: [
+                    {
+                        label: __('View form', 'give'),
+                        url: permalink,
+                    },
+                ],
             });
         }
-    }
+    };
 
     const {mode} = useEditorState();
     const dispatchEditorState = useEditorStateDispatch();
@@ -108,7 +114,7 @@ const HeaderContainer = ({
         if (EditorMode.design === mode) {
             dispatchEditorState(setEditorMode(EditorMode.schema));
         }
-    }
+    };
 
     // @ts-ignore
     return (
@@ -126,7 +132,7 @@ const HeaderContainer = ({
                                 borderRadius: '4px',
                                 display: 'flex',
                                 gap: 'var(--givewp-spacing-2)',
-                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)'
+                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)',
                             }}
                             onClick={() => toggleEditorMode()}
                             icon={EditIcon}
@@ -140,7 +146,10 @@ const HeaderContainer = ({
                     <TextControl
                         className={'givewp-form-title'}
                         value={formTitle}
-                        onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
+                        onChange={(formTitle) => {
+                            !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                            dispatch(setFormSettings({formTitle}));
+                        }}
                     />
                 }
                 contentRight={
@@ -154,16 +163,11 @@ const HeaderContainer = ({
                             {isSaving && 'draft' === isSaving
                                 ? __('Saving...', 'give')
                                 : 'draft' === formSettings.formStatus
-                                    ? __('Save as Draft', 'give')
-                                    : __('Switch to Draft', 'give')}
+                                ? __('Save as Draft', 'give')
+                                : __('Switch to Draft', 'give')}
                         </Button>
                         {isPublished && (
-                            <Button
-                                label={__('View form', 'give')}
-                                href={permalink}
-                                target="_blank"
-                                icon={external}
-                            />
+                            <Button label={__('View form', 'give')} href={permalink} target="_blank" icon={external} />
                         )}
                         <Button
                             onClick={() => onSave('publish')}
@@ -174,8 +178,8 @@ const HeaderContainer = ({
                             {isSaving && 'publish' === isSaving
                                 ? __('Updating...', 'give')
                                 : 'publish' === formSettings.formStatus
-                                    ? __('Update', 'give')
-                                    : __('Publish', 'give')}
+                                ? __('Update', 'give')
+                                : __('Publish', 'give')}
                         </Button>
                         <Button onClick={toggleShowSidebar} isPressed={showSidebar} icon={drawerRight} />
                         <Dropdown
@@ -189,12 +193,12 @@ const HeaderContainer = ({
                                         icon={moreVertical}
                                         onClick={() => {
                                             if (transfer.showTooltip) {
-                                                dispatch(setTransferState({showTooltip: false}))
+                                                dispatch(setTransferState({showTooltip: false}));
                                             }
                                             onToggle();
                                         }}
                                     />
-                                )
+                                );
                             }}
                             renderContent={({onClose}) => (
                                 <div style={{minWidth: '280px', maxWidth: '400px'}}>
@@ -214,7 +218,9 @@ const HeaderContainer = ({
                                         {isMigratedForm && !isTransferredForm && !transfer.showNotice && (
                                             <>
                                                 <MenuItem
-                                                    className={transfer.showTooltip && 'givewp-transfer-selected-menuitem'}
+                                                    className={
+                                                        transfer.showTooltip && 'givewp-transfer-selected-menuitem'
+                                                    }
                                                     onClick={() => {
                                                         dispatch(setTransferState({showTransferModal: true}));
                                                         onClose();
@@ -225,7 +231,10 @@ const HeaderContainer = ({
 
                                                 {transfer.showTooltip && (
                                                     <div className="givewp-transfer-tooltip">
-                                                        {__('Want to transfer donation data later? Access this option in the three dots menu above at any time.', 'give')}
+                                                        {__(
+                                                            'Want to transfer donation data later? Access this option in the three dots menu above at any time.',
+                                                            'give'
+                                                        )}
                                                     </div>
                                                 )}
                                             </>
@@ -236,9 +245,7 @@ const HeaderContainer = ({
                                         href="https://docs.givewp.com/nextgenfeedback"
                                         rel="noopener noreferrer"
                                     >
-                                        <MenuItem icon={external}>
-                                                {__('Submit Feedback', 'give')}
-                                        </MenuItem>
+                                        <MenuItem icon={external}>{__('Submit Feedback', 'give')}</MenuItem>
                                     </ExternalLink>
                                 </div>
                             )}

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -1,8 +1,8 @@
 import React, {useState} from 'react';
 import {EditIcon, GiveIcon} from '../components/icons';
-import {drawerRight, external, moreVertical} from '@wordpress/icons';
+import {drawerRight, moreVertical, external} from '@wordpress/icons';
 import {setFormSettings, setTransferState, useFormState, useFormStateDispatch} from '../stores/form-state';
-import {Button, Dropdown, ExternalLink, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
+import {Button, Dropdown, ExternalLink, Icon, MenuGroup, MenuItem, TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {Header} from '../components';
 import {getWindowData, Storage} from '../common';
@@ -11,10 +11,9 @@ import {setIsDirty} from '@givewp/form-builder/stores/form-state/reducer';
 import revertMissingBlocks from '@givewp/form-builder/common/revertMissingBlocks';
 import {Markup} from 'interweave';
 import {InfoModal, ModalType} from '../components/modal';
-import {setEditorMode, useEditorState, useEditorStateDispatch} from '@givewp/form-builder/stores/editor-state';
-import EditorMode from '@givewp/form-builder/types/editorMode';
-import {useDispatch} from '@wordpress/data';
-import {cleanForSlug} from '@wordpress/url';
+import {setEditorMode, useEditorState, useEditorStateDispatch} from "@givewp/form-builder/stores/editor-state";
+import EditorMode from "@givewp/form-builder/types/editorMode";
+import {useDispatch} from "@wordpress/data";
 
 const Logo = () => (
     <div
@@ -38,7 +37,11 @@ const Logo = () => (
     </div>
 );
 
-const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleShowSidebar}) => {
+const HeaderContainer = ({
+                             SecondarySidebarButtons = null,
+                             showSidebar,
+                             toggleShowSidebar,
+                         }) => {
     const {blocks, settings: formSettings, isDirty, transfer} = useFormState();
 
     const {formTitle} = formSettings;
@@ -69,7 +72,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                 setErrorMessage(error.message);
             })
             .then(({formTitle, pageSlug}: FormSettings) => {
-                dispatch(setFormSettings({formTitle, pageSlug: isPublished ? pageSlug : cleanForSlug(formTitle)}));
+                dispatch(setFormSettings({formTitle, pageSlug}));
                 dispatch(setIsDirty(false));
                 setSaving(null);
                 showOnSaveNotice(formStatus);
@@ -79,25 +82,22 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
     const showOnSaveNotice = (formStatus: string) => {
         if ('draft' === formStatus) {
             createSuccessNotice(__('Draft saved.', 'give'), {
-                type: 'snackbar',
+                type: 'snackbar'
             });
         } else {
-            const notice =
-                'publish' === formStatus && formSettings.formStatus !== 'draft'
-                    ? __('Form updated.', 'give')
-                    : __('Form published.', 'give');
+            const notice = 'publish' === formStatus && formSettings.formStatus !== 'draft'
+                ? __('Form updated.', 'give')
+                : __('Form published.', 'give')
 
             createSuccessNotice(notice, {
                 type: 'snackbar',
-                actions: [
-                    {
-                        label: __('View form', 'give'),
-                        url: permalink,
-                    },
-                ],
+                actions: [{
+                    label: __('View form', 'give'),
+                    url: permalink
+                }]
             });
         }
-    };
+    }
 
     const {mode} = useEditorState();
     const dispatchEditorState = useEditorStateDispatch();
@@ -108,7 +108,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
         if (EditorMode.design === mode) {
             dispatchEditorState(setEditorMode(EditorMode.schema));
         }
-    };
+    }
 
     // @ts-ignore
     return (
@@ -126,7 +126,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                 borderRadius: '4px',
                                 display: 'flex',
                                 gap: 'var(--givewp-spacing-2)',
-                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)',
+                                padding: 'var(--givewp-spacing-3) var(--givewp-spacing-4)'
                             }}
                             onClick={() => toggleEditorMode()}
                             icon={EditIcon}
@@ -154,11 +154,16 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                             {isSaving && 'draft' === isSaving
                                 ? __('Saving...', 'give')
                                 : 'draft' === formSettings.formStatus
-                                ? __('Save as Draft', 'give')
-                                : __('Switch to Draft', 'give')}
+                                    ? __('Save as Draft', 'give')
+                                    : __('Switch to Draft', 'give')}
                         </Button>
                         {isPublished && (
-                            <Button label={__('View form', 'give')} href={permalink} target="_blank" icon={external} />
+                            <Button
+                                label={__('View form', 'give')}
+                                href={permalink}
+                                target="_blank"
+                                icon={external}
+                            />
                         )}
                         <Button
                             onClick={() => onSave('publish')}
@@ -169,8 +174,8 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                             {isSaving && 'publish' === isSaving
                                 ? __('Updating...', 'give')
                                 : 'publish' === formSettings.formStatus
-                                ? __('Update', 'give')
-                                : __('Publish', 'give')}
+                                    ? __('Update', 'give')
+                                    : __('Publish', 'give')}
                         </Button>
                         <Button onClick={toggleShowSidebar} isPressed={showSidebar} icon={drawerRight} />
                         <Dropdown
@@ -184,12 +189,12 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         icon={moreVertical}
                                         onClick={() => {
                                             if (transfer.showTooltip) {
-                                                dispatch(setTransferState({showTooltip: false}));
+                                                dispatch(setTransferState({showTooltip: false}))
                                             }
                                             onToggle();
                                         }}
                                     />
-                                );
+                                )
                             }}
                             renderContent={({onClose}) => (
                                 <div style={{minWidth: '280px', maxWidth: '400px'}}>
@@ -209,9 +214,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         {isMigratedForm && !isTransferredForm && !transfer.showNotice && (
                                             <>
                                                 <MenuItem
-                                                    className={
-                                                        transfer.showTooltip && 'givewp-transfer-selected-menuitem'
-                                                    }
+                                                    className={transfer.showTooltip && 'givewp-transfer-selected-menuitem'}
                                                     onClick={() => {
                                                         dispatch(setTransferState({showTransferModal: true}));
                                                         onClose();
@@ -222,10 +225,7 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
 
                                                 {transfer.showTooltip && (
                                                     <div className="givewp-transfer-tooltip">
-                                                        {__(
-                                                            'Want to transfer donation data later? Access this option in the three dots menu above at any time.',
-                                                            'give'
-                                                        )}
+                                                        {__('Want to transfer donation data later? Access this option in the three dots menu above at any time.', 'give')}
                                                     </div>
                                                 )}
                                             </>
@@ -236,7 +236,9 @@ const HeaderContainer = ({SecondarySidebarButtons = null, showSidebar, toggleSho
                                         href="https://docs.givewp.com/nextgenfeedback"
                                         rel="noopener noreferrer"
                                     >
-                                        <MenuItem icon={external}>{__('Submit Feedback', 'give')}</MenuItem>
+                                        <MenuItem icon={external}>
+                                                {__('Submit Feedback', 'give')}
+                                        </MenuItem>
                                     </ExternalLink>
                                 </div>
                             )}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -5,6 +5,9 @@ import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-
 import {isFormPageEnabled, PageSlugControl} from './page-slug';
 import {cleanForSlug} from '@wordpress/url';
 
+/**
+ * @unreleased dispatch page slug from form title on initial publish.
+ */
 const FormSummarySettings = () => {
     const {
         settings: {formTitle, pageSlug, formStatus},

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -31,7 +31,7 @@ const FormSummarySettings = () => {
             </PanelRow>
             {!!isFormPageEnabled && (
                 <PanelRow>
-                    <PageSlugControl pageSlug={isPublished ? pageSlug : cleanForSlug(formTitle)} />
+                    <PageSlugControl pageSlug={!isPublished && formTitle !== 'Donation Form' ? cleanForSlug(formTitle):pageSlug} />
                 </PanelRow>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -3,14 +3,12 @@ import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
 import {isFormPageEnabled, PageSlugControl} from './page-slug';
-import {cleanForSlug} from '@wordpress/url';
 
 const FormSummarySettings = () => {
     const {
-        settings: {formTitle, pageSlug, formStatus},
+        settings: {formTitle},
     } = useFormState();
     const dispatch = useFormStateDispatch();
-    const isPublished = 'publish' === formStatus;
 
     return (
         <PanelBody className={'givewp-panel-body--summary'} title={__('Summary', 'give')} initialOpen={true}>
@@ -18,15 +16,12 @@ const FormSummarySettings = () => {
                 <TextControl
                     label={__('Title')}
                     value={formTitle}
-                    onChange={(formTitle) => {
-                        !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
-                        dispatch(setFormSettings({formTitle}));
-                    }}
+                    onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
                 />
             </PanelRow>
             {!!isFormPageEnabled && (
                 <PanelRow>
-                    <PageSlugControl pageSlug={isPublished ? pageSlug : cleanForSlug(formTitle)} />
+                    <PageSlugControl />
                 </PanelRow>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -14,7 +14,7 @@ const FormSummarySettings = () => {
     } = useFormState();
     const dispatch = useFormStateDispatch();
     const isPublished = 'publish' === formStatus;
-    const isTitleSlug = isPublished && cleanForSlug(formTitle) === pageSlug;
+    const isTitleSlug = !isPublished && cleanForSlug(formTitle) === pageSlug;
 
     return (
         <PanelBody className={'givewp-panel-body--summary'} title={__('Summary', 'give')} initialOpen={true}>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -3,12 +3,14 @@ import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
 import {isFormPageEnabled, PageSlugControl} from './page-slug';
+import {cleanForSlug} from '@wordpress/url';
 
 const FormSummarySettings = () => {
     const {
-        settings: {formTitle},
+        settings: {formTitle, pageSlug, formStatus},
     } = useFormState();
     const dispatch = useFormStateDispatch();
+    const isPublished = 'publish' === formStatus;
 
     return (
         <PanelBody className={'givewp-panel-body--summary'} title={__('Summary', 'give')} initialOpen={true}>
@@ -16,12 +18,15 @@ const FormSummarySettings = () => {
                 <TextControl
                     label={__('Title')}
                     value={formTitle}
-                    onChange={(formTitle) => dispatch(setFormSettings({formTitle}))}
+                    onChange={(formTitle) => {
+                        !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                        dispatch(setFormSettings({formTitle}));
+                    }}
                 />
             </PanelRow>
             {!!isFormPageEnabled && (
                 <PanelRow>
-                    <PageSlugControl />
+                    <PageSlugControl pageSlug={isPublished ? pageSlug : cleanForSlug(formTitle)} />
                 </PanelRow>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -14,6 +14,7 @@ const FormSummarySettings = () => {
     } = useFormState();
     const dispatch = useFormStateDispatch();
     const isPublished = 'publish' === formStatus;
+    const isTitleSlug = isPublished && cleanForSlug(formTitle) === pageSlug;
 
     return (
         <PanelBody className={'givewp-panel-body--summary'} title={__('Summary', 'give')} initialOpen={true}>
@@ -22,18 +23,14 @@ const FormSummarySettings = () => {
                     label={__('Title')}
                     value={formTitle}
                     onChange={(formTitle) => {
-                        !isPublished &&
-                            formTitle !== 'Donation Form' &&
-                            dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                        !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
                         dispatch(setFormSettings({formTitle}));
                     }}
                 />
             </PanelRow>
             {!!isFormPageEnabled && (
                 <PanelRow>
-                    <PageSlugControl
-                        pageSlug={!isPublished && formTitle !== 'Donation Form' ? cleanForSlug(formTitle) : pageSlug}
-                    />
+                    <PageSlugControl pageSlug={isTitleSlug ? cleanForSlug(formTitle) : pageSlug} />
                 </PanelRow>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -19,7 +19,9 @@ const FormSummarySettings = () => {
                     label={__('Title')}
                     value={formTitle}
                     onChange={(formTitle) => {
-                        !isPublished && dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
+                        !isPublished &&
+                            formTitle !== 'Donation Form' &&
+                            dispatch(setFormSettings({pageSlug: cleanForSlug(formTitle)}));
                         dispatch(setFormSettings({formTitle}));
                     }}
                 />

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/index.js
@@ -31,7 +31,9 @@ const FormSummarySettings = () => {
             </PanelRow>
             {!!isFormPageEnabled && (
                 <PanelRow>
-                    <PageSlugControl pageSlug={!isPublished && formTitle !== 'Donation Form' ? cleanForSlug(formTitle):pageSlug} />
+                    <PageSlugControl
+                        pageSlug={!isPublished && formTitle !== 'Donation Form' ? cleanForSlug(formTitle) : pageSlug}
+                    />
                 </PanelRow>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -19,7 +19,7 @@ const {
  */
 const PageSlugControl = ({pageSlug}) => {
     const dispatch = useFormStateDispatch();
-    const [editedSlug, setEditedSlug] = useState();
+    const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
 
     useEffect(() => {
         setEditedSlug(safeDecodeURIComponent(pageSlug));

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -1,6 +1,6 @@
 import {Button, Dropdown, ExternalLink, TextControl} from '@wordpress/components';
 import {close, Icon} from '@wordpress/icons';
-import {setFormSettings, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
+import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
 import {getWindowData} from '@givewp/form-builder/common';
 import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
@@ -14,65 +14,68 @@ const {
  * @since 3.0.0
  * @see https://github.com/WordPress/gutenberg/blob/a8c5605f5dd077a601aefce6f58409f54d7d4447/packages/editor/src/components/post-slug/index.js
  */
-const PageSlugControl = ({pageSlug}) => {
+const PageSlugControl = () => {
+    const {
+        settings: {pageSlug},
+    } = useFormState();
     const dispatch = useFormStateDispatch();
-    const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
+  const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
 
-    const updateSlug = useCallback(() => {
-        const cleanEditedSlug = cleanForSlug(editedSlug);
-        setEditedSlug(cleanEditedSlug);
+  const updateSlug = useCallback(() => {
+      const cleanEditedSlug = cleanForSlug(editedSlug);
+      setEditedSlug(cleanEditedSlug);
 
-        if (cleanEditedSlug !== pageSlug) {
-            dispatch(setFormSettings({pageSlug: cleanEditedSlug}));
-        }
-    }, [pageSlug, editedSlug, dispatch]);
+      if (cleanEditedSlug !== pageSlug) {
+          dispatch(setFormSettings({pageSlug: cleanEditedSlug}));
+      }
+  }, [pageSlug, editedSlug, dispatch]);
 
-    return (
-        !!isEnabled && (
-            <Dropdown
-                className="my-container-class-name"
-                contentClassName="givewp-sidebar-dropdown-content"
-                popoverProps={{placement: 'bottom-start'}}
-                focusOnMount={'container'}
-                renderToggle={({isOpen, onToggle}) => (
-                    <TextControl
-                        label={'URL'}
-                        value={'/donations/' + editedSlug}
-                        onChange={() => null}
-                        onClick={onToggle}
-                        aria-expanded={isOpen}
-                    />
-                )}
-                renderContent={({onClose}) => (
-                    <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
-                        <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                            <strong style={{fontSize: '14px'}}>{'URL'}</strong>
-                            <Button onClick={onClose}>
-                                <Icon icon={close} size={14}></Icon>
-                            </Button>
-                        </div>
-                        <TextControl
-                            label={'Permalink'}
-                            value={editedSlug}
-                            autoComplete="off"
-                            spellCheck="false"
-                            onChange={(newPageSlug) => {
-                                setEditedSlug(newPageSlug);
-                            }}
-                            help={'The last part of the URL.'}
-                            onBlur={() => updateSlug()}
-                        />
-                        <div>
-                            <strong style={{fontSize: '14px'}}>View Page</strong>
-                        </div>
-                        <ExternalLink href={permalink} style={{fontSize: '14px'}}>
-                            {sprintf('%s/%s', rewriteSlug, editedSlug)}
-                        </ExternalLink>
-                    </div>
-                )}
-            />
-        )
-    );
+  return (
+      !!isEnabled && (
+          <Dropdown
+              className="my-container-class-name"
+              contentClassName="givewp-sidebar-dropdown-content"
+              popoverProps={{placement: 'bottom-start'}}
+              focusOnMount={'container'}
+              renderToggle={({isOpen, onToggle}) => (
+                  <TextControl
+                      label={'URL'}
+                      value={'/donations/' + editedSlug}
+                      onChange={() => null}
+                      onClick={onToggle}
+                      aria-expanded={isOpen}
+                  />
+              )}
+              renderContent={({onClose}) => (
+                  <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
+                      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                          <strong style={{fontSize: '14px'}}>{'URL'}</strong>
+                          <Button onClick={onClose}>
+                              <Icon icon={close} size={14}></Icon>
+                          </Button>
+                      </div>
+                      <TextControl
+                          label={'Permalink'}
+                          value={editedSlug}
+                          autoComplete="off"
+                          spellCheck="false"
+                          onChange={(newPageSlug) => {
+                              setEditedSlug(newPageSlug);
+                          }}
+                          help={'The last part of the URL.'}
+                          onBlur={() => updateSlug()}
+                      />
+                      <div>
+                          <strong style={{fontSize: '14px'}}>View Page</strong>
+                      </div>
+                      <ExternalLink href={permalink} style={{fontSize: '14px'}}>
+                          {sprintf('%s/%s', rewriteSlug, editedSlug)}
+                      </ExternalLink>
+                  </div>
+              )}
+          />
+      )
+  );
 };
 
 export default PageSlugControl;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -5,6 +5,7 @@ import {setFormSettings, useFormStateDispatch} from '@givewp/form-builder/stores
 import {getWindowData} from '@givewp/form-builder/common';
 import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
 import {useCallback, useState} from '@wordpress/element';
+import {__} from '@wordpress/i18n';
 
 const {
     formPage: {isEnabled, permalink, rewriteSlug},
@@ -37,7 +38,7 @@ const PageSlugControl = ({pageSlug}) => {
                 focusOnMount={'container'}
                 renderToggle={({isOpen, onToggle}) => (
                     <TextControl
-                        label={'URL'}
+                        label={__('URL', 'give')}
                         value={'/donations/' + editedSlug}
                         onChange={() => null}
                         onClick={onToggle}
@@ -47,20 +48,20 @@ const PageSlugControl = ({pageSlug}) => {
                 renderContent={({onClose}) => (
                     <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
                         <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                            <strong style={{fontSize: '14px'}}>{'URL'}</strong>
+                            <strong style={{fontSize: '14px'}}>{__('URL', 'give')}</strong>
                             <Button onClick={onClose}>
                                 <Icon icon={close} size={14}></Icon>
                             </Button>
                         </div>
                         <TextControl
-                            label={'Permalink'}
+                            label={__('Permalink', 'give')}
                             value={editedSlug}
                             autoComplete="off"
                             spellCheck="false"
                             onChange={(newPageSlug) => {
                                 setEditedSlug(newPageSlug);
                             }}
-                            help={'The last part of the URL.'}
+                            help={__('The last part of the URL.', 'give')}
                             onBlur={() => updateSlug()}
                         />
                         <div>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -11,6 +11,7 @@ const {
 } = getWindowData();
 
 /**
+ * @unreleased pass page slug from parent component to support form title as initial slug.
  * @since 3.0.0
  * @see https://github.com/WordPress/gutenberg/blob/a8c5605f5dd077a601aefce6f58409f54d7d4447/packages/editor/src/components/post-slug/index.js
  */

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -1,6 +1,6 @@
 import {Button, Dropdown, ExternalLink, TextControl} from '@wordpress/components';
 import {close, Icon} from '@wordpress/icons';
-import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
+import {setFormSettings, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
 import {getWindowData} from '@givewp/form-builder/common';
 import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
@@ -14,68 +14,65 @@ const {
  * @since 3.0.0
  * @see https://github.com/WordPress/gutenberg/blob/a8c5605f5dd077a601aefce6f58409f54d7d4447/packages/editor/src/components/post-slug/index.js
  */
-const PageSlugControl = () => {
-    const {
-        settings: {pageSlug},
-    } = useFormState();
+const PageSlugControl = ({pageSlug}) => {
     const dispatch = useFormStateDispatch();
-  const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
+    const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
 
-  const updateSlug = useCallback(() => {
-      const cleanEditedSlug = cleanForSlug(editedSlug);
-      setEditedSlug(cleanEditedSlug);
+    const updateSlug = useCallback(() => {
+        const cleanEditedSlug = cleanForSlug(editedSlug);
+        setEditedSlug(cleanEditedSlug);
 
-      if (cleanEditedSlug !== pageSlug) {
-          dispatch(setFormSettings({pageSlug: cleanEditedSlug}));
-      }
-  }, [pageSlug, editedSlug, dispatch]);
+        if (cleanEditedSlug !== pageSlug) {
+            dispatch(setFormSettings({pageSlug: cleanEditedSlug}));
+        }
+    }, [pageSlug, editedSlug, dispatch]);
 
-  return (
-      !!isEnabled && (
-          <Dropdown
-              className="my-container-class-name"
-              contentClassName="givewp-sidebar-dropdown-content"
-              popoverProps={{placement: 'bottom-start'}}
-              focusOnMount={'container'}
-              renderToggle={({isOpen, onToggle}) => (
-                  <TextControl
-                      label={'URL'}
-                      value={'/donations/' + editedSlug}
-                      onChange={() => null}
-                      onClick={onToggle}
-                      aria-expanded={isOpen}
-                  />
-              )}
-              renderContent={({onClose}) => (
-                  <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
-                      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                          <strong style={{fontSize: '14px'}}>{'URL'}</strong>
-                          <Button onClick={onClose}>
-                              <Icon icon={close} size={14}></Icon>
-                          </Button>
-                      </div>
-                      <TextControl
-                          label={'Permalink'}
-                          value={editedSlug}
-                          autoComplete="off"
-                          spellCheck="false"
-                          onChange={(newPageSlug) => {
-                              setEditedSlug(newPageSlug);
-                          }}
-                          help={'The last part of the URL.'}
-                          onBlur={() => updateSlug()}
-                      />
-                      <div>
-                          <strong style={{fontSize: '14px'}}>View Page</strong>
-                      </div>
-                      <ExternalLink href={permalink} style={{fontSize: '14px'}}>
-                          {sprintf('%s/%s', rewriteSlug, editedSlug)}
-                      </ExternalLink>
-                  </div>
-              )}
-          />
-      )
-  );
+    return (
+        !!isEnabled && (
+            <Dropdown
+                className="my-container-class-name"
+                contentClassName="givewp-sidebar-dropdown-content"
+                popoverProps={{placement: 'bottom-start'}}
+                focusOnMount={'container'}
+                renderToggle={({isOpen, onToggle}) => (
+                    <TextControl
+                        label={'URL'}
+                        value={'/donations/' + editedSlug}
+                        onChange={() => null}
+                        onClick={onToggle}
+                        aria-expanded={isOpen}
+                    />
+                )}
+                renderContent={({onClose}) => (
+                    <div style={{minWidth: 'calc(var(--givewp-sidebar-width) - 48px)'}}>
+                        <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+                            <strong style={{fontSize: '14px'}}>{'URL'}</strong>
+                            <Button onClick={onClose}>
+                                <Icon icon={close} size={14}></Icon>
+                            </Button>
+                        </div>
+                        <TextControl
+                            label={'Permalink'}
+                            value={editedSlug}
+                            autoComplete="off"
+                            spellCheck="false"
+                            onChange={(newPageSlug) => {
+                                setEditedSlug(newPageSlug);
+                            }}
+                            help={'The last part of the URL.'}
+                            onBlur={() => updateSlug()}
+                        />
+                        <div>
+                            <strong style={{fontSize: '14px'}}>View Page</strong>
+                        </div>
+                        <ExternalLink href={permalink} style={{fontSize: '14px'}}>
+                            {sprintf('%s/%s', rewriteSlug, editedSlug)}
+                        </ExternalLink>
+                    </div>
+                )}
+            />
+        )
+    );
 };
 
 export default PageSlugControl;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/form-summary/page-slug.js
@@ -4,8 +4,9 @@ import {setFormSettings, useFormStateDispatch} from '@givewp/form-builder/stores
 
 import {getWindowData} from '@givewp/form-builder/common';
 import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
-import {useCallback, useState} from '@wordpress/element';
 import {__} from '@wordpress/i18n';
+
+import {useCallback, useEffect, useState} from 'react';
 
 const {
     formPage: {isEnabled, permalink, rewriteSlug},
@@ -18,7 +19,11 @@ const {
  */
 const PageSlugControl = ({pageSlug}) => {
     const dispatch = useFormStateDispatch();
-    const [editedSlug, setEditedSlug] = useState(safeDecodeURIComponent(pageSlug));
+    const [editedSlug, setEditedSlug] = useState();
+
+    useEffect(() => {
+        setEditedSlug(safeDecodeURIComponent(pageSlug));
+    }, [pageSlug]);
 
     const updateSlug = useCallback(() => {
         const cleanEditedSlug = cleanForSlug(editedSlug);


### PR DESCRIPTION
Resolves Asana task: https://app.asana.com/0/1205428662243164/1205735215345414/f

## Description

This PR saves the form title as the page slug when a form first publishes. After a form has been published the page slug can still be edited, however it is not respective of the form title on any subsequent change.

If the form title is not updated on the first publish the page slug will continue to to work as it previously did, generating the slug trailing with a new number.

I had looked into a central way of dispatching this in the onSave function call - however had inconsistent state changes and the page slug was being overwritten on refresh.  Due to this I've opted to include conditional dispatch call's for the page slug on both form title controls.

Re: https://lw.slack.com/archives/C05QFUQ805V/p1697494770284989?thread_ts=1694639392.259359&cid=C05QFUQ805V

## Visuals


https://github.com/impress-org/givewp/assets/75056371/e5eb541a-b730-4ac5-bbc5-4bd127d91163



## Testing Instructions

- Create a form
- Update the form title.
- Publish the form.
- View new page slug.
- Visit page - verify pageslug works.

## Pre-review Checklist

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205799200925606