### PR TITLE
Fix: duplicate meta keys

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -921,7 +921,7 @@ class Give_Donate_Form {
 		if ( ! isset( $this->sales ) ) {
 
 			if ( '' == give_get_meta( $this->ID, '_give_form_sales', true ) ) {
-				add_post_meta( $this->ID, '_give_form_sales', 0 );
+                give_update_meta( $this->ID, '_give_form_sales', 0 );
 			} // End if
 
 			$this->sales = give_get_meta( $this->ID, '_give_form_sales', true );
@@ -1009,7 +1009,7 @@ class Give_Donate_Form {
 		if ( ! isset( $this->earnings ) ) {
 
 			if ( '' == give_get_meta( $this->ID, '_give_form_earnings', true ) ) {
-				add_post_meta( $this->ID, '_give_form_earnings', 0 );
+                give_update_meta( $this->ID, '_give_form_earnings', 0 );
 			}
 
 			$this->earnings = give_get_meta( $this->ID, '_give_form_earnings', true );

--- a/src/DonationForms/Migrations/RemoveDuplicateMeta.php
+++ b/src/DonationForms/Migrations/RemoveDuplicateMeta.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Give\DonationForms\Migrations;
+
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+
+/**
+ * Remove duplicate meta keys and set correct value for form earnings
+ *
+ * @unreleased
+ */
+class RemoveDuplicateMeta extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public static function id()
+    {
+        return 'donation-forms-remove-duplicate-meta';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function title()
+    {
+        return 'Remove duplicate meta';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp()
+    {
+        return strtotime('2023-06-12');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function run()
+    {
+        $posts = DB::table('posts')
+            ->select('ID')
+            ->where('post_type', 'give_forms')
+            ->getAll();
+
+        foreach ($posts as $post) {
+            $formEarnings = give_get_meta($post->ID, '_give_form_earnings');
+
+            // Update meta with duplicate keys only
+            if (count($formEarnings) > 1) {
+                // Delete all meta
+                give_delete_meta($post->ID, '_give_form_earnings');
+
+                // Get earnings from donations
+                $earnings = $this->getEarningsFromDonations($post->ID);
+                give_update_meta($post->ID, '_give_form_earnings', $earnings);
+            }
+        }
+    }
+
+    /**
+     * Get earnings from donations by Form ID
+     *
+     * @param $formId
+     *
+     * @return int
+     */
+    private function getEarningsFromDonations($formId): int
+    {
+        $donations = Db::table('posts')
+            ->attachMeta(
+                'give_donationmeta',
+                'ID',
+                'donation_id',
+                [DonationMetaKeys::FORM_ID(), 'formId'],
+                [DonationMetaKeys::AMOUNT(), 'amount'])
+            ->where('post_type', 'give_payment')
+            ->where('give_donationmeta_attach_meta_formId.meta_value', $formId)
+            ->getAll('ARRAY_A');
+
+        $amounts = array_column($donations, 'amount');
+
+        return array_sum($amounts);
+    }
+
+}

--- a/src/DonationForms/Migrations/RemoveDuplicateMeta.php
+++ b/src/DonationForms/Migrations/RemoveDuplicateMeta.php
@@ -81,13 +81,13 @@ class RemoveDuplicateMeta extends Migration
      */
     private function getEarningsFromDonations($formId)
     {
-        $donations = Db::table('posts')
+        $donations = DB::table('posts')
             ->attachMeta(
                 'give_donationmeta',
                 'ID',
                 'donation_id',
-                [DonationMetaKeys::FORM_ID(), 'formId'],
-                [DonationMetaKeys::AMOUNT(), 'amount'])
+                [DonationMetaKeys::FORM_ID, 'formId'],
+                [DonationMetaKeys::AMOUNT, 'amount'])
             ->where('post_type', 'give_payment')
             ->where('give_donationmeta_attach_meta_formId.meta_value', $formId)
             ->getAll('ARRAY_A');
@@ -106,12 +106,12 @@ class RemoveDuplicateMeta extends Migration
      */
     private function getSalesCountFromDonations($formId): int
     {
-        return Db::table('posts')
+        return DB::table('posts')
             ->attachMeta(
                 'give_donationmeta',
                 'ID',
                 'donation_id',
-                [DonationMetaKeys::FORM_ID(), 'formId']
+                [DonationMetaKeys::FORM_ID, 'formId']
             )
             ->where('post_type', 'give_payment')
             ->where('post_status', 'publish')

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -17,6 +17,7 @@ use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
 use Give\DonationForms\FormDesigns\MultiStepFormDesign\MultiStepFormDesign;
 use Give\DonationForms\FormPage\TemplateHandler;
 use Give\DonationForms\Migrations\CleanMultipleSlashesOnDB;
+use Give\DonationForms\Migrations\RemoveDuplicateMeta;
 use Give\DonationForms\Repositories\DonationFormRepository;
 use Give\DonationForms\Routes\AuthenticationRoute;
 use Give\DonationForms\Routes\DonateRoute;
@@ -73,6 +74,7 @@ class ServiceProvider implements ServiceProviderInterface
 
         give(MigrationsRegister::class)->addMigrations([
             CleanMultipleSlashesOnDB::class,
+            RemoveDuplicateMeta::class,
         ]);
     }
 

--- a/src/FormMigration/Actions/TransferDonations.php
+++ b/src/FormMigration/Actions/TransferDonations.php
@@ -45,14 +45,14 @@ class TransferDonations
             give_update_meta(
                 $destinationId,
                 '_give_form_sales',
-                give_get_meta($this->sourceId, '_give_form_sales', true)
+                (float)give_get_meta($this->sourceId, '_give_form_sales', true)
             );
             give_update_meta($this->sourceId, '_give_form_sales', 0);
 
             give_update_meta(
                 $destinationId,
                 '_give_form_earnings',
-                give_get_meta($this->sourceId, '_give_form_earnings', true)
+                (float)give_get_meta($this->sourceId, '_give_form_earnings', true)
             );
             give_update_meta($this->sourceId, '_give_form_earnings', 0);
 

--- a/src/FormMigration/Actions/TransferDonations.php
+++ b/src/FormMigration/Actions/TransferDonations.php
@@ -45,7 +45,7 @@ class TransferDonations
             give_update_meta(
                 $destinationId,
                 '_give_form_sales',
-                (float)give_get_meta($this->sourceId, '_give_form_sales', true)
+                (int)give_get_meta($this->sourceId, '_give_form_sales', true)
             );
             give_update_meta($this->sourceId, '_give_form_sales', 0);
 


### PR DESCRIPTION
Resolves [GIVE-137]

## Description
This PR resolves the issue of duplicate donation forms. The problem was in the logic of the `get_earnings` method combined with the donation transfer logic which resulted in the meta key being duplicated on every page load. That also affected the donation forms list table which was displaying duplicated results. 

The issue is resolved by using `update_post_meta` instead of `add_post_meta` function, and by adding a migration for deleting duplicated meta keys (`_give_form_earnings`, `_give_form_sales`) and setting the correct values for  `_give_form_earnings` is added. 

## Affects

Donation Forms list table
Donation Form data transfer


## Testing Instructions

The best way to test this is on an existing site that has this problem.

Create a new site by using Local or something similar.
Install All-In-On WP Migration plugin.
Download the site backup and import it (https://drive.google.com/file/d/16SIlaCQ-1nMvneFpYvdLStA2_ovtQ6vG/view?usp=sharing).
After import, verify that the problem exists by checking the donation forms list table, or even better by querying the `give_formmeta` table. Something like: 
```sql 
select form_id, meta_key from wp_give_formmeta where form_id = FORM_ID and ( meta_key = '_give_form_sales' or  meta_key = '_give_form_earnings');
```

Now delete or disable the existing Give plugin and install Give from GitHub repo.
Switch to this branch `fix/duplicate-meta-keys`
Check the donation forms list table.



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-137]: https://stellarwp.atlassian.net/browse/GIVE-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ