### PR TITLE
Hotfix: PayPal Donations payment methods should render in donation form

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
+++ b/src/PaymentGateways/PayPalCommerce/ScriptLoader.php
@@ -188,6 +188,7 @@ EOT;
     /**
      * Load public assets.
      *
+     * @unreleased Get form id from post content if form id is not available.
      * @unreleased Use EnqueueScript to register and enqueue script.
      * @since 2.32.0 Handle exception if client token is not generated.
      * @since 2.9.0


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-114]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The PayPal donations script does not load if the donation form is added to post content as a shortcode. For this reason, the payment method is not rendered in the donation form. I implemented a logic to resolve this.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
PayPal donations payment method in a donation form with a legacy form template.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] PayPal donation payment methods should render correctly if a donation form shortcode is added to a post or page content.
- [ ] PayPal donation payment methods should render correctly if a donation form block is added to a post or page content.
- [ ] Donors should be able to process one-time donations with smart buttons and advanced card fields.
- [ ] Donors should be able to process subscription donations with smart buttons and advanced card fields. 

There are a few known issues that I will resolve in a separate pull request:
- Display style setting does not work with legacy format template in donation form shortcode.
- Advanced card field style is not good if payment method options are not visible initially with legacy form templates like modal, button, and reveal display style.
- Donation form does not render correctly if added using the widget.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-114]: https://stellarwp.atlassian.net/browse/GIVE-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ