### PR TITLE
Add filters when a payment is complete, processing or pending

### DIFF
--- a/src/Framework/PaymentGateways/Actions/HandleGatewayPaymentCommand.php
+++ b/src/Framework/PaymentGateways/Actions/HandleGatewayPaymentCommand.php
@@ -45,6 +45,8 @@ class HandleGatewayPaymentCommand
 
             $handler->handle($donation);
 
+            do_action('give_payment_complete', $donation);
+
             return new RedirectResponse(give_get_success_page_uri());
         }
 
@@ -53,6 +55,8 @@ class HandleGatewayPaymentCommand
 
             $handler->handle($donation);
 
+            do_action('give_payment_processing', $donation);
+
             return new RedirectResponse(give_get_success_page_uri());
         }
 
@@ -60,6 +64,8 @@ class HandleGatewayPaymentCommand
             $handler = new PaymentPendingHandler($command);
 
             $handler->handle($donation);
+
+            do_action('give_payment_pending', $donation);
 
             return new RedirectResponse(give_get_success_page_uri());
         }


### PR DESCRIPTION
I need a filter when a payment is accepted, before the confirmation page is displayed. I started the discussion [https://github.com/impress-org/givewp/discussions/7108] to explain my problem. I suggest directly these filters.


