### PR TITLE
Fix: prevent donation form block from causing error on edit page load.

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
@@ -6,9 +6,27 @@ import DonationFormSelector from './components/DonationFormSelector';
 import useFormOptions from './hooks/useFormOptions';
 import DonationFormBlockControls from './components/DonationFormBlockControls';
 import DonationFormBlockPreview from './components/DonationFormBlockPreview';
+import type {BlockPreviewProps} from './components/DonationFormBlockPreview';
 
 import './styles/index.scss';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * @unreleased
+ *
+ * @see 'class-give-block-donation-form.php'
+ */
+type DonationFormBlockAttributes = {
+    id: number;
+    prevId: number;
+    blockId: string;
+    displayStyle: BlockPreviewProps['formFormat'];
+    continueButtonTitle: string;
+    showTitle: boolean;
+    showGoal: boolean;
+    showContent: boolean;
+    contentDisplay: string;
+}
 
 /**
  * @unreleased added isResolving loading state to prevent forms from prematurely being rendered.
@@ -16,13 +34,13 @@ import { __ } from '@wordpress/i18n';
  * @since 3.0.0
  */
 export default function Edit({attributes, isSelected, setAttributes, className, clientId}: BlockEditProps<any>) {
-    const {id, blockId, displayStyle, continueButtonTitle} = attributes;
+    const {id, blockId, displayStyle, continueButtonTitle} = attributes as DonationFormBlockAttributes;
     const {formOptions, isResolving} = useFormOptions();
     const [showPreview, setShowPreview] = useState<boolean>(!!id);
 
     const handleSelect = (id) => {
-        setShowPreview(true);
         setAttributes({id});
+        setShowPreview(true);
     };
 
     useEffect(() => {
@@ -36,7 +54,7 @@ export default function Edit({attributes, isSelected, setAttributes, className, 
     }, []);
 
     const [isLegacyForm, isLegacyTemplate, link] = (() => {
-        const form = formOptions.find((form) => form.value == id);
+        const form = formOptions.find((form) => form.value === String(id));
 
         return [form?.isLegacyForm, form?.isLegacyTemplate, form?.link];
     })();

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
@@ -54,7 +54,7 @@ export default function Edit({attributes, isSelected, setAttributes, className, 
     }, []);
 
     const [isLegacyForm, isLegacyTemplate, link] = (() => {
-        const form = formOptions.find((form) => form.value === String(id));
+        const form = formOptions.find((form) => form.value === id);
 
         return [form?.isLegacyForm, form?.isLegacyTemplate, form?.link];
     })();

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
@@ -8,8 +8,10 @@ import DonationFormBlockControls from './components/DonationFormBlockControls';
 import DonationFormBlockPreview from './components/DonationFormBlockPreview';
 
 import './styles/index.scss';
+import { __ } from '@wordpress/i18n';
 
 /**
+ * @unreleased added isResolving loading state to prevent forms from prematurely being rendered.
  * @since 3.2.0 updated to handle v2 forms.
  * @since 3.0.0
  */
@@ -38,6 +40,12 @@ export default function Edit({attributes, isSelected, setAttributes, className, 
 
         return [form?.isLegacyForm, form?.isLegacyTemplate, form?.link];
     })();
+
+    if (isResolving !== false) {
+        return <div {...useBlockProps()}>
+            <p>{__('Loading...', 'give')}</p>
+        </div>
+    }
 
     return (
         <div {...useBlockProps()}>

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
@@ -1,7 +1,7 @@
 import {ExternalLink, PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {InspectorControls} from '@wordpress/block-editor';
-import {FormOption} from '../hooks/useFormOptions';
+import type {FormOption} from '../hooks/useFormOptions';
 
 interface DonationFormBlockControls {
     attributes: Readonly<any>;

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
@@ -1,19 +1,19 @@
 import {ExternalLink, PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {InspectorControls} from '@wordpress/block-editor';
-import {Option} from '../types';
+import {FormOption} from '../hooks/useFormOptions';
 
 interface DonationFormBlockControls {
     attributes: Readonly<any>;
     setAttributes: (newAttributes: Record<string, any>) => void;
-    formOptions: Option[];
+    formOptions: FormOption[];
     isResolving: boolean;
     isLegacyTemplate: boolean;
     isLegacyForm: boolean;
 }
 
 /**
- * @unreleased updated setAttributes ID to be a number.
+ * @unreleased updated setAttributes ID to be a number and formOptions to return select options.
  * @since 3.2.0
  */
 export default function DonationFormBlockControls({
@@ -48,7 +48,7 @@ export default function DonationFormBlockControls({
                             options={[
                                 // add a disabled selector manually
                                 ...[{value: '', label: __('Select...', 'give'), disabled: true}],
-                                ...formOptions,
+                                ...formOptions.map((form) => ({label: form.label, value: String(form.value)})),
                             ]}
                             onChange={(newFormId) => {
                                 setAttributes({id: Number(newFormId)});

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockControls.tsx
@@ -13,6 +13,7 @@ interface DonationFormBlockControls {
 }
 
 /**
+ * @unreleased updated setAttributes ID to be a number.
  * @since 3.2.0
  */
 export default function DonationFormBlockControls({
@@ -38,7 +39,7 @@ export default function DonationFormBlockControls({
         <InspectorControls>
             <PanelBody title={__('Form Settings', 'give')} initialOpen={true}>
                 <PanelRow>
-                    {!isResolving && formOptions.length === 0 ? (
+                    {isResolving === false && formOptions.length === 0 ? (
                         <p>{__('No forms were found using the GiveWP form builder.', 'give')}</p>
                     ) : (
                         <SelectControl
@@ -50,7 +51,7 @@ export default function DonationFormBlockControls({
                                 ...formOptions,
                             ]}
                             onChange={(newFormId) => {
-                                setAttributes({id: newFormId});
+                                setAttributes({id: Number(newFormId)});
                             }}
                         />
                     )}

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
@@ -4,7 +4,7 @@ import {useSelect} from '@wordpress/data';
 
 import '../styles/index.scss';
 
-interface BlockPreviewProps {
+export interface BlockPreviewProps {
     formId: number;
     clientId: string;
     formFormat: 'fullForm' | 'modal' | 'newTab' | 'reveal';

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormSelector.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormSelector.tsx
@@ -7,16 +7,23 @@ import {reactSelectStyles, reactSelectThemeStyles} from '../styles/reactSelectSt
 import logo from '../images/givewp-logo.svg';
 
 import '../styles/index.scss';
+import {FormOption} from '../hooks/useFormOptions';
 
 // @ts-ignore
 const savePost = () => dispatch('core/editor').savePost();
 
+type DonationFormSelectorProps = {
+    formOptions: FormOption[];
+    isResolving: boolean;
+    handleSelect: (id: number) => void;
+}
+
 /**
  * @since 3.2.0
  */
-export default function DonationFormSelector({formOptions, isResolving, handleSelect}) {
-    const [selectedForm, setSelectedForm] = useState(null);
-    const form = formOptions.find(form => form.value == selectedForm);
+export default function DonationFormSelector({formOptions, isResolving, handleSelect}: DonationFormSelectorProps) {
+    const [selectedForm, setSelectedForm] = useState<number>(null);
+    const form = formOptions.find(form => form.value === selectedForm);
     const {isSaving, isDisabled} = usePostState();
 
     return (

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormSelector.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormSelector.tsx
@@ -7,11 +7,14 @@ import {reactSelectStyles, reactSelectThemeStyles} from '../styles/reactSelectSt
 import logo from '../images/givewp-logo.svg';
 
 import '../styles/index.scss';
-import {FormOption} from '../hooks/useFormOptions';
+import type {FormOption} from '../hooks/useFormOptions';
 
 // @ts-ignore
 const savePost = () => dispatch('core/editor').savePost();
 
+/**
+ * @unreleased
+ */
 type DonationFormSelectorProps = {
     formOptions: FormOption[];
     isResolving: boolean;

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
@@ -1,9 +1,15 @@
 import {__} from '@wordpress/i18n';
 import {useSelect} from '@wordpress/data';
 import type {Post} from '@wordpress/core-data/src/entity-types';
-import type {Form, Option} from '../types';
+import type {Form} from '../types';
 
-type FormOption = Form & Option;
+/**
+ * @unreleased
+ */
+export interface FormOption extends Form {
+    label: string;
+    value: number;
+}
 
 /**
  * @since 3.2.0 include isLegacyForm, isLegacyFormTemplate & link.

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
@@ -6,7 +6,7 @@ import type {Form, Option} from '../types';
 type FormOption = Form & Option;
 
 /**
- * unreleased include isLegacyForm, isLegacyFormTemplate & link.
+ * @since 3.2.0 include isLegacyForm, isLegacyFormTemplate & link.
  * @since 3.0.0
  */
 export default function useFormOptions(): {

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/usePostState.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/usePostState.ts
@@ -1,6 +1,7 @@
 import {useSelect} from '@wordpress/data';
 
 /**
+ * @unreleased updated isDisabled to use isEditedPostSaveable
  * @since 3.0.0
  */
 export default function usePostState(): { isSaving: boolean, isDisabled: boolean } {
@@ -11,7 +12,7 @@ export default function usePostState(): { isSaving: boolean, isDisabled: boolean
 
     const isDisabled = useSelect((select) => {
         // @ts-ignore
-        return !select('core/editor').isEditedPostPublishable();
+        return !select('core/editor').isEditedPostSaveable();
     }, []);
 
     return {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-147]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- This prevents the donation form block to render an error when v2 forms are included in the list of forms.
- This also fixes the block inspector form selector to persist the correct form id value

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation form block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a mix of v2 and v3 forms
- Add a new page with donation form block
- Select a v2 form
- Refresh the page
- You should not get an error.
- Now select a new form using the block inspector settings and save
- Refresh the page
- You should see the form preview of the form you selected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-147]: https://stellarwp.atlassian.net/browse/GIVE-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ