### PR TITLE
Refactor: changes to accommodate Funds and Designations 3.0 Compatibility

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsHeader.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsHeader.tsx
@@ -1,15 +1,15 @@
-import {__} from '@wordpress/i18n';
 import {BaseControl, Button} from '@wordpress/components';
 
 import {plusCircle} from './icons';
+import {OptionsHeaderProps} from '@givewp/form-builder/components/OptionsPanel/types';
 
-export default function OptionsHeader({handleAddOption}: {handleAddOption: () => void}) {
+export default function OptionsHeader({handleAddOption, label, readOnly}: OptionsHeaderProps) {
     return (
         <div className={'givewp-options-header'}>
-            <BaseControl.VisualLabel className={'givewp-options-header--label'}>
-                {__('Options', 'give')}
-            </BaseControl.VisualLabel>
-            <Button icon={plusCircle} className={'givewp-options-header--button'} onClick={handleAddOption} />
+            <BaseControl.VisualLabel className={'givewp-options-header--label'}>{label}</BaseControl.VisualLabel>
+            {!readOnly && (
+                <Button icon={plusCircle} className={'givewp-options-header--button'} onClick={handleAddOption} />
+            )}
         </div>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsItem.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsItem.tsx
@@ -18,6 +18,7 @@ export default function OptionsItem({
     handleUpdateOptionValue,
     handleUpdateOptionChecked,
     handleRemoveOption,
+    readOnly,
 }: OptionsItemProps) {
     return (
         <div className={'givewp-options-list--item'} ref={provided.innerRef} {...provided.draggableProps}>
@@ -64,6 +65,7 @@ export default function OptionsItem({
                             value={option.label}
                             placeholder={__('Label', 'give')}
                             onChange={(event) => handleUpdateOptionLabel(event.target.value)}
+                            readOnly={readOnly}
                         />
 
                         {showValues && (
@@ -72,16 +74,19 @@ export default function OptionsItem({
                                 value={option.value}
                                 placeholder={__('Value', 'give')}
                                 onChange={(event) => handleUpdateOptionValue(event.target.value)}
+                                readOnly={readOnly}
                             />
                         )}
                     </>
                 )}
             </div>
-            <Button
-                icon={minusCircle}
-                className={'givewp-options-list--item--button'}
-                onClick={() => handleRemoveOption()}
-            />
+            {!readOnly && (
+                <Button
+                    icon={minusCircle}
+                    className={'givewp-options-list--item--button'}
+                    onClick={() => handleRemoveOption()}
+                />
+            )}
         </div>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsList.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/OptionsList.tsx
@@ -12,6 +12,7 @@ export default function OptionsList({
     setOptions,
     defaultControlsTooltip,
     onRemoveOption,
+    readOnly,
 }: OptionsListProps) {
     const handleRemoveOption = (index: number) => (): void => {
         if (onRemoveOption) {
@@ -94,6 +95,7 @@ export default function OptionsList({
                                             handleUpdateOptionLabel={handleUpdateOptionLabel(index)}
                                             handleUpdateOptionValue={handleUpdateOptionValue(index)}
                                             handleUpdateOptionChecked={handleUpdateOptionChecked(index, multiple)}
+                                            readOnly={readOnly}
                                         />
                                     )}
                                 </Draggable>

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/index.tsx
@@ -15,6 +15,8 @@ export default function Options({
     defaultControlsTooltip,
     onAddOption,
     onRemoveOption,
+    readOnly = false,
+    label = __('Options', 'give'),
 }: OptionsPanelProps) {
     const [showValues, setShowValues] = useState<boolean>(false);
 
@@ -29,7 +31,7 @@ export default function Options({
 
     return (
         <>
-            {!currency && (
+            {!currency && !readOnly && (
                 <PanelRow>
                     <ToggleControl
                         label={__('Show values', 'give')}
@@ -40,7 +42,7 @@ export default function Options({
             )}
             <PanelRow>
                 <BaseControl id={'give'}>
-                    <OptionsHeader handleAddOption={handleAddOption} />
+                    <OptionsHeader handleAddOption={handleAddOption} label={label} readOnly={readOnly} />
                     <OptionsList
                         currency={currency}
                         options={options}
@@ -50,6 +52,7 @@ export default function Options({
                         setOptions={setOptions}
                         defaultControlsTooltip={defaultControlsTooltip}
                         onRemoveOption={onRemoveOption}
+                        readOnly={readOnly}
                     />
                 </BaseControl>
             </PanelRow>

--- a/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/components/OptionsPanel/types.ts
@@ -7,6 +7,8 @@ export interface OptionsPanelProps {
     setOptions: (options: OptionProps[]) => void;
     onRemoveOption?: (option: OptionProps, index: number) => void;
     onAddOption?: () => void;
+    label?: string;
+    readOnly?: boolean;
 }
 
 export interface OptionsListProps {
@@ -18,6 +20,7 @@ export interface OptionsListProps {
     defaultControlsTooltip?: string;
     setOptions: (options: OptionProps[]) => void;
     onRemoveOption?: (option: OptionProps, index: number) => void;
+    readOnly?: boolean;
 }
 
 export interface OptionsItemProps {
@@ -32,6 +35,13 @@ export interface OptionsItemProps {
     handleUpdateOptionValue: (value: string) => void;
     handleUpdateOptionChecked: (checked: boolean) => void;
     handleRemoveOption: () => void;
+    readOnly?: boolean;
+}
+
+export interface OptionsHeaderProps {
+    handleAddOption: () => void;
+    label: string;
+    readOnly: boolean;
 }
 
 export interface OptionProps {

--- a/src/FormBuilder/resources/js/form-builder/src/components/index.js
+++ b/src/FormBuilder/resources/js/form-builder/src/components/index.js
@@ -1,5 +1,6 @@
 import {CurrencyControl} from '@givewp/form-builder/components/CurrencyControl';
 import ClassicEditor from '@givewp/form-builder/components/ClassicEditor';
+import OptionsPanel from '@givewp/form-builder/components/OptionsPanel';
 
 export {default as Header} from './header';
 export {SecondarySidebar, Sidebar} from './sidebar';
@@ -8,4 +9,5 @@ export default function registerComponents() {
     window.givewp.form.components = window.givewp.form.components || {};
     window.givewp.form.components.CurrencyControl = CurrencyControl;
     window.givewp.form.components.ClassicEditor = ClassicEditor;
+    window.givewp.form.components.OptionsPanel = OptionsPanel;
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-11]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

In the Funds block UI design for the new form builder, there is a setting that allows users to select which funds should be displayed in the selector.

To accomplish that the `OptionsPanel` component was used in the design prototype, but with a new feature: read-only option. 

So, this PR implements a new way to use this component with this new feature and it also adds a way to customize the label of the options list.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `OptionsPanel` component.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/16308864/06e34668-c13f-47ca-8658-22035b8942ad)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Follow the instructions in the related PR: https://github.com/impress-org/give-funds/pull/125

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-11]: https://stellarwp.atlassian.net/browse/GIVE-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ