### PR TITLE
Fix: Prevent duplicate "Donate Now" button on legacy form template

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1587,7 +1587,7 @@ function give_get_default_form_shortcode_args() {
 		'show_goal'             => true,
 		'show_content'          => '',
 		'float_labels'          => '',
-        'display_style'         => 'fullForm',
+        'display_style'         => 'onpage',
         'continue_button_title' => __('Donate now', 'give'),
 
 		// This attribute belong to form template functionality.

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -5,7 +5,7 @@ import IframeResizer from 'iframe-resizer-react';
 import '../editor/styles/index.scss';
 
 type DonationFormBlockAppProps = {
-    formFormat: 'fullForm' | 'newTab' | 'modal' | string;
+    formFormat: 'onpage' | 'newTab' | 'modal' | string;
     dataSrc: string;
     embedId: string;
     openFormButton: string;

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
@@ -64,7 +64,7 @@ export default function DonationFormBlockControls({
                                 [
                                     {
                                         label: __('Full Form', 'give'),
-                                        value: 'fullForm',
+                                        value: 'onpage',
                                     },
                                     {
                                         label: __('Modal', 'give'),

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
@@ -7,7 +7,7 @@ import '../styles/index.scss';
 interface BlockPreviewProps {
     formId: number;
     clientId: string;
-    formFormat: 'fullForm' | 'modal' | 'newTab' | 'reveal';
+    formFormat: 'onpage' | 'modal' | 'newTab' | 'reveal';
     openFormButton: string;
     link: string;
 }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR prevents a duplicate "Donate Now" button on the legacy form template, in which the modal launch button is being rendered when the display option is not set to modal.

Specifically, this issue is resolved by reverting the `fullForm` display option to the original `onpage`.