### PR TITLE
Fix: resolve donor details page error when they have no donations

### DIFF
--- a/src/Donors/CustomFields/Controllers/DonorDetailsController.php
+++ b/src/Donors/CustomFields/Controllers/DonorDetailsController.php
@@ -35,6 +35,7 @@ class DonorDetailsController
     }
 
     /**
+     * @unreleased added array fallback when no donations are found
      * @since 3.0.0
      *
      * @param  Donor  $donor
@@ -45,7 +46,7 @@ class DonorDetailsController
     {
         $formIds = array_map(static function (Donation $donation) {
             return $donation->formId;
-        }, $donor->donations ?? []);
+        }, $donor->donations()->getAll() ?? []);
 
         $formIds = array_filter($formIds, static function ($formId) {
             return !give(DonationFormRepository::class)->isLegacyForm($formId);

--- a/src/Donors/CustomFields/Controllers/DonorDetailsController.php
+++ b/src/Donors/CustomFields/Controllers/DonorDetailsController.php
@@ -45,7 +45,7 @@ class DonorDetailsController
     {
         $formIds = array_map(static function (Donation $donation) {
             return $donation->formId;
-        }, $donor->donations);
+        }, $donor->donations ?? []);
 
         $formIds = array_filter($formIds, static function ($formId) {
             return !give(DonationFormRepository::class)->isLegacyForm($formId);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7130, [GIVE-146]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes an error on the donor details page when the donor has no donations.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Donor details page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

### Before:
<img width="1255" alt="Screenshot 2023-12-07 at 11 16 54 AM" src="https://github.com/impress-org/givewp/assets/10138447/c83a7103-ac20-401f-8c52-687babe6dc83">

### After:

<img width="1256" alt="Screenshot 2023-12-07 at 11 22 47 AM" src="https://github.com/impress-org/givewp/assets/10138447/0d6d22d9-d1f3-4d7d-9327-b9fdaa781400">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Test for Donors with and without donations

- Create a donor with donations
- Create a donor without donations
- View both donor details pages

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-146]: https://stellarwp.atlassian.net/browse/GIVE-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ