### PR TITLE
Fix: return get_post_metadata compatible result from custom filter hook

### DIFF
--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -126,7 +126,7 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Retrieve payment meta field for a payment.
 	 *
-	 * @unreleased Return array, when request raw metadata if $single is set to false and metadata does not exist.
+	 * @unreleased Return empty array, when request raw metadata if $single is set to false and metadata does not exist.
 	 * @since   2.0
 	 *
 	 * @param   int    $id       Pst Type  ID.

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -126,7 +126,7 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Retrieve payment meta field for a payment.
 	 *
-	 * @access  public
+	 * @unreleased Return array, when request raw metadata if $single is set to false and metadata does not exist.
 	 * @since   2.0
 	 *
 	 * @param   int    $id       Pst Type  ID.
@@ -150,7 +150,7 @@ class Give_DB_Meta extends Give_DB {
 
 		if ( $this->raw_result ) {
 			if ( ! ( $value = get_metadata( $this->meta_type, $id, $meta_key, false ) ) ) {
-				$value = '';
+				$value = $single ? '' : array();
 			}
 
 			// Reset flag.


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves https://github.com/impress-org/givewp/discussions/6798

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
https://github.com/impress-org/givewp/blob/33cffa1cc6a2d64f820411eac1d0b65058d4ed85/includes/database/class-give-db-meta.php#L153

I found that `Give_DB_Meta::get_meta` returns an empty `string` when `$single` is set to `false` and metadata does not exist in the database, but the expected value is empty `array.` This triggers a fatal error on PHP `7.4` if this value passes to a function that expects an `array` like: `count`.
To resolve the issue, this function returns `string|array` on the basis of `$single` value.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
This change affects GiveWP core metadata-related queries which use the `get_post_meta` function.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] You should get the same result type when you query metadata for donation and post.
```php
$donation_meta = get_post_meta( 236, 'foo' );
$post_meta = get_post_meta( 1, 'foo' );
```
- [ ] Donors should be able to donate.
- [ ]  Admin should be able to view and edit donors.
- [ ] Admin should be able to view and edit donations.
- [ ] Admin should be able to view and edit the donation form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205830876745239