### PR TITLE
Hotfix: remove default display argument on `[give_form]` to support legacy form meta

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1587,7 +1587,7 @@ function give_get_default_form_shortcode_args() {
 		'show_goal'             => true,
 		'show_content'          => '',
 		'float_labels'          => '',
-        'display_style'         => 'fullForm',
+        'display_style'         => '',
         'continue_button_title' => __('Donate now', 'give'),
 
 		// This attribute belong to form template functionality.


### PR DESCRIPTION
Resolves #7132, [GIVE-145]

Related: https://github.com/impress-org/givewp/pull/7134

## Description

This PR removes the default argument supplied to the give form shortcode. Legacy templates rely on this value being empty. When no value is present the Legacy template can use the default values stored in the form meta for display.

## Affects

Donation Form shortcode/block

## Visuals

https://github.com/impress-org/givewp/assets/75056371/5863829b-f50b-4118-822a-7d005043f29a

https://github.com/impress-org/givewp/assets/75056371/3ac8d923-e871-484a-bfaa-4c6b7a0a4f81


## Testing Instructions

- Create a v2 Legacy template form
- Edit the form & select a form display option
- Create a shortcode and do not use the display style attribute in the shortcode.
- Example: [give_form id=100]
- View page verify the shortcode displays the form with the proper display selected from the edit page.
- Edit the shortcode -> add a display style -> verify new display works on page.
- Repeat for each legacy template display style.

## Pre-review Checklist

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-145]: https://stellarwp.atlassian.net/browse/GIVE-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ