### PR TITLE
Fix: pass form id by reference in totals shortcode to avoid PHP warning

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -632,7 +632,7 @@ function give_totals_shortcode( $atts ) {
 			$form_ids = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 		}
 
-        array_map(
+        $form_ids = array_map(
             static function ($id) {
                 _give_redirect_form_id($id);
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -25,6 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Displays a user's donation history.
  *
+ * @unreleased pass form id by reference in give_totals shortcode.
  * @since  1.0
  *
  * @param array       $atts
@@ -639,7 +640,7 @@ function give_totals_shortcode( $atts ) {
             },
             $form_ids
         );
-        
+
 		/**
 		 * Filter to modify WP Query for Total Goal.
 		 *

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -631,8 +631,15 @@ function give_totals_shortcode( $atts ) {
 			$form_ids = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 		}
 
-        array_walk($form_ids, '_give_redirect_form_id');
+        array_map(
+            static function ($id) {
+                _give_redirect_form_id($id);
 
+                return $id;
+            },
+            $form_ids
+        );
+        
 		/**
 		 * Filter to modify WP Query for Total Goal.
 		 *

--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -94,6 +94,7 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
             <?php
             if (
                 $atts['show_comments']
+                && empty($donation['_give_anonymous_donation'])
                 && absint($atts['comment_length'])
                 && !empty($donation['donor_comment'])
             ) :


### PR DESCRIPTION
Resolves https://app.asana.com/0/1205428662243164/1205836070799020

## Description

This PR addresses the following warning 
`Warning: _give_redirect_form_id(): Argument #2 must be passed by reference, value given in /Users/joshuadinh/Local Sites/givewpdeveloper/app/public/wp-content/plugins/givewp/includes/shortcodes.php on line 634 from this line         array_walk($form_ids, '_give_redirect_form_id');
`

## Testing Instructions

- Add totals shortccode to a page.
- Verify no warning displays.
- Example shortcode : `[give_totals ids="1460" message="Thanks to you, we’ve raised {total} across all our congregations combined! Let's keep it up!" progress_bar="true"]`

## Pre-review Checklist
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205845725895553