### PR TITLE
Refactor: plans and pricing promotional content

### DIFF
--- a/src/Framework/PaymentGateways/Routes/RouteSignature.php
+++ b/src/Framework/PaymentGateways/Routes/RouteSignature.php
@@ -2,8 +2,6 @@
 
 namespace Give\Framework\PaymentGateways\Routes;
 
-use Give\Framework\Shims\Shim;
-
 /**
  * Route signature for creating secure gateway route methods
  *

--- a/src/Promotions/InPluginUpsells/AddonsAdminPage.php
+++ b/src/Promotions/InPluginUpsells/AddonsAdminPage.php
@@ -5,7 +5,6 @@ namespace Give\Promotions\InPluginUpsells;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-use Give\Framework\Shims\Shim;
 use Give\Helpers\EnqueueScript;
 
 /**

--- a/src/Promotions/InPluginUpsells/SaleBanners.php
+++ b/src/Promotions/InPluginUpsells/SaleBanners.php
@@ -5,7 +5,6 @@ namespace Give\Promotions\InPluginUpsells;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-use Give\Framework\Shims\Shim;
 
 /**
  * @since 2.17.0

--- a/src/Promotions/InPluginUpsells/resources/js/components/PricingPlans.js
+++ b/src/Promotions/InPluginUpsells/resources/js/components/PricingPlans.js
@@ -3,6 +3,7 @@ import {Hero} from './Hero';
 import styles from './PricingPlans.module.css';
 
 const {heading, description, plansButtonCaption, plans} = window.GiveAddons.pricingPlans;
+const {promotionalData} = window.GiveAddons;
 
 const customPlanOrder = ['Plus Plan', 'Pro Plan', 'Basic Plan', 'Agency Plan'];
 
@@ -14,7 +15,7 @@ const sortedPlans = plans.slice().sort((a, b) => {
 
 export const PricingPlans = () => (
     <article>
-        <Hero heading={heading} description={description} />
+        <Hero heading={promotionalData?.heading ?? heading} description={promotionalData?.description ?? description} />
         <ul className={styles.plans}>
             {sortedPlans.map((plan) => (
                 <li key={plan.name}>
@@ -24,7 +25,7 @@ export const PricingPlans = () => (
                         actionText={plansButtonCaption}
                         actionLink={plan.url}
                         icon={plan.icon}
-                        savingsPercentage={plan.savingsPercentage}
+                        savingsPercentage={promotionalData.savingsPercentage ?? plan.savingsPercentage}
                         includes={plan.includes}
                         isMostPopular={plan.mostPopular}
                     />


### PR DESCRIPTION
Resolves: https://app.asana.com/0/1205251546311816/1205651762721233

## Description

This PR allows promotional pricing content to be inserted into the Add-ons page during the BF event week notifying users of discounted sale's prices on plans. 

Sale's period:
```
'startDate' => '2023-11-20 00:00',
'endDate' => '2023-11-29 23:59',
```

## Affects
- Add-ons page

## Visuals
### Before:
<img width="1719" alt="Screen Shot 2023-11-06 at 10 11 57 AM" src="https://github.com/impress-org/givewp/assets/75056371/66a5447e-6c31-44fb-a0b1-8a0c51b7426f">

### After:
<img width="1719" alt="Screen Shot 2023-11-06 at 10 11 41 AM" src="https://github.com/impress-org/givewp/assets/75056371/eea7d051-f52b-4950-8643-47619ac98ce9">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

