### PR TITLE
PHP 8.2 compatibility 

### DIFF
--- a/give.php
+++ b/give.php
@@ -138,6 +138,7 @@ if (!defined('ABSPATH')) {
  *
  * @mixin Container
  */
+#[AllowDynamicProperties]
 final class Give
 {
     /**

--- a/give.php
+++ b/give.php
@@ -138,7 +138,6 @@ if (!defined('ABSPATH')) {
  *
  * @mixin Container
  */
-#[AllowDynamicProperties]
 final class Give
 {
     /**
@@ -170,6 +169,18 @@ final class Give
      * @var Give_Stripe
      */
     public $stripe;
+
+    /**
+     * @var Give_DB_Customers
+     * @deprecated use give()->donors instead
+     */
+    public $customers;
+
+    /**
+     * @var Give_DB_Customer_Meta
+     * @deprecated use give()->donor_meta instead
+     */
+    public $customer_meta;
 
     /**
      * @since 2.8.0

--- a/includes/admin/abstract-admin-settings-page.php
+++ b/includes/admin/abstract-admin-settings-page.php
@@ -20,6 +20,7 @@ if ( ! class_exists( 'Give_Settings_Page' ) ) :
 	 *
 	 * @sine 1.8
 	 */
+    #[\AllowDynamicProperties]
 	class Give_Settings_Page {
 
 		/**

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -30,6 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property $earnings
  * @property $post_type
  */
+#[\AllowDynamicProperties]
 class Give_Donate_Form {
 
 	/**

--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.0
  */
+#[\AllowDynamicProperties]
 class Give_Donor {
 
 	/**

--- a/src/Donors/Repositories/DonorRepositoryProxy.php
+++ b/src/Donors/Repositories/DonorRepositoryProxy.php
@@ -17,7 +17,7 @@ use Give_DB_Donors;
  *
  * @throws InvalidArgumentException
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class DonorRepositoryProxy
 {
     const SHARED_METHODS = ['insert', 'update', 'delete'];

--- a/src/Donors/Repositories/DonorRepositoryProxy.php
+++ b/src/Donors/Repositories/DonorRepositoryProxy.php
@@ -17,6 +17,7 @@ use Give_DB_Donors;
  *
  * @throws InvalidArgumentException
  */
+#[AllowDynamicProperties]
 class DonorRepositoryProxy
 {
     const SHARED_METHODS = ['insert', 'update', 'delete'];

--- a/src/Framework/FieldsAPI/Option.php
+++ b/src/Framework/FieldsAPI/Option.php
@@ -56,6 +56,7 @@ class Option implements JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Framework/QueryBuilder/Clauses/From.php
+++ b/src/Framework/QueryBuilder/Clauses/From.php
@@ -20,12 +20,15 @@ class From
     public $alias;
 
     /**
-     * @param  string|RawSQL  $table
-     * @param  string|null  $alias
+     * @param string|RawSQL $table
+     * @param string|null   $alias
      */
     public function __construct($table, $alias = null)
     {
         $this->table = QueryBuilder::prefixTable($table);
-        $this->alias = trim($alias);
+
+        if ( ! is_null($alias)) {
+            $this->alias = trim($alias);
+        }
     }
 }

--- a/src/Framework/QueryBuilder/Clauses/Join.php
+++ b/src/Framework/QueryBuilder/Clauses/Join.php
@@ -35,7 +35,10 @@ class Join
     {
         $this->table    = QueryBuilder::prefixTable($table);
         $this->joinType = $this->getJoinType($joinType);
-        $this->alias    = trim($alias);
+
+        if ( ! is_null($alias)) {
+            $this->alias = trim($alias);
+        }
     }
 
     /**

--- a/src/Framework/QueryBuilder/Clauses/Select.php
+++ b/src/Framework/QueryBuilder/Clauses/Select.php
@@ -24,6 +24,9 @@ class Select
     public function __construct($column, $alias = null)
     {
         $this->column = trim($column);
-        $this->alias  = trim($alias);
+
+        if ( ! is_null($alias)) {
+            $this->alias = trim($alias);
+        }
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

Resolves #7141

## Description

This PR adds PHP 8.2 compatibility to Give Core, but it fails to do that 100% since we use packages that we can't update without bumping the min required PHP version for Give Core.

Packages that require updates:

**moneyphp/money**
Currently, we use v3.3.1 which throws notices running on servers that use PHP 8.2
To fix this we have to update this package to v4.0.0. The problem is that this version requires PHP ^8.0

**myclabs/php-enum**
Currently, we use v1.6 which throws notices running on servers that use PHP 8.2
 To fix this we have to update this package to ^1.8.0. The problem is that this version requires PHP ^7.3

## Affects
Give Core


## Testing Instructions

Install Give on server that runs PHP 8.2
Enable `WP_DEBUG` and `WP_DEBUG_LOG`
Add donation forms
Make donations
Edit donors
Preview forms on frontend
Browse admin pages

Check if there are any notices inside the debug.log file related to Give core

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

