### PR TITLE
Refactor: create new forms using block models for translatable strings

### DIFF
--- a/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
+++ b/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Give\FormBuilder\Actions;
+
+use Give\Framework\Blocks\BlockCollection;
+use Give\Framework\Blocks\BlockModel;
+
+/**
+ * @unreleased
+ */
+class GenerateDefaultDonationFormBlockCollection
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(): BlockCollection
+    {
+        $section1 = $this->createSection(
+            __('How much would you like to donate today?', 'give'),
+            __('All donations directly impact our organization and help us further our mission.?', 'give'),
+            $this->createAmountBlock()
+        );
+
+        $section2 = $this->createSection(
+            __('Who\'s Giving Today?', 'give'),
+            __('We\'ll never share this information with anyone', 'give'),
+            $this->createDonorNameBlock(),
+            $this->createEmailBlock()
+        );
+
+        $section3 = $this->createSection(
+            __('Payment Details', 'give'),
+            __('How would you like to pay for your donation?', 'give'),
+            $this->createDonationSummaryBlock(),
+            $this->createPaymentGatewaysBlock()
+        );
+
+        return BlockCollection::make([
+            $section1,
+            $section2,
+            $section3
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createSection(string $title, string $description, BlockModel ...$innerBlocks): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/section',
+            'attributes' => [
+                'title' => $title,
+                'description' => $description,
+            ],
+            'innerBlocks' => new BlockCollection($innerBlocks),
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createAmountBlock(): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/donation-amount',
+            'attributes' => [
+                "label" => __("Donation Amount", 'give'),
+                "levels" => [
+                    10,
+                    25,
+                    50,
+                    100,
+                    250,
+                    500
+                ],
+                "defaultLevel" => 10,
+                "priceOption" => "multi",
+                "setPrice" => 25,
+                "customAmount" => true,
+                "customAmountMin" => 1,
+                "recurringBillingPeriodOptions" => [
+                    "month"
+                ],
+                "recurringBillingInterval" => 1,
+                "recurringEnabled" => false,
+                "recurringLengthOfTime" => "0",
+                "recurringOptInDefaultBillingPeriod" => "month",
+                "recurringEnableOneTimeDonations" => true
+            ],
+            'innerBlocks' => [],
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createDonorNameBlock(): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/donor-name',
+            'attributes' => [
+                "showHonorific" => false,
+                "honorifics" => [
+                    __("Mr", 'give'),
+                    __("Ms", 'give'),
+                    __("Mrs", 'give')
+                ],
+                "firstNameLabel" => __("First name", 'give'),
+                "firstNamePlaceholder" => __("First name", 'give'),
+                "lastNameLabel" => __("Last name", 'give'),
+                "lastNamePlaceholder" => __("Last name", 'give'),
+                "requireLastName" => false
+            ],
+            "innerBlocks" => []
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createEmailBlock(): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/email',
+            'attributes' => [
+                "label" => __("Email Address", 'give'),
+                "isRequired" => true,
+            ],
+            "innerBlocks" => []
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createDonationSummaryBlock(): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/donation-summary',
+            'attributes' => [],
+            'innerBlocks' => []
+        ]);
+    }
+
+     /**
+     * @unreleased
+     */
+    protected function createPaymentGatewaysBlock(): BlockModel
+    {
+        return BlockModel::make([
+            'name' => 'givewp/payment-gateways',
+            'attributes' => [],
+            'innerBlocks' => []
+        ]);
+    }
+}

--- a/src/FormBuilder/Routes/CreateFormRoute.php
+++ b/src/FormBuilder/Routes/CreateFormRoute.php
@@ -16,6 +16,7 @@ use Give\Helpers\Hooks;
 class CreateFormRoute
 {
     /**
+     * @unreleased updated default form blocks to be generated from block models instead of json
      * @since 3.0.0
      *
      * @return void

--- a/src/FormBuilder/Routes/CreateFormRoute.php
+++ b/src/FormBuilder/Routes/CreateFormRoute.php
@@ -6,8 +6,8 @@ use Exception;
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\ValueObjects\DonationFormStatus;
+use Give\FormBuilder\Actions\GenerateDefaultDonationFormBlockCollection;
 use Give\FormBuilder\FormBuilderRouteBuilder;
-use Give\Framework\Blocks\BlockCollection;
 use Give\Helpers\Hooks;
 
 /**
@@ -30,10 +30,6 @@ class CreateFormRoute
                 exit();
             }
             if ('new' === $_GET['donationFormID']) {
-                $blocksJson = file_get_contents(
-                    GIVE_PLUGIN_DIR . 'src/FormBuilder/resources/js/form-builder/src/blocks.json'
-                );
-
                 $form = new DonationForm([
                     'title' => __('GiveWP Donation Form', 'give'),
                     'status' => DonationFormStatus::DRAFT(),
@@ -41,7 +37,7 @@ class CreateFormRoute
                         'enableDonationGoal' => true,
                         'goalAmount' => 1000,
                     ]),
-                    'blocks' => BlockCollection::fromJson($blocksJson)
+                    'blocks' => (new GenerateDefaultDonationFormBlockCollection())(),
                 ]);
 
                 Hooks::doAction('givewp_form_builder_new_form', $form);

--- a/src/Framework/Blocks/BlockModel.php
+++ b/src/Framework/Blocks/BlockModel.php
@@ -29,6 +29,8 @@ class BlockModel implements Arrayable
     public $innerBlocks;
 
     /**
+     * @unreleased added innerBlocks sanitization
+     * @since 3.0.0
      * @param string $name
      * @param string $clientId
      * @param bool $isValid
@@ -50,8 +52,9 @@ class BlockModel implements Arrayable
     }
 
     /**
-     * @param  array|BlockCollection|null  $innerBlocks
      * @unreleased
+     *
+     * @param  array|BlockCollection|null  $innerBlocks
      */
     public function sanitizeInnerBlocks($innerBlocks): BlockCollection
     {
@@ -114,6 +117,7 @@ class BlockModel implements Arrayable
     }
 
     /**
+     * @unreleased simplified innerBlocks param
      * @since 3.0.0
      *
      * @param  array  $blockData

--- a/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
+++ b/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Give\Tests\Unit\Actions;
+
+use Give\FormBuilder\Actions\GenerateDefaultDonationFormBlockCollection;
+use Give\Framework\Blocks\BlockModel;
+use Give\Tests\TestCase;
+
+/**
+ * @unreleased
+ */
+class GenerateDefaultDonationFormBlockCollectionTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    public function testShouldReturnDefaultBlockCollection(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $this->assertCount(3, $blockCollection->getBlocks());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldIncludeDefaultDonationAmountBlock(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $block = $blockCollection->findByName('givewp/donation-amount');
+
+        $this->assertInstanceOf(BlockModel::class, $block);
+
+        $this->assertEquals(
+            $block->getAttributes(),
+            [
+                "label" => __("Donation Amount", 'give'),
+                "levels" => [
+                    10,
+                    25,
+                    50,
+                    100,
+                    250,
+                    500
+                ],
+                "defaultLevel" => 10,
+                "priceOption" => "multi",
+                "setPrice" => 25,
+                "customAmount" => true,
+                "customAmountMin" => 1,
+                "recurringBillingPeriodOptions" => [
+                    "month"
+                ],
+                "recurringBillingInterval" => 1,
+                "recurringEnabled" => false,
+                "recurringLengthOfTime" => "0",
+                "recurringOptInDefaultBillingPeriod" => "month",
+                "recurringEnableOneTimeDonations" => true
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldIncludeDefaultDonorNameBlock(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $block = $blockCollection->findByName('givewp/donor-name');
+
+        $this->assertInstanceOf(BlockModel::class, $block);
+
+        $this->assertEquals(
+            $block->getAttributes(),
+            [
+                "showHonorific" => false,
+                "honorifics" => [
+                    __("Mr", 'give'),
+                    __("Ms", 'give'),
+                    __("Mrs", 'give')
+                ],
+                "firstNameLabel" => __("First name", 'give'),
+                "firstNamePlaceholder" => __("First name", 'give'),
+                "lastNameLabel" => __("Last name", 'give'),
+                "lastNamePlaceholder" => __("Last name", 'give'),
+                "requireLastName" => false
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldIncludeDefaultEmailBlock(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $block = $blockCollection->findByName('givewp/email');
+
+        $this->assertInstanceOf(BlockModel::class, $block);
+
+        $this->assertEquals(
+            $block->getAttributes(),
+            [
+                "label" => __("Email Address", 'give'),
+                "isRequired" => true,
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldIncludeDefaultDonationSummaryBlock(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $block = $blockCollection->findByName('givewp/donation-summary');
+
+        $this->assertInstanceOf(BlockModel::class, $block);
+
+        $this->assertEquals([], $block->getAttributes());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldIncludeDefaultPaymentGatewaysBlock(): void
+    {
+        $blockCollection = (new GenerateDefaultDonationFormBlockCollection())();
+
+        $block = $blockCollection->findByName('givewp/payment-gateways');
+
+        $this->assertInstanceOf(BlockModel::class, $block);
+
+        $this->assertEquals([], $block->getAttributes());
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: #7035

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

### The problem
Previously we have been generating new forms using our static `blocks.json` file.  This was problematic with translation because we are simply storing english words in the database.  WordPress translation only works with static strings, so once you store your strings in the database - they will remain untranslated until translated manually.

### The solution
This updates the generation of a new form to use block models instead of the static `blocks.json` file.  This is necessary to include translatable strings during the initial form creation as all user-facing strings are wrapped in translation functions.  

Of course this isn't perfect, the strings would need to be pre-translated before creating a new form so the translated words are stored in the database.  Yet, this is a good start as at least the strings will be included in the translation file.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- New v3 form creation

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Example of pre-translated string in italiano and creating a new form:**

<img width="1257" alt="Screenshot 2023-10-19 at 3 32 29 PM" src="https://github.com/impress-org/givewp/assets/10138447/2457391d-fbdb-45f7-84e3-bff92b00c649">

<img width="1178" alt="Screenshot 2023-10-19 at 3 33 28 PM" src="https://github.com/impress-org/givewp/assets/10138447/dc8d8b61-7e58-4379-ae04-8e521b1d1722">



## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

QA build: 
https://github.com/impress-org/givewp/actions/runs/6617533934

- First make sure you can create a new form without any issues
- Then try creating a form in a different language (with default section strings translated)
for example: `How much would you like to donate today?`
- Those default section strings should not be in english.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205761241674736