### PR TITLE
Fix: narrow scope of checking if editing v2 forms 

### DIFF
--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -125,7 +125,7 @@ class DonationFormsAdminPage
 
     /**
      * Load migration onboarding scripts
-     * @since 3.2.0
+     * @unreleased
      *
      * @return void
      */
@@ -269,13 +269,14 @@ class DonationFormsAdminPage
     /**
      * Helper function to determine if current page is the edit v2 form page
      *
+     * @unreleased added global $post to isset
      * @since 3.0.0
      *
      * @return bool
      */
     private function isShowingEditV2FormPage(): bool
     {
-        return isset($_GET['action']) && $_GET['action'] === 'edit' && $GLOBALS['post']->post_type === 'give_forms';
+        return isset($_GET['action'], $GLOBALS['post']) && $_GET['action'] === 'edit' && $GLOBALS['post']->post_type === 'give_forms';
     }
 
     /**

--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -125,7 +125,7 @@ class DonationFormsAdminPage
 
     /**
      * Load migration onboarding scripts
-     * @unreleased
+     * @since 3.2.0
      *
      * @return void
      */

--- a/src/Promotions/InPluginUpsells/LegacyFormEditor.php
+++ b/src/Promotions/InPluginUpsells/LegacyFormEditor.php
@@ -48,18 +48,15 @@ class LegacyFormEditor
     }
 
     /**
-     *
+     * @unreleased replaced logic to be give_forms post_type specific
      * @since 2.27.1
-     *
      */
     public static function isShowing(): bool
     {
-        $queryParameters = $_GET;
+        global $post, $pagenow;
 
-        if (isset($queryParameters['action']) && $queryParameters['action'] === 'edit' && $queryParameters['post']) {
-            return true;
-        }
-
-        return false;
+        return $post &&
+            in_array($pagenow, ['post-new.php', 'post.php'], true) &&
+            'give_forms' === get_post_type($post);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7092, [GIVE-1]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Replaced logic for checking if editing v2 forms to be `give_forms` post_type specific to avoid showing up on unrelated WordPress pages.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- v2 donation form admin page editing conditional

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- As an admin, go to `/wp-admin/nav-menus.php` to edit menus (make sure you have WP_DEBUG set to true)
- You should _not_ get this visual error:

<img width="1431" alt="Screenshot 2023-12-07 at 12 00 39 PM" src="https://github.com/impress-org/givewp/assets/10138447/bc90719b-ce5d-4ced-ba64-462d50a9b6a3">


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1]: https://stellarwp.atlassian.net/browse/GIVE-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ