### PR TITLE
Feature: Allow donors to update or reset their password

### DIFF
--- a/src/DonorDashboards/Routes/PasswordResetRoute.php
+++ b/src/DonorDashboards/Routes/PasswordResetRoute.php
@@ -9,7 +9,7 @@ use WP_REST_Response;
 
 
 /**
- * @since 2.10.0
+ * @unreleased
  */
 class PasswordResetRoute implements RestRoute
 {

--- a/src/DonorDashboards/Routes/PasswordResetRoute.php
+++ b/src/DonorDashboards/Routes/PasswordResetRoute.php
@@ -45,7 +45,7 @@ class PasswordResetRoute implements RestRoute
     /**
      * Handles logout request
      *
-     * @since 2.10.0
+     * @unreleased
      *
      * @param WP_REST_Request $request
      *

--- a/src/DonorDashboards/Routes/PasswordResetRoute.php
+++ b/src/DonorDashboards/Routes/PasswordResetRoute.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Give\DonorDashboards\Routes;
+
+use Give\API\RestRoute;
+use Give\DonorDashboards\Helpers as DonorDashboardHelpers;
+use WP_REST_Request;
+use WP_REST_Response;
+
+
+/**
+ * @since 2.10.0
+ */
+class PasswordResetRoute implements RestRoute
+{
+
+    /** @var string */
+    protected $endpoint = 'donor-dashboard/reset-password';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'POST',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => '__return_true',
+                ],
+                'args' => [
+                    'email' => [
+                        'type' => 'string',
+                        'required' => true,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Handles logout request
+     *
+     * @since 2.10.0
+     *
+     * @param WP_REST_Request $request
+     *
+     * @return WP_REST_Response
+     *
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        $sent = retrieve_password($request->get_param('email'));
+
+        return $sent
+            ? new WP_REST_Response(
+                [
+                    'status' => 200,
+                    'response' => 'password_reset_sent',
+                    'body_response' => [
+                        'message' => __('The password reset email has been sent.', 'give'),
+                    ],
+                ]
+            )
+            : new WP_REST_Response(
+                [
+                    'status' => 400,
+                    'response' => 'error',
+                    'body_response' => [
+                        'error' => 'password_reset_failed',
+                        'message' => esc_html__('Unable to reset password. Please try again.', 'give'),
+                    ],
+                ]
+            );
+    }
+
+    /**
+     * Check permissions
+     */
+    public function permissionsCheck(): bool
+    {
+        return DonorDashboardHelpers::isDonorLoggedIn();
+    }
+}

--- a/src/DonorDashboards/ServiceProvider.php
+++ b/src/DonorDashboards/ServiceProvider.php
@@ -11,6 +11,7 @@ use Give\DonorDashboards\Profile as Profile;
 use Give\DonorDashboards\RequestHandler as RequestHandler;
 use Give\DonorDashboards\Routes\LoginRoute;
 use Give\DonorDashboards\Routes\LogoutRoute;
+use Give\DonorDashboards\Routes\PasswordResetRoute;
 use Give\DonorDashboards\Routes\VerifyEmailRoute;
 use Give\DonorDashboards\Shortcode as Shortcode;
 use Give\DonorDashboards\Tabs\DonationHistoryTab\Tab as DonationHistoryTab;
@@ -56,6 +57,7 @@ class ServiceProvider implements ServiceProviderInterface
 
         Hooks::addAction('rest_api_init', LoginRoute::class, 'registerRoute');
         Hooks::addAction('rest_api_init', LogoutRoute::class, 'registerRoute');
+        Hooks::addAction('rest_api_init', PasswordResetRoute::class, 'registerRoute');
 
         if (give_is_setting_enabled(give_get_option('email_access'))) {
             Hooks::addAction('rest_api_init', VerifyEmailRoute::class, 'registerRoute');

--- a/src/DonorDashboards/resources/js/app/components/auth-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/auth-modal/index.js
@@ -4,7 +4,7 @@ import {__} from '@wordpress/i18n';
 import TextControl from '../text-control';
 import Button from '../button';
 
-import {loginWithAPI, verifyEmailWithAPI} from './utils';
+import {loginWithAPI, verifyEmailWithAPI, resetPasswordWithAPI} from './utils';
 import {getWindowData} from '../../utils';
 
 import ReCAPTCHA from 'react-google-recaptcha';
@@ -21,6 +21,9 @@ const AuthModal = () => {
     const [verifyingEmail, setVerifyingEmail] = useState(false);
     const [emailSent, setEmailSent] = useState(false);
     const [emailError, setEmailError] = useState(null);
+    const [passwordResetEmail, setPasswordResetEmail] = useState('');
+    const [showPasswordReset, setShowPasswordReset] = useState(false);
+    const [passwordResetSent, setPasswordResetSent] = useState(false);
     const emailAccessEnabled = getWindowData('emailAccessEnabled');
     const loggedInWithoutDonor = getWindowData('loggedInWithoutDonor');
     const recaptchaKey = getWindowData('recaptchaKey');
@@ -65,6 +68,21 @@ const AuthModal = () => {
 
             if (status === 200) {
                 setEmailSent(true);
+            } else {
+                setEmailError(body_response.message);
+            }
+        }
+    };
+
+    const handlePasswordReset = async (e) => {
+        e.preventDefault();
+        if (passwordResetEmail) {
+            // eslint-disable-next-line camelcase
+            const {status, body_response} = await resetPasswordWithAPI(passwordResetEmail);
+
+            if (status === 200) {
+                setPasswordResetSent(true);
+                setShowPasswordReset(false);
             } else {
                 setEmailError(body_response.message);
             }
@@ -124,38 +142,70 @@ const AuthModal = () => {
                         <div className="give-donor-dashboard__auth-modal-seperator" />
                     )}
                     {loginEnabled && (
-                        <Fragment>
-                            <div className="give-donor-dashboard__auth-modal-instruction">
-                                {emailAccessEnabled && (
-                                    <Fragment>
-                                        {__('Already have an account?', 'give')} <br />
-                                    </Fragment>
-                                )}
-                                {__('Log in below to access your dashboard', 'give')}
-                            </div>
-                            <form className="give-donor-dashboard__auth-modal-form" onSubmit={(e) => handleLogin(e)}>
-                                <TextControl icon="user" value={login} onChange={(value) => setLogin(value)} />
-                                <TextControl
-                                    icon="lock"
-                                    type="password"
-                                    value={password}
-                                    onChange={(value) => setPassword(value)}
-                                />
-                                <div className="give-donor-dashboard__auth-modal-row">
-                                    <Button type="submit">
-                                        {__('Log in', 'give')}
-                                        <FontAwesomeIcon
-                                            className={loggingIn ? 'give-donor-dashboard__auth-modal-spinner' : ''}
-                                            icon={loggingIn ? 'spinner' : 'chevron-right'}
-                                            fixedWidth
+                        <>
+                            {showPasswordReset && (
+                                <>
+                                    <div className="give-donor-dashboard__auth-modal-instruction">
+                                        {__('Reset your password by entering your email address.', 'give')}
+                                    </div>
+                                    <form className="give-donor-dashboard__auth-modal-form" onSubmit={(e) => handlePasswordReset(e)}>
+                                        <TextControl icon="envelope" value={passwordResetEmail} onChange={(value) => setPasswordResetEmail(value)} />
+                                        <div className="give-donor-dashboard__auth-modal-row">
+                                            <Button type="submit">
+                                                {__('Reset Password', 'give')}
+                                                <FontAwesomeIcon
+                                                    className={loggingIn ? 'give-donor-dashboard__auth-modal-spinner' : ''}
+                                                    icon={loggingIn ? 'spinner' : 'chevron-right'}
+                                                    fixedWidth
+                                                />
+                                            </Button>
+                                        </div>
+                                    </form>
+                                </>
+                            )}
+                            {!showPasswordReset && (
+                                <>
+                                    <div className="give-donor-dashboard__auth-modal-instruction">
+                                        {emailAccessEnabled && (
+                                            <Fragment>
+                                                {__('Already have an account?', 'give')} <br />
+                                            </Fragment>
+                                        )}
+                                        {__('Log in below to access your dashboard', 'give')}
+                                    </div>
+                                    <form className="give-donor-dashboard__auth-modal-form" onSubmit={(e) => handleLogin(e)}>
+                                        <TextControl icon="user" value={login} onChange={(value) => setLogin(value)} />
+                                        <TextControl
+                                            icon="lock"
+                                            type="password"
+                                            value={password}
+                                            onChange={(value) => setPassword(value)}
                                         />
-                                    </Button>
-                                    {loginError && (
-                                        <div className="give-donor-dashboard__auth-modal-error">{loginError}</div>
-                                    )}
-                                </div>
-                            </form>
-                        </Fragment>
+                                        <div className="give-donor-dashboard__auth-modal-row">
+                                            <Button type="submit">
+                                                {__('Log in', 'give')}
+                                                <FontAwesomeIcon
+                                                    className={loggingIn ? 'give-donor-dashboard__auth-modal-spinner' : ''}
+                                                    icon={loggingIn ? 'spinner' : 'chevron-right'}
+                                                    fixedWidth
+                                                />
+                                            </Button>
+                                            <Button type="button" onClick={() => setShowPasswordReset(true)}>{__('Forgot Password?', 'give')}</Button>
+                                            {loginError && (
+                                                <div className="give-donor-dashboard__auth-modal-error">{loginError}</div>
+                                            )}
+                                        </div>
+                                    </form>
+                                </>
+                            )}
+                            {passwordResetSent && (
+                                <>
+                                    <div className="give-donor-dashboard__auth-modal-instruction">
+                                        {__('Instructions for resetting your password have been sent to you email.', 'give')}
+                                    </div>
+                                </>
+                            )}
+                        </>
                     )}
                 </div>
             </div>

--- a/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
@@ -26,3 +26,16 @@ export const verifyEmailWithAPI = ({email, recaptcha}) => {
         )
         .then((response) => response.data);
 };
+
+
+export const resetPasswordWithAPI = (email) => {
+    return axios
+        .post(
+            getAPIRoot() + 'give-api/v2/donor-dashboard/reset-password',
+            {
+                email,
+            },
+            {}
+        )
+        .then((response) => response.data);
+};


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a Password Reset feature to the Donor Dashboard login modal.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Password Reset Button
![Screenshot 2023-12-05 at 16-29-09 Donor Dashboard – WordPress](https://github.com/impress-org/givewp/assets/10858303/0c4b422c-124f-4b70-9d9c-d5557b0ab5d0)

### Password Reset Form
![Screenshot 2023-12-05 at 16-29-16 Donor Dashboard – WordPress](https://github.com/impress-org/givewp/assets/10858303/b28908c2-1bb5-4149-99a9-3aff0c6eb8f8)

### Password Reset Sent
![Screenshot 2023-12-05 at 16-29-26 Donor Dashboard – WordPress](https://github.com/impress-org/givewp/assets/10858303/969e3a74-2e15-4dac-af56-49f65b16436f)


