### PR TITLE
feature: include shortcode format support for v3 forms

### DIFF
--- a/src/DonationForms/Shortcodes/GiveFormShortcode.php
+++ b/src/DonationForms/Shortcodes/GiveFormShortcode.php
@@ -19,10 +19,16 @@ class GiveFormShortcode
             return $output;
         }
 
+        $formFormat = (isset($atts['display_style']) && !empty($atts['display_style'])) ? $atts['display_style'] : 'full';
+        $openFormButton = (isset($atts['continue_button_title']) && !empty($atts['continue_button_title'])) ? $atts['continue_button_title'] : __('Donate now','give');
+
         $controller = new BlockRenderController();
         $blockAttributes = [
             'formId' => $formId,
             'blockId' => 'give-form-shortcode-' . uniqid(),
+            'showTitle' => $atts['show_title'],
+            'formFormat' => $formFormat,
+            'openFormButton' => $openFormButton
         ];
 
         $output = $controller->render($blockAttributes);


### PR DESCRIPTION
## Description

This PR includes changes required to pass both 'display_style' and 'continue_button_title' from a shortcode to a v3 form.


## Affects

shortcode with v3 forms.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

