### PR TITLE
Hot Fix: Prevent fatal error on save posts or pages with [give_multi_form_goal] shortcode

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.0.2
+ * Version: 3.0.3
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.0.2');
+            define('GIVE_VERSION', '3.0.3');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.0.2
+Stable tag: 3.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.0.3: October 20th, 2023 =
+* Fix: Using the multi-form shortcode with the ids attribute no longer causes a fatal error
+
 = 3.0.2: October 19th, 2023 =
 * Fix: Stripe per-form settings are included when migrating a form to the Visual Donation Form Builder
 * Fix: Gateways are properly separated in the settings page and Global Settings for Fee Recovery shows all gateways when you select per gateway

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -26,6 +26,7 @@ class Shortcode
     /**
      * Returns Shortcode markup
      *
+     * @unreleased Use static function on array_map callback to pass the id as reference for _give_redirect_form_id to prevent warnings on PHP 8.0.1 or plus
      * @since 2.9.0
      **/
     public function renderCallback($attributes)
@@ -49,7 +50,12 @@ class Shortcode
 
         $multiFormGoal = new MultiFormGoal(
             [
-                'ids' => array_map('_give_redirect_form_id', $attributes['ids']),
+                'ids' => array_map(
+                    static function ($id) {
+                        _give_redirect_form_id($id);
+                    },
+                    $attributes['ids']
+                ),
                 'tags' => $attributes['tags'],
                 'categories' => $attributes['categories'],
                 'goal' => $attributes['goal'],

--- a/src/MultiFormGoals/MultiFormGoal/Shortcode.php
+++ b/src/MultiFormGoals/MultiFormGoal/Shortcode.php
@@ -26,7 +26,7 @@ class Shortcode
     /**
      * Returns Shortcode markup
      *
-     * @unreleased Use static function on array_map callback to pass the id as reference for _give_redirect_form_id to prevent warnings on PHP 8.0.1 or plus
+     * @since 3.0.3 Use static function on array_map callback to pass the id as reference for _give_redirect_form_id to prevent warnings on PHP 8.0.1 or plus
      * @since 2.9.0
      **/
     public function renderCallback($attributes)

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -38,7 +38,7 @@ class Model
     /**
      * Get forms associated with Progress Bar
      *
-     * @unreleased Return empty array instead of false
+     * @since 3.0.3 Return empty array instead of false
      * @since 2.9.0
      */
     public function getForms(): array

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -38,6 +38,7 @@ class Model
     /**
      * Get forms associated with Progress Bar
      *
+     * @unreleased Return empty array instead of false
      * @since 2.9.0
      */
     public function getForms(): array
@@ -78,7 +79,7 @@ class Model
 
             return $query->posts;
         } else {
-            return false;
+            return [];
         }
     }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7060

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We are getting a fatal error when users try to use the multi-form shortcode with the ids attribute. 

Something like this: `[give_multi_form_goal ids="31,39] `

This PR fixes this bug - by returning the proper data type in the `getForms()` method - and allows users to use the ids attribute without throwing any fatal error.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The give_multi_form_goal shortcode.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add the Multi-Form Goal Shortcode to a page or post and include the "ids" parameter to only include one or more forms. Example: `[give_multi_form_goal ids="31,39]`
2. Click on "Update"
3. No fatal errors should be thrown and the form should get updated without problems.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205770488963851