### PR TITLE
fix: Restore givewp namespace for supports feature

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -25,7 +25,7 @@ const FieldSettingsHOC = createHigherOrderComponent((BlockEdit) => {
 
         const fieldSettings: FieldSettings = useMemo(() => {
             // @ts-ignore
-          const giveSupports = getBlockSupport(name, 'give') as GiveWPSupports;
+          const giveSupports = getBlockSupport(name, 'givewp') as GiveWPSupports;
 
             return normalizeFieldSettings(giveSupports?.fieldSettings);
         }, [name]);


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR restore the supports feature namespace to `givewp`.

The namespace for the supports feature is `givewp,` but was updated to `give` during a recent update of text domains for translations.

This effects the Text Field and other custom fields provided by Form Field Manager.

See [https://github.com/impress-org/givewp/commit/e63e340f4af1525e22c3d4467668b4fe717d1188#diff-0c9fff56298afb7f25c7be3f[…]d99ddf3c2cfe0890d4db5f5ff83L28](https://github.com/impress-org/givewp/commit/e63e340f4af1525e22c3d4467668b4fe717d1188#diff-0c9fff56298afb7f25c7be3fbba6479227010d99ddf3c2cfe0890d4db5f5ff83L28)

```diff
        const fieldSettings: FieldSettings = useMemo(() => {
            // @ts-ignore
-          const giveSupports = getBlockSupport(name, 'givewp') as GiveWPSupports;
+          const giveSupports = getBlockSupport(name, 'give') as GiveWPSupports;

            return normalizeFieldSettings(giveSupports?.fieldSettings);
        }, [name]);
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Check that the Text Field block has sidebar settings.
- Same for all FFM custom field blocks.

