### PR TITLE
Fix: provide fallback for donation mode during model queries

### DIFF
--- a/src/Donations/DataTransferObjects/DonationQueryData.php
+++ b/src/Donations/DataTransferObjects/DonationQueryData.php
@@ -124,6 +124,7 @@ final class DonationQueryData
     /**
      * Convert data from object to Donation
      *
+     * @unreleased add fallback for donation mode
      * @since 2.23.0 remove parentId property
      * @since 2.22.0 add support for company field
      * @since 2.20.0 update for new amount property, fee amount recovered, and exchange rate
@@ -139,6 +140,7 @@ final class DonationQueryData
 
         $currency = $donationQueryObject->{DonationMetaKeys::CURRENCY()->getKeyAsCamelCase()};
         $feeAmountRecovered = $donationQueryObject->{DonationMetaKeys::FEE_AMOUNT_RECOVERED()->getKeyAsCamelCase()};
+        $donationMode = $donationQueryObject->{DonationMetaKeys::MODE()->getKeyAsCamelCase()};
 
         $self->id = (int)$donationQueryObject->id;
         $self->formId = (int)$donationQueryObject->{DonationMetaKeys::FORM_ID()->getKeyAsCamelCase()};
@@ -158,7 +160,7 @@ final class DonationQueryData
         $self->updatedAt = Temporal::toDateTime($donationQueryObject->updatedAt);
         $self->status = new DonationStatus($donationQueryObject->status);
         $self->subscriptionId = (int)$donationQueryObject->{DonationMetaKeys::SUBSCRIPTION_ID()->getKeyAsCamelCase()};
-        $self->mode = new DonationMode($donationQueryObject->{DonationMetaKeys::MODE()->getKeyAsCamelCase()});
+        $self->mode = DonationMode::isValid($donationMode) ? new DonationMode($donationMode) : DonationMode::LIVE();
         $self->billingAddress = BillingAddress::fromArray([
             'country' => $donationQueryObject->{DonationMetaKeys::BILLING_COUNTRY()->getKeyAsCamelCase()},
             'city' => $donationQueryObject->{DonationMetaKeys::BILLING_CITY()->getKeyAsCamelCase()},

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -276,13 +276,7 @@ class ListDonations extends Endpoint
         }
 
         if ($hasWhereConditions) {
-            if ($testMode){
-                $query->having(
-                'give_donationmeta_attach_meta_mode.meta_value',
-                '=',
-                DonationMode::TEST
-                );
-            }
+           $query->havingRaw('HAVING COALESCE(give_donationmeta_attach_meta_mode.meta_value, %s) = %s', DonationMode::LIVE, $testMode ? DonationMode::TEST : DonationMode::LIVE);
         } elseif ($testMode) {
             $query->where('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST);
         } else {

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -276,14 +276,24 @@ class ListDonations extends Endpoint
         }
 
         if ($hasWhereConditions) {
-            // TODO this would only work if the donation mode is set to test or live - not null
-            $query->having('give_donationmeta_attach_meta_mode.meta_value', '=', $testMode ? DonationMode::TEST : DonationMode::LIVE);
+            $query->having(
+                'give_donationmeta_attach_meta_mode.meta_value',
+                '=',
+                $testMode ? DonationMode::TEST : DonationMode::LIVE
+            );
+
+            if (!$testMode) {
+                $query->orHaving('give_donationmeta_attach_meta_mode.meta_value', '=', '');
+            }
         } elseif ($testMode){
             $query->where('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST);
         } else {
             $query->whereIsNull('give_donationmeta_attach_meta_mode.meta_value')
-                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::LIVE);
+                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::LIVE)
+                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST, '<>');
         }
+
+
 
         return [
             $query,

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -8,6 +8,7 @@ use Give\Donations\ValueObjects\DonationMode;
 use Give\Framework\Database\DB;
 use Give\Framework\ListTable\Exceptions\ColumnIdCollisionException;
 use Give\Framework\QueryBuilder\QueryBuilder;
+use Give\Framework\QueryBuilder\Types\Operator;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -275,9 +276,13 @@ class ListDonations extends Endpoint
         }
 
         if ($hasWhereConditions) {
+            // TODO this would only work if the donation mode is set to test or live - not null
             $query->having('give_donationmeta_attach_meta_mode.meta_value', '=', $testMode ? DonationMode::TEST : DonationMode::LIVE);
+        } elseif ($testMode){
+            $query->where('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST);
         } else {
-            $query->where('give_donationmeta_attach_meta_mode.meta_value', $testMode ? DonationMode::TEST : DonationMode::LIVE);
+            $query->whereIsNull('give_donationmeta_attach_meta_mode.meta_value')
+                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::LIVE);
         }
 
         return [

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -276,24 +276,19 @@ class ListDonations extends Endpoint
         }
 
         if ($hasWhereConditions) {
-            $query->having(
+            if ($testMode){
+                $query->having(
                 'give_donationmeta_attach_meta_mode.meta_value',
                 '=',
-                $testMode ? DonationMode::TEST : DonationMode::LIVE
-            );
-
-            if (!$testMode) {
-                $query->orHaving('give_donationmeta_attach_meta_mode.meta_value', '=', '');
+                DonationMode::TEST
+                );
             }
-        } elseif ($testMode){
+        } elseif ($testMode) {
             $query->where('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST);
         } else {
             $query->whereIsNull('give_donationmeta_attach_meta_mode.meta_value')
-                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::LIVE)
-                ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST, '<>');
+            ->orWhere('give_donationmeta_attach_meta_mode.meta_value', DonationMode::TEST, '<>');
         }
-
-
 
         return [
             $query,

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -209,6 +209,7 @@ class ListDonations extends Endpoint
     }
 
     /**
+     * @unreleased Updated query to account for possible null and empty values for _give_payment_mode meta
      * @since 2.24.0 Remove joins as it uses ModelQueryBuilder and change clauses to use attach_meta
      * @since      2.21.0
      *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7096 [GIVE-27]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves an issue where in some cases the donation mode was not stored in the database and the donation model query was causing an error from expecting a value.  This is most notable on the admin list table.  The simplest way to resolve this is to have a static fallback which was updated in this PR.  

Typically we would create a migration for missing data that is expected, but this is unique in that we would have no way of knowing what the actual donation mode was at the time of creation.  Furthermore, in terms of backwards compatibility - this could be a persistent issue from a third party add-on that intercepts or modifies the donation.  So the safest and simplest option is just to have a static fallback value of "live" as that is always the assumption unless specifically defined as "test".

For clarity, in GiveWP 3.0+ forms, we are confident that the payment mode is always stored.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The donation list table when payment mode meta is missing

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a donation without a payment mode
- View the list table and make sure it shows up properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-27]: https://stellarwp.atlassian.net/browse/GIVE-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ