### PR TITLE
Fix: use custom gateway label for confirmation page payment method

### DIFF
--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -80,6 +80,11 @@ class GenerateConfirmationPageReceipt
     {
         /** @var PaymentGatewayRegister $paymentGatewayRegistrar */
         $paymentGatewayRegistrar = give(PaymentGatewayRegister::class);
+        $paymentMethodLabel = give_get_gateway_checkout_label($receipt->donation->gatewayId, null);
+
+        if (empty($paymentMethodLabel) || $paymentMethodLabel === $receipt->donation->gatewayId) {
+            $paymentMethodLabel = $paymentGatewayRegistrar->hasPaymentGateway($receipt->donation->gatewayId) ? $paymentGatewayRegistrar->getPaymentGateway($receipt->donation->gatewayId)->getPaymentMethodLabel() : $receipt->donation->gatewayId;
+        }
 
         $receipt->donationDetails->addDetails([
                 new ReceiptDetail(
@@ -88,9 +93,7 @@ class GenerateConfirmationPageReceipt
                 ),
                 new ReceiptDetail(
                     __('Payment Method', 'give'),
-                    $paymentGatewayRegistrar->hasPaymentGateway(
-                        $receipt->donation->gatewayId
-                    ) ? $receipt->donation->gateway()->getPaymentMethodLabel() : $receipt->donation->gatewayId
+                    $paymentMethodLabel
                 ),
                 new ReceiptDetail(
                     __('Donation Amount', 'give'),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7084

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the confirmation page "Payment Method" label to display as the gateway checkout label as defined in gateway settings.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation confirmation page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="676" alt="Screenshot 2023-11-02 at 3 33 02 PM" src="https://github.com/impress-org/givewp/assets/10138447/48d48c56-5774-43ec-a169-ed64a05b0e23">

<img width="828" alt="Screenshot 2023-11-02 at 3 33 08 PM" src="https://github.com/impress-org/givewp/assets/10138447/51fe0c8d-f2f9-43b2-87cd-dd0753ceee60">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Go to gateway settings and update the checkout label to something different
- Enable the gateway and donate with it using a v3 form
- The confirmation page should display the defined checkout label from settings in the "payment method" line item

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205864698866801