### PR TITLE
Feature: All donors are registered as users (only applies to v3 forms)

### DIFF
--- a/src/DonationForms/Controllers/DonateController.php
+++ b/src/DonationForms/Controllers/DonateController.php
@@ -20,6 +20,7 @@ class DonateController
     /**
      * First we create a donation and/or subscription, then move on to the gateway processing
      *
+     * @unreleased Pass the form ID to match updated signature for getOrCreateDonor().
      * @since 3.0.0
      *
      * @return void
@@ -28,6 +29,7 @@ class DonateController
     public function donate(DonateControllerData $formData, PaymentGateway $gateway)
     {
         $donor = $this->getOrCreateDonor(
+            $formData->formId,
             $formData->wpUserId,
             $formData->email,
             $formData->firstName,
@@ -76,8 +78,10 @@ class DonateController
     }
 
     /**
+     * @unreleased Added $formId to the signature for passing to do_action hooks.
      * @since 3.0.0
      *
+     * @param  int  $formId
      * @param  int|null  $userId
      * @param  string  $donorEmail
      * @param  string  $firstName
@@ -87,6 +91,7 @@ class DonateController
      * @throws Exception
      */
     private function getOrCreateDonor(
+        int $formId,
         int $userId,
         string $donorEmail,
         string $firstName,
@@ -115,6 +120,13 @@ class DonateController
                 'email' => $donorEmail,
                 'userId' => $userId ?: null
             ]);
+
+            /**
+             * @unreleased Add a new do_action hook to differentiate when a v3 form creates a new donor.
+             * @param Donor $donor
+             * @param int $formId
+             */
+            do_action('givewp_donate_controller_donor_created', $donor, $formId);
         }
 
         return $donor;

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -63,6 +63,7 @@ class FormSettings implements Arrayable, Jsonable
      */
     public $goalAmount;
     /**
+     * @unreleased Added registrationNotification property.
      * @var string
      */
     public $registrationNotification;
@@ -175,6 +176,7 @@ class FormSettings implements Arrayable, Jsonable
     public $pdfSettings;
 
     /**
+     * @unreleased Added registrationNotification
      * @since 3.0.0
      */
     public static function fromArray(array $array): self

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -65,7 +65,7 @@ class FormSettings implements Arrayable, Jsonable
     /**
      * @var string
      */
-    public $registration;
+    public $registrationNotification;
     /**
      * @var string
      */
@@ -200,7 +200,7 @@ class FormSettings implements Arrayable, Jsonable
         $self->primaryColor = $array['primaryColor'] ?? '#69b86b';
         $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';
         $self->goalAmount = $array['goalAmount'] ?? 0;
-        $self->registration = $array['registration'] ?? 'none';
+        $self->registrationNotification = $array['registrationNotification'] ?? false;
         $self->customCss = $array['customCss'] ?? '';
         $self->pageSlug = $array['pageSlug'] ?? '';
         $self->goalAchievedMessage = $array['goalAchievedMessage'] ?? __(

--- a/src/Donors/Actions/CreateUserFromDonor.php
+++ b/src/Donors/Actions/CreateUserFromDonor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Give\Donors\Actions;
+
+use Give\Donors\Models\Donor;
+
+/**
+ * @unreleased
+ */
+class CreateUserFromDonor
+{
+    public function __invoke(Donor $donor)
+    {
+        $userIdOrError = wp_insert_user(apply_filters(
+            'givewp_create_donor_new_user',
+            [
+                'user_login'      => $donor->email,
+                'user_pass'       => wp_generate_password(),
+                'user_email'      => $donor->email,
+                'first_name'      => $donor->firstName,
+                'last_name'       => $donor->lastName,
+                'role'            => give_get_option( 'donor_default_user_role', 'give_donor' ),
+            ],
+            $donor
+        ));
+
+        if(!is_wp_error($userIdOrError)) {
+            $donor->userId = $userIdOrError;
+        } else {
+            // How should we handle this?
+            throw new \Exception('Could not create user from donor');
+        }
+
+        do_action('givewp_donor_user_created', $donor);
+
+        $donor->save();
+
+        return $donor;
+    }
+}

--- a/src/Donors/Actions/SendDonorUserRegistrationNotification.php
+++ b/src/Donors/Actions/SendDonorUserRegistrationNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Give\Donors\Actions;
+
+use Give\Donors\Models\Donor;
+use Give_Donor_Register_Email;
+
+/**
+ * @unreleased
+ */
+class SendDonorUserRegistrationNotification
+{
+    /**
+     * @var Give_Donor_Register_Email
+     */
+    protected $email;
+
+    public function __construct(Give_Donor_Register_Email $email)
+    {
+        $this->email = $email;
+        $this->email->init();
+    }
+
+    public function __invoke(Donor $donor)
+    {
+        // Enable the `donor-register` (legacy) email notification.
+        add_filter( "give_donor-register_is_email_notification_active", '__return_true' );
+
+        // For legacy email notifications `setup_email_notification()` calls `send_email_notification()`.
+        $this->email->setup_email_notification($donor->userId, [
+            'email' => $donor->email
+        ]);
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-20]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements the feature that all donors created by v3 forms have a registered WordPress user.

Additionally, the form can be configured to send a New User Registration email when a WordPress user is created.

Note: The New User Registration Email can be disabled globally. In order to be sent by a v3 form the email must be enabled globally AND the notification must be enabled in the v3 form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Adds a new `do_action` hook to the Donate Controller when a donor is created.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/c49cc84a-f9b8-4d10-8e71-67e219e749c0)

![image](https://github.com/impress-org/givewp/assets/10858303/67eb8ad5-a32c-43e8-a51d-8e26513daf77)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- New donors should have an associated WordPress user.
- If enabled, new donors should receive a New User Registration Email.