### PR TITLE
Hot Fix: Prevent fatal errors on legacy forms (v2) when it has 'post_content' populated

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.0.1
+ * Version: 3.0.3
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.0.1');
+            define('GIVE_VERSION', '3.0.3');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.0.1
+Stable tag: 3.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.0.3: October 20th, 2023 =
+* Fix: Forms no longer have fatal errors on Elementor websites when the Display Content option is enabled
+
 = 3.0.1: October 17th, 2023 =
 * Fix: Resolved a conflict with Matomo plugin that was causing a fatal error
 

--- a/src/DonationForms/FormPage/TemplateHandler.php
+++ b/src/DonationForms/FormPage/TemplateHandler.php
@@ -2,8 +2,12 @@
 
 namespace Give\DonationForms\FormPage;
 
+use Give\Helpers\Form\Utils;
 use WP_Post as Post;
 
+/**
+ * @since 3.0.0
+ */
 class TemplateHandler
 {
     /**
@@ -22,6 +26,9 @@ class TemplateHandler
         $this->formPageTemplatePath = $formPageTemplatePath;
     }
 
+    /**
+     * @since 3.0.0
+     */
     public function handle($template)
     {
         return $this->isNextGenForm()
@@ -29,10 +36,14 @@ class TemplateHandler
             : $template;
     }
 
+    /**
+     * @unreleased Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
+     * @since      3.0.0
+     */
     protected function isNextGenForm(): bool
     {
         return $this->post
-               && $this->post->post_content
-               &&'give_forms' === $this->post->post_type;
+               && Utils::isV3Form($this->post->ID)
+               && 'give_forms' === $this->post->post_type;
     }
 }

--- a/src/DonationForms/FormPage/TemplateHandler.php
+++ b/src/DonationForms/FormPage/TemplateHandler.php
@@ -37,7 +37,7 @@ class TemplateHandler
     }
 
     /**
-     * @unreleased Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
+     * @since 3.0.3 Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
      * @since      3.0.0
      */
     protected function isNextGenForm(): bool

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -478,7 +478,7 @@ class DonationFormRepository
     }
 
     /**
-     * @unreleased Use isV3Form() method instead of 'post_content' to check if it's a legacy form
+     * @since 3.0.3 Use isV3Form() method instead of 'post_content' to check if it's a legacy form
      * @since 3.0.0
      */
     public function isLegacyForm(int $formId): bool

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -19,6 +19,7 @@ use Give\Framework\Models\ModelQueryBuilder;
 use Give\Framework\PaymentGateways\PaymentGateway;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Helpers\Form\Utils;
 use Give\Helpers\Hooks;
 use Give\Log\Log;
 
@@ -477,13 +478,12 @@ class DonationFormRepository
     }
 
     /**
+     * @unreleased Use isV3Form() method instead of 'post_content' to check if it's a legacy form
      * @since 3.0.0
      */
     public function isLegacyForm(int $formId): bool
     {
-        $form = DB::table('posts')->select(['post_content', 'data'])->where('ID', $formId)->get();
-
-        return empty($form->data);
+        return ! Utils::isV3Form($formId);
     }
 
     /**

--- a/src/FormBuilder/Routes/EditFormRoute.php
+++ b/src/FormBuilder/Routes/EditFormRoute.php
@@ -3,6 +3,7 @@
 namespace Give\FormBuilder\Routes;
 
 use Give\FormBuilder\FormBuilderRouteBuilder;
+use Give\Helpers\Form\Utils;
 
 /**
  * Route to edit an existing form
@@ -10,6 +11,7 @@ use Give\FormBuilder\FormBuilderRouteBuilder;
 class EditFormRoute
 {
     /**
+     * @unreleased Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
      * @since 3.0.0
      *
      * @return void
@@ -18,7 +20,7 @@ class EditFormRoute
     {
         if (isset($_GET['post'], $_GET['action']) && 'edit' === $_GET['action']) {
             $post = get_post(abs($_GET['post']));
-            if ('give_forms' === $post->post_type && $post->post_content) {
+            if ('give_forms' === $post->post_type && Utils::isV3Form($post->ID)) {
                 wp_redirect(FormBuilderRouteBuilder::makeEditFormRoute($post->ID));
                 exit();
             }

--- a/src/FormBuilder/Routes/EditFormRoute.php
+++ b/src/FormBuilder/Routes/EditFormRoute.php
@@ -11,7 +11,7 @@ use Give\Helpers\Form\Utils;
 class EditFormRoute
 {
     /**
-     * @unreleased Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
+     * @since 3.0.3 Use isV3Form() method instead of 'post_content' to check if the form is built with Visual Builder
      * @since 3.0.0
      *
      * @return void


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7057

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

In some places of our codebase, we are assuming that a form is v2 when the `post_content` is empty and v3 when the `post_content` isn't empty. 

The problem is that some users use page editors like Elementor to edit the content (the `post_content` column) of v2 forms. So after doing that a fatal error is thrown and the form doesn't get more rendered in the frontend, and no more can't be edited in the WP admin area.  

This PR fixes this problem!

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Legacy forms with `post_content` populated.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**To replicate the problem:**

1. install GiveWP 3.0 + Elementor
2. create a new legacy form and make sure the Display Content option is enabled
3. Enable Elementor editing for donation forms under Elementor > Settings
4. go back to the form and click on Edit with Elementor
5. add a new paragraph or heading using Elementor
6. save it
7. check the front end - it should be broken

**To test this fix:** 

1. Just pull this branch and the form will not be broken anymore

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205751039286548