### PR TITLE
Fix: add translation to all gateways, form builder scripts, and fix text domain typo

### DIFF
--- a/src/DonationForms/Routes/AuthenticationRoute.php
+++ b/src/DonationForms/Routes/AuthenticationRoute.php
@@ -46,7 +46,7 @@ class AuthenticationRoute
         if (is_wp_error($userOrError)) {
             wp_send_json_error([
                 'type' => 'authentication_error',
-                'message' => __('The login/password does not match or is incorrect.', 'givewp'),
+                'message' => __('The login/password does not match or is incorrect.', 'give'),
             ], 401);
             exit;
         }

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -141,7 +141,7 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
             setErrorMessage(
                 'authentication_error' === responseData.type
                     ? responseData.message
-                    : __('Something went wrong. Please try or again or contact a site administrator.', 'givewp')
+                    : __('Something went wrong. Please try or again or contact a site administrator.', 'give')
             );
         }
     };
@@ -162,7 +162,7 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
                 }}
             >
                 <button style={{width: 'auto'}} onClick={tryLogin}>
-                    {__('Log In', 'givewp')}
+                    {__('Log In', 'give')}
                 </button>
                 <a
                     onClick={(event) => {
@@ -172,7 +172,7 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
                         window.top.location.assign(passwordResetUrl);
                     }}
                 >
-                    {__('Reset Password', 'givewp')}
+                    {__('Reset Password', 'give')}
                 </a>
             </div>
         </div>

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -58,6 +58,7 @@ class RegisterFormBuilderPageRoute
     /**
      * Render page with scripts
      *
+     * @unreleased set translations for scripts
      * @since 3.0.0
      *
      * @return void
@@ -93,6 +94,7 @@ class RegisterFormBuilderPageRoute
         Language::setScriptTranslations($registrarsScriptHandle);
 
         /**
+         * @unreleased set translations for scripts
          * @since 3.0.0
          * Using `wp_enqueue_script` instead of `new EnqueueScript` for more control over dependencies.
          * The `EnqueueScript` class discovers the dependencies from the associated `asset.php` file,

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -5,9 +5,9 @@ namespace Give\FormBuilder\Routes;
 
 use Give\FormBuilder\FormBuilderRouteBuilder;
 use Give\FormBuilder\ViewModels\FormBuilderViewModel;
-use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Framework\Views\View;
 use Give\Helpers\Hooks;
+use Give\Helpers\Language;
 use Give\Log\Log;
 
 use function wp_enqueue_style;
@@ -79,8 +79,9 @@ class RegisterFormBuilderPageRoute
             GIVE_PLUGIN_URL . 'build/formBuilderRegistrars.css'
         );
 
+        $registrarsScriptHandle = '@givewp/form-builder/registrars';
         wp_enqueue_script(
-            '@givewp/form-builder/registrars',
+            $registrarsScriptHandle,
             $formBuilderViewModel->jsPathToRegistrars(),
             $this->getRegisteredFormBuilderJsDependencies(
                 $formBuilderViewModel->jsRegistrarsDependencies()
@@ -88,6 +89,8 @@ class RegisterFormBuilderPageRoute
             GIVE_VERSION,
             true
         );
+
+        Language::setScriptTranslations($registrarsScriptHandle);
 
         /**
          * @since 3.0.0
@@ -98,6 +101,7 @@ class RegisterFormBuilderPageRoute
          */
         Hooks::doAction('givewp_form_builder_enqueue_scripts');
 
+        $formBuilderScriptPath = '@givewp/form-builder/script';
         wp_enqueue_script(
             '@givewp/form-builder/script',
             $formBuilderViewModel->jsPathFromPluginRoot(),
@@ -107,6 +111,8 @@ class RegisterFormBuilderPageRoute
             GIVE_VERSION,
             true
         );
+
+        Language::setScriptTranslations($formBuilderScriptPath);
 
         wp_add_inline_script(
             '@givewp/form-builder/script',

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
@@ -1,11 +1,11 @@
 import {FieldBlock} from '@givewp/form-builder/types';
 import defaultSettings from '../settings';
-import {__} from "@wordpress/i18n";
-import BlockIcon from "./icon";
+import {__} from '@wordpress/i18n';
+import BlockIcon from './icon';
 import {Button, PanelBody, PanelRow, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
-import {BlockEditProps} from "@wordpress/blocks";
-import {Icon, external} from "@wordpress/icons";
+import {BlockEditProps} from '@wordpress/blocks';
+import {external, Icon} from '@wordpress/icons';
 
 const login: FieldBlock = {
     name: 'givewp/login',
@@ -28,44 +28,50 @@ const login: FieldBlock = {
             },
             loginNotice: {
                 type: 'string',
-                default: __('Already have an account? Log in.', 'givewp'),
+                default: __('Already have an account? Log in.', 'give'),
             },
             loginConfirmation: {
                 type: 'string',
                 default: __('Thank you for your continued support.', 'give'),
-            }
+            },
         },
         edit: ({attributes, setAttributes}: BlockEditProps<any>) => {
             const {required, loginRedirect, loginNotice, loginConfirmation} = attributes;
 
             return (
                 <>
-
                     {!!required && (
                         <div style={{display: 'flex', flexDirection: 'column', gap: '15px'}}>
                             <div style={{display: 'flex', flexDirection: 'row', gap: '15px'}}>
                                 <TextControl
-                                    label={__('Login', 'givewp')}
+                                    label={__('Login', 'give')}
                                     onChange={() => null}
                                     value={''}
-                                    placeholder={__('Username or Email Address', 'givewp')}
+                                    placeholder={__('Username or Email Address', 'give')}
                                 />
                                 <TextControl
                                     type="password"
-                                    label={__('Password', 'givewp')}
+                                    label={__('Password', 'give')}
                                     onChange={() => null}
                                     value={'password123'}
                                 />
                             </div>
-                            <div style={{display: 'flex', flexDirection: 'row-reverse', gap: '15px', justifyContent: 'space-between'}}>
-                                <Button variant={'primary'}>{__('Log In', 'givewp')}</Button>
-                                <Button variant={'link'}>{__('Reset Password', 'givewp')}</Button>
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    flexDirection: 'row-reverse',
+                                    gap: '15px',
+                                    justifyContent: 'space-between',
+                                }}
+                            >
+                                <Button variant={'primary'}>{__('Log In', 'give')}</Button>
+                                <Button variant={'link'}>{__('Reset Password', 'give')}</Button>
                             </div>
                         </div>
                     )}
 
                     {!required && (
-                        <div style={{display: 'flex', flexDirection: "row-reverse"}}>
+                        <div style={{display: 'flex', flexDirection: 'row-reverse'}}>
                             <Button
                                 variant={'link'}
                                 icon={!!loginRedirect ? <Icon icon={external} /> : undefined}
@@ -110,9 +116,9 @@ const login: FieldBlock = {
                         </PanelBody>
                     </InspectorControls>
                 </>
-            )
+            );
         },
-    }
+    },
 };
 
 export default login;

--- a/src/FormBuilder/resources/js/form-builder/src/components/editor/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/editor/index.tsx
@@ -35,9 +35,9 @@ export default function Editor ({onChange, value, className}: EditorProps) {
         }
 
         frame = window.wp.media({
-            title: __('Add or upload file', 'givewp'),
+            title: __('Add or upload file', 'give'),
             button: {
-                text: __('Use this media', 'givewp'),
+                text: __('Use this media', 'give'),
             },
             multiple: false, // Set to true to allow multiple files to be selected
         });

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/index.tsx
@@ -12,13 +12,13 @@ export default () => {
 
     return (
         <>
-            <PanelBody title={__('Email Settings', 'givewp')} initialOpen={false}>
+            <PanelBody title={__('Email Settings', 'give')} initialOpen={false}>
                 <PanelRow>
                     <SelectControl
-                        label={__('Email Options', 'givewp')}
+                        label={__('Email Options', 'give')}
                         options={[
-                            {label: __('Global', 'givewp'), value: 'global'},
-                            {label: __('Customize', 'givewp'), value: 'enabled'},
+                            {label: __('Global', 'give'), value: 'global'},
+                            {label: __('Customize', 'give'), value: 'enabled'},
                         ]}
                         value={emailOptionsStatus}
                         onChange={(emailOptionsStatus) => dispatch(setFormSettings({emailOptionsStatus}))}
@@ -28,11 +28,11 @@ export default () => {
                     <>
                         <PanelRow>
                             <SelectControl
-                                label={__('Email Template', 'givewp')}
-                                help={__('Choose your template from the available registered template types', 'givewp')}
+                                label={__('Email Template', 'give')}
+                                help={__('Choose your template from the available registered template types', 'give')}
                                 options={[
-                                    {label: __('Default template', 'givewp'), value: 'default'},
-                                    {label: __('No template, plain text only', 'givewp'), value: 'none'},
+                                    {label: __('Default template', 'give'), value: 'default'},
+                                    {label: __('No template, plain text only', 'give'), value: 'none'},
                                 ]}
                                 value={emailTemplate}
                                 onChange={(emailTemplate) => dispatch(setFormSettings({emailTemplate}))}
@@ -46,7 +46,7 @@ export default () => {
                         </PanelRow>
                         <PanelRow>
                             <TextControl
-                                label={__('From Name', 'givewp')}
+                                label={__('From Name', 'give')}
                                 help={__(
                                     'The name which appears in the "From" field in all GiveWP donation emails.',
                                     'givewp'
@@ -57,7 +57,7 @@ export default () => {
                         </PanelRow>
                         <PanelRow>
                             <TextControl
-                                label={__('From Email', 'givewp')}
+                                label={__('From Email', 'give')}
                                 help={__(
                                     'Email address from which all GiveWP emails are sent from. This will act as the "from" and "reply-to" email address.',
                                     'givewp'

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/index.tsx
@@ -49,7 +49,7 @@ export default () => {
                                 label={__('From Name', 'give')}
                                 help={__(
                                     'The name which appears in the "From" field in all GiveWP donation emails.',
-                                    'givewp'
+                                    'give'
                                 )}
                                 value={emailFromName}
                                 onChange={(emailFromName) => dispatch(setFormSettings({emailFromName}))}
@@ -60,7 +60,7 @@ export default () => {
                                 label={__('From Email', 'give')}
                                 help={__(
                                     'Email address from which all GiveWP emails are sent from. This will act as the "from" and "reply-to" email address.',
-                                    'givewp'
+                                    'give'
                                 )}
                                 value={emailFromEmail}
                                 onChange={(emailFromEmail) => dispatch(setFormSettings({emailFromEmail}))}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/logo-upload/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/logo-upload/index.tsx
@@ -23,9 +23,9 @@ export default ({value, onChange}) => {
         }
 
         frame = window.wp.media({
-            title: __('Add or upload file', 'givewp'),
+            title: __('Add or upload file', 'give'),
             button: {
-                text: __('Use this media', 'givewp'),
+                text: __('Use this media', 'gie'),
             },
             multiple: false, // Set to true to allow multiple files to be selected
         });
@@ -45,7 +45,7 @@ export default ({value, onChange}) => {
             <div>
                 {' '}
                 {/* Wrapping the TextControl solves a spacing issue */}
-                <TextControl type={'url'} label={__('Logo URL', 'givewp')} value={value} onChange={onChange} />
+                <TextControl type={'url'} label={__('Logo URL', 'give')} value={value} onChange={onChange} />
             </div>
             <Button
                 icon={upload}
@@ -53,7 +53,7 @@ export default ({value, onChange}) => {
                 onClick={openMediaLibrary}
                 style={{width: '100%', justifyContent: 'center', marginBottom: '8px'}}
             >
-                {__('Add or upload file', 'givewp')}
+                {__('Add or upload file', 'give')}
             </Button>
         </div>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/components/copy-to-clipboard-button.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/components/copy-to-clipboard-button.tsx
@@ -10,7 +10,7 @@ const CopyToClipboardButton = ({text}: CopyClipboardButtonProps) => {
         successDuration: 1000,
     });
 
-    const label = isCopied ? __('Copied!', 'givewp') : __('Copy tag', 'givewp');
+  const label = isCopied ? __('Copied!', 'give') : __('Copy tag', 'give');
 
     const CopyIcon = ({size}) => {
         return <Icon icon={copy} size={size} />;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/components/send-preview-email.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/components/send-preview-email.tsx
@@ -49,13 +49,13 @@ export default ({emailType, defaultEmailAddress}: SendPreviewEmailProps) => {
 
     return (
         <>
-            <h2 className={'email-settings__header'}>{__('Send a test email', 'givewp')}</h2>
+            <h2 className={'email-settings__header'}>{__('Send a test email', 'give')}</h2>
             <p className={'email-settings__description'}>
-                {__('Specify below the email address you want to send a test email to', 'givewp')}
+                {__('Specify below the email address you want to send a test email to', 'give')}
             </p>
             {defaultEmailAddress !== null && <TextControl onChange={setEmailAddress} value={emailAddress} />}
             <Button className={'email-settings__email-btn'} variant={'secondary'} onClick={sendTestEmail}>
-                {__('Send test email', 'givewp')}
+                {__('Send test email', 'give')}
             </Button>
         </>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
@@ -30,7 +30,7 @@ export default () => {
     const templateTagsDescription = createInterpolateElement(
         __(
             'Available template tags for this email. HTML is accepted. <a>See our documentation</a> for examples of how to use custom meta email tags to output additional donor or donation information in your GiveWP emails',
-            'givewp'
+            'give'
         ),
         {
             a: <a href="https://make.wordpress.org" target="_blank" />,

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/index.tsx
@@ -45,11 +45,11 @@ export default () => {
                 variant={'secondary'}
                 style={{width: '100%', justifyContent: 'center'}}
             >
-                {__('Customize email templates', 'givewp')}
+                {__('Customize email templates', 'give')}
             </Button>
             {isOpen && (
                 <Modal
-                    title={showPreview ? __('Preview Email', 'givewp') : __('Email Settings', 'give')}
+                    title={showPreview ? __('Preview Email', 'give') : __('Email Settings', 'give')}
                     onRequestClose={closeModal}
                     isDismissible={false}
                     shouldCloseOnClickOutside={false}
@@ -69,7 +69,7 @@ export default () => {
                                 variant={'secondary'}
                                 onClick={() => setShowPreview(false)}
                             >
-                                {__('Back to template settings', 'givewp')}
+                                {__('Back to template settings', 'give')}
                             </Button>
                         </>
                     )}
@@ -82,7 +82,7 @@ export default () => {
                                     variant={'primary'}
                                     onClick={closeModal}
                                 >
-                                    {__('Close', 'givewp')}
+                                    {__('Close', 'give')}
                                 </Button>
                                 <div className={'email-settings__col-left'}>
                                     <TabPanel
@@ -120,16 +120,16 @@ export default () => {
                                     }}
                                 >
                                     <div>
-                                        <h2 className={'email-settings__header'}>{__('Preview email', 'givewp')}</h2>
+                                        <h2 className={'email-settings__header'}>{__('Preview email', 'give')}</h2>
                                         <p className={'email-settings__description'}>
-                                            {__('Preview the email message in your browser', 'givewp')}
+                                            {__('Preview the email message in your browser', 'give')}
                                         </p>
                                         <Button
                                             className={'email-settings__email-btn'}
                                             variant={'secondary'}
                                             onClick={() => setShowPreview(true)}
                                         >
-                                            {__('Preview email', 'givewp')}
+                                            {__('Preview email', 'give')}
                                         </Button>
                                     </div>
                                     <div>
@@ -139,7 +139,7 @@ export default () => {
                                         />
                                     </div>
                                     <div>
-                                        <h2 className={'email-settings__header'}>{__('Template tags', 'givewp')}</h2>
+                                        <h2 className={'email-settings__header'}>{__('Template tags', 'give')}</h2>
                                         <p className={'email-settings__description'}>{templateTagsDescription}</p>
                                         <ul className={'email-settings-template-tags'}>
                                             {emailTemplateTags.map((tag) => (

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/settings.tsx
@@ -54,7 +54,7 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
                 hideLabelFromVision={true}
                 help={__(
                     'Global options are set in GiveWP settings. You may override them for this form here',
-                    'givewp'
+                    'give'
                 )}
                 selected={option.status ?? 'global'}
                 options={config.statusOptions}
@@ -149,7 +149,7 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
                             label={__('Email', 'give')}
                             help={__(
                                 'This email is automatically sent to the individual fundraiser and the recipient cannot be customized.',
-                                'givewp'
+                                'give'
                             )}
                             onChange={() => null}
                             value="{donor_email}"

--- a/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/email/template-options/settings.tsx
@@ -50,7 +50,7 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
         <div className={'email-settings-template__container'}>
             <RadioControl
                 className="radio-control--email-options"
-                label={__('Email options', 'givewp')}
+                label={__('Email options', 'give')}
                 hideLabelFromVision={true}
                 help={__(
                     'Global options are set in GiveWP settings. You may override them for this form here',
@@ -64,15 +64,15 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
             {'enabled' === option.status && (
                 <>
                     <TextControl
-                        label={__('Email Subject', 'givewp')}
-                        help={__('Enter the email subject line', 'givewp')}
+                        label={__('Email Subject', 'give')}
+                        help={__('Enter the email subject line', 'give')}
                         onChange={(value) => updateEmailTemplateOption('email_subject', value)}
                         value={option.email_subject || config.defaultValues.email_subject}
                     />
 
                     <TextControl
-                        label={__('Email Header', 'givewp')}
-                        help={__('Enter the email header that appears at the top of the email', 'givewp')}
+                        label={__('Email Header', 'give')}
+                        help={__('Enter the email header that appears at the top of the email', 'give')}
                         onChange={(value) => updateEmailTemplateOption('email_header', value)}
                         // @ts-ignore
                         value={option.email_header || config.defaultValues.email_header}
@@ -86,24 +86,24 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
                     <SelectControl
                         className={'select-control--email-options'}
                         onChange={(value) => updateEmailTemplateOption('email_content_type', value)}
-                        label={__('Email content type', 'givewp')}
-                        help={__('Choose email type', 'givewp')}
+                        label={__('Email content type', 'give')}
+                        help={__('Choose email type', 'give')}
                         value={option.email_content_type || config.defaultValues.email_content_type}
                         options={[
-                            {label: __('HTML', 'givewp'), value: 'text/html'},
-                            {label: __('Plain', 'givewp'), value: 'text/plain'},
+                            {label: __('HTML', 'give'), value: 'text/html'},
+                            {label: __('Plain', 'give'), value: 'text/plain'},
                         ]}
                     />
 
                     {config.supportsRecipients && (
                         <div className={'email-settings-template__recipient'}>
                             <div>
-                                <h2 className={'email-settings__header'}>{__('Email recipient', 'givewp')}</h2>
+                                <h2 className={'email-settings__header'}>{__('Email recipient', 'give')}</h2>
                                 <p className={'email-settings__description'}>
-                                    {__('Email address that should receive a notification', 'givewp')}
+                                    {__('Email address that should receive a notification', 'give')}
                                 </p>
                             </div>
-                            <BaseControl id={'give-email-template-recipient'} label={__('Email', 'givewp')}>
+                            <BaseControl id={'give-email-template-recipient'} label={__('Email', 'give')}>
                                 {recipients.map((recipientEmail, index) => {
                                     return (
                                         <li
@@ -138,7 +138,7 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
                                     variant={'secondary'}
                                     onClick={() => updateEmailTemplateOption('recipient', [...recipients, ''])}
                                 >
-                                    <WPIcon size={17} icon={plus} /> {__('Add email', 'givewp')}
+                                    <WPIcon size={17} icon={plus} /> {__('Add email', 'give')}
                                 </Button>
                             </BaseControl>
                         </div>
@@ -146,7 +146,7 @@ const EmailTemplateSettings = ({notification}: EmailTemplateSettingsProps) => {
                     {!config.supportsRecipients && (
                         <TextControl
                             disabled={true}
-                            label={__('Email', 'givewp')}
+                            label={__('Email', 'give')}
                             help={__(
                                 'This email is automatically sent to the individual fundraiser and the recipient cannot be customized.',
                                 'givewp'

--- a/src/FormBuilder/resources/js/form-builder/src/settings/styles/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/styles/index.tsx
@@ -1,63 +1,70 @@
-import {useState} from "react";
-import AceEditor from "react-ace";
+import {useState} from 'react';
+import AceEditor from 'react-ace';
 import debounce from 'lodash.debounce';
-import {__} from "@wordpress/i18n";
-import { fullscreen } from '@wordpress/icons';
-import {Button, Modal, PanelBody, PanelRow} from "@wordpress/components";
+import {__} from '@wordpress/i18n';
+import {fullscreen} from '@wordpress/icons';
+import {Button, Modal, PanelBody, PanelRow} from '@wordpress/components';
 
-import "ace-builds/src-noconflict/mode-css";
+import 'ace-builds/src-noconflict/mode-css';
 import 'ace-builds/src-noconflict/snippets/css';
-import "ace-builds/src-noconflict/theme-textmate";
-import {setFormSettings, useFormState, useFormStateDispatch} from "@givewp/form-builder/stores/form-state";
+import 'ace-builds/src-noconflict/theme-textmate';
+import {setFormSettings, useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 
 const CustomStyleSettings = () => {
-
-    const [ isOpen, setOpen ] = useState<boolean>( false );
-    const openModal = () => setOpen( true );
-    const closeModal = () => setOpen( false );
+    const [isOpen, setOpen] = useState<boolean>(false);
+    const openModal = () => setOpen(true);
+    const closeModal = () => setOpen(false);
 
     return (
-        <PanelBody title={__('Custom Styles', 'givewp')} initialOpen={false}>
+        <PanelBody title={__('Custom Styles', 'give')} initialOpen={false}>
             <PanelRow>
-
-                <div style={{
-                    width: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '10px',
-                }}>
-                    <Button icon={fullscreen} onClick={ openModal }>
-                        { __( 'Edit in Modal', 'givewp' ) }
+                <div
+                    style={{
+                        width: '100%',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '10px',
+                    }}
+                >
+                    <Button icon={fullscreen} onClick={openModal}>
+                        {__('Edit in Modal', 'give')}
                     </Button>
 
-                    <div style={{
-                        margin: '.5rem -16px -16px -16px', // Offset the panel padding in order to fill the inspector width.
-                    }}>
+                    <div
+                        style={{
+                            margin: '.5rem -16px -16px -16px', // Offset the panel padding in order to fill the inspector width.
+                        }}
+                    >
                         <CustomStyleCodeControl />
                     </div>
-
                 </div>
 
-                { !! isOpen && (
-                    <Modal overlayClassName="components-modal__screen-overlay--givewpwp-custom-css" title={ __( 'Custom Styles', 'givewp' ) } onRequestClose={ closeModal } style={{
-                        height: '100%',
-                        maxHeight: '100%', // Override the max height of the modal component.
-                        width: '500px',
-                        position: 'absolute',
-                        right: '0',
-                    }}>
-                        <div style={{
-                            margin: '0 -31px -23px -31px', // Offset the modal padding in order to fill the available space.
-                        }}>
+                {!!isOpen && (
+                    <Modal
+                        overlayClassName="components-modal__screen-overlay--givewpwp-custom-css"
+                        title={__('Custom Styles', 'give')}
+                        onRequestClose={closeModal}
+                        style={{
+                            height: '100%',
+                            maxHeight: '100%', // Override the max height of the modal component.
+                            width: '500px',
+                            position: 'absolute',
+                            right: '0',
+                        }}
+                    >
+                        <div
+                            style={{
+                                margin: '0 -31px -23px -31px', // Offset the modal padding in order to fill the available space.
+                            }}
+                        >
                             <CustomStyleCodeControl />
                         </div>
                     </Modal>
-                ) }
-
+                )}
             </PanelRow>
         </PanelBody>
-    )
-}
+    );
+};
 
 const CustomStyleCodeControl = () => {
 

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -25,7 +25,7 @@ const FieldSettingsHOC = createHigherOrderComponent((BlockEdit) => {
 
         const fieldSettings: FieldSettings = useMemo(() => {
             // @ts-ignore
-            const giveSupports = getBlockSupport(name, 'givewp') as GiveWPSupports;
+          const giveSupports = getBlockSupport(name, 'give') as GiveWPSupports;
 
             return normalizeFieldSettings(giveSupports?.fieldSettings);
         }, [name]);

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -77,7 +77,7 @@ class ServiceProvider implements ServiceProviderInterface
                     'id' => [
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
-                        'description' => __('The ID of the form (v2) to migrate to v3.', 'givewp'),
+                        'description' => __('The ID of the form (v2) to migrate to v3.', 'give'),
                     ],
                 ],
             ]);
@@ -101,7 +101,7 @@ class ServiceProvider implements ServiceProviderInterface
                             return intval($value);
                             // return array_map('intval', explode(',', $value));
                         },
-                        'description' => __('The ID of the form (v3) to transfer donations (from v2).', 'givewp'),
+                        'description' => __('The ID of the form (v3) to transfer donations (from v2).', 'give'),
                     ],
                     'changeUrl' => [
                         'type' => 'boolean',

--- a/src/Framework/FieldsAPI/Authentication.php
+++ b/src/Framework/FieldsAPI/Authentication.php
@@ -21,11 +21,11 @@ class Authentication extends Group
         return parent::make($name)
             ->append(
                 Text::make('login')
-                    ->label(__('Username or Email Address', 'givewp'))
+                    ->label(__('Username or Email Address', 'give'))
             )
             ->append(
                 Password::make('password')
-                ->label(__('Password', 'givewp'))
+                    ->label(__('Password', 'give'))
             );
     }
 

--- a/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
@@ -3,6 +3,7 @@
 namespace Give\PaymentGateways\Gateways\PayPalCommerce;
 
 use Give\Framework\Support\Scripts\Concerns\HasScriptAssetFile;
+use Give\Helpers\Language;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
 use Give\PaymentGateways\PayPalCommerce\PayPalCommerce;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
@@ -35,14 +36,17 @@ class PayPalCommerceGateway extends PayPalCommerce
     public function enqueueScript(int $formId)
     {
         $assets = $this->getScriptAsset(GIVE_PLUGIN_DIR . 'build/payPalCommerceGateway.asset.php');
+        $handle = $this::id();
 
         wp_enqueue_script(
-            self::id(),
+            $handle,
             GIVE_PLUGIN_URL . 'build/payPalCommerceGateway.js',
             $assets['dependencies'],
             $assets['version'],
             true
         );
+
+        Language::setScriptTranslations($handle);
     }
 
     /**

--- a/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
@@ -31,6 +31,7 @@ class PayPalCommerceGateway extends PayPalCommerce
     }
 
     /**
+     * @unreleased set translations for script
      * @since 3.0.0
      */
     public function enqueueScript(int $formId)

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -316,7 +316,7 @@ import {CSSProperties, useEffect, useState} from 'react';
                             hostedFieldType="expirationDate"
                             options={{
                                 selector: '#expiration-date',
-                                placeholder: 'MM/YYYY',
+                                placeholder: __('MM/YYYY', 'give'),
                             }}
                         />
                         <PayPalHostedField
@@ -326,7 +326,7 @@ import {CSSProperties, useEffect, useState} from 'react';
                             hostedFieldType="cvv"
                             options={{
                                 selector: '#cvv',
-                                placeholder: 'CVV',
+                                placeholder: __('CVV', 'give'),
                                 maskInput: true,
                             }}
                         />

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -292,7 +292,7 @@ import {CSSProperties, useEffect, useState} from 'react';
                         className="givewp-fields"
                         label={__('Cardholder Name', 'give')}
                         hideLabelFromVision={true}
-                        placeholder={'Cardholder Name'}
+                        placeholder={__('Cardholder Name', 'give')}
                         value={_cardholderName ?? cardholderDefault}
                         onChange={(value) => setCardholderName(value)}
                     />

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -91,6 +91,7 @@ class PayPalStandard extends PaymentGateway
     }
 
     /**
+     * @unreleased set translations for script
      * @since 3.0.0
      */
     public function enqueueScript(int $formId)

--- a/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/PayPalStandard.php
@@ -10,6 +10,7 @@ use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Framework\PaymentGateways\Traits\HandleHttpResponses;
 use Give\Framework\Support\Scripts\Concerns\HasScriptAssetFile;
+use Give\Helpers\Language;
 use Give\PaymentGateways\Gateways\PayPalStandard\Actions\CreatePayPalStandardPaymentURL;
 use Give\PaymentGateways\Gateways\PayPalStandard\Controllers\PayPalStandardWebhook;
 use Give\PaymentGateways\Gateways\PayPalStandard\Views\PayPalStandardBillingFields;
@@ -95,14 +96,17 @@ class PayPalStandard extends PaymentGateway
     public function enqueueScript(int $formId)
     {
         $assets = $this->getScriptAsset(GIVE_PLUGIN_DIR . 'build/payPalStandardGateway.asset.php');
+        $handle = $this::id();
 
         wp_enqueue_script(
-            self::id(),
+            $handle,
             GIVE_PLUGIN_URL . 'build/payPalStandardGateway.js',
             $assets['dependencies'],
             $assets['version'],
             true
         );
+
+        Language::setScriptTranslations($handle);
     }
 
     /**

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -52,6 +52,7 @@ class StripePaymentElementGateway extends PaymentGateway
     }
 
     /**
+     * @unreleased set translations for script
      * @since 3.0.0
      */
     public function enqueueScript(int $formId)

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -7,6 +7,7 @@ use Give\Framework\PaymentGateways\Commands\GatewayCommand;
 use Give\Framework\PaymentGateways\Commands\RespondToBrowser;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Framework\Support\Scripts\Concerns\HasScriptAssetFile;
+use Give\Helpers\Language;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\DataTransferObjects\StripeGatewayData;
 use Stripe\Exception\ApiErrorException;
 
@@ -56,14 +57,17 @@ class StripePaymentElementGateway extends PaymentGateway
     public function enqueueScript(int $formId)
     {
         $assets = $this->getScriptAsset(GIVE_PLUGIN_DIR . 'build/stripePaymentElementGateway.asset.php');
+        $handle = $this::id();
 
         wp_enqueue_script(
-            self::id(),
+            $handle,
             GIVE_PLUGIN_URL . 'build/stripePaymentElementGateway.js',
             $assets['dependencies'],
             $assets['version'],
             true
         );
+
+        Language::setScriptTranslations($handle);
     }
 
     /**

--- a/src/PaymentGateways/Gateways/TestOffsiteGateway/TestOffsiteGateway.php
+++ b/src/PaymentGateways/Gateways/TestOffsiteGateway/TestOffsiteGateway.php
@@ -74,6 +74,7 @@ class TestOffsiteGateway extends PaymentGateway
     }
 
     /**
+     * @unreleased set translations for script
      * @since 2.30.0
      */
     public function enqueueScript(int $formId)

--- a/src/PaymentGateways/Gateways/TestOffsiteGateway/TestOffsiteGateway.php
+++ b/src/PaymentGateways/Gateways/TestOffsiteGateway/TestOffsiteGateway.php
@@ -12,6 +12,7 @@ use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Helpers\Form\Utils as FormUtils;
+use Give\Helpers\Language;
 use Give\PaymentGateways\Gateways\TestGateway\Views\LegacyFormFieldMarkup;
 
 /**
@@ -78,6 +79,7 @@ class TestOffsiteGateway extends PaymentGateway
     public function enqueueScript(int $formId)
     {
         $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/testOffsiteGateway.asset.php');
+        $handle = $this::id();
 
         wp_enqueue_script(
             $this::id(),
@@ -86,6 +88,8 @@ class TestOffsiteGateway extends PaymentGateway
             $scriptAsset['version'],
             true
         );
+
+        Language::setScriptTranslations($handle);
     }
 
     /**

--- a/src/Promotions/WelcomeBanner/resources/js/app/app.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/app.tsx
@@ -22,7 +22,7 @@ export default function App() {
             <div className={'givewp-welcome-banner__dismiss-container'}>
                 <Badge
                     variant={'primary'}
-                    caption={__('UPDATED', 'givewp')}
+                    caption={__('UPDATED', 'give')}
                     iconSrc={`${assets}/green-circle-check-icon.svg`}
                     alt={'check-mark'}
                 />

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/LeftContentSection.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/LeftContentSection.tsx
@@ -20,7 +20,7 @@ export default function LeftContentSection({assets}: LeftContentSectionProps) {
                     <p>
                         {__(
                             'GiveWP 3.0 introduces an enhanced forms experience powered by the new Visual Donations Form Builder.',
-                            'givewp'
+                            'give'
                         )}
                     </p>
                 </header>
@@ -47,7 +47,7 @@ export default function LeftContentSection({assets}: LeftContentSectionProps) {
                 <p>
                     {__(
                         'The team is still working on some new features, add-on and payment gateway compatibility to make your form experience better.',
-                        'givewp'
+                        'give'
                     )}
                 </p>
                 <ExternalLink href={'https://docs.givewp.com/welcome-docs'}>

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/LeftContentSection.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/LeftContentSection.tsx
@@ -16,7 +16,7 @@ export default function LeftContentSection({assets}: LeftContentSectionProps) {
         <section className={'givewp-welcome-banner-left-content'}>
             <Row>
                 <header className={'givewp-welcome-banner-row__header'}>
-                    <h1>{__("What's new in GiveWP 3.0", 'givewp')}</h1>
+                    <h1>{__("What's new in GiveWP 3.0", 'give')}</h1>
                     <p>
                         {__(
                             'GiveWP 3.0 introduces an enhanced forms experience powered by the new Visual Donations Form Builder.',
@@ -30,20 +30,20 @@ export default function LeftContentSection({assets}: LeftContentSectionProps) {
                 <span>
                     <Badge
                         variant={'secondary'}
-                        caption={__('NEW', 'givewp')}
+                        caption={__('NEW', 'give')}
                         iconSrc={`${assets}/shades-white-star-icon.svg`}
                         alt={'star'}
                     />
-                    <h2>{__('Create a donation form', 'givewp')}</h2>
+                    <h2>{__('Create a donation form', 'give')}</h2>
                 </span>
-                <p>{__('This is powered by the new Visual Donation Form Builder', 'givewp')}</p>
+                <p>{__('This is powered by the new Visual Donation Form Builder', 'give')}</p>
                 <InternalLink href={'/wp-admin/edit.php?post_type=give_forms&page=givewp-form-builder'}>
-                    {__('Try the new form builder', 'givewp')}
+                    {__('Try the new form builder', 'give')}
                 </InternalLink>
             </Row>
 
             <Row>
-                <h2>{__('GiveWP 3.0 Updates', 'givewp')}</h2>
+                <h2>{__('GiveWP 3.0 Updates', 'give')}</h2>
                 <p>
                     {__(
                         'The team is still working on some new features, add-on and payment gateway compatibility to make your form experience better.',
@@ -51,7 +51,7 @@ export default function LeftContentSection({assets}: LeftContentSectionProps) {
                     )}
                 </p>
                 <ExternalLink href={'https://docs.givewp.com/welcome-docs'}>
-                    {__('Read documentation', 'givewp')}
+                    {__('Read documentation', 'give')}
                 </ExternalLink>
             </Row>
         </section>

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
@@ -13,10 +13,10 @@ type RightContentSectionProps = {
 export default function RightContentSection({assets}: RightContentSectionProps) {
     return (
         <section className={'givewp-welcome-banner-right-content'}>
-            <h2>{__('Spotlight on awesome features', 'givewp')}</h2>
+            <h2>{__('Spotlight on awesome features', 'give')}</h2>
             <div className={'givewp-welcome-banner-right-content__media-container'}>
                 <SpotLight
-                    title={__('Design mode', 'givewp')}
+                    title={__('Design mode', 'give')}
                     description={__(
                         'See exactly what your form looks like for potential donors using the “Design” tab of the builder. Changes are visible immediately.',
                         'givewp'
@@ -26,7 +26,7 @@ export default function RightContentSection({assets}: RightContentSectionProps) 
                 </SpotLight>
 
                 <SpotLight
-                    title={__('Custom Paragraph and Sections', 'givewp')}
+                    title={__('Custom Paragraph and Sections', 'give')}
                     description={__(
                         'Add custom paragraphs or add whole sections anywhere in your form, no code required.',
                         'givewp'

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Sections/RightContentSection.tsx
@@ -19,7 +19,7 @@ export default function RightContentSection({assets}: RightContentSectionProps) 
                     title={__('Design mode', 'give')}
                     description={__(
                         'See exactly what your form looks like for potential donors using the “Design” tab of the builder. Changes are visible immediately.',
-                        'givewp'
+                        'give'
                     )}
                 >
                     <VideoPlayer src={`${assets}/design-mode.mp4`} fallbackImage={`${assets}/design-mode.min.png`} />
@@ -29,7 +29,7 @@ export default function RightContentSection({assets}: RightContentSectionProps) 
                     title={__('Custom Paragraph and Sections', 'give')}
                     description={__(
                         'Add custom paragraphs or add whole sections anywhere in your form, no code required.',
-                        'givewp'
+                        'give'
                     )}
                 >
                     <VideoPlayer


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Related: https://github.com/impress-org/givewp/issues/7035#issuecomment-1771434420

This sets all core gateways and form builder script handles for translation.

This also fixes a typo in the textdomain for various string from `'givewp'` to `'give'`

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Sets translation for following scripts:
- Form Builder Registrars (blocks)
- Form Builder App
- PayPal standard
- PayPal commerce
- Stripe Payment Element
- Test Offsite gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

In Italiano

<img width="372" alt="Screenshot 2023-10-19 at 4 17 29 PM" src="https://github.com/impress-org/givewp/assets/10138447/ea2e49ef-1962-433a-ae8f-0564fc607aa0">

<img width="627" alt="Screenshot 2023-10-19 at 4 24 55 PM" src="https://github.com/impress-org/givewp/assets/10138447/4d05b5d1-8bb3-4d6b-9ba5-f1025c4c4648">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**Form Builder**

Using a different language than english (ex: italiano has a lot of give support) view the form builder:

You should notice the form builder settings / labels are translated

**Gateways**

The easiest one to test would be PayPal Standard as there are no fields, just text.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205797235059704
  - https://app.asana.com/0/0/1205762247353628