### PR TITLE
Fix: mysql information displays properly in WP 6.4

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -300,11 +300,7 @@ $give_updates = Give_Updates::get_instance();
 		<?php
 	endif;
 
-	if ( $wpdb->use_mysqli ) {
-		$ver = mysqli_get_server_info( $wpdb->dbh );
-	} else {
-		$ver = mysql_get_server_info();
-	}
+    $ver = mysqli_get_server_info($wpdb->dbh);
 
 	if ( ! empty( $wpdb->is_mysql ) && ! stristr( $ver, 'MariaDB' ) ) :
 		?>


### PR DESCRIPTION
## Description

WordPress has held backwards compatibility for the MySQL PHP extension for a long time, and provided the `$wpdb->use_mysqli` property as a way of checking if a WP instance is using the old extension, or the new(er) mysqli extension.

In WP 6.4, support for the [old extension is being dropped](https://core.trac.wordpress.org/ticket/59118), due to the fact that the extension doesn't exist in PHP 7.0, which is the new minimum required version of WordPress. With this, WP is also dropping the `$wpdb->use_mysqli` property because it's meaningless.

Our code was using both that property _and_, conditionally, the function the used the old extension. Since we don't support <PHP 7.2, we can also drop the use of that function and WP property.

## Affects

The MySQL portion of the system info page

## Testing Instructions

Make sure that the MySQL info loads properly on WP 6.3 **and** 6.4.

## Pre-review Checklist

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

