### PR TITLE
Avoid a fatal error when activating GiveWP for a new site

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -26,32 +26,30 @@ class SetPayPalStandardGatewayId extends Migration
         $give_settings = give_get_settings();
         $gateways = $give_settings['gateways'];
         $updateSettings = false;
-        if ( $gateways ) {
 
-            if (array_key_exists('paypal-standard', $gateways)) {
-                unset($gateways['paypal-standard']);
-                $gateways['paypal'] = '1';
-                $give_settings['gateways'] = $gateways;
-    
+        if (is_array($gateways) && array_key_exists('paypal-standard', $gateways)) {
+            unset($gateways['paypal-standard']);
+            $gateways['paypal'] = '1';
+            $give_settings['gateways'] = $gateways;
+
+            $updateSettings = true;
+        }
+
+        // Reset paypal gateway custom label.
+        if (isset($give_settings['gateways_label'])) {
+            $gateways_label = $give_settings['gateways_label'];
+            if (array_key_exists('paypal-standard', $gateways_label)) {
+                $gateways_label['paypal'] = $gateways_label['paypal-standard'];
+                unset($gateways_label['paypal-standard']);
+                $give_settings['gateways_label'] = $gateways_label;
                 $updateSettings = true;
             }
-    
-            // Reset paypal gateway custom label.
-            if (isset($give_settings['gateways_label'])) {
-                $gateways_label = $give_settings['gateways_label'];
-                if (array_key_exists('paypal-standard', $gateways_label)) {
-                    $gateways_label['paypal'] = $gateways_label['paypal-standard'];
-                    unset($gateways_label['paypal-standard']);
-                    $give_settings['gateways_label'] = $gateways_label;
-                    $updateSettings = true;
-                }
-            }
-    
-            // Set paypal standard as default payment gateway.
-            if ('paypal-standard' === $give_settings['default_gateway']) {
-                $give_settings['default_gateway'] = 'paypal';
-                $updateSettings = true;
-            }
+        }
+
+        // Set paypal standard as default payment gateway.
+        if ('paypal-standard' === $give_settings['default_gateway']) {
+            $give_settings['default_gateway'] = 'paypal';
+            $updateSettings = true;
         }
 
         if ($updateSettings) {

--- a/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -26,30 +26,32 @@ class SetPayPalStandardGatewayId extends Migration
         $give_settings = give_get_settings();
         $gateways = $give_settings['gateways'];
         $updateSettings = false;
+        if ( $gateways ) {
 
-        if (array_key_exists('paypal-standard', $gateways)) {
-            unset($gateways['paypal-standard']);
-            $gateways['paypal'] = '1';
-            $give_settings['gateways'] = $gateways;
-
-            $updateSettings = true;
-        }
-
-        // Reset paypal gateway custom label.
-        if (isset($give_settings['gateways_label'])) {
-            $gateways_label = $give_settings['gateways_label'];
-            if (array_key_exists('paypal-standard', $gateways_label)) {
-                $gateways_label['paypal'] = $gateways_label['paypal-standard'];
-                unset($gateways_label['paypal-standard']);
-                $give_settings['gateways_label'] = $gateways_label;
+            if (array_key_exists('paypal-standard', $gateways)) {
+                unset($gateways['paypal-standard']);
+                $gateways['paypal'] = '1';
+                $give_settings['gateways'] = $gateways;
+    
                 $updateSettings = true;
             }
-        }
-
-        // Set paypal standard as default payment gateway.
-        if ('paypal-standard' === $give_settings['default_gateway']) {
-            $give_settings['default_gateway'] = 'paypal';
-            $updateSettings = true;
+    
+            // Reset paypal gateway custom label.
+            if (isset($give_settings['gateways_label'])) {
+                $gateways_label = $give_settings['gateways_label'];
+                if (array_key_exists('paypal-standard', $gateways_label)) {
+                    $gateways_label['paypal'] = $gateways_label['paypal-standard'];
+                    unset($gateways_label['paypal-standard']);
+                    $give_settings['gateways_label'] = $gateways_label;
+                    $updateSettings = true;
+                }
+            }
+    
+            // Set paypal standard as default payment gateway.
+            if ('paypal-standard' === $give_settings['default_gateway']) {
+                $give_settings['default_gateway'] = 'paypal';
+                $updateSettings = true;
+            }
         }
 
         if ($updateSettings) {


### PR DESCRIPTION
If GiveWP is activated on a new site, there is a fatal error:  Fatal error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in /var/www/html/wordpress/wp-content/plugins/give/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php:30 Stack trace: #0 

For a new site, no gateway is defined, and $gateways is null.