### PR TITLE
Refactor: use wp scripts to compile Gutenberg blocks

### DIFF
--- a/assets/src/css/frontend/progress-bar.scss
+++ b/assets/src/css/frontend/progress-bar.scss
@@ -7,6 +7,10 @@
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
 */
 
+.components-base-control__field input[type=text]:focus {
+    box-shadow: none !important;
+}
+
 .give-goal-progress {
     display: flex;
     flex-direction: column;

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -618,13 +618,13 @@ class Give_Scripts {
             GIVE_VERSION
         );
 
-        $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/gutenberg.asset.php');
+        $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/adminBlocks.asset.php');
 
         $handle = 'give-blocks-js';
         wp_enqueue_script(
             $handle,
-            GIVE_PLUGIN_URL . 'build/gutenberg.js',
-            $scriptAsset['dependencies'],
+            GIVE_PLUGIN_URL . 'build/adminBlocks.js',
+            array_merge(['give-admin-scripts'], $scriptAsset['dependencies']),
             $scriptAsset['version'],
             true
         );

--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -1,6 +1,8 @@
 <?php
 
+use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Helpers\EnqueueScript;
+use Give\Helpers\Language;
 
 /**
  * Loads the plugin's scripts and styles.
@@ -602,18 +604,13 @@ class Give_Scripts {
     /**
      * Gutenberg admin scripts.
      *
+     * @unreleased Use wp scripts to compile blocks
      * @since 2.19.0 Remove undefined gutenberg.css
      * @since 2.19.6 Load script with EnqueueScript.
      * @since 2.19.6 Load missing block styles
      */
     public function gutenberg_admin_scripts()
     {
-        // Enqueue the bundled block JS file
-        EnqueueScript::make('give-blocks-js', 'assets/dist/js/gutenberg.js')
-            ->dependencies(['give-admin-scripts'])
-            ->registerTranslations()
-            ->enqueue();
-
         wp_enqueue_style(
             'give-blocks-css',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-block-editor.css',
@@ -621,6 +618,17 @@ class Give_Scripts {
             GIVE_VERSION
         );
 
+        $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/gutenberg.asset.php');
 
+        $handle = 'give-blocks-js';
+        wp_enqueue_script(
+            $handle,
+            GIVE_PLUGIN_URL . 'build/gutenberg.js',
+            $scriptAsset['dependencies'],
+            $scriptAsset['version'],
+            true
+        );
+
+        Language::setScriptTranslations($handle);
     }
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -617,6 +617,7 @@ function give_totals_shortcode( $atts ) {
 	/**
 	 * Give Action fire before the shortcode is rendering is started.
 	 *
+     * @unreleased Use static function on array_map callback to pass the id as reference for _give_redirect_form_id to prevent warnings on PHP 8.0.1 or plus
 	 * @since 2.1.4
 	 *
 	 * @param array $atts shortcode attribute.
@@ -631,7 +632,14 @@ function give_totals_shortcode( $atts ) {
 			$form_ids = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 		}
 
-        array_walk($form_ids, '_give_redirect_form_id');
+        array_map(
+            static function ($id) {
+                _give_redirect_form_id($id);
+
+                return $id;
+            },
+            $form_ids
+        );
 
 		/**
 		 * Filter to modify WP Query for Total Goal.

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -34,7 +34,6 @@ mix.setPublicPath('assets/dist')
     .js('assets/src/js/admin/reports/widget.js', 'js/admin-reports-widget.js')
     .js('assets/src/js/admin/onboarding-wizard/index.js', 'js/admin-onboarding-wizard.js')
     .js('includes/admin/shortcodes/admin-shortcodes.js', 'js/')
-    .js('blocks/load.js', 'js/gutenberg.js')
     .js('src/Views/Form/Templates/Sequoia/assets/js/form.js', 'js/give-sequoia-template.js')
     .js('src/Views/Form/Templates/Classic/resources/js/form.js', 'js/give-classic-template.js')
     .js('src/DonorDashboards/resources/js/app/index.js', 'js/donor-dashboards-app.js')
@@ -81,10 +80,6 @@ mix.webpackConfig({
             '@givewp/css': path.resolve(__dirname, 'assets/src/css/'),
             '@givewp/promotions': path.resolve(__dirname, 'src/Promotions/sharedResources/'),
         },
-    },
-    externals: {
-        react: 'React',
-        'react-dom': 'ReactDOM',
     },
     plugins: [
         /*

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -55,7 +55,7 @@ module.exports = {
         baseFormDesignCss: srcPath('DonationForms/resources/styles/base.scss'),
         formBuilderApp: srcPath('FormBuilder/resources/js/form-builder/src/index.tsx'),
         formBuilderRegistrars: srcPath('FormBuilder/resources/js/registrars/index.ts'),
-        gutenberg: path.resolve(process.cwd(), 'blocks', 'load.js'),
+        adminBlocks: path.resolve(process.cwd(), 'blocks', 'load.js'),
     },
 };
 

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
         baseFormDesignCss: srcPath('DonationForms/resources/styles/base.scss'),
         formBuilderApp: srcPath('FormBuilder/resources/js/form-builder/src/index.tsx'),
         formBuilderRegistrars: srcPath('FormBuilder/resources/js/registrars/index.ts'),
+        gutenberg: path.resolve(process.cwd(), 'blocks', 'load.js'),
     },
 };
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Initially, I added [these lines](https://github.com/impress-org/givewp/blob/develop/webpack.mix.js#L85-L88) in the webpack settings file to solve [this other bug](https://github.com/impress-org/givewp/pull/7069) and I didn't notice that it prevent the Donor Dashboard to get loaded.

So, to fix the initial problem and keep the Donor Dashboard working, it was necessary to compile the scripts used in the Gutenberg blocks with WP Scripts.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Multi-Form Goal Block > Progress Bar > Filters
- Donor Dashboard

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a new page;
2. Add the multi-form goal block;
3. Click on the progress bar;
4. On the right side, click on Filters and Filter by form;
5. No more errors should be displayed.
6. Access the Donor Dashboard, it should load without problems.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205799879062087