### PR TITLE
Fix: ensure embedded v3 forms redirect to confirmation page

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.1.0
+ * Version: 3.1.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -391,7 +391,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.1.0');
+            define('GIVE_VERSION', '3.1.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.1.0
+Stable tag: 3.1.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.1.1: November 3rd, 2023 =
+* Fix: Embedded forms created with the Visual Builder now redirect to the confirmation page after a completed donation.
+
 = 3.1.0: October 25th, 2023 =
 * Feature: Design Mode changes in the Form Builder are now instant and awesome! Instant gratification!
 * Feature: Donor prefixes can now easily be reordered in the Donor Name block

--- a/src/DonationForms/Shortcodes/GiveFormShortcode.php
+++ b/src/DonationForms/Shortcodes/GiveFormShortcode.php
@@ -13,7 +13,7 @@ class GiveFormShortcode
     public static $instance = 0;
 
     /**
-     * @unreleased use static instance ID to simulate blockId attribute
+     * @since 3.1.1 use static instance ID to simulate blockId attribute
      * @since 3.0.0
      */
     public function __invoke(string $output, array $atts): string

--- a/src/DonationForms/Shortcodes/GiveFormShortcode.php
+++ b/src/DonationForms/Shortcodes/GiveFormShortcode.php
@@ -8,10 +8,18 @@ use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderControlle
 class GiveFormShortcode
 {
     /**
+     * @var int $instance
+     */
+    public static $instance = 0;
+
+    /**
+     * @unreleased use static instance ID to simulate blockId attribute
      * @since 3.0.0
      */
     public function __invoke(string $output, array $atts): string
     {
+        self::$instance++;
+
         $formId = absint($atts['id']);
         $isV3Form = (bool) give()->form_meta->get_meta($formId, 'formBuilderSettings', true);
 
@@ -22,7 +30,7 @@ class GiveFormShortcode
         $controller = new BlockRenderController();
         $blockAttributes = [
             'formId' => $formId,
-            'blockId' => 'give-form-shortcode-' . uniqid(),
+            'blockId' => 'give-form-shortcode-' . self::$instance,
         ];
 
         $output = $controller->render($blockAttributes);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7086

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This ensures embedded v3 forms redirect to the confirmation page.  

More specifically, this adds a static instance counter to the shortcode action to simulate the `blockId` attribute that v3 form blocks use (which is philosophically the same). When the page is redirecting with the intention of displaying the confirmation inline, the embed ID needs to exist on the page so it knows where to place an inline redirect.  Previously this was using a `uniqueId()` which means the embed Id was never found.  

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- v3 Forms rendered from a shortcode (or existing v2 form block).

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="847" alt="Screenshot 2023-11-02 at 5 25 29 PM" src="https://github.com/impress-org/givewp/assets/10138447/4940ea55-a9ce-4433-94b1-42f0d223c92e">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a v3 form 
- Create a new page
- Add 2 or more forms to a page using the give form shortcode and/or donation form block
- Use stripe payment element test mode and submit a form
- The page should refresh and the one submitted should display the confirmation page inline.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205870379741212