### PR TITLE
Hot Fix: properly record the Stripe renewals on the Give side

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/ChargeRefunded.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/ChargeRefunded.php
@@ -22,6 +22,7 @@ class ChargeRefunded
      *
      * @see https://stripe.com/docs/api/events/types#event_types-charge.refunded
      *
+     * @unreleased Add exit statement only when the event is successfully processed.
      * @since 3.0.0
      *
      * @return void
@@ -30,20 +31,21 @@ class ChargeRefunded
     public function __invoke(Event $event)
     {
         try {
-            $this->processEvent($event);
+            if ($this->processEvent($event)) {
+                exit;
+            }
         } catch (Exception $exception) {
             $this->logWebhookError($event, $exception);
         }
-
-        exit;
     }
 
     /**
+     * @unreleased Return a bool value.
      * @since 3.0.0
      *
      * @throws Exception
      */
-    public function processEvent(Event $event)
+    public function processEvent(Event $event): bool
     {
         /* @var Charge $stripeCharge */
         $stripeCharge = $event->data->object;
@@ -51,7 +53,7 @@ class ChargeRefunded
         $donation = give()->donations->getByGatewayTransactionId($stripeCharge->payment_intent);
 
         if (!$donation || !$this->shouldProcessDonation($donation)) {
-            return;
+            return false;
         }
 
         if ($stripeCharge->refunded && !$donation->status->isRefunded()) {
@@ -63,5 +65,7 @@ class ChargeRefunded
                 'content' => __('Payment refunded in Stripe.', 'give'),
             ]);
         }
+
+        return true;
     }
 }

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionCreated.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionCreated.php
@@ -20,6 +20,7 @@ class CustomerSubscriptionCreated
      *
      * @see https://stripe.com/docs/api/events/types#event_types-customer.subscription.created
      *
+     * @unreleased Add exit statement only when the event is successfully processed.
      * @since 3.0.0
      *
      * @return void
@@ -28,18 +29,19 @@ class CustomerSubscriptionCreated
     public function __invoke(Event $event)
     {
         try {
-            $this->processEvent($event);
+            if ($this->processEvent($event)) {
+                exit;
+            }
         } catch (Exception $exception) {
             $this->logWebhookError($event, $exception);
         }
-
-        exit;
     }
 
     /**
+     * @unreleased Return a bool value.
      * @since 3.0.0
      */
-    public function processEvent(Event $event)
+    public function processEvent(Event $event): bool
     {
         /* @var StripeSubscription $stripeSubscription */
         $stripeSubscription = $event->data->object;
@@ -48,11 +50,11 @@ class CustomerSubscriptionCreated
 
         // only use this for next gen for now
         if (!$subscription || !$this->shouldProcessSubscription($subscription)) {
-            return;
+            return false;
         }
 
         // exit early to prevent legacy webhook
         // we don't need to do anything here at the moment because the subscription is already created & active
-        exit;
+        return true;
     }
 }

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionDeleted.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionDeleted.php
@@ -21,6 +21,7 @@ class CustomerSubscriptionDeleted
      *
      * @see https://stripe.com/docs/api/events/types#event_types-customer.subscription.deleted
      *
+     * @unreleased Add exit statement only when the event is successfully processed.
      * @since 3.0.0
      *
      * @return void
@@ -29,19 +30,20 @@ class CustomerSubscriptionDeleted
     public function __invoke(Event $event)
     {
         try {
-            $this->processEvent($event);
+            if ($this->processEvent($event)) {
+                exit;
+            }
         } catch (Exception $exception) {
             $this->logWebhookError($event, $exception);
         }
-
-        exit;
     }
 
     /**
+     * @unreleased Return a bool value.
      * @since 3.0.0
      * @throws Exception
      */
-    public function processEvent(Event $event)
+    public function processEvent(Event $event): bool
     {
         /* @var StripeSubscription $stripeSubscription */
         $stripeSubscription = $event->data->object;
@@ -50,12 +52,14 @@ class CustomerSubscriptionDeleted
 
         // only use this for next gen for now
         if (!$subscription || !$this->shouldProcessSubscription($subscription)) {
-            return;
+            return false;
         }
 
         if (!$subscription->status->isCancelled() && !$subscription->status->isCompleted()) {
             $subscription->status = SubscriptionStatus::COMPLETED();
             $subscription->save();
         }
+
+        return true;
     }
 }

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentFailed.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentFailed.php
@@ -21,6 +21,7 @@ class InvoicePaymentFailed
      *
      * @see https://stripe.com/docs/api/events/types#event_types-invoice.payment_failed
      *
+     * @unreleased Add exit statement only when the event is successfully processed.
      * @since 3.0.0
      *
      * @return void
@@ -29,20 +30,21 @@ class InvoicePaymentFailed
     public function __invoke(Event $event)
     {
         try {
-            $this->processEvent($event);
+            if ($this->processEvent($event)) {
+                exit;
+            }
         } catch (Exception $exception) {
             $this->logWebhookError($event, $exception);
         }
-
-        exit;
     }
 
     /**
+     * @unreleased Return a bool value.
      * @since 3.0.0
      *
      * @throws Exception
      */
-    public function processEvent(Event $event)
+    public function processEvent(Event $event): bool
     {
         /* @var Invoice $invoice */
         $invoice = $event->data->object;
@@ -51,7 +53,7 @@ class InvoicePaymentFailed
 
         // only use this for next gen for now
         if (!$subscription || !$this->shouldProcessSubscription($subscription)) {
-            return;
+            return false;
         }
 
         if (
@@ -64,6 +66,8 @@ class InvoicePaymentFailed
             $subscription->status = SubscriptionStatus::FAILING();
             $subscription->save();
         }
+
+        return true;
     }
 
     /**

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/PaymentIntentSucceeded.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/PaymentIntentSucceeded.php
@@ -22,6 +22,7 @@ class PaymentIntentSucceeded
      *
      * @see https://stripe.com/docs/api/events/types#event_types-invoice.payment_succeeded
      *
+     * @unreleased Add exit statement only when the event is successfully processed.
      * @since 3.0.0
      *
      * @return void
@@ -30,18 +31,19 @@ class PaymentIntentSucceeded
     public function __invoke(Event $event)
     {
         try {
-            $this->processEvent($event);
+            if ($this->processEvent($event)) {
+                exit;
+            }
         } catch (Exception $exception) {
             $this->logWebhookError($event, $exception);
         }
-
-        exit;
     }
 
     /**
+     * @unreleased Return a bool value.
      * @since 3.0.0
      */
-    public function processEvent(Event $event)
+    public function processEvent(Event $event): bool
     {
         /* @var PaymentIntent $paymentIntent */
         $paymentIntent = $event->data->object;
@@ -49,7 +51,7 @@ class PaymentIntentSucceeded
         $donation = give()->donations->getByGatewayTransactionId($paymentIntent->id);
 
         if (!$donation || !$this->shouldProcessDonation($donation)) {
-            return;
+            return false;
         }
 
         if ($donation->type->isSingle() && !$donation->status->isComplete()) {
@@ -61,5 +63,7 @@ class PaymentIntentSucceeded
                 'content' => __('Payment succeeded in Stripe.', 'give'),
             ]);
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7076

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The webhook events used by the Stripe Element were using the exit in the wrong place and it was preventing the events from the legacy codebase from running.

This PR fixes this problem.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe renewals in donations/subscriptions created with v2 forms.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Using the latest version of GiveWP and the Recurring Donations add-on, make a recurring donation on a V2 form
2. Spoof a renewal in Stripe by resetting the billing cycle: https://somup.com/c06tcOBP02
3. The renewals should be recorded on the Give side.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205823108730572