### PR TITLE
Installing in WP multisite only if network admin

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -29,17 +29,16 @@ if (!defined('ABSPATH')) {
  * successful install, the user is redirected to the Give Onboarding Wizard.
  *
  * @since 1.0
- *
- * @param bool $network_wide
+ * @since 3.1.3 installing in WP multisite only if network admin
  *
  * @return void
  * @global     $wpdb
  */
-function give_install($network_wide = false)
+function give_install()
 {
     global $wpdb;
 
-    if (is_multisite() && $network_wide) {
+    if (is_multisite() && is_network_admin()) {
         foreach ($wpdb->get_col("SELECT blog_id FROM $wpdb->blogs LIMIT 100") as $blog_id) {
             switch_to_blog($blog_id);
             give_run_install();


### PR DESCRIPTION
When I activate the plugin on a sub-site, I want it only on this sub-site.
When I activate it on the root site, it's network enabled, the plugin will be installed on all sites.

Activate GiveWP on all sites causes a fatal error:
`Fatal error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in /var/www/html/wordpress/wp-content/plugins/give/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php:30 `

Support suggested me to delete give settings in wp_options and the 'wp_give%' tables for the root site. But the error returns because when installing GiveWP on all sites, some of these table are recreated. Installing GiveWP in a sub-site works only works if the previous $network_wide parameter is false. 

We also have errors while deleting a site: all GiveWP setings were gone. I hypothesize that this also comes from the root site 'wp_give%' tables.