### PR TITLE
Fix: Remove default value for `continue_button_title` - [GIVE-145]

### DIFF
--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -3,15 +3,15 @@
  * Give Form Functions
  *
  * @package     GiveWP
- * @subpackage  Includes/Forms
+ * @since       1.1
  * @copyright   Copyright (c) 2016, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
- * @since       1.1
+ * @subpackage  Includes/Forms
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if ( ! defined('ABSPATH')) {
+    exit;
 }
 
 use Give\Helpers\Form\Utils as FormUtils;
@@ -21,18 +21,18 @@ use Give\Helpers\Form\Utils as FormUtils;
  *
  * @return bool
  */
-function give_shortcode_button_condition() {
+function give_shortcode_button_condition()
+{
+    global $typenow;
 
-	global $typenow;
+    if ($typenow != 'give_forms') {
+        return true;
+    }
 
-	if ( $typenow != 'give_forms' ) {
-		return true;
-	}
-
-	return false;
+    return false;
 }
 
-add_filter( 'give_shortcode_button_condition', 'give_shortcode_button_condition' );
+add_filter('give_shortcode_button_condition', 'give_shortcode_button_condition');
 
 
 /**
@@ -42,14 +42,13 @@ add_filter( 'give_shortcode_button_condition', 'give_shortcode_button_condition'
  *
  * @return int|false
  */
-function get_form_id_from_args( $args ) {
+function get_form_id_from_args($args)
+{
+    if (isset($args['form_id']) && $args['form_id'] != 0) {
+        return intval($args['form_id']);
+    }
 
-	if ( isset( $args['form_id'] ) && $args['form_id'] != 0 ) {
-
-		return intval( $args['form_id'] );
-	}
-
-	return false;
+    return false;
 }
 
 /**
@@ -61,28 +60,28 @@ function get_form_id_from_args( $args ) {
  *
  * @return bool
  */
-function give_is_float_labels_enabled( $args ) {
+function give_is_float_labels_enabled($args)
+{
+    $float_labels = '';
 
-	$float_labels = '';
+    if ( ! empty($args['float_labels'])) {
+        $float_labels = $args['float_labels'];
+    }
 
-	if ( ! empty( $args['float_labels'] ) ) {
-		$float_labels = $args['float_labels'];
-	}
+    if (empty($float_labels)) {
+        $float_labels = give_get_meta($args['form_id'], '_give_form_floating_labels', true);
+    }
 
-	if ( empty( $float_labels ) ) {
-		$float_labels = give_get_meta( $args['form_id'], '_give_form_floating_labels', true );
-	}
+    if (empty($float_labels) || ('global' === $float_labels)) {
+        $float_labels = give_get_option('floatlabels', 'disabled');
+    }
 
-	if ( empty( $float_labels ) || ( 'global' === $float_labels ) ) {
-		$float_labels = give_get_option( 'floatlabels', 'disabled' );
-	}
+    // If the form is using a non-legacy form template, do not use floating labels
+    if ( ! FormUtils::isLegacyForm($args['form_id'])) {
+        $float_labels = 'disabled';
+    }
 
-	// If the form is using a non-legacy form template, do not use floating labels
-	if ( ! FormUtils::isLegacyForm( $args['form_id'] ) ) {
-		$float_labels = 'disabled';
-	}
-
-	return give_is_setting_enabled( $float_labels );
+    return give_is_setting_enabled($float_labels);
 }
 
 /**
@@ -94,11 +93,11 @@ function give_is_float_labels_enabled( $args ) {
  *
  * @return bool Can user checkout?
  */
-function give_can_checkout() {
+function give_can_checkout()
+{
+    $can_checkout = true;
 
-	$can_checkout = true;
-
-	return (bool) apply_filters( 'give_can_checkout', $can_checkout );
+    return (bool)apply_filters('give_can_checkout', $can_checkout);
 }
 
 /**
@@ -109,14 +108,15 @@ function give_can_checkout() {
  *
  * @return      string
  */
-function give_get_success_page_uri() {
-	$give_options = give_get_settings();
+function give_get_success_page_uri()
+{
+    $give_options = give_get_settings();
 
-	$success_page = isset( $give_options['success_page'] )
-		? get_permalink( absint( $give_options['success_page'] ) )
-		: get_bloginfo( 'url' );
+    $success_page = isset($give_options['success_page'])
+        ? get_permalink(absint($give_options['success_page']))
+        : get_bloginfo('url');
 
-	return apply_filters( 'give_get_success_page_uri', $success_page );
+    return apply_filters('give_get_success_page_uri', $success_page);
 }
 
 /**
@@ -126,12 +126,13 @@ function give_get_success_page_uri() {
  *
  * @return bool True if on the Success page, false otherwise.
  */
-function give_is_success_page() {
-	$give_options = give_get_settings();
+function give_is_success_page()
+{
+    $give_options = give_get_settings();
 
-	$success_page = isset( $give_options['success_page'] ) ? is_page( $give_options['success_page'] ) : false;
+    $success_page = isset($give_options['success_page']) ? is_page($give_options['success_page']) : false;
 
-	return apply_filters( 'give_is_success_page', $success_page );
+    return apply_filters('give_is_success_page', $success_page);
 }
 
 /**
@@ -139,23 +140,25 @@ function give_is_success_page() {
  *
  * Sends the user to the success page.
  *
+ * @since       1.0
+ *
  * @param string $query_string
  *
  * @access      public
- * @since       1.0
  * @return      void
  */
-function give_send_to_success_page( $query_string = null ) {
-	$redirect = give_get_success_page_uri();
+function give_send_to_success_page($query_string = null)
+{
+    $redirect = give_get_success_page_uri();
 
-	if ( $query_string ) {
-		$redirect .= $query_string;
-	}
+    if ($query_string) {
+        $redirect .= $query_string;
+    }
 
-	$gateway = isset( $_REQUEST['give-gateway'] ) ? give_clean( $_REQUEST['give-gateway'] ) : '';
+    $gateway = isset($_REQUEST['give-gateway']) ? give_clean($_REQUEST['give-gateway']) : '';
 
-	wp_redirect( apply_filters( 'give_success_page_redirect', $redirect, $gateway, $query_string ) );
-	give_die();
+    wp_redirect(apply_filters('give_success_page_redirect', $redirect, $gateway, $query_string));
+    give_die();
 }
 
 
@@ -164,67 +167,68 @@ function give_send_to_success_page( $query_string = null ) {
  *
  * Used to redirect a user back to the donation form if there are errors present.
  *
+ * @since  2.21.0 Auto set "payment-mode" in redirect url.
+ * @since  1.0
+ *
  * @param array|string $args
  *
  * @access public
- * @since 2.21.0 Auto set "payment-mode" in redirect url.
- * @since  1.0
  * @return Void
  */
-function give_send_back_to_checkout( $args = [] ) {
-
-	$url     = isset( $_POST['give-current-url'] ) ? sanitize_text_field( $_POST['give-current-url'] ) : '';
-	$form_id = 0;
+function give_send_back_to_checkout($args = [])
+{
+    $url = isset($_POST['give-current-url']) ? sanitize_text_field($_POST['give-current-url']) : '';
+    $form_id = 0;
     $defaults = [];
 
-	// Set the form_id.
-	if ( isset( $_POST['give-form-id'] ) ) {
-        $defaults['form-id'] = (int) sanitize_text_field( $_POST['give-form-id'] );
-	}
-
-    // Set the payment mode.
-    if ( isset( $_POST['payment-mode'] ) ) {
-        $defaults['payment-mode'] = sanitize_text_field( $_POST['payment-mode'] );
+    // Set the form_id.
+    if (isset($_POST['give-form-id'])) {
+        $defaults['form-id'] = (int)sanitize_text_field($_POST['give-form-id']);
     }
 
-	// Need a URL to continue. If none, redirect back to single form.
-	if ( empty( $url ) ) {
-		wp_safe_redirect( get_permalink( $form_id ) );
-		give_die();
-	}
+    // Set the payment mode.
+    if (isset($_POST['payment-mode'])) {
+        $defaults['payment-mode'] = sanitize_text_field($_POST['payment-mode']);
+    }
 
-	// Set the $level_id.
-	if ( isset( $_POST['give-price-id'] ) ) {
-		$defaults['level-id'] = sanitize_text_field( $_POST['give-price-id'] );
+    // Need a URL to continue. If none, redirect back to single form.
+    if (empty($url)) {
+        wp_safe_redirect(get_permalink($form_id));
+        give_die();
+    }
 
-		// If custom, set amount
-		if( 'custom' === $defaults[ 'level-id' ] ) {
-			$defaults['custom-amount'] = sanitize_text_field( $_POST['give-amount'] );
-		}
-	}
+    // Set the $level_id.
+    if (isset($_POST['give-price-id'])) {
+        $defaults['level-id'] = sanitize_text_field($_POST['give-price-id']);
 
-	// Check for backward compatibility.
-	if ( is_string( $args ) ) {
-		$args = str_replace( '?', '', $args );
-	}
+        // If custom, set amount
+        if ('custom' === $defaults['level-id']) {
+            $defaults['custom-amount'] = sanitize_text_field($_POST['give-amount']);
+        }
+    }
 
-	$args = wp_parse_args( $args, $defaults );
+    // Check for backward compatibility.
+    if (is_string($args)) {
+        $args = str_replace('?', '', $args);
+    }
 
-	// Merge URL query with $args to maintain third-party URL parameters after redirect.
-	$redirect = add_query_arg( $args, $url );
+    $args = wp_parse_args($args, $defaults);
 
-	// Precaution: don't allow any CC info.
-	$redirect = remove_query_arg( [ 'card_number', 'card_cvc' ], $redirect );
+    // Merge URL query with $args to maintain third-party URL parameters after redirect.
+    $redirect = add_query_arg($args, $url);
 
-	// Redirect them.
-	$redirect .= "#give-form-{$form_id}-wrap";
+    // Precaution: don't allow any CC info.
+    $redirect = remove_query_arg(['card_number', 'card_cvc'], $redirect);
 
-	/**
-	 * Filter the redirect url
-	 */
-	wp_safe_redirect( esc_url_raw( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) ) );
+    // Redirect them.
+    $redirect .= "#give-form-{$form_id}-wrap";
 
-	give_die();
+    /**
+     * Filter the redirect url
+     */
+    wp_safe_redirect(esc_url_raw(apply_filters('give_send_back_to_checkout', $redirect, $args)));
+
+    give_die();
 }
 
 /**
@@ -232,21 +236,22 @@ function give_send_back_to_checkout( $args = [] ) {
  *
  * Gets the success page URL.
  *
+ * @since       1.0
+ *
  * @param string $query_string
  *
  * @access      public
- * @since       1.0
  * @return      string
  */
-function give_get_success_page_url( $query_string = null ) {
-	$success_page = give_get_success_page_uri();
+function give_get_success_page_url($query_string = null)
+{
+    $success_page = give_get_success_page_uri();
 
-	if ( $query_string ) {
-		$success_page .= $query_string;
-	}
+    if ($query_string) {
+        $success_page .= $query_string;
+    }
 
-	return apply_filters( 'give_success_page_url', $success_page );
-
+    return apply_filters('give_success_page_url', $success_page);
 }
 
 /**
@@ -258,31 +263,32 @@ function give_get_success_page_url( $query_string = null ) {
  *
  * @return mixed Full URL to the Failed Donation Page, if present, home page if it doesn't exist.
  */
-function give_get_failed_transaction_uri( $extras = false ) {
-	$give_options = give_get_settings();
+function give_get_failed_transaction_uri($extras = false)
+{
+    $give_options = give_get_settings();
 
-	// Remove question mark.
-	if ( 0 === strpos( $extras, '?' ) ) {
-		$extras = substr( $extras, 1 );
-	}
+    // Remove question mark.
+    if (0 === strpos($extras, '?')) {
+        $extras = substr($extras, 1);
+    }
 
-	$extras_args = wp_parse_args( $extras );
+    $extras_args = wp_parse_args($extras);
 
-	// Set nonce if payment id exist in extra params.
-	if ( array_key_exists( 'payment-id', $extras_args ) ) {
-		$extras_args['_wpnonce'] = wp_create_nonce( "give-failed-donation-{$extras_args['payment-id']}" );
-		$extras                  = http_build_query( $extras_args );
-	}
+    // Set nonce if payment id exist in extra params.
+    if (array_key_exists('payment-id', $extras_args)) {
+        $extras_args['_wpnonce'] = wp_create_nonce("give-failed-donation-{$extras_args['payment-id']}");
+        $extras = http_build_query($extras_args);
+    }
 
-	$uri = ! empty( $give_options['failure_page'] ) ?
-		trailingslashit( get_permalink( $give_options['failure_page'] ) ) :
-		home_url();
+    $uri = ! empty($give_options['failure_page']) ?
+        trailingslashit(get_permalink($give_options['failure_page'])) :
+        home_url();
 
-	if ( $extras ) {
-		$uri .= "?{$extras}";
-	}
+    if ($extras) {
+        $uri .= "?{$extras}";
+    }
 
-	return apply_filters( 'give_get_failed_transaction_uri', $uri );
+    return apply_filters('give_get_failed_transaction_uri', $uri);
 }
 
 /**
@@ -291,11 +297,12 @@ function give_get_failed_transaction_uri( $extras = false ) {
  * @since 1.0
  * @return bool True if on the Failed Donation Page, false otherwise.
  */
-function give_is_failed_transaction_page() {
-	$give_options = give_get_settings();
-	$ret          = isset( $give_options['failure_page'] ) ? is_page( $give_options['failure_page'] ) : false;
+function give_is_failed_transaction_page()
+{
+    $give_options = give_get_settings();
+    $ret = isset($give_options['failure_page']) ? is_page($give_options['failure_page']) : false;
 
-	return apply_filters( 'give_is_failure_page', $ret );
+    return apply_filters('give_is_failure_page', $ret);
 }
 
 /**
@@ -306,20 +313,21 @@ function give_is_failed_transaction_page() {
  *
  * @return bool
  */
-function give_listen_for_failed_payments() {
-	$payment_id = ! empty( $_GET['payment-id'] ) ? absint( $_GET['payment-id'] ) : 0;
-	$nonce      = ! empty( $_GET['_wpnonce'] ) ? give_clean( $_GET['_wpnonce'] ) : false;
+function give_listen_for_failed_payments()
+{
+    $payment_id = ! empty($_GET['payment-id']) ? absint($_GET['payment-id']) : 0;
+    $nonce = ! empty($_GET['_wpnonce']) ? give_clean($_GET['_wpnonce']) : false;
 
-	// Bailout.
-	if ( ! $payment_id || ! wp_verify_nonce( $nonce, "give-failed-donation-{$payment_id}" ) ) {
-		return false;
-	}
+    // Bailout.
+    if ( ! $payment_id || ! wp_verify_nonce($nonce, "give-failed-donation-{$payment_id}")) {
+        return false;
+    }
 
-	// Set payment status to failure
-	give_update_payment_status( $payment_id, 'failed' );
+    // Set payment status to failure
+    give_update_payment_status($payment_id, 'failed');
 }
 
-add_action( 'template_redirect', 'give_listen_for_failed_payments', 0 );
+add_action('template_redirect', 'give_listen_for_failed_payments', 0);
 
 /**
  * Retrieve the Donation History page URI
@@ -329,12 +337,15 @@ add_action( 'template_redirect', 'give_listen_for_failed_payments', 0 );
  *
  * @return      string
  */
-function give_get_history_page_uri() {
-	$give_options = give_get_settings();
+function give_get_history_page_uri()
+{
+    $give_options = give_get_settings();
 
-	$history_page = isset( $give_options['history_page'] ) ? get_permalink( absint( $give_options['history_page'] ) ) : get_bloginfo( 'url' );
+    $history_page = isset($give_options['history_page']) ? get_permalink(
+        absint($give_options['history_page'])
+    ) : get_bloginfo('url');
 
-	return apply_filters( 'give_get_history_page_uri', $history_page );
+    return apply_filters('give_get_history_page_uri', $history_page);
 }
 
 /**
@@ -344,29 +355,33 @@ function give_get_history_page_uri() {
  *
  * @return bool True if on the History page, false otherwise.
  */
-function give_is_history_page() {
-	$give_options = give_get_settings();
+function give_is_history_page()
+{
+    $give_options = give_get_settings();
 
-	$history_page = isset( $give_options['history_page'] ) ? absint( $give_options['history_page'] ) : 0;
+    $history_page = isset($give_options['history_page']) ? absint($give_options['history_page']) : 0;
 
-	return apply_filters( 'give_is_history_page', is_page( $history_page ) );
+    return apply_filters('give_is_history_page', is_page($history_page));
 }
 
 /**
  * Check if a field is required
  *
- * @param string $field
+ * @since       1.0
+ *
  * @param int    $form_id
  *
  * @access      public
- * @since       1.0
+ *
+ * @param string $field
+ *
  * @return      bool
  */
-function give_field_is_required( $field, $form_id ) {
+function give_field_is_required($field, $form_id)
+{
+    $required_fields = give_get_required_fields($form_id);
 
-	$required_fields = give_get_required_fields( $form_id );
-
-	return array_key_exists( $field, $required_fields );
+    return array_key_exists($field, $required_fields);
 }
 
 /**
@@ -376,30 +391,32 @@ function give_field_is_required( $field, $form_id ) {
  *
  * @since 1.0
  *
- * @param int         $give_form_id  Give Form ID.
+ * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ *
  * @param int         $payment_id    Payment ID.
  * @param bool|int    $price_id      Price ID, if any.
  * @param string|null $donation_date The date of the donation.
  *
- * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ * @param int         $give_form_id  Give Form ID.
  *
  * @return void
  */
-function give_record_donation_in_log( $give_form_id, $payment_id, $price_id = false, $donation_date = null ) {
-	$log_data = [
-		'log_content'  => 'Payment log info',
-		'log_parent'   => $payment_id,
-		'log_type'     => 'sale',
-		'log_date'     => isset( $donation_date ) ? $donation_date : null,
-		'log_date_gmt' => isset( $donation_date ) ? $donation_date : null,
-	];
+function give_record_donation_in_log($give_form_id, $payment_id, $price_id = false, $donation_date = null)
+{
+    $log_data = [
+        'log_content'  => 'Payment log info',
+        'log_parent'   => $payment_id,
+        'log_type'     => 'sale',
+        'log_date'     => isset($donation_date) ? $donation_date : null,
+        'log_date_gmt' => isset($donation_date) ? $donation_date : null,
+    ];
 
-	$log_meta = [
-		'form_id'  => $give_form_id,
-		'price_id' => (int) $price_id,
-	];
+    $log_meta = [
+        'form_id'  => $give_form_id,
+        'price_id' => (int)$price_id,
+    ];
 
-	Give()->logs->insert_log( $log_data, $log_meta );
+    Give()->logs->insert_log($log_data, $log_meta);
 }
 
 
@@ -413,13 +430,14 @@ function give_record_donation_in_log( $give_form_id, $payment_id, $price_id = fa
  *
  * @return bool|int
  */
-function give_increase_donation_count( $form_id = 0, $quantity = 1 ) {
-	$quantity = (int) $quantity;
+function give_increase_donation_count($form_id = 0, $quantity = 1)
+{
+    $quantity = (int)$quantity;
 
-	/** @var \Give_Donate_Form $form */
-	$form = new Give_Donate_Form( $form_id );
+    /** @var \Give_Donate_Form $form */
+    $form = new Give_Donate_Form($form_id);
 
-	return $form->increase_sales( $quantity );
+    return $form->increase_sales($quantity);
 }
 
 /**
@@ -431,20 +449,20 @@ function give_increase_donation_count( $form_id = 0, $quantity = 1 ) {
  *
  * @return void
  */
-function give_update_goal_progress( $form_id = 0 ) {
+function give_update_goal_progress($form_id = 0)
+{
+    // Get goal option meta key
+    $is_goal_enabled = give_is_setting_enabled(give_get_meta($form_id, '_give_goal_option', true, 'disabled'));
 
-	// Get goal option meta key
-	$is_goal_enabled = give_is_setting_enabled( give_get_meta( $form_id, '_give_goal_option', true, 'disabled' ) );
+    // Check, if the form goal is enabled.
+    if ($is_goal_enabled) {
+        $goal_stats = give_goal_progress_stats($form_id);
+        $form_goal_progress_value = ! empty($goal_stats['progress']) ? $goal_stats['progress'] : 0;
+    } else {
+        $form_goal_progress_value = -1;
+    }
 
-	// Check, if the form goal is enabled.
-	if ( $is_goal_enabled ) {
-		$goal_stats               = give_goal_progress_stats( $form_id );
-		$form_goal_progress_value = ! empty( $goal_stats['progress'] ) ? $goal_stats['progress'] : 0;
-	} else {
-		$form_goal_progress_value = -1;
-	}
-
-	give_update_meta( $form_id, '_give_form_goal_progress', $form_goal_progress_value );
+    give_update_meta($form_id, '_give_form_goal_progress', $form_goal_progress_value);
 }
 
 /**
@@ -457,13 +475,14 @@ function give_update_goal_progress( $form_id = 0 ) {
  *
  * @return bool|int
  */
-function give_decrease_donation_count( $form_id = 0, $quantity = 1 ) {
-	$quantity = (int) $quantity;
+function give_decrease_donation_count($form_id = 0, $quantity = 1)
+{
+    $quantity = (int)$quantity;
 
-	/** @var \Give_Donate_Form $form */
-	$form = new Give_Donate_Form( $form_id );
+    /** @var \Give_Donate_Form $form */
+    $form = new Give_Donate_Form($form_id);
 
-	return $form->decrease_sales( $quantity );
+    return $form->decrease_sales($quantity);
 }
 
 /**
@@ -473,19 +492,21 @@ function give_decrease_donation_count( $form_id = 0, $quantity = 1 ) {
  *
  * @since 2.1 Pass donation id.
  *
- * @param int $give_form_id Give Form ID
+ * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ *
  * @param int $amount       Earnings
  * @param int $payment_id   Donation ID.
  *
- * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
+ * @param int $give_form_id Give Form ID
  *
  * @return bool|int
  */
-function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
-	/** @var \Give_Donate_Form $form */
-	$form = new Give_Donate_Form( $give_form_id );
+function give_increase_earnings($give_form_id, $amount, $payment_id = 0)
+{
+    /** @var \Give_Donate_Form $form */
+    $form = new Give_Donate_Form($give_form_id);
 
-	return $form->increase_earnings( $amount, $payment_id );
+    return $form->increase_earnings($amount, $payment_id);
 }
 
 /**
@@ -497,19 +518,21 @@ function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
  *
  * @since 2.1 Pass donation id.
  *
- * @param int $form_id    Give Form ID
+ * @since 2.12.0 default value for the $form_id parameter is removed to prevent PHP8 warnings.
+ *
  * @param int $amount     Earnings
  * @param int $payment_id Donation ID.
  *
- * @since 2.12.0 default value for the $form_id parameter is removed to prevent PHP8 warnings.
+ * @param int $form_id    Give Form ID
  *
  * @return bool|int
  */
-function give_decrease_form_earnings( $form_id, $amount, $payment_id = 0 ) {
-	/** @var \Give_Donate_Form $form */
-	$form = new Give_Donate_Form( $form_id );
+function give_decrease_form_earnings($form_id, $amount, $payment_id = 0)
+{
+    /** @var \Give_Donate_Form $form */
+    $form = new Give_Donate_Form($form_id);
 
-	return $form->decrease_earnings( $amount, $payment_id );
+    return $form->decrease_earnings($amount, $payment_id);
 }
 
 
@@ -522,15 +545,16 @@ function give_decrease_form_earnings( $form_id, $amount, $payment_id = 0 ) {
  *
  * @return int $earnings Earnings for a certain form
  */
-function give_get_form_earnings_stats( $form_id = 0 ) {
-	$give_form = new Give_Donate_Form( $form_id );
+function give_get_form_earnings_stats($form_id = 0)
+{
+    $give_form = new Give_Donate_Form($form_id);
 
-	/**
-	 * Filter the form earnings
-	 *
-	 * @since 1.8.17
-	 */
-	return apply_filters( 'give_get_form_earnings_stats', $give_form->earnings, $form_id, $give_form );
+    /**
+     * Filter the form earnings
+     *
+     * @since 1.8.17
+     */
+    return apply_filters('give_get_form_earnings_stats', $give_form->earnings, $form_id, $give_form);
 }
 
 
@@ -543,10 +567,11 @@ function give_get_form_earnings_stats( $form_id = 0 ) {
  *
  * @return int $sales Amount of sales for a certain form
  */
-function give_get_form_sales_stats( $give_form_id = 0 ) {
-	$give_form = new Give_Donate_Form( $give_form_id );
+function give_get_form_sales_stats($give_form_id = 0)
+{
+    $give_form = new Give_Donate_Form($give_form_id);
 
-	return $give_form->sales;
+    return $give_form->sales;
 }
 
 
@@ -559,19 +584,20 @@ function give_get_form_sales_stats( $give_form_id = 0 ) {
  *
  * @return float $sales Average monthly sales
  */
-function give_get_average_monthly_form_sales( $form_id = 0 ) {
-	$sales        = give_get_form_sales_stats( $form_id );
-	$release_date = get_post_field( 'post_date', $form_id );
+function give_get_average_monthly_form_sales($form_id = 0)
+{
+    $sales = give_get_form_sales_stats($form_id);
+    $release_date = get_post_field('post_date', $form_id);
 
-	$diff = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
+    $diff = abs(current_time('timestamp') - strtotime($release_date));
 
-	$months = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
+    $months = floor($diff / (30 * 60 * 60 * 24)); // Number of months since publication
 
-	if ( $months > 0 ) {
-		$sales = ( $sales / $months );
-	}
+    if ($months > 0) {
+        $sales = ($sales / $months);
+    }
 
-	return $sales;
+    return $sales;
 }
 
 
@@ -584,19 +610,20 @@ function give_get_average_monthly_form_sales( $form_id = 0 ) {
  *
  * @return float $earnings Average monthly earnings
  */
-function give_get_average_monthly_form_earnings( $form_id = 0 ) {
-	$earnings     = give_get_form_earnings_stats( $form_id );
-	$release_date = get_post_field( 'post_date', $form_id );
+function give_get_average_monthly_form_earnings($form_id = 0)
+{
+    $earnings = give_get_form_earnings_stats($form_id);
+    $release_date = get_post_field('post_date', $form_id);
 
-	$diff = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
+    $diff = abs(current_time('timestamp') - strtotime($release_date));
 
-	$months = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
+    $months = floor($diff / (30 * 60 * 60 * 24)); // Number of months since publication
 
-	if ( $months > 0 ) {
-		$earnings = ( $earnings / $months );
-	}
+    if ($months > 0) {
+        $earnings = ($earnings / $months);
+    }
 
-	return $earnings < 0 ? 0 : $earnings;
+    return $earnings < 0 ? 0 : $earnings;
 }
 
 
@@ -614,34 +641,36 @@ function give_get_average_monthly_form_earnings( $form_id = 0 ) {
  *
  * @return string $price_name Name of the price option
  */
-function give_get_price_option_name( $form_id = 0, $price_id = 0, $payment_id = 0, $use_fallback = true ) {
+function give_get_price_option_name($form_id = 0, $price_id = 0, $payment_id = 0, $use_fallback = true)
+{
+    $prices = give_get_variable_prices($form_id);
+    $price_name = '';
 
-	$prices     = give_get_variable_prices( $form_id );
-	$price_name = '';
+    if ( ! $prices) {
+        return $price_name;
+    }
 
-	if ( ! $prices ) {
-		return $price_name;
-	}
+    foreach ($prices as $price) {
+        if (intval($price['_give_id']['level_id']) === intval($price_id)) {
+            $price_text = apply_filters(
+                'give_form_level_text',
+                isset($price['_give_text']) ? $price['_give_text'] : '',
+                $form_id,
+                $price
+            );
+            $price_fallback = $use_fallback ?
+                give_currency_filter(
+                    give_format_amount(
+                        $price['_give_amount'],
+                        ['sanitize' => false]
+                    ),
+                    ['decode_currency' => true]
+                ) : '';
+            $price_name = ! empty($price_text) ? $price_text : $price_fallback;
+        }
+    }
 
-	foreach ( $prices as $price ) {
-
-		if ( intval( $price['_give_id']['level_id'] ) === intval( $price_id ) ) {
-
-			$price_text     = apply_filters( 'give_form_level_text', isset( $price['_give_text'] ) ? $price['_give_text'] : '', $form_id, $price );
-			$price_fallback = $use_fallback ?
-				give_currency_filter(
-					give_format_amount(
-						$price['_give_amount'],
-						[ 'sanitize' => false ]
-					),
-					[ 'decode_currency' => true ]
-				) : '';
-			$price_name     = ! empty( $price_text ) ? $price_text : $price_fallback;
-
-		}
-	}
-
-	return apply_filters( 'give_get_price_option_name', $price_name, $form_id, $payment_id, $price_id );
+    return apply_filters('give_get_price_option_name', $price_name, $form_id, $payment_id, $price_id);
 }
 
 
@@ -655,24 +684,29 @@ function give_get_price_option_name( $form_id = 0, $price_id = 0, $payment_id = 
  *
  * @return string $range A fully formatted price range
  */
-function give_price_range( $form_id = 0, $formatted = true ) {
-	$low        = give_get_lowest_price_option( $form_id );
-	$high       = give_get_highest_price_option( $form_id );
-	$order_type = ! empty( $_REQUEST['order'] ) ? $_REQUEST['order'] : 'asc';
+function give_price_range($form_id = 0, $formatted = true)
+{
+    $low = give_get_lowest_price_option($form_id);
+    $high = give_get_highest_price_option($form_id);
+    $order_type = ! empty($_REQUEST['order']) ? $_REQUEST['order'] : 'asc';
 
-	$range = sprintf(
-		'<span class="give_price_range_%1$s">%2$s</span><span class="give_price_range_sep">&nbsp;&ndash;&nbsp;</span><span class="give_price_range_%3$s">%4$s</span>',
-		'asc' === $order_type ? 'low' : 'high',
-		'asc' === $order_type ? give_currency_filter( give_format_amount( $low, [ 'sanitize' => false ] ) ) : give_currency_filter( give_format_amount( $high, [ 'sanitize' => false ] ) ),
-		'asc' === $order_type ? 'high' : 'low',
-		'asc' === $order_type ? give_currency_filter( give_format_amount( $high, [ 'sanitize' => false ] ) ) : give_currency_filter( give_format_amount( $low, [ 'sanitize' => false ] ) )
-	);
+    $range = sprintf(
+        '<span class="give_price_range_%1$s">%2$s</span><span class="give_price_range_sep">&nbsp;&ndash;&nbsp;</span><span class="give_price_range_%3$s">%4$s</span>',
+        'asc' === $order_type ? 'low' : 'high',
+        'asc' === $order_type ? give_currency_filter(
+            give_format_amount($low, ['sanitize' => false])
+        ) : give_currency_filter(give_format_amount($high, ['sanitize' => false])),
+        'asc' === $order_type ? 'high' : 'low',
+        'asc' === $order_type ? give_currency_filter(
+            give_format_amount($high, ['sanitize' => false])
+        ) : give_currency_filter(give_format_amount($low, ['sanitize' => false]))
+    );
 
-	if ( ! $formatted ) {
-		$range = wp_strip_all_tags( $range );
-	}
+    if ( ! $formatted) {
+        $range = wp_strip_all_tags($range);
+    }
 
-	return apply_filters( 'give_price_range', $range, $form_id, $low, $high );
+    return apply_filters('give_price_range', $range, $form_id, $low, $high);
 }
 
 
@@ -687,41 +721,39 @@ function give_price_range( $form_id = 0, $formatted = true ) {
  *
  * @return int ID of the lowest price
  */
-function give_get_lowest_price_id( $form_id = 0 ) {
+function give_get_lowest_price_id($form_id = 0)
+{
+    if (empty($form_id)) {
+        $form_id = get_the_ID();
+    }
 
-	if ( empty( $form_id ) ) {
-		$form_id = get_the_ID();
-	}
+    if ( ! give_has_variable_prices($form_id)) {
+        return give_get_form_price($form_id);
+    }
 
-	if ( ! give_has_variable_prices( $form_id ) ) {
-		return give_get_form_price( $form_id );
-	}
+    $prices = give_get_variable_prices($form_id);
 
-	$prices = give_get_variable_prices( $form_id );
+    $min = $min_id = 0;
 
-	$min = $min_id = 0;
+    if ( ! empty($prices)) {
+        foreach ($prices as $key => $price) {
+            if (empty($price['_give_amount'])) {
+                continue;
+            }
 
-	if ( ! empty( $prices ) ) {
+            if ( ! isset($min)) {
+                $min = $price['_give_amount'];
+            } else {
+                $min = min($min, $price['_give_amount']);
+            }
 
-		foreach ( $prices as $key => $price ) {
+            if ($price['_give_amount'] == $min) {
+                $min_id = $price['_give_id']['level_id'];
+            }
+        }
+    }
 
-			if ( empty( $price['_give_amount'] ) ) {
-				continue;
-			}
-
-			if ( ! isset( $min ) ) {
-				$min = $price['_give_amount'];
-			} else {
-				$min = min( $min, $price['_give_amount'] );
-			}
-
-			if ( $price['_give_amount'] == $min ) {
-				$min_id = $price['_give_id']['level_id'];
-			}
-		}
-	}
-
-	return (int) $min_id;
+    return (int)$min_id;
 }
 
 /**
@@ -733,22 +765,23 @@ function give_get_lowest_price_id( $form_id = 0 ) {
  *
  * @return float Amount of the lowest price
  */
-function give_get_lowest_price_option( $form_id = 0 ) {
-	if ( empty( $form_id ) ) {
-		$form_id = get_the_ID();
-	}
+function give_get_lowest_price_option($form_id = 0)
+{
+    if (empty($form_id)) {
+        $form_id = get_the_ID();
+    }
 
-	if ( ! give_has_variable_prices( $form_id ) ) {
-		return give_get_form_price( $form_id );
-	}
+    if ( ! give_has_variable_prices($form_id)) {
+        return give_get_form_price($form_id);
+    }
 
-	if ( ! ( $low = get_post_meta( $form_id, '_give_levels_minimum_amount', true ) ) ) {
-		// Backward compatibility.
-		$prices = wp_list_pluck( give_get_variable_prices( $form_id ), '_give_amount' );
-		$low    = ! empty( $prices ) ? min( $prices ) : 0;
-	}
+    if ( ! ($low = get_post_meta($form_id, '_give_levels_minimum_amount', true))) {
+        // Backward compatibility.
+        $prices = wp_list_pluck(give_get_variable_prices($form_id), '_give_amount');
+        $low = ! empty($prices) ? min($prices) : 0;
+    }
 
-	return give_maybe_sanitize_amount( $low );
+    return give_maybe_sanitize_amount($low);
 }
 
 /**
@@ -760,23 +793,23 @@ function give_get_lowest_price_option( $form_id = 0 ) {
  *
  * @return float Amount of the highest price
  */
-function give_get_highest_price_option( $form_id = 0 ) {
+function give_get_highest_price_option($form_id = 0)
+{
+    if (empty($form_id)) {
+        $form_id = get_the_ID();
+    }
 
-	if ( empty( $form_id ) ) {
-		$form_id = get_the_ID();
-	}
+    if ( ! give_has_variable_prices($form_id)) {
+        return give_get_form_price($form_id);
+    }
 
-	if ( ! give_has_variable_prices( $form_id ) ) {
-		return give_get_form_price( $form_id );
-	}
+    if ( ! ($high = get_post_meta($form_id, '_give_levels_maximum_amount', true))) {
+        // Backward compatibility.
+        $prices = wp_list_pluck(give_get_variable_prices($form_id), '_give_amount');
+        $high = ! empty($prices) ? max($prices) : 0;
+    }
 
-	if ( ! ( $high = get_post_meta( $form_id, '_give_levels_maximum_amount', true ) ) ) {
-		// Backward compatibility.
-		$prices = wp_list_pluck( give_get_variable_prices( $form_id ), '_give_amount' );
-		$high   = ! empty( $prices ) ? max( $prices ) : 0;
-	}
-
-	return give_maybe_sanitize_amount( $high );
+    return give_maybe_sanitize_amount($high);
 }
 
 /**
@@ -788,15 +821,15 @@ function give_get_highest_price_option( $form_id = 0 ) {
  *
  * @return mixed string|int Price of the form
  */
-function give_get_form_price( $form_id = 0 ) {
+function give_get_form_price($form_id = 0)
+{
+    if (empty($form_id)) {
+        return false;
+    }
 
-	if ( empty( $form_id ) ) {
-		return false;
-	}
+    $form = new Give_Donate_Form($form_id);
 
-	$form = new Give_Donate_Form( $form_id );
-
-	return $form->__get( 'price' );
+    return $form->__get('price');
 }
 
 /**
@@ -808,16 +841,15 @@ function give_get_form_price( $form_id = 0 ) {
  *
  * @return mixed string|int Minimum price of the form
  */
-function give_get_form_minimum_price( $form_id = 0 ) {
+function give_get_form_minimum_price($form_id = 0)
+{
+    if (empty($form_id)) {
+        return false;
+    }
 
-	if ( empty( $form_id ) ) {
-		return false;
-	}
+    $form = new Give_Donate_Form($form_id);
 
-	$form = new Give_Donate_Form( $form_id );
-
-	return $form->get_minimum_price();
-
+    return $form->get_minimum_price();
 }
 
 /**
@@ -829,15 +861,15 @@ function give_get_form_minimum_price( $form_id = 0 ) {
  *
  * @return bool|float
  */
-function give_get_form_maximum_price( $form_id = 0 ) {
+function give_get_form_maximum_price($form_id = 0)
+{
+    if (empty($form_id)) {
+        return false;
+    }
 
-	if ( empty( $form_id ) ) {
-		return false;
-	}
+    $form = new Give_Donate_Form($form_id);
 
-	$form = new Give_Donate_Form( $form_id );
-
-	return $form->get_maximum_price();
+    return $form->get_maximum_price();
 }
 
 /**
@@ -851,48 +883,45 @@ function give_get_form_maximum_price( $form_id = 0 ) {
  *
  * @return int $formatted_price
  */
-function give_price( $form_id = 0, $echo = true, $price_id = false ) {
-	$price = 0;
+function give_price($form_id = 0, $echo = true, $price_id = false)
+{
+    $price = 0;
 
-	if ( empty( $form_id ) ) {
-		$form_id = get_the_ID();
-	}
+    if (empty($form_id)) {
+        $form_id = get_the_ID();
+    }
 
-	if ( give_has_variable_prices( $form_id ) ) {
+    if (give_has_variable_prices($form_id)) {
+        $prices = give_get_variable_prices($form_id);
 
-		$prices = give_get_variable_prices( $form_id );
+        if (false !== $price_id) {
+            // loop through multi-prices to see which is default
+            foreach ($prices as $price) {
+                // this is the default price
+                if (isset($price['_give_default']) && $price['_give_default'] === 'default') {
+                    $price = (float)$price['_give_amount'];
+                };
+            }
+        } else {
+            $price = give_get_lowest_price_option($form_id);
+        }
+    } else {
+        $price = give_get_form_price($form_id);
+    }
 
-		if ( false !== $price_id ) {
+    $price = apply_filters('give_form_price', give_maybe_sanitize_amount($price), $form_id);
+    $formatted_price = '<span class="give_price" id="give_price_' . $form_id . '">' . $price . '</span>';
+    $formatted_price = apply_filters('give_form_price_after_html', $formatted_price, $form_id, $price);
 
-			// loop through multi-prices to see which is default
-			foreach ( $prices as $price ) {
-				// this is the default price
-				if ( isset( $price['_give_default'] ) && $price['_give_default'] === 'default' ) {
-					$price = (float) $price['_give_amount'];
-				};
-			}
-		} else {
-
-			$price = give_get_lowest_price_option( $form_id );
-		}
-	} else {
-
-		$price = give_get_form_price( $form_id );
-	}
-
-	$price           = apply_filters( 'give_form_price', give_maybe_sanitize_amount( $price ), $form_id );
-	$formatted_price = '<span class="give_price" id="give_price_' . $form_id . '">' . $price . '</span>';
-	$formatted_price = apply_filters( 'give_form_price_after_html', $formatted_price, $form_id, $price );
-
-	if ( $echo ) {
-		echo $formatted_price;
-	} else {
-		return $formatted_price;
-	}
+    if ($echo) {
+        echo $formatted_price;
+    } else {
+        return $formatted_price;
+    }
 }
 
-add_filter( 'give_form_price', 'give_format_amount', 10 );
-add_filter( 'give_form_price', 'give_currency_filter', 20 );
+add_filter('give_form_price', 'give_format_amount', 10);
+add_filter('give_form_price', 'give_currency_filter', 20);
 
 
 /**
@@ -905,29 +934,30 @@ add_filter( 'give_form_price', 'give_currency_filter', 20 );
  *
  * @return float $amount Amount of the price option
  */
-function give_get_price_option_amount( $form_id = 0, $price_id = 0 ) {
-	$prices = give_get_variable_prices( $form_id );
+function give_get_price_option_amount($form_id = 0, $price_id = 0)
+{
+    $prices = give_get_variable_prices($form_id);
 
-	$amount = 0.00;
+    $amount = 0.00;
 
-	foreach ( $prices as $price ) {
-		if ( isset( $price['_give_id']['level_id'] ) && $price['_give_id']['level_id'] == $price_id ) {
-			$amount = isset( $price['_give_amount'] ) ? $price['_give_amount'] : 0.00;
-			break;
-		}
-	}
+    foreach ($prices as $price) {
+        if (isset($price['_give_id']['level_id']) && $price['_give_id']['level_id'] == $price_id) {
+            $amount = isset($price['_give_amount']) ? $price['_give_amount'] : 0.00;
+            break;
+        }
+    }
 
-	/**
-	 * Filter the price amount
-	 *
-	 * @since 1.0
-	 */
-	return apply_filters(
-		'give_get_price_option_amount',
-		give_maybe_sanitize_amount( $amount, [ 'currency' => give_get_currency( $form_id ) ] ),
-		$form_id,
-		$price_id
-	);
+    /**
+     * Filter the price amount
+     *
+     * @since 1.0
+     */
+    return apply_filters(
+        'give_get_price_option_amount',
+        give_maybe_sanitize_amount($amount, ['currency' => give_get_currency($form_id)]),
+        $form_id,
+        $price_id
+    );
 }
 
 /**
@@ -939,16 +969,15 @@ function give_get_price_option_amount( $form_id = 0, $price_id = 0 ) {
  *
  * @return mixed string|int Goal of the form
  */
-function give_get_form_goal( $form_id = 0 ) {
+function give_get_form_goal($form_id = 0)
+{
+    if (empty($form_id)) {
+        return false;
+    }
 
-	if ( empty( $form_id ) ) {
-		return false;
-	}
+    $form = new Give_Donate_Form($form_id);
 
-	$form = new Give_Donate_Form( $form_id );
-
-	return $form->goal;
-
+    return $form->goal;
 }
 
 /**
@@ -960,14 +989,13 @@ function give_get_form_goal( $form_id = 0 ) {
  *
  * @return mixed string|int Goal of the form
  */
-function give_get_form_goal_format( $form_id = 0 ) {
+function give_get_form_goal_format($form_id = 0)
+{
+    if (empty($form_id)) {
+        return false;
+    }
 
-	if ( empty( $form_id ) ) {
-		return false;
-	}
-
-	return give_get_meta( $form_id, '_give_goal_format', true );
-
+    return give_get_meta($form_id, '_give_goal_format', true);
 }
 
 /**
@@ -980,37 +1008,37 @@ function give_get_form_goal_format( $form_id = 0 ) {
  *
  * @return string $formatted_goal
  */
-function give_goal( $form_id = 0, $echo = true ) {
+function give_goal($form_id = 0, $echo = true)
+{
+    if (empty($form_id)) {
+        $form_id = get_the_ID();
+    }
 
-	if ( empty( $form_id ) ) {
-		$form_id = get_the_ID();
-	}
+    $goal = give_get_form_goal($form_id);
+    $goal_format = give_get_form_goal_format($form_id);
 
-	$goal        = give_get_form_goal( $form_id );
-	$goal_format = give_get_form_goal_format( $form_id );
+    if ('donation' === $goal_format) {
+        $goal = "{$goal} donations";
+    } else {
+        $goal = apply_filters('give_form_goal', give_maybe_sanitize_amount($goal), $form_id);
+    }
 
-	if ( 'donation' === $goal_format ) {
-		$goal = "{$goal} donations";
-	} else {
-		$goal = apply_filters( 'give_form_goal', give_maybe_sanitize_amount( $goal ), $form_id );
-	}
+    $formatted_goal = sprintf(
+        '<span class="give_price" id="give_price_%1$s">%2$s</span>',
+        $form_id,
+        $goal
+    );
+    $formatted_goal = apply_filters('give_form_price_after_html', $formatted_goal, $form_id, $goal);
 
-	$formatted_goal = sprintf(
-		'<span class="give_price" id="give_price_%1$s">%2$s</span>',
-		$form_id,
-		$goal
-	);
-	$formatted_goal = apply_filters( 'give_form_price_after_html', $formatted_goal, $form_id, $goal );
-
-	if ( $echo ) {
-		echo $formatted_goal;
-	} else {
-		return $formatted_goal;
-	}
+    if ($echo) {
+        echo $formatted_goal;
+    } else {
+        return $formatted_goal;
+    }
 }
 
-add_filter( 'give_form_goal', 'give_format_amount', 10 );
-add_filter( 'give_form_goal', 'give_currency_filter', 20 );
+add_filter('give_form_goal', 'give_format_amount', 10);
+add_filter('give_form_goal', 'give_currency_filter', 20);
 
 
 /**
@@ -1018,19 +1046,20 @@ add_filter( 'give_form_goal', 'give_currency_filter', 20 );
  *
  * @since  1.0
  *
- * @param  int $form_id Give form ID
+ * @param int $form_id Give form ID
  *
  * @return bool  $ret Whether or not the logged_in_only setting is set
  */
-function give_logged_in_only( $form_id ) {
-	// If _give_logged_in_only is set to enable then guest can donate from that specific form.
-	// Otherwise it is member only donation form.
-	$val = give_get_meta( $form_id, '_give_logged_in_only', true );
-	$val = ! empty( $val ) ? $val : 'enabled';
+function give_logged_in_only($form_id)
+{
+    // If _give_logged_in_only is set to enable then guest can donate from that specific form.
+    // Otherwise it is member only donation form.
+    $val = give_get_meta($form_id, '_give_logged_in_only', true);
+    $val = ! empty($val) ? $val : 'enabled';
 
-	$ret = ! give_is_setting_enabled( $val );
+    $ret = ! give_is_setting_enabled($val);
 
-	return (bool) apply_filters( 'give_logged_in_only', $ret, $form_id );
+    return (bool)apply_filters('give_logged_in_only', $ret, $form_id);
 }
 
 
@@ -1043,12 +1072,11 @@ function give_logged_in_only( $form_id ) {
  *
  * @return string
  */
-function give_show_login_register_option( $form_id ) {
+function give_show_login_register_option($form_id)
+{
+    $show_register_form = give_get_meta($form_id, '_give_show_register_form', true);
 
-	$show_register_form = give_get_meta( $form_id, '_give_show_register_form', true );
-
-	return apply_filters( 'give_show_register_form', $show_register_form, $form_id );
-
+    return apply_filters('give_show_register_form', $show_register_form, $form_id);
 }
 
 
@@ -1059,74 +1087,75 @@ function give_show_login_register_option( $form_id ) {
  *
  * @since  1.8
  *
- * @param  int $form_id Form ID.
+ * @param int $form_id Form ID.
  *
  * @return array
  */
-function _give_get_prefill_form_field_values( $form_id ) {
-	$logged_in_donor_info = [];
+function _give_get_prefill_form_field_values($form_id)
+{
+    $logged_in_donor_info = [];
 
-	if ( is_user_logged_in() ) :
-		$donor_data    = get_userdata( get_current_user_id() );
-		$donor         = new Give_Donor( get_current_user_id(), true );
-		$donor_address = $donor->get_donor_address();
-		$company_name  = $donor->get_company_name();
+    if (is_user_logged_in()) :
+        $donor_data = get_userdata(get_current_user_id());
+        $donor = new Give_Donor(get_current_user_id(), true);
+        $donor_address = $donor->get_donor_address();
+        $company_name = $donor->get_company_name();
 
-		$logged_in_donor_info = [
-			// First name.
-			'give_first'      => $donor_data->first_name,
+        $logged_in_donor_info = [
+            // First name.
+            'give_first'      => $donor_data->first_name,
 
-			// Last name.
-			'give_last'       => $donor_data->last_name,
+            // Last name.
+            'give_last'       => $donor_data->last_name,
 
-			// Title Prefix.
-			'give_title'      => $donor->get_meta( '_give_donor_title_prefix', true ),
+            // Title Prefix.
+            'give_title'      => $donor->get_meta('_give_donor_title_prefix', true),
 
-			// Company name.
-			'company_name'    => $company_name,
+            // Company name.
+            'company_name'    => $company_name,
 
-			// Email.
-			'give_email'      => $donor_data->user_email,
+            // Email.
+            'give_email'      => $donor_data->user_email,
 
-			// Street address 1.
-			'card_address'    => $donor_address['line1'],
+            // Street address 1.
+            'card_address'    => $donor_address['line1'],
 
-			// Street address 2.
-			'card_address_2'  => $donor_address['line2'],
+            // Street address 2.
+            'card_address_2'  => $donor_address['line2'],
 
-			// Country.
-			'billing_country' => $donor_address['country'],
+            // Country.
+            'billing_country' => $donor_address['country'],
 
-			// State.
-			'card_state'      => $donor_address['state'],
+            // State.
+            'card_state'      => $donor_address['state'],
 
-			// City.
-			'card_city'       => $donor_address['city'],
+            // City.
+            'card_city'       => $donor_address['city'],
 
-			// Zipcode
-			'card_zip'        => $donor_address['zip'],
-		];
-	endif;
+            // Zipcode
+            'card_zip'        => $donor_address['zip'],
+        ];
+    endif;
 
-	// Bailout: Auto fill form field values only form form which donor is donating.
-	if (
-		empty( $_GET['form-id'] )
-		|| ! $form_id
-		|| ( $form_id !== absint( $_GET['form-id'] ) )
-	) {
-		return $logged_in_donor_info;
-	}
+    // Bailout: Auto fill form field values only form form which donor is donating.
+    if (
+        empty($_GET['form-id'])
+        || ! $form_id
+        || ($form_id !== absint($_GET['form-id']))
+    ) {
+        return $logged_in_donor_info;
+    }
 
-	// Get purchase data.
-	$give_purchase_data = Give()->session->get( 'give_purchase' );
+    // Get purchase data.
+    $give_purchase_data = Give()->session->get('give_purchase');
 
-	// Get donor info from form data.
-	$give_donor_info_in_session = empty( $give_purchase_data['post_data'] )
-		? []
-		: $give_purchase_data['post_data'];
+    // Get donor info from form data.
+    $give_donor_info_in_session = empty($give_purchase_data['post_data'])
+        ? []
+        : $give_purchase_data['post_data'];
 
-	// Output.
-	return wp_parse_args( $give_donor_info_in_session, $logged_in_donor_info );
+    // Output.
+    return wp_parse_args($give_donor_info_in_session, $logged_in_donor_info);
 }
 
 /**
@@ -1139,28 +1168,29 @@ function _give_get_prefill_form_field_values( $form_id ) {
  *
  * @return int
  */
-function give_get_form_donor_count( $form_id, $args = [] ) {
-	global $wpdb;
+function give_get_form_donor_count($form_id, $args = [])
+{
+    global $wpdb;
 
-	$cache_key   = Give_Cache::get_key( "form_donor_count_{$form_id}", $args, false );
-	$donor_count = absint( Give_Cache::get_db_query( $cache_key ) );
+    $cache_key = Give_Cache::get_key("form_donor_count_{$form_id}", $args, false);
+    $donor_count = absint(Give_Cache::get_db_query($cache_key));
 
-	if ( $form_id && ! $donor_count ) {
-		// Set arguments.
-		$args = wp_parse_args(
-			$args,
-			[
-				'unique' => true,
-			]
-		);
+    if ($form_id && ! $donor_count) {
+        // Set arguments.
+        $args = wp_parse_args(
+            $args,
+            [
+                'unique' => true,
+            ]
+        );
 
-		$donation_meta_table  = Give()->payment_meta->table_name;
-		$donation_id_col_name = Give()->payment_meta->get_meta_type() . '_id';
+        $donation_meta_table = Give()->payment_meta->table_name;
+        $donation_id_col_name = Give()->payment_meta->get_meta_type() . '_id';
 
-		$distinct = $args['unique'] ? 'DISTINCT meta_value' : 'meta_value';
+        $distinct = $args['unique'] ? 'DISTINCT meta_value' : 'meta_value';
 
-		$query = $wpdb->prepare(
-			"
+        $query = $wpdb->prepare(
+            "
 			SELECT COUNT({$distinct})
 			FROM {$donation_meta_table}
 			WHERE meta_key=%s
@@ -1174,75 +1204,75 @@ function give_get_form_donor_count( $form_id, $args = [] ) {
 				AND p.post_status=%s
 			)
 			",
-			'_give_payment_donor_id',
-			'_give_payment_form_id',
-			$form_id,
-			'publish'
-		);
+            '_give_payment_donor_id',
+            '_give_payment_form_id',
+            $form_id,
+            'publish'
+        );
 
-		$donor_count = absint( $wpdb->get_var( $query ) );
-	}
+        $donor_count = absint($wpdb->get_var($query));
+    }
 
-	/**
-	 * Filter the donor count
-	 *
-	 * @since 2.1.0
-	 */
-	$donor_count = apply_filters( 'give_get_form_donor_count', $donor_count, $form_id, $args );
+    /**
+     * Filter the donor count
+     *
+     * @since 2.1.0
+     */
+    $donor_count = apply_filters('give_get_form_donor_count', $donor_count, $form_id, $args);
 
-	return $donor_count;
+    return $donor_count;
 }
 
 /**
  * Verify the form status.
  *
- * @param int $form_id Donation Form ID.
- *
  * @since 2.1
+ *
+ * @param int $form_id Donation Form ID.
  *
  * @return void
  */
-function give_set_form_closed_status( $form_id ) {
+function give_set_form_closed_status($form_id)
+{
+    // Bailout.
+    if (empty($form_id)) {
+        return;
+    }
 
-	// Bailout.
-	if ( empty( $form_id ) ) {
-		return;
-	}
+    $open_form = false;
+    $is_goal_enabled = give_is_setting_enabled(give_get_meta($form_id, '_give_goal_option', true, 'disabled'));
 
-	$open_form       = false;
-	$is_goal_enabled = give_is_setting_enabled( give_get_meta( $form_id, '_give_goal_option', true, 'disabled' ) );
+    // Proceed, if the form goal is enabled.
+    if ($is_goal_enabled) {
+        $close_form_when_goal_achieved = give_is_setting_enabled(
+            give_get_meta($form_id, '_give_close_form_when_goal_achieved', true, 'disabled')
+        );
 
-	// Proceed, if the form goal is enabled.
-	if ( $is_goal_enabled ) {
+        // Proceed, if close form when goal achieved option is enabled.
+        if ($close_form_when_goal_achieved) {
+            $form = new Give_Donate_Form($form_id);
+            $goal_progress_stats = give_goal_progress_stats($form);
 
-		$close_form_when_goal_achieved = give_is_setting_enabled( give_get_meta( $form_id, '_give_close_form_when_goal_achieved', true, 'disabled' ) );
+            // Verify whether the form is closed or not after processing data.
+            $closed = $goal_progress_stats['raw_goal'] <= $goal_progress_stats['raw_actual'];
 
-		// Proceed, if close form when goal achieved option is enabled.
-		if ( $close_form_when_goal_achieved ) {
+            // Update form meta if verified that the form is closed.
+            if ($closed) {
+                give_update_meta($form_id, '_give_form_status', 'closed');
+            } else {
+                $open_form = true;
+            }
+        } else {
+            $open_form = true;
+        }
+    } else {
+        $open_form = true;
+    }
 
-			$form                = new Give_Donate_Form( $form_id );
-			$goal_progress_stats = give_goal_progress_stats( $form );
-
-			// Verify whether the form is closed or not after processing data.
-			$closed = $goal_progress_stats['raw_goal'] <= $goal_progress_stats['raw_actual'];
-
-			// Update form meta if verified that the form is closed.
-			if ( $closed ) {
-				give_update_meta( $form_id, '_give_form_status', 'closed' );
-			} else {
-				$open_form = true;
-			}
-		} else {
-			$open_form = true;
-		}
-	} else {
-		$open_form = true;
-	}
-
-	// If $open_form is true, then update form status to open.
-	if ( $open_form ) {
-		give_update_meta( $form_id, '_give_form_status', 'open' );
-	}
+    // If $open_form is true, then update form status to open.
+    if ($open_form) {
+        give_update_meta($form_id, '_give_form_status', 'open');
+    }
 }
 
 /**
@@ -1250,43 +1280,52 @@ function give_set_form_closed_status( $form_id ) {
  *
  * @since 2.19.0 Prevent divide by zero issue in goal percentage calculation logic.
  *
- * @param int $form_id Form ID.
- *
  * @since 2.1.0
+ *
+ * @param int $form_id Form ID.
  *
  * @return string
  */
-function give_admin_form_goal_stats( $form_id ) {
+function give_admin_form_goal_stats($form_id)
+{
+    $html = '';
+    $goal_stats = give_goal_progress_stats($form_id);
+    $percent_complete = $goal_stats['raw_goal'] ? round(
+                                                      ($goal_stats['raw_actual'] / $goal_stats['raw_goal']),
+                                                      3
+                                                  ) * 100 : 0;
 
-	$html             = '';
-	$goal_stats       = give_goal_progress_stats( $form_id );
-	$percent_complete = $goal_stats['raw_goal'] ? round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100 : 0;
-
-	$html .= sprintf(
-		'<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">
+    $html .= sprintf(
+        '<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">
 <span style="width:%1$s%%;"></span>
 </div>',
-		esc_attr( $goal_stats['progress'] )
-	);
+        esc_attr($goal_stats['progress'])
+    );
 
-	$html .= sprintf(
-		( 'percentage' !== $goal_stats['format'] ) ?
-			'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s ' :
-			'<div class="give-goal-text"><a href="%3$s">%1$s </a>',
-		( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
-		( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
-		esc_url( admin_url( "post.php?post={$form_id}&action=edit&give_tab=donation_goal_options" ) ),
-		$goal_stats['goal'],
-		( 'donors' === $goal_stats['format'] ? __( 'donors', 'give' ) : ( 'donation' === $goal_stats['format'] ? __( 'donations', 'give' ) : '' ) )
-	);
+    $html .= sprintf(
+        ('percentage' !== $goal_stats['format']) ?
+            '<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s ' :
+            '<div class="give-goal-text"><a href="%3$s">%1$s </a>',
+        ('percentage' !== $goal_stats['format']) ? $goal_stats['actual'] : $percent_complete . '%',
+        ('percentage' !== $goal_stats['format']) ? __('of', 'give') : '',
+        esc_url(admin_url("post.php?post={$form_id}&action=edit&give_tab=donation_goal_options")),
+        $goal_stats['goal'],
+        ('donors' === $goal_stats['format'] ? __('donors', 'give') : ('donation' === $goal_stats['format'] ? __(
+            'donations',
+            'give'
+        ) : ''))
+    );
 
-	if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
-		$html .= sprintf( '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>', __( 'Goal achieved', 'give' ) );
-	}
+    if ($goal_stats['raw_actual'] >= $goal_stats['raw_goal']) {
+        $html .= sprintf(
+            '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>',
+            __('Goal achieved', 'give')
+        );
+    }
 
-	$html .= '</div>';
+    $html .= '</div>';
 
-	return $html;
+    return $html;
 }
 
 /**
@@ -1298,43 +1337,46 @@ function give_admin_form_goal_stats( $form_id ) {
  *
  * @return null | array
  */
-function give_form_get_default_level( $form_id ) {
-	$default_level = null;
+function give_form_get_default_level($form_id)
+{
+    $default_level = null;
 
-	// If donation form has variable prices.
-	if ( give_has_variable_prices( $form_id ) ) {
-		/**
-		 * Filter the variable pricing
-		 *
-		 * @since      1.0
-		 * @deprecated 2.2 Use give_get_donation_levels filter instead of give_form_variable_prices.
-		 *                 Check Give_Donate_Form::get_prices().
-		 *
-		 * @param array $prices Array of variable prices.
-		 * @param int   $form   Form ID.
-		 */
-		$prices = apply_filters( 'give_form_variable_prices', give_get_variable_prices( $form_id ), $form_id );
+    // If donation form has variable prices.
+    if (give_has_variable_prices($form_id)) {
+        /**
+         * Filter the variable pricing
+         *
+         * @since          1.0
+         *
+         * @param array $prices Array of variable prices.
+         * @param int   $form   Form ID.
+         *
+         * @deprecated     2.2 Use give_get_donation_levels filter instead of give_form_variable_prices.
+         *                 Check Give_Donate_Form::get_prices().
+         *
+         */
+        $prices = apply_filters('give_form_variable_prices', give_get_variable_prices($form_id), $form_id);
 
-		// Go through each of the level and get the default level id.
-		foreach ( $prices as $level ) {
-			if (
-				isset( $level['_give_default'] )
-				&& $level['_give_default'] === 'default'
-			) {
-				$default_level = $level;
-			}
-		}
-	}
+        // Go through each of the level and get the default level id.
+        foreach ($prices as $level) {
+            if (
+                isset($level['_give_default'])
+                && $level['_give_default'] === 'default'
+            ) {
+                $default_level = $level;
+            }
+        }
+    }
 
-	/**
-	 * Filter the default donation level id.
-	 *
-	 * @since 2.2.0
-	 *
-	 * @param array   $default_level Default level price data.
-	 * @param integer $form_id       Donation form ID.
-	 */
-	return apply_filters( 'give_form_get_default_level', $default_level, $form_id );
+    /**
+     * Filter the default donation level id.
+     *
+     * @since 2.2.0
+     *
+     * @param array   $default_level Default level price data.
+     * @param integer $form_id       Donation form ID.
+     */
+    return apply_filters('give_form_get_default_level', $default_level, $form_id);
 }
 
 /**
@@ -1347,144 +1389,153 @@ function give_form_get_default_level( $form_id ) {
  *
  * @return boolean
  */
-function give_is_default_level_id( $price_or_level_id, $form_id = 0 ) {
-	$is_default = false;
+function give_is_default_level_id($price_or_level_id, $form_id = 0)
+{
+    $is_default = false;
 
-	if (
-		! empty( $form_id )
-		&& is_numeric( $price_or_level_id )
-	) {
-		// Get default level id.
-		$form_price_data = give_form_get_default_level( $form_id );
+    if (
+        ! empty($form_id)
+        && is_numeric($price_or_level_id)
+    ) {
+        // Get default level id.
+        $form_price_data = give_form_get_default_level($form_id);
 
-		$is_default = ! is_null( $form_price_data ) && ( $price_or_level_id === absint( $form_price_data['_give_id']['level_id'] ) );
-	}
+        $is_default = ! is_null($form_price_data) && ($price_or_level_id === absint(
+                    $form_price_data['_give_id']['level_id']
+                ));
+    }
 
-	$is_default = false === $is_default && is_array( $price_or_level_id ) ?
-		( isset( $price_or_level_id['_give_default'] ) && $price_or_level_id['_give_default'] === 'default' )
-		: $is_default;
+    $is_default = false === $is_default && is_array($price_or_level_id) ?
+        (isset($price_or_level_id['_give_default']) && $price_or_level_id['_give_default'] === 'default')
+        : $is_default;
 
-	/**
-	 * Allow developers to modify the default level id checks.
-	 *
-	 * @since 2.2.0
-	 *
-	 * @param bool          $is_default        True if it is default price level id otherwise false.
-	 * @param array|integer $price_or_level_id Price Data.
-	 */
-	return apply_filters( 'give_is_default_level_id', $is_default, $price_or_level_id );
+    /**
+     * Allow developers to modify the default level id checks.
+     *
+     * @since 2.2.0
+     *
+     * @param bool          $is_default        True if it is default price level id otherwise false.
+     * @param array|integer $price_or_level_id Price Data.
+     */
+    return apply_filters('give_is_default_level_id', $is_default, $price_or_level_id);
 }
 
 
 /**
  * Get Name Title Prefixes (a.k.a. Salutation) value.
  *
- * @param int $form_id Donation Form ID.
- *
  * @since 2.2.0
+ *
+ * @param int $form_id Donation Form ID.
  *
  * @return array
  */
-function give_get_name_title_prefixes( $form_id = 0 ) {
+function give_get_name_title_prefixes($form_id = 0)
+{
+    $name_title_prefix = give_is_name_title_prefix_enabled($form_id);
+    $title_prefixes = give_get_option('title_prefixes', give_get_default_title_prefixes());
 
-	$name_title_prefix = give_is_name_title_prefix_enabled( $form_id );
-	$title_prefixes    = give_get_option( 'title_prefixes', give_get_default_title_prefixes() );
+    // If form id exists, then fetch form specific title prefixes.
+    if (intval($form_id) > 0 && $name_title_prefix) {
+        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
+        if ('global' !== $form_title_prefix) {
+            $form_title_prefixes = give_get_meta(
+                $form_id,
+                '_give_title_prefixes',
+                true,
+                give_get_default_title_prefixes()
+            );
 
-	// If form id exists, then fetch form specific title prefixes.
-	if ( intval( $form_id ) > 0 && $name_title_prefix ) {
+            // Check whether the form based title prefixes exists or not.
+            if (is_array($form_title_prefixes) && count($form_title_prefixes) > 0) {
+                $title_prefixes = $form_title_prefixes;
+            }
+        }
+    }
 
-		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
-		if ( 'global' !== $form_title_prefix ) {
-			$form_title_prefixes = give_get_meta( $form_id, '_give_title_prefixes', true, give_get_default_title_prefixes() );
-
-			// Check whether the form based title prefixes exists or not.
-			if ( is_array( $form_title_prefixes ) && count( $form_title_prefixes ) > 0 ) {
-				$title_prefixes = $form_title_prefixes;
-			}
-		}
-	}
-
-	return array_filter( (array) $title_prefixes );
+    return array_filter((array)$title_prefixes);
 }
 
 /**
  * Check whether the name title prefix is enabled or not.
  *
- * @param int    $form_id Donation Form ID.
+ * @since 2.2.0
+ *
  * @param string $status  Status to set status based on option value.
  *
- * @since 2.2.0
+ * @param int    $form_id Donation Form ID.
  *
  * @return bool
  */
-function give_is_name_title_prefix_enabled( $form_id = 0, $status = '' ) {
-	if ( empty( $status ) ) {
-		$status = [ 'required', 'optional' ];
-	} else {
-		$status = [ $status ];
-	}
+function give_is_name_title_prefix_enabled($form_id = 0, $status = '')
+{
+    if (empty($status)) {
+        $status = ['required', 'optional'];
+    } else {
+        $status = [$status];
+    }
 
-	$title_prefix_status = give_is_setting_enabled( give_get_option( 'name_title_prefix' ), $status );
+    $title_prefix_status = give_is_setting_enabled(give_get_option('name_title_prefix'), $status);
 
-	if ( intval( $form_id ) > 0 ) {
-		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
+    if (intval($form_id) > 0) {
+        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
 
-		if ( 'disabled' === $form_title_prefix ) {
-			$title_prefix_status = false;
-		} elseif ( in_array( $form_title_prefix, $status, true ) ) {
-			$title_prefix_status = give_is_setting_enabled( $form_title_prefix, $status );
-		}
-	}
+        if ('disabled' === $form_title_prefix) {
+            $title_prefix_status = false;
+        } elseif (in_array($form_title_prefix, $status, true)) {
+            $title_prefix_status = give_is_setting_enabled($form_title_prefix, $status);
+        }
+    }
 
-	return $title_prefix_status;
-
+    return $title_prefix_status;
 }
 
 /**
  * Get Donor Name with Title Prefix
  *
- * @param int|Give_Donor $donor Donor Information.
- *
  * @since 2.2.0
+ *
+ * @param int|Give_Donor $donor Donor Information.
  *
  * @return object
  */
-function give_get_name_with_title_prefixes( $donor ) {
+function give_get_name_with_title_prefixes($donor)
+{
+    // Prepare Give_Donor object, if $donor is numeric.
+    if (is_numeric($donor)) {
+        $donor = new Give_Donor($donor);
+    }
 
-	// Prepare Give_Donor object, if $donor is numeric.
-	if ( is_numeric( $donor ) ) {
-		$donor = new Give_Donor( $donor );
-	}
+    $title_prefix = Give()->donor_meta->get_meta($donor->id, '_give_donor_title_prefix', true);
 
-	$title_prefix = Give()->donor_meta->get_meta( $donor->id, '_give_donor_title_prefix', true );
+    // Update Donor name, if non empty title prefix.
+    if ( ! empty($title_prefix)) {
+        $donor->name = give_get_donor_name_with_title_prefixes($title_prefix, $donor->name);
+    }
 
-	// Update Donor name, if non empty title prefix.
-	if ( ! empty( $title_prefix ) ) {
-		$donor->name = give_get_donor_name_with_title_prefixes( $title_prefix, $donor->name );
-	}
-
-	return $donor;
+    return $donor;
 }
 
 /**
  * This function will generate donor name with title prefix if it is required.
  *
- * @param string $title_prefix Title Prefix of Donor
+ * @since 2.2.0
+ *
  * @param string $name         Donor Name.
  *
- * @since 2.2.0
+ * @param string $title_prefix Title Prefix of Donor
  *
  * @return string
  */
-function give_get_donor_name_with_title_prefixes( $title_prefix, $name ) {
+function give_get_donor_name_with_title_prefixes($title_prefix, $name)
+{
+    $donor_name = $name;
 
-	$donor_name = $name;
+    if ( ! empty($title_prefix) && ! empty($name)) {
+        $donor_name = "{$title_prefix} {$name}";
+    }
 
-	if ( ! empty( $title_prefix ) && ! empty( $name ) ) {
-		$donor_name = "{$title_prefix} {$name}";
-	}
-
-	return trim( $donor_name );
+    return trim($donor_name);
 }
 
 /**
@@ -1494,53 +1545,54 @@ function give_get_donor_name_with_title_prefixes( $title_prefix, $name ) {
  *
  * @return array
  */
-function give_get_default_title_prefixes() {
-	/**
-	 * Filter the data
-	 * Set default title prefixes.
-	 *
-	 * @since 2.2.0
-	 */
-	return apply_filters(
-		'give_get_default_title_prefixes',
-		[
-			'Mr.'  => __( 'Mr.', 'give' ),
-			'Mrs.' => __( 'Mrs.', 'give' ),
-			'Ms.'  => __( 'Ms.', 'give' ),
-		]
-	);
+function give_get_default_title_prefixes()
+{
+    /**
+     * Filter the data
+     * Set default title prefixes.
+     *
+     * @since 2.2.0
+     */
+    return apply_filters(
+        'give_get_default_title_prefixes',
+        [
+            'Mr.'  => __('Mr.', 'give'),
+            'Mrs.' => __('Mrs.', 'give'),
+            'Ms.'  => __('Ms.', 'give'),
+        ]
+    );
 }
 
 /**
  * This function will check whether the name title prefix field is required or not.
  *
- * @param int $form_id Donation Form ID.
- *
  * @since 2.2.0
+ *
+ * @param int $form_id Donation Form ID.
  *
  * @return bool
  */
-function give_is_name_title_prefix_required( $form_id = 0 ) {
+function give_is_name_title_prefix_required($form_id = 0)
+{
+    // Bail out, if name title prefix is not enabled.
+    if ( ! give_is_name_title_prefix_enabled($form_id)) {
+        return false;
+    }
 
-	// Bail out, if name title prefix is not enabled.
-	if ( ! give_is_name_title_prefix_enabled( $form_id ) ) {
-		return false;
-	}
+    $status = ['optional'];
+    $is_optional = give_is_setting_enabled(give_get_option('name_title_prefix'), $status);
 
-	$status      = [ 'optional' ];
-	$is_optional = give_is_setting_enabled( give_get_option( 'name_title_prefix' ), $status );
+    if (intval($form_id) > 0) {
+        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
 
-	if ( intval( $form_id ) > 0 ) {
-		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
+        if ('required' === $form_title_prefix) {
+            $is_optional = false;
+        } elseif ('optional' === $form_title_prefix) {
+            $is_optional = true;
+        }
+    }
 
-		if ( 'required' === $form_title_prefix ) {
-			$is_optional = false;
-		} elseif ( 'optional' === $form_title_prefix ) {
-			$is_optional = true;
-		}
-	}
-
-	return ( ! $is_optional );
+    return ( ! $is_optional);
 }
 
 /**
@@ -1552,26 +1604,26 @@ function give_is_name_title_prefix_required( $form_id = 0 ) {
  *
  * @return void
  */
-function give_handle_form_meta_on_delete( $id ) {
+function give_handle_form_meta_on_delete($id)
+{
+    global $wpdb;
 
-	global $wpdb;
+    $form = get_post($id);
+    $get_data = give_clean($_GET);
 
-	$form     = get_post( $id );
-	$get_data = give_clean( $_GET );
-
-	if (
-		'give_forms' === $form->post_type &&
-		'trash' === $form->post_status &&
-		(
-			( isset( $get_data['action'] ) && 'delete' === $get_data['action'] ) ||
-			! empty( $get_data['delete_all'] )
-		)
-	) {
-		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->formmeta} WHERE form_id = '%d'", $form->ID ) );
-	}
+    if (
+        'give_forms' === $form->post_type &&
+        'trash' === $form->post_status &&
+        (
+            (isset($get_data['action']) && 'delete' === $get_data['action']) ||
+            ! empty($get_data['delete_all'])
+        )
+    ) {
+        $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->formmeta} WHERE form_id = '%d'", $form->ID));
+    }
 }
 
-add_action( 'before_delete_post', 'give_handle_form_meta_on_delete', 10, 1 );
+add_action('before_delete_post', 'give_handle_form_meta_on_delete', 10, 1);
 
 
 /**
@@ -1582,25 +1634,26 @@ add_action( 'before_delete_post', 'give_handle_form_meta_on_delete', 10, 1 );
  *
  * @return array
  */
-function give_get_default_form_shortcode_args() {
-	$default = [
-		'id'                    => '',
-		'show_title'            => true,
-		'show_goal'             => true,
-		'show_content'          => '',
-		'float_labels'          => '',
+function give_get_default_form_shortcode_args()
+{
+    $default = [
+        'id'                    => '',
+        'show_title'            => true,
+        'show_goal'             => true,
+        'show_content'          => '',
+        'float_labels'          => '',
         'display_style'         => '',
-        'continue_button_title' => __('Donate now', 'give'),
+        'continue_button_title' => '',
 
-		// This attribute belong to form template functionality.
-		// You can use this attribute to set modal open button background color.
-		'button_color'          => '#28C77B',
-	];
+        // This attribute belong to form template functionality.
+        // You can use this attribute to set modal open button background color.
+        'button_color'          => '#28C77B',
+    ];
 
-	/**
-	 * Fire the filter
-	 */
-	$default = apply_filters( 'give_get_default_form_shortcode_args', $default );
+    /**
+     * Fire the filter
+     */
+    $default = apply_filters('give_get_default_form_shortcode_args', $default);
 
-	return $default;
+    return $default;
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -3,15 +3,15 @@
  * Give Form Functions
  *
  * @package     GiveWP
- * @since       1.1
+ * @subpackage  Includes/Forms
  * @copyright   Copyright (c) 2016, GiveWP
  * @license     https://opensource.org/licenses/gpl-license GNU Public License
- * @subpackage  Includes/Forms
+ * @since       1.1
  */
 
 // Exit if accessed directly.
-if ( ! defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 use Give\Helpers\Form\Utils as FormUtils;
@@ -21,18 +21,18 @@ use Give\Helpers\Form\Utils as FormUtils;
  *
  * @return bool
  */
-function give_shortcode_button_condition()
-{
-    global $typenow;
+function give_shortcode_button_condition() {
 
-    if ($typenow != 'give_forms') {
-        return true;
-    }
+	global $typenow;
 
-    return false;
+	if ( $typenow != 'give_forms' ) {
+		return true;
+	}
+
+	return false;
 }
 
-add_filter('give_shortcode_button_condition', 'give_shortcode_button_condition');
+add_filter( 'give_shortcode_button_condition', 'give_shortcode_button_condition' );
 
 
 /**
@@ -42,13 +42,14 @@ add_filter('give_shortcode_button_condition', 'give_shortcode_button_condition')
  *
  * @return int|false
  */
-function get_form_id_from_args($args)
-{
-    if (isset($args['form_id']) && $args['form_id'] != 0) {
-        return intval($args['form_id']);
-    }
+function get_form_id_from_args( $args ) {
 
-    return false;
+	if ( isset( $args['form_id'] ) && $args['form_id'] != 0 ) {
+
+		return intval( $args['form_id'] );
+	}
+
+	return false;
 }
 
 /**
@@ -60,28 +61,28 @@ function get_form_id_from_args($args)
  *
  * @return bool
  */
-function give_is_float_labels_enabled($args)
-{
-    $float_labels = '';
+function give_is_float_labels_enabled( $args ) {
 
-    if ( ! empty($args['float_labels'])) {
-        $float_labels = $args['float_labels'];
-    }
+	$float_labels = '';
 
-    if (empty($float_labels)) {
-        $float_labels = give_get_meta($args['form_id'], '_give_form_floating_labels', true);
-    }
+	if ( ! empty( $args['float_labels'] ) ) {
+		$float_labels = $args['float_labels'];
+	}
 
-    if (empty($float_labels) || ('global' === $float_labels)) {
-        $float_labels = give_get_option('floatlabels', 'disabled');
-    }
+	if ( empty( $float_labels ) ) {
+		$float_labels = give_get_meta( $args['form_id'], '_give_form_floating_labels', true );
+	}
 
-    // If the form is using a non-legacy form template, do not use floating labels
-    if ( ! FormUtils::isLegacyForm($args['form_id'])) {
-        $float_labels = 'disabled';
-    }
+	if ( empty( $float_labels ) || ( 'global' === $float_labels ) ) {
+		$float_labels = give_get_option( 'floatlabels', 'disabled' );
+	}
 
-    return give_is_setting_enabled($float_labels);
+	// If the form is using a non-legacy form template, do not use floating labels
+	if ( ! FormUtils::isLegacyForm( $args['form_id'] ) ) {
+		$float_labels = 'disabled';
+	}
+
+	return give_is_setting_enabled( $float_labels );
 }
 
 /**
@@ -93,11 +94,11 @@ function give_is_float_labels_enabled($args)
  *
  * @return bool Can user checkout?
  */
-function give_can_checkout()
-{
-    $can_checkout = true;
+function give_can_checkout() {
 
-    return (bool)apply_filters('give_can_checkout', $can_checkout);
+	$can_checkout = true;
+
+	return (bool) apply_filters( 'give_can_checkout', $can_checkout );
 }
 
 /**
@@ -108,15 +109,14 @@ function give_can_checkout()
  *
  * @return      string
  */
-function give_get_success_page_uri()
-{
-    $give_options = give_get_settings();
+function give_get_success_page_uri() {
+	$give_options = give_get_settings();
 
-    $success_page = isset($give_options['success_page'])
-        ? get_permalink(absint($give_options['success_page']))
-        : get_bloginfo('url');
+	$success_page = isset( $give_options['success_page'] )
+		? get_permalink( absint( $give_options['success_page'] ) )
+		: get_bloginfo( 'url' );
 
-    return apply_filters('give_get_success_page_uri', $success_page);
+	return apply_filters( 'give_get_success_page_uri', $success_page );
 }
 
 /**
@@ -126,13 +126,12 @@ function give_get_success_page_uri()
  *
  * @return bool True if on the Success page, false otherwise.
  */
-function give_is_success_page()
-{
-    $give_options = give_get_settings();
+function give_is_success_page() {
+	$give_options = give_get_settings();
 
-    $success_page = isset($give_options['success_page']) ? is_page($give_options['success_page']) : false;
+	$success_page = isset( $give_options['success_page'] ) ? is_page( $give_options['success_page'] ) : false;
 
-    return apply_filters('give_is_success_page', $success_page);
+	return apply_filters( 'give_is_success_page', $success_page );
 }
 
 /**
@@ -140,25 +139,23 @@ function give_is_success_page()
  *
  * Sends the user to the success page.
  *
- * @since       1.0
- *
  * @param string $query_string
  *
  * @access      public
+ * @since       1.0
  * @return      void
  */
-function give_send_to_success_page($query_string = null)
-{
-    $redirect = give_get_success_page_uri();
+function give_send_to_success_page( $query_string = null ) {
+	$redirect = give_get_success_page_uri();
 
-    if ($query_string) {
-        $redirect .= $query_string;
-    }
+	if ( $query_string ) {
+		$redirect .= $query_string;
+	}
 
-    $gateway = isset($_REQUEST['give-gateway']) ? give_clean($_REQUEST['give-gateway']) : '';
+	$gateway = isset( $_REQUEST['give-gateway'] ) ? give_clean( $_REQUEST['give-gateway'] ) : '';
 
-    wp_redirect(apply_filters('give_success_page_redirect', $redirect, $gateway, $query_string));
-    give_die();
+	wp_redirect( apply_filters( 'give_success_page_redirect', $redirect, $gateway, $query_string ) );
+	give_die();
 }
 
 
@@ -167,68 +164,67 @@ function give_send_to_success_page($query_string = null)
  *
  * Used to redirect a user back to the donation form if there are errors present.
  *
- * @since  2.21.0 Auto set "payment-mode" in redirect url.
- * @since  1.0
- *
  * @param array|string $args
  *
  * @access public
+ * @since 2.21.0 Auto set "payment-mode" in redirect url.
+ * @since  1.0
  * @return Void
  */
-function give_send_back_to_checkout($args = [])
-{
-    $url = isset($_POST['give-current-url']) ? sanitize_text_field($_POST['give-current-url']) : '';
-    $form_id = 0;
+function give_send_back_to_checkout( $args = [] ) {
+
+	$url     = isset( $_POST['give-current-url'] ) ? sanitize_text_field( $_POST['give-current-url'] ) : '';
+	$form_id = 0;
     $defaults = [];
 
-    // Set the form_id.
-    if (isset($_POST['give-form-id'])) {
-        $defaults['form-id'] = (int)sanitize_text_field($_POST['give-form-id']);
-    }
+	// Set the form_id.
+	if ( isset( $_POST['give-form-id'] ) ) {
+        $defaults['form-id'] = (int) sanitize_text_field( $_POST['give-form-id'] );
+	}
 
     // Set the payment mode.
-    if (isset($_POST['payment-mode'])) {
-        $defaults['payment-mode'] = sanitize_text_field($_POST['payment-mode']);
+    if ( isset( $_POST['payment-mode'] ) ) {
+        $defaults['payment-mode'] = sanitize_text_field( $_POST['payment-mode'] );
     }
 
-    // Need a URL to continue. If none, redirect back to single form.
-    if (empty($url)) {
-        wp_safe_redirect(get_permalink($form_id));
-        give_die();
-    }
+	// Need a URL to continue. If none, redirect back to single form.
+	if ( empty( $url ) ) {
+		wp_safe_redirect( get_permalink( $form_id ) );
+		give_die();
+	}
 
-    // Set the $level_id.
-    if (isset($_POST['give-price-id'])) {
-        $defaults['level-id'] = sanitize_text_field($_POST['give-price-id']);
+	// Set the $level_id.
+	if ( isset( $_POST['give-price-id'] ) ) {
+		$defaults['level-id'] = sanitize_text_field( $_POST['give-price-id'] );
 
-        // If custom, set amount
-        if ('custom' === $defaults['level-id']) {
-            $defaults['custom-amount'] = sanitize_text_field($_POST['give-amount']);
-        }
-    }
+		// If custom, set amount
+		if( 'custom' === $defaults[ 'level-id' ] ) {
+			$defaults['custom-amount'] = sanitize_text_field( $_POST['give-amount'] );
+		}
+	}
 
-    // Check for backward compatibility.
-    if (is_string($args)) {
-        $args = str_replace('?', '', $args);
-    }
+	// Check for backward compatibility.
+	if ( is_string( $args ) ) {
+		$args = str_replace( '?', '', $args );
+	}
 
-    $args = wp_parse_args($args, $defaults);
+	$args = wp_parse_args( $args, $defaults );
 
-    // Merge URL query with $args to maintain third-party URL parameters after redirect.
-    $redirect = add_query_arg($args, $url);
+	// Merge URL query with $args to maintain third-party URL parameters after redirect.
+	$redirect = add_query_arg( $args, $url );
 
-    // Precaution: don't allow any CC info.
-    $redirect = remove_query_arg(['card_number', 'card_cvc'], $redirect);
+	// Precaution: don't allow any CC info.
+	$redirect = remove_query_arg( [ 'card_number', 'card_cvc' ], $redirect );
 
-    // Redirect them.
-    $redirect .= "#give-form-{$form_id}-wrap";
+	// Redirect them.
+	$redirect .= "#give-form-{$form_id}-wrap";
 
-    /**
-     * Filter the redirect url
-     */
-    wp_safe_redirect(esc_url_raw(apply_filters('give_send_back_to_checkout', $redirect, $args)));
+	/**
+	 * Filter the redirect url
+	 */
+	wp_safe_redirect( esc_url_raw( apply_filters( 'give_send_back_to_checkout', $redirect, $args ) ) );
 
-    give_die();
+	give_die();
 }
 
 /**
@@ -236,22 +232,21 @@ function give_send_back_to_checkout($args = [])
  *
  * Gets the success page URL.
  *
- * @since       1.0
- *
  * @param string $query_string
  *
  * @access      public
+ * @since       1.0
  * @return      string
  */
-function give_get_success_page_url($query_string = null)
-{
-    $success_page = give_get_success_page_uri();
+function give_get_success_page_url( $query_string = null ) {
+	$success_page = give_get_success_page_uri();
 
-    if ($query_string) {
-        $success_page .= $query_string;
-    }
+	if ( $query_string ) {
+		$success_page .= $query_string;
+	}
 
-    return apply_filters('give_success_page_url', $success_page);
+	return apply_filters( 'give_success_page_url', $success_page );
+
 }
 
 /**
@@ -263,32 +258,31 @@ function give_get_success_page_url($query_string = null)
  *
  * @return mixed Full URL to the Failed Donation Page, if present, home page if it doesn't exist.
  */
-function give_get_failed_transaction_uri($extras = false)
-{
-    $give_options = give_get_settings();
+function give_get_failed_transaction_uri( $extras = false ) {
+	$give_options = give_get_settings();
 
-    // Remove question mark.
-    if (0 === strpos($extras, '?')) {
-        $extras = substr($extras, 1);
-    }
+	// Remove question mark.
+	if ( 0 === strpos( $extras, '?' ) ) {
+		$extras = substr( $extras, 1 );
+	}
 
-    $extras_args = wp_parse_args($extras);
+	$extras_args = wp_parse_args( $extras );
 
-    // Set nonce if payment id exist in extra params.
-    if (array_key_exists('payment-id', $extras_args)) {
-        $extras_args['_wpnonce'] = wp_create_nonce("give-failed-donation-{$extras_args['payment-id']}");
-        $extras = http_build_query($extras_args);
-    }
+	// Set nonce if payment id exist in extra params.
+	if ( array_key_exists( 'payment-id', $extras_args ) ) {
+		$extras_args['_wpnonce'] = wp_create_nonce( "give-failed-donation-{$extras_args['payment-id']}" );
+		$extras                  = http_build_query( $extras_args );
+	}
 
-    $uri = ! empty($give_options['failure_page']) ?
-        trailingslashit(get_permalink($give_options['failure_page'])) :
-        home_url();
+	$uri = ! empty( $give_options['failure_page'] ) ?
+		trailingslashit( get_permalink( $give_options['failure_page'] ) ) :
+		home_url();
 
-    if ($extras) {
-        $uri .= "?{$extras}";
-    }
+	if ( $extras ) {
+		$uri .= "?{$extras}";
+	}
 
-    return apply_filters('give_get_failed_transaction_uri', $uri);
+	return apply_filters( 'give_get_failed_transaction_uri', $uri );
 }
 
 /**
@@ -297,12 +291,11 @@ function give_get_failed_transaction_uri($extras = false)
  * @since 1.0
  * @return bool True if on the Failed Donation Page, false otherwise.
  */
-function give_is_failed_transaction_page()
-{
-    $give_options = give_get_settings();
-    $ret = isset($give_options['failure_page']) ? is_page($give_options['failure_page']) : false;
+function give_is_failed_transaction_page() {
+	$give_options = give_get_settings();
+	$ret          = isset( $give_options['failure_page'] ) ? is_page( $give_options['failure_page'] ) : false;
 
-    return apply_filters('give_is_failure_page', $ret);
+	return apply_filters( 'give_is_failure_page', $ret );
 }
 
 /**
@@ -313,21 +306,20 @@ function give_is_failed_transaction_page()
  *
  * @return bool
  */
-function give_listen_for_failed_payments()
-{
-    $payment_id = ! empty($_GET['payment-id']) ? absint($_GET['payment-id']) : 0;
-    $nonce = ! empty($_GET['_wpnonce']) ? give_clean($_GET['_wpnonce']) : false;
+function give_listen_for_failed_payments() {
+	$payment_id = ! empty( $_GET['payment-id'] ) ? absint( $_GET['payment-id'] ) : 0;
+	$nonce      = ! empty( $_GET['_wpnonce'] ) ? give_clean( $_GET['_wpnonce'] ) : false;
 
-    // Bailout.
-    if ( ! $payment_id || ! wp_verify_nonce($nonce, "give-failed-donation-{$payment_id}")) {
-        return false;
-    }
+	// Bailout.
+	if ( ! $payment_id || ! wp_verify_nonce( $nonce, "give-failed-donation-{$payment_id}" ) ) {
+		return false;
+	}
 
-    // Set payment status to failure
-    give_update_payment_status($payment_id, 'failed');
+	// Set payment status to failure
+	give_update_payment_status( $payment_id, 'failed' );
 }
 
-add_action('template_redirect', 'give_listen_for_failed_payments', 0);
+add_action( 'template_redirect', 'give_listen_for_failed_payments', 0 );
 
 /**
  * Retrieve the Donation History page URI
@@ -337,15 +329,12 @@ add_action('template_redirect', 'give_listen_for_failed_payments', 0);
  *
  * @return      string
  */
-function give_get_history_page_uri()
-{
-    $give_options = give_get_settings();
+function give_get_history_page_uri() {
+	$give_options = give_get_settings();
 
-    $history_page = isset($give_options['history_page']) ? get_permalink(
-        absint($give_options['history_page'])
-    ) : get_bloginfo('url');
+	$history_page = isset( $give_options['history_page'] ) ? get_permalink( absint( $give_options['history_page'] ) ) : get_bloginfo( 'url' );
 
-    return apply_filters('give_get_history_page_uri', $history_page);
+	return apply_filters( 'give_get_history_page_uri', $history_page );
 }
 
 /**
@@ -355,33 +344,29 @@ function give_get_history_page_uri()
  *
  * @return bool True if on the History page, false otherwise.
  */
-function give_is_history_page()
-{
-    $give_options = give_get_settings();
+function give_is_history_page() {
+	$give_options = give_get_settings();
 
-    $history_page = isset($give_options['history_page']) ? absint($give_options['history_page']) : 0;
+	$history_page = isset( $give_options['history_page'] ) ? absint( $give_options['history_page'] ) : 0;
 
-    return apply_filters('give_is_history_page', is_page($history_page));
+	return apply_filters( 'give_is_history_page', is_page( $history_page ) );
 }
 
 /**
  * Check if a field is required
  *
- * @since       1.0
- *
+ * @param string $field
  * @param int    $form_id
  *
  * @access      public
- *
- * @param string $field
- *
+ * @since       1.0
  * @return      bool
  */
-function give_field_is_required($field, $form_id)
-{
-    $required_fields = give_get_required_fields($form_id);
+function give_field_is_required( $field, $form_id ) {
 
-    return array_key_exists($field, $required_fields);
+	$required_fields = give_get_required_fields( $form_id );
+
+	return array_key_exists( $field, $required_fields );
 }
 
 /**
@@ -391,32 +376,30 @@ function give_field_is_required($field, $form_id)
  *
  * @since 1.0
  *
- * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
- *
+ * @param int         $give_form_id  Give Form ID.
  * @param int         $payment_id    Payment ID.
  * @param bool|int    $price_id      Price ID, if any.
  * @param string|null $donation_date The date of the donation.
  *
- * @param int         $give_form_id  Give Form ID.
+ * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
  *
  * @return void
  */
-function give_record_donation_in_log($give_form_id, $payment_id, $price_id = false, $donation_date = null)
-{
-    $log_data = [
-        'log_content'  => 'Payment log info',
-        'log_parent'   => $payment_id,
-        'log_type'     => 'sale',
-        'log_date'     => isset($donation_date) ? $donation_date : null,
-        'log_date_gmt' => isset($donation_date) ? $donation_date : null,
-    ];
+function give_record_donation_in_log( $give_form_id, $payment_id, $price_id = false, $donation_date = null ) {
+	$log_data = [
+		'log_content'  => 'Payment log info',
+		'log_parent'   => $payment_id,
+		'log_type'     => 'sale',
+		'log_date'     => isset( $donation_date ) ? $donation_date : null,
+		'log_date_gmt' => isset( $donation_date ) ? $donation_date : null,
+	];
 
-    $log_meta = [
-        'form_id'  => $give_form_id,
-        'price_id' => (int)$price_id,
-    ];
+	$log_meta = [
+		'form_id'  => $give_form_id,
+		'price_id' => (int) $price_id,
+	];
 
-    Give()->logs->insert_log($log_data, $log_meta);
+	Give()->logs->insert_log( $log_data, $log_meta );
 }
 
 
@@ -430,14 +413,13 @@ function give_record_donation_in_log($give_form_id, $payment_id, $price_id = fal
  *
  * @return bool|int
  */
-function give_increase_donation_count($form_id = 0, $quantity = 1)
-{
-    $quantity = (int)$quantity;
+function give_increase_donation_count( $form_id = 0, $quantity = 1 ) {
+	$quantity = (int) $quantity;
 
-    /** @var \Give_Donate_Form $form */
-    $form = new Give_Donate_Form($form_id);
+	/** @var \Give_Donate_Form $form */
+	$form = new Give_Donate_Form( $form_id );
 
-    return $form->increase_sales($quantity);
+	return $form->increase_sales( $quantity );
 }
 
 /**
@@ -449,20 +431,20 @@ function give_increase_donation_count($form_id = 0, $quantity = 1)
  *
  * @return void
  */
-function give_update_goal_progress($form_id = 0)
-{
-    // Get goal option meta key
-    $is_goal_enabled = give_is_setting_enabled(give_get_meta($form_id, '_give_goal_option', true, 'disabled'));
+function give_update_goal_progress( $form_id = 0 ) {
 
-    // Check, if the form goal is enabled.
-    if ($is_goal_enabled) {
-        $goal_stats = give_goal_progress_stats($form_id);
-        $form_goal_progress_value = ! empty($goal_stats['progress']) ? $goal_stats['progress'] : 0;
-    } else {
-        $form_goal_progress_value = -1;
-    }
+	// Get goal option meta key
+	$is_goal_enabled = give_is_setting_enabled( give_get_meta( $form_id, '_give_goal_option', true, 'disabled' ) );
 
-    give_update_meta($form_id, '_give_form_goal_progress', $form_goal_progress_value);
+	// Check, if the form goal is enabled.
+	if ( $is_goal_enabled ) {
+		$goal_stats               = give_goal_progress_stats( $form_id );
+		$form_goal_progress_value = ! empty( $goal_stats['progress'] ) ? $goal_stats['progress'] : 0;
+	} else {
+		$form_goal_progress_value = -1;
+	}
+
+	give_update_meta( $form_id, '_give_form_goal_progress', $form_goal_progress_value );
 }
 
 /**
@@ -475,14 +457,13 @@ function give_update_goal_progress($form_id = 0)
  *
  * @return bool|int
  */
-function give_decrease_donation_count($form_id = 0, $quantity = 1)
-{
-    $quantity = (int)$quantity;
+function give_decrease_donation_count( $form_id = 0, $quantity = 1 ) {
+	$quantity = (int) $quantity;
 
-    /** @var \Give_Donate_Form $form */
-    $form = new Give_Donate_Form($form_id);
+	/** @var \Give_Donate_Form $form */
+	$form = new Give_Donate_Form( $form_id );
 
-    return $form->decrease_sales($quantity);
+	return $form->decrease_sales( $quantity );
 }
 
 /**
@@ -492,21 +473,19 @@ function give_decrease_donation_count($form_id = 0, $quantity = 1)
  *
  * @since 2.1 Pass donation id.
  *
- * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
- *
+ * @param int $give_form_id Give Form ID
  * @param int $amount       Earnings
  * @param int $payment_id   Donation ID.
  *
- * @param int $give_form_id Give Form ID
+ * @since 2.12.0 default value for the $give_form_id parameter is removed to prevent PHP8 warnings.
  *
  * @return bool|int
  */
-function give_increase_earnings($give_form_id, $amount, $payment_id = 0)
-{
-    /** @var \Give_Donate_Form $form */
-    $form = new Give_Donate_Form($give_form_id);
+function give_increase_earnings( $give_form_id, $amount, $payment_id = 0 ) {
+	/** @var \Give_Donate_Form $form */
+	$form = new Give_Donate_Form( $give_form_id );
 
-    return $form->increase_earnings($amount, $payment_id);
+	return $form->increase_earnings( $amount, $payment_id );
 }
 
 /**
@@ -518,21 +497,19 @@ function give_increase_earnings($give_form_id, $amount, $payment_id = 0)
  *
  * @since 2.1 Pass donation id.
  *
- * @since 2.12.0 default value for the $form_id parameter is removed to prevent PHP8 warnings.
- *
+ * @param int $form_id    Give Form ID
  * @param int $amount     Earnings
  * @param int $payment_id Donation ID.
  *
- * @param int $form_id    Give Form ID
+ * @since 2.12.0 default value for the $form_id parameter is removed to prevent PHP8 warnings.
  *
  * @return bool|int
  */
-function give_decrease_form_earnings($form_id, $amount, $payment_id = 0)
-{
-    /** @var \Give_Donate_Form $form */
-    $form = new Give_Donate_Form($form_id);
+function give_decrease_form_earnings( $form_id, $amount, $payment_id = 0 ) {
+	/** @var \Give_Donate_Form $form */
+	$form = new Give_Donate_Form( $form_id );
 
-    return $form->decrease_earnings($amount, $payment_id);
+	return $form->decrease_earnings( $amount, $payment_id );
 }
 
 
@@ -545,16 +522,15 @@ function give_decrease_form_earnings($form_id, $amount, $payment_id = 0)
  *
  * @return int $earnings Earnings for a certain form
  */
-function give_get_form_earnings_stats($form_id = 0)
-{
-    $give_form = new Give_Donate_Form($form_id);
+function give_get_form_earnings_stats( $form_id = 0 ) {
+	$give_form = new Give_Donate_Form( $form_id );
 
-    /**
-     * Filter the form earnings
-     *
-     * @since 1.8.17
-     */
-    return apply_filters('give_get_form_earnings_stats', $give_form->earnings, $form_id, $give_form);
+	/**
+	 * Filter the form earnings
+	 *
+	 * @since 1.8.17
+	 */
+	return apply_filters( 'give_get_form_earnings_stats', $give_form->earnings, $form_id, $give_form );
 }
 
 
@@ -567,11 +543,10 @@ function give_get_form_earnings_stats($form_id = 0)
  *
  * @return int $sales Amount of sales for a certain form
  */
-function give_get_form_sales_stats($give_form_id = 0)
-{
-    $give_form = new Give_Donate_Form($give_form_id);
+function give_get_form_sales_stats( $give_form_id = 0 ) {
+	$give_form = new Give_Donate_Form( $give_form_id );
 
-    return $give_form->sales;
+	return $give_form->sales;
 }
 
 
@@ -584,20 +559,19 @@ function give_get_form_sales_stats($give_form_id = 0)
  *
  * @return float $sales Average monthly sales
  */
-function give_get_average_monthly_form_sales($form_id = 0)
-{
-    $sales = give_get_form_sales_stats($form_id);
-    $release_date = get_post_field('post_date', $form_id);
+function give_get_average_monthly_form_sales( $form_id = 0 ) {
+	$sales        = give_get_form_sales_stats( $form_id );
+	$release_date = get_post_field( 'post_date', $form_id );
 
-    $diff = abs(current_time('timestamp') - strtotime($release_date));
+	$diff = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
 
-    $months = floor($diff / (30 * 60 * 60 * 24)); // Number of months since publication
+	$months = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
 
-    if ($months > 0) {
-        $sales = ($sales / $months);
-    }
+	if ( $months > 0 ) {
+		$sales = ( $sales / $months );
+	}
 
-    return $sales;
+	return $sales;
 }
 
 
@@ -610,20 +584,19 @@ function give_get_average_monthly_form_sales($form_id = 0)
  *
  * @return float $earnings Average monthly earnings
  */
-function give_get_average_monthly_form_earnings($form_id = 0)
-{
-    $earnings = give_get_form_earnings_stats($form_id);
-    $release_date = get_post_field('post_date', $form_id);
+function give_get_average_monthly_form_earnings( $form_id = 0 ) {
+	$earnings     = give_get_form_earnings_stats( $form_id );
+	$release_date = get_post_field( 'post_date', $form_id );
 
-    $diff = abs(current_time('timestamp') - strtotime($release_date));
+	$diff = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
 
-    $months = floor($diff / (30 * 60 * 60 * 24)); // Number of months since publication
+	$months = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
 
-    if ($months > 0) {
-        $earnings = ($earnings / $months);
-    }
+	if ( $months > 0 ) {
+		$earnings = ( $earnings / $months );
+	}
 
-    return $earnings < 0 ? 0 : $earnings;
+	return $earnings < 0 ? 0 : $earnings;
 }
 
 
@@ -641,36 +614,34 @@ function give_get_average_monthly_form_earnings($form_id = 0)
  *
  * @return string $price_name Name of the price option
  */
-function give_get_price_option_name($form_id = 0, $price_id = 0, $payment_id = 0, $use_fallback = true)
-{
-    $prices = give_get_variable_prices($form_id);
-    $price_name = '';
+function give_get_price_option_name( $form_id = 0, $price_id = 0, $payment_id = 0, $use_fallback = true ) {
 
-    if ( ! $prices) {
-        return $price_name;
-    }
+	$prices     = give_get_variable_prices( $form_id );
+	$price_name = '';
 
-    foreach ($prices as $price) {
-        if (intval($price['_give_id']['level_id']) === intval($price_id)) {
-            $price_text = apply_filters(
-                'give_form_level_text',
-                isset($price['_give_text']) ? $price['_give_text'] : '',
-                $form_id,
-                $price
-            );
-            $price_fallback = $use_fallback ?
-                give_currency_filter(
-                    give_format_amount(
-                        $price['_give_amount'],
-                        ['sanitize' => false]
-                    ),
-                    ['decode_currency' => true]
-                ) : '';
-            $price_name = ! empty($price_text) ? $price_text : $price_fallback;
-        }
-    }
+	if ( ! $prices ) {
+		return $price_name;
+	}
 
-    return apply_filters('give_get_price_option_name', $price_name, $form_id, $payment_id, $price_id);
+	foreach ( $prices as $price ) {
+
+		if ( intval( $price['_give_id']['level_id'] ) === intval( $price_id ) ) {
+
+			$price_text     = apply_filters( 'give_form_level_text', isset( $price['_give_text'] ) ? $price['_give_text'] : '', $form_id, $price );
+			$price_fallback = $use_fallback ?
+				give_currency_filter(
+					give_format_amount(
+						$price['_give_amount'],
+						[ 'sanitize' => false ]
+					),
+					[ 'decode_currency' => true ]
+				) : '';
+			$price_name     = ! empty( $price_text ) ? $price_text : $price_fallback;
+
+		}
+	}
+
+	return apply_filters( 'give_get_price_option_name', $price_name, $form_id, $payment_id, $price_id );
 }
 
 
@@ -684,29 +655,24 @@ function give_get_price_option_name($form_id = 0, $price_id = 0, $payment_id = 0
  *
  * @return string $range A fully formatted price range
  */
-function give_price_range($form_id = 0, $formatted = true)
-{
-    $low = give_get_lowest_price_option($form_id);
-    $high = give_get_highest_price_option($form_id);
-    $order_type = ! empty($_REQUEST['order']) ? $_REQUEST['order'] : 'asc';
+function give_price_range( $form_id = 0, $formatted = true ) {
+	$low        = give_get_lowest_price_option( $form_id );
+	$high       = give_get_highest_price_option( $form_id );
+	$order_type = ! empty( $_REQUEST['order'] ) ? $_REQUEST['order'] : 'asc';
 
-    $range = sprintf(
-        '<span class="give_price_range_%1$s">%2$s</span><span class="give_price_range_sep">&nbsp;&ndash;&nbsp;</span><span class="give_price_range_%3$s">%4$s</span>',
-        'asc' === $order_type ? 'low' : 'high',
-        'asc' === $order_type ? give_currency_filter(
-            give_format_amount($low, ['sanitize' => false])
-        ) : give_currency_filter(give_format_amount($high, ['sanitize' => false])),
-        'asc' === $order_type ? 'high' : 'low',
-        'asc' === $order_type ? give_currency_filter(
-            give_format_amount($high, ['sanitize' => false])
-        ) : give_currency_filter(give_format_amount($low, ['sanitize' => false]))
-    );
+	$range = sprintf(
+		'<span class="give_price_range_%1$s">%2$s</span><span class="give_price_range_sep">&nbsp;&ndash;&nbsp;</span><span class="give_price_range_%3$s">%4$s</span>',
+		'asc' === $order_type ? 'low' : 'high',
+		'asc' === $order_type ? give_currency_filter( give_format_amount( $low, [ 'sanitize' => false ] ) ) : give_currency_filter( give_format_amount( $high, [ 'sanitize' => false ] ) ),
+		'asc' === $order_type ? 'high' : 'low',
+		'asc' === $order_type ? give_currency_filter( give_format_amount( $high, [ 'sanitize' => false ] ) ) : give_currency_filter( give_format_amount( $low, [ 'sanitize' => false ] ) )
+	);
 
-    if ( ! $formatted) {
-        $range = wp_strip_all_tags($range);
-    }
+	if ( ! $formatted ) {
+		$range = wp_strip_all_tags( $range );
+	}
 
-    return apply_filters('give_price_range', $range, $form_id, $low, $high);
+	return apply_filters( 'give_price_range', $range, $form_id, $low, $high );
 }
 
 
@@ -721,39 +687,41 @@ function give_price_range($form_id = 0, $formatted = true)
  *
  * @return int ID of the lowest price
  */
-function give_get_lowest_price_id($form_id = 0)
-{
-    if (empty($form_id)) {
-        $form_id = get_the_ID();
-    }
+function give_get_lowest_price_id( $form_id = 0 ) {
 
-    if ( ! give_has_variable_prices($form_id)) {
-        return give_get_form_price($form_id);
-    }
+	if ( empty( $form_id ) ) {
+		$form_id = get_the_ID();
+	}
 
-    $prices = give_get_variable_prices($form_id);
+	if ( ! give_has_variable_prices( $form_id ) ) {
+		return give_get_form_price( $form_id );
+	}
 
-    $min = $min_id = 0;
+	$prices = give_get_variable_prices( $form_id );
 
-    if ( ! empty($prices)) {
-        foreach ($prices as $key => $price) {
-            if (empty($price['_give_amount'])) {
-                continue;
-            }
+	$min = $min_id = 0;
 
-            if ( ! isset($min)) {
-                $min = $price['_give_amount'];
-            } else {
-                $min = min($min, $price['_give_amount']);
-            }
+	if ( ! empty( $prices ) ) {
 
-            if ($price['_give_amount'] == $min) {
-                $min_id = $price['_give_id']['level_id'];
-            }
-        }
-    }
+		foreach ( $prices as $key => $price ) {
 
-    return (int)$min_id;
+			if ( empty( $price['_give_amount'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $min ) ) {
+				$min = $price['_give_amount'];
+			} else {
+				$min = min( $min, $price['_give_amount'] );
+			}
+
+			if ( $price['_give_amount'] == $min ) {
+				$min_id = $price['_give_id']['level_id'];
+			}
+		}
+	}
+
+	return (int) $min_id;
 }
 
 /**
@@ -765,23 +733,22 @@ function give_get_lowest_price_id($form_id = 0)
  *
  * @return float Amount of the lowest price
  */
-function give_get_lowest_price_option($form_id = 0)
-{
-    if (empty($form_id)) {
-        $form_id = get_the_ID();
-    }
+function give_get_lowest_price_option( $form_id = 0 ) {
+	if ( empty( $form_id ) ) {
+		$form_id = get_the_ID();
+	}
 
-    if ( ! give_has_variable_prices($form_id)) {
-        return give_get_form_price($form_id);
-    }
+	if ( ! give_has_variable_prices( $form_id ) ) {
+		return give_get_form_price( $form_id );
+	}
 
-    if ( ! ($low = get_post_meta($form_id, '_give_levels_minimum_amount', true))) {
-        // Backward compatibility.
-        $prices = wp_list_pluck(give_get_variable_prices($form_id), '_give_amount');
-        $low = ! empty($prices) ? min($prices) : 0;
-    }
+	if ( ! ( $low = get_post_meta( $form_id, '_give_levels_minimum_amount', true ) ) ) {
+		// Backward compatibility.
+		$prices = wp_list_pluck( give_get_variable_prices( $form_id ), '_give_amount' );
+		$low    = ! empty( $prices ) ? min( $prices ) : 0;
+	}
 
-    return give_maybe_sanitize_amount($low);
+	return give_maybe_sanitize_amount( $low );
 }
 
 /**
@@ -793,23 +760,23 @@ function give_get_lowest_price_option($form_id = 0)
  *
  * @return float Amount of the highest price
  */
-function give_get_highest_price_option($form_id = 0)
-{
-    if (empty($form_id)) {
-        $form_id = get_the_ID();
-    }
+function give_get_highest_price_option( $form_id = 0 ) {
 
-    if ( ! give_has_variable_prices($form_id)) {
-        return give_get_form_price($form_id);
-    }
+	if ( empty( $form_id ) ) {
+		$form_id = get_the_ID();
+	}
 
-    if ( ! ($high = get_post_meta($form_id, '_give_levels_maximum_amount', true))) {
-        // Backward compatibility.
-        $prices = wp_list_pluck(give_get_variable_prices($form_id), '_give_amount');
-        $high = ! empty($prices) ? max($prices) : 0;
-    }
+	if ( ! give_has_variable_prices( $form_id ) ) {
+		return give_get_form_price( $form_id );
+	}
 
-    return give_maybe_sanitize_amount($high);
+	if ( ! ( $high = get_post_meta( $form_id, '_give_levels_maximum_amount', true ) ) ) {
+		// Backward compatibility.
+		$prices = wp_list_pluck( give_get_variable_prices( $form_id ), '_give_amount' );
+		$high   = ! empty( $prices ) ? max( $prices ) : 0;
+	}
+
+	return give_maybe_sanitize_amount( $high );
 }
 
 /**
@@ -821,15 +788,15 @@ function give_get_highest_price_option($form_id = 0)
  *
  * @return mixed string|int Price of the form
  */
-function give_get_form_price($form_id = 0)
-{
-    if (empty($form_id)) {
-        return false;
-    }
+function give_get_form_price( $form_id = 0 ) {
 
-    $form = new Give_Donate_Form($form_id);
+	if ( empty( $form_id ) ) {
+		return false;
+	}
 
-    return $form->__get('price');
+	$form = new Give_Donate_Form( $form_id );
+
+	return $form->__get( 'price' );
 }
 
 /**
@@ -841,15 +808,16 @@ function give_get_form_price($form_id = 0)
  *
  * @return mixed string|int Minimum price of the form
  */
-function give_get_form_minimum_price($form_id = 0)
-{
-    if (empty($form_id)) {
-        return false;
-    }
+function give_get_form_minimum_price( $form_id = 0 ) {
 
-    $form = new Give_Donate_Form($form_id);
+	if ( empty( $form_id ) ) {
+		return false;
+	}
 
-    return $form->get_minimum_price();
+	$form = new Give_Donate_Form( $form_id );
+
+	return $form->get_minimum_price();
+
 }
 
 /**
@@ -861,15 +829,15 @@ function give_get_form_minimum_price($form_id = 0)
  *
  * @return bool|float
  */
-function give_get_form_maximum_price($form_id = 0)
-{
-    if (empty($form_id)) {
-        return false;
-    }
+function give_get_form_maximum_price( $form_id = 0 ) {
 
-    $form = new Give_Donate_Form($form_id);
+	if ( empty( $form_id ) ) {
+		return false;
+	}
 
-    return $form->get_maximum_price();
+	$form = new Give_Donate_Form( $form_id );
+
+	return $form->get_maximum_price();
 }
 
 /**
@@ -883,45 +851,48 @@ function give_get_form_maximum_price($form_id = 0)
  *
  * @return int $formatted_price
  */
-function give_price($form_id = 0, $echo = true, $price_id = false)
-{
-    $price = 0;
+function give_price( $form_id = 0, $echo = true, $price_id = false ) {
+	$price = 0;
 
-    if (empty($form_id)) {
-        $form_id = get_the_ID();
-    }
+	if ( empty( $form_id ) ) {
+		$form_id = get_the_ID();
+	}
 
-    if (give_has_variable_prices($form_id)) {
-        $prices = give_get_variable_prices($form_id);
+	if ( give_has_variable_prices( $form_id ) ) {
 
-        if (false !== $price_id) {
-            // loop through multi-prices to see which is default
-            foreach ($prices as $price) {
-                // this is the default price
-                if (isset($price['_give_default']) && $price['_give_default'] === 'default') {
-                    $price = (float)$price['_give_amount'];
-                };
-            }
-        } else {
-            $price = give_get_lowest_price_option($form_id);
-        }
-    } else {
-        $price = give_get_form_price($form_id);
-    }
+		$prices = give_get_variable_prices( $form_id );
 
-    $price = apply_filters('give_form_price', give_maybe_sanitize_amount($price), $form_id);
-    $formatted_price = '<span class="give_price" id="give_price_' . $form_id . '">' . $price . '</span>';
-    $formatted_price = apply_filters('give_form_price_after_html', $formatted_price, $form_id, $price);
+		if ( false !== $price_id ) {
 
-    if ($echo) {
-        echo $formatted_price;
-    } else {
-        return $formatted_price;
-    }
+			// loop through multi-prices to see which is default
+			foreach ( $prices as $price ) {
+				// this is the default price
+				if ( isset( $price['_give_default'] ) && $price['_give_default'] === 'default' ) {
+					$price = (float) $price['_give_amount'];
+				};
+			}
+		} else {
+
+			$price = give_get_lowest_price_option( $form_id );
+		}
+	} else {
+
+		$price = give_get_form_price( $form_id );
+	}
+
+	$price           = apply_filters( 'give_form_price', give_maybe_sanitize_amount( $price ), $form_id );
+	$formatted_price = '<span class="give_price" id="give_price_' . $form_id . '">' . $price . '</span>';
+	$formatted_price = apply_filters( 'give_form_price_after_html', $formatted_price, $form_id, $price );
+
+	if ( $echo ) {
+		echo $formatted_price;
+	} else {
+		return $formatted_price;
+	}
 }
 
-add_filter('give_form_price', 'give_format_amount', 10);
-add_filter('give_form_price', 'give_currency_filter', 20);
+add_filter( 'give_form_price', 'give_format_amount', 10 );
+add_filter( 'give_form_price', 'give_currency_filter', 20 );
 
 
 /**
@@ -934,30 +905,29 @@ add_filter('give_form_price', 'give_currency_filter', 20);
  *
  * @return float $amount Amount of the price option
  */
-function give_get_price_option_amount($form_id = 0, $price_id = 0)
-{
-    $prices = give_get_variable_prices($form_id);
+function give_get_price_option_amount( $form_id = 0, $price_id = 0 ) {
+	$prices = give_get_variable_prices( $form_id );
 
-    $amount = 0.00;
+	$amount = 0.00;
 
-    foreach ($prices as $price) {
-        if (isset($price['_give_id']['level_id']) && $price['_give_id']['level_id'] == $price_id) {
-            $amount = isset($price['_give_amount']) ? $price['_give_amount'] : 0.00;
-            break;
-        }
-    }
+	foreach ( $prices as $price ) {
+		if ( isset( $price['_give_id']['level_id'] ) && $price['_give_id']['level_id'] == $price_id ) {
+			$amount = isset( $price['_give_amount'] ) ? $price['_give_amount'] : 0.00;
+			break;
+		}
+	}
 
-    /**
-     * Filter the price amount
-     *
-     * @since 1.0
-     */
-    return apply_filters(
-        'give_get_price_option_amount',
-        give_maybe_sanitize_amount($amount, ['currency' => give_get_currency($form_id)]),
-        $form_id,
-        $price_id
-    );
+	/**
+	 * Filter the price amount
+	 *
+	 * @since 1.0
+	 */
+	return apply_filters(
+		'give_get_price_option_amount',
+		give_maybe_sanitize_amount( $amount, [ 'currency' => give_get_currency( $form_id ) ] ),
+		$form_id,
+		$price_id
+	);
 }
 
 /**
@@ -969,15 +939,16 @@ function give_get_price_option_amount($form_id = 0, $price_id = 0)
  *
  * @return mixed string|int Goal of the form
  */
-function give_get_form_goal($form_id = 0)
-{
-    if (empty($form_id)) {
-        return false;
-    }
+function give_get_form_goal( $form_id = 0 ) {
 
-    $form = new Give_Donate_Form($form_id);
+	if ( empty( $form_id ) ) {
+		return false;
+	}
 
-    return $form->goal;
+	$form = new Give_Donate_Form( $form_id );
+
+	return $form->goal;
+
 }
 
 /**
@@ -989,13 +960,14 @@ function give_get_form_goal($form_id = 0)
  *
  * @return mixed string|int Goal of the form
  */
-function give_get_form_goal_format($form_id = 0)
-{
-    if (empty($form_id)) {
-        return false;
-    }
+function give_get_form_goal_format( $form_id = 0 ) {
 
-    return give_get_meta($form_id, '_give_goal_format', true);
+	if ( empty( $form_id ) ) {
+		return false;
+	}
+
+	return give_get_meta( $form_id, '_give_goal_format', true );
+
 }
 
 /**
@@ -1008,37 +980,37 @@ function give_get_form_goal_format($form_id = 0)
  *
  * @return string $formatted_goal
  */
-function give_goal($form_id = 0, $echo = true)
-{
-    if (empty($form_id)) {
-        $form_id = get_the_ID();
-    }
+function give_goal( $form_id = 0, $echo = true ) {
 
-    $goal = give_get_form_goal($form_id);
-    $goal_format = give_get_form_goal_format($form_id);
+	if ( empty( $form_id ) ) {
+		$form_id = get_the_ID();
+	}
 
-    if ('donation' === $goal_format) {
-        $goal = "{$goal} donations";
-    } else {
-        $goal = apply_filters('give_form_goal', give_maybe_sanitize_amount($goal), $form_id);
-    }
+	$goal        = give_get_form_goal( $form_id );
+	$goal_format = give_get_form_goal_format( $form_id );
 
-    $formatted_goal = sprintf(
-        '<span class="give_price" id="give_price_%1$s">%2$s</span>',
-        $form_id,
-        $goal
-    );
-    $formatted_goal = apply_filters('give_form_price_after_html', $formatted_goal, $form_id, $goal);
+	if ( 'donation' === $goal_format ) {
+		$goal = "{$goal} donations";
+	} else {
+		$goal = apply_filters( 'give_form_goal', give_maybe_sanitize_amount( $goal ), $form_id );
+	}
 
-    if ($echo) {
-        echo $formatted_goal;
-    } else {
-        return $formatted_goal;
-    }
+	$formatted_goal = sprintf(
+		'<span class="give_price" id="give_price_%1$s">%2$s</span>',
+		$form_id,
+		$goal
+	);
+	$formatted_goal = apply_filters( 'give_form_price_after_html', $formatted_goal, $form_id, $goal );
+
+	if ( $echo ) {
+		echo $formatted_goal;
+	} else {
+		return $formatted_goal;
+	}
 }
 
-add_filter('give_form_goal', 'give_format_amount', 10);
-add_filter('give_form_goal', 'give_currency_filter', 20);
+add_filter( 'give_form_goal', 'give_format_amount', 10 );
+add_filter( 'give_form_goal', 'give_currency_filter', 20 );
 
 
 /**
@@ -1046,20 +1018,19 @@ add_filter('give_form_goal', 'give_currency_filter', 20);
  *
  * @since  1.0
  *
- * @param int $form_id Give form ID
+ * @param  int $form_id Give form ID
  *
  * @return bool  $ret Whether or not the logged_in_only setting is set
  */
-function give_logged_in_only($form_id)
-{
-    // If _give_logged_in_only is set to enable then guest can donate from that specific form.
-    // Otherwise it is member only donation form.
-    $val = give_get_meta($form_id, '_give_logged_in_only', true);
-    $val = ! empty($val) ? $val : 'enabled';
+function give_logged_in_only( $form_id ) {
+	// If _give_logged_in_only is set to enable then guest can donate from that specific form.
+	// Otherwise it is member only donation form.
+	$val = give_get_meta( $form_id, '_give_logged_in_only', true );
+	$val = ! empty( $val ) ? $val : 'enabled';
 
-    $ret = ! give_is_setting_enabled($val);
+	$ret = ! give_is_setting_enabled( $val );
 
-    return (bool)apply_filters('give_logged_in_only', $ret, $form_id);
+	return (bool) apply_filters( 'give_logged_in_only', $ret, $form_id );
 }
 
 
@@ -1072,11 +1043,12 @@ function give_logged_in_only($form_id)
  *
  * @return string
  */
-function give_show_login_register_option($form_id)
-{
-    $show_register_form = give_get_meta($form_id, '_give_show_register_form', true);
+function give_show_login_register_option( $form_id ) {
 
-    return apply_filters('give_show_register_form', $show_register_form, $form_id);
+	$show_register_form = give_get_meta( $form_id, '_give_show_register_form', true );
+
+	return apply_filters( 'give_show_register_form', $show_register_form, $form_id );
+
 }
 
 
@@ -1087,75 +1059,74 @@ function give_show_login_register_option($form_id)
  *
  * @since  1.8
  *
- * @param int $form_id Form ID.
+ * @param  int $form_id Form ID.
  *
  * @return array
  */
-function _give_get_prefill_form_field_values($form_id)
-{
-    $logged_in_donor_info = [];
+function _give_get_prefill_form_field_values( $form_id ) {
+	$logged_in_donor_info = [];
 
-    if (is_user_logged_in()) :
-        $donor_data = get_userdata(get_current_user_id());
-        $donor = new Give_Donor(get_current_user_id(), true);
-        $donor_address = $donor->get_donor_address();
-        $company_name = $donor->get_company_name();
+	if ( is_user_logged_in() ) :
+		$donor_data    = get_userdata( get_current_user_id() );
+		$donor         = new Give_Donor( get_current_user_id(), true );
+		$donor_address = $donor->get_donor_address();
+		$company_name  = $donor->get_company_name();
 
-        $logged_in_donor_info = [
-            // First name.
-            'give_first'      => $donor_data->first_name,
+		$logged_in_donor_info = [
+			// First name.
+			'give_first'      => $donor_data->first_name,
 
-            // Last name.
-            'give_last'       => $donor_data->last_name,
+			// Last name.
+			'give_last'       => $donor_data->last_name,
 
-            // Title Prefix.
-            'give_title'      => $donor->get_meta('_give_donor_title_prefix', true),
+			// Title Prefix.
+			'give_title'      => $donor->get_meta( '_give_donor_title_prefix', true ),
 
-            // Company name.
-            'company_name'    => $company_name,
+			// Company name.
+			'company_name'    => $company_name,
 
-            // Email.
-            'give_email'      => $donor_data->user_email,
+			// Email.
+			'give_email'      => $donor_data->user_email,
 
-            // Street address 1.
-            'card_address'    => $donor_address['line1'],
+			// Street address 1.
+			'card_address'    => $donor_address['line1'],
 
-            // Street address 2.
-            'card_address_2'  => $donor_address['line2'],
+			// Street address 2.
+			'card_address_2'  => $donor_address['line2'],
 
-            // Country.
-            'billing_country' => $donor_address['country'],
+			// Country.
+			'billing_country' => $donor_address['country'],
 
-            // State.
-            'card_state'      => $donor_address['state'],
+			// State.
+			'card_state'      => $donor_address['state'],
 
-            // City.
-            'card_city'       => $donor_address['city'],
+			// City.
+			'card_city'       => $donor_address['city'],
 
-            // Zipcode
-            'card_zip'        => $donor_address['zip'],
-        ];
-    endif;
+			// Zipcode
+			'card_zip'        => $donor_address['zip'],
+		];
+	endif;
 
-    // Bailout: Auto fill form field values only form form which donor is donating.
-    if (
-        empty($_GET['form-id'])
-        || ! $form_id
-        || ($form_id !== absint($_GET['form-id']))
-    ) {
-        return $logged_in_donor_info;
-    }
+	// Bailout: Auto fill form field values only form form which donor is donating.
+	if (
+		empty( $_GET['form-id'] )
+		|| ! $form_id
+		|| ( $form_id !== absint( $_GET['form-id'] ) )
+	) {
+		return $logged_in_donor_info;
+	}
 
-    // Get purchase data.
-    $give_purchase_data = Give()->session->get('give_purchase');
+	// Get purchase data.
+	$give_purchase_data = Give()->session->get( 'give_purchase' );
 
-    // Get donor info from form data.
-    $give_donor_info_in_session = empty($give_purchase_data['post_data'])
-        ? []
-        : $give_purchase_data['post_data'];
+	// Get donor info from form data.
+	$give_donor_info_in_session = empty( $give_purchase_data['post_data'] )
+		? []
+		: $give_purchase_data['post_data'];
 
-    // Output.
-    return wp_parse_args($give_donor_info_in_session, $logged_in_donor_info);
+	// Output.
+	return wp_parse_args( $give_donor_info_in_session, $logged_in_donor_info );
 }
 
 /**
@@ -1168,29 +1139,28 @@ function _give_get_prefill_form_field_values($form_id)
  *
  * @return int
  */
-function give_get_form_donor_count($form_id, $args = [])
-{
-    global $wpdb;
+function give_get_form_donor_count( $form_id, $args = [] ) {
+	global $wpdb;
 
-    $cache_key = Give_Cache::get_key("form_donor_count_{$form_id}", $args, false);
-    $donor_count = absint(Give_Cache::get_db_query($cache_key));
+	$cache_key   = Give_Cache::get_key( "form_donor_count_{$form_id}", $args, false );
+	$donor_count = absint( Give_Cache::get_db_query( $cache_key ) );
 
-    if ($form_id && ! $donor_count) {
-        // Set arguments.
-        $args = wp_parse_args(
-            $args,
-            [
-                'unique' => true,
-            ]
-        );
+	if ( $form_id && ! $donor_count ) {
+		// Set arguments.
+		$args = wp_parse_args(
+			$args,
+			[
+				'unique' => true,
+			]
+		);
 
-        $donation_meta_table = Give()->payment_meta->table_name;
-        $donation_id_col_name = Give()->payment_meta->get_meta_type() . '_id';
+		$donation_meta_table  = Give()->payment_meta->table_name;
+		$donation_id_col_name = Give()->payment_meta->get_meta_type() . '_id';
 
-        $distinct = $args['unique'] ? 'DISTINCT meta_value' : 'meta_value';
+		$distinct = $args['unique'] ? 'DISTINCT meta_value' : 'meta_value';
 
-        $query = $wpdb->prepare(
-            "
+		$query = $wpdb->prepare(
+			"
 			SELECT COUNT({$distinct})
 			FROM {$donation_meta_table}
 			WHERE meta_key=%s
@@ -1204,75 +1174,75 @@ function give_get_form_donor_count($form_id, $args = [])
 				AND p.post_status=%s
 			)
 			",
-            '_give_payment_donor_id',
-            '_give_payment_form_id',
-            $form_id,
-            'publish'
-        );
+			'_give_payment_donor_id',
+			'_give_payment_form_id',
+			$form_id,
+			'publish'
+		);
 
-        $donor_count = absint($wpdb->get_var($query));
-    }
+		$donor_count = absint( $wpdb->get_var( $query ) );
+	}
 
-    /**
-     * Filter the donor count
-     *
-     * @since 2.1.0
-     */
-    $donor_count = apply_filters('give_get_form_donor_count', $donor_count, $form_id, $args);
+	/**
+	 * Filter the donor count
+	 *
+	 * @since 2.1.0
+	 */
+	$donor_count = apply_filters( 'give_get_form_donor_count', $donor_count, $form_id, $args );
 
-    return $donor_count;
+	return $donor_count;
 }
 
 /**
  * Verify the form status.
  *
- * @since 2.1
- *
  * @param int $form_id Donation Form ID.
+ *
+ * @since 2.1
  *
  * @return void
  */
-function give_set_form_closed_status($form_id)
-{
-    // Bailout.
-    if (empty($form_id)) {
-        return;
-    }
+function give_set_form_closed_status( $form_id ) {
 
-    $open_form = false;
-    $is_goal_enabled = give_is_setting_enabled(give_get_meta($form_id, '_give_goal_option', true, 'disabled'));
+	// Bailout.
+	if ( empty( $form_id ) ) {
+		return;
+	}
 
-    // Proceed, if the form goal is enabled.
-    if ($is_goal_enabled) {
-        $close_form_when_goal_achieved = give_is_setting_enabled(
-            give_get_meta($form_id, '_give_close_form_when_goal_achieved', true, 'disabled')
-        );
+	$open_form       = false;
+	$is_goal_enabled = give_is_setting_enabled( give_get_meta( $form_id, '_give_goal_option', true, 'disabled' ) );
 
-        // Proceed, if close form when goal achieved option is enabled.
-        if ($close_form_when_goal_achieved) {
-            $form = new Give_Donate_Form($form_id);
-            $goal_progress_stats = give_goal_progress_stats($form);
+	// Proceed, if the form goal is enabled.
+	if ( $is_goal_enabled ) {
 
-            // Verify whether the form is closed or not after processing data.
-            $closed = $goal_progress_stats['raw_goal'] <= $goal_progress_stats['raw_actual'];
+		$close_form_when_goal_achieved = give_is_setting_enabled( give_get_meta( $form_id, '_give_close_form_when_goal_achieved', true, 'disabled' ) );
 
-            // Update form meta if verified that the form is closed.
-            if ($closed) {
-                give_update_meta($form_id, '_give_form_status', 'closed');
-            } else {
-                $open_form = true;
-            }
-        } else {
-            $open_form = true;
-        }
-    } else {
-        $open_form = true;
-    }
+		// Proceed, if close form when goal achieved option is enabled.
+		if ( $close_form_when_goal_achieved ) {
 
-    // If $open_form is true, then update form status to open.
-    if ($open_form) {
-        give_update_meta($form_id, '_give_form_status', 'open');
-    }
+			$form                = new Give_Donate_Form( $form_id );
+			$goal_progress_stats = give_goal_progress_stats( $form );
+
+			// Verify whether the form is closed or not after processing data.
+			$closed = $goal_progress_stats['raw_goal'] <= $goal_progress_stats['raw_actual'];
+
+			// Update form meta if verified that the form is closed.
+			if ( $closed ) {
+				give_update_meta( $form_id, '_give_form_status', 'closed' );
+			} else {
+				$open_form = true;
+			}
+		} else {
+			$open_form = true;
+		}
+	} else {
+		$open_form = true;
+	}
+
+	// If $open_form is true, then update form status to open.
+	if ( $open_form ) {
+		give_update_meta( $form_id, '_give_form_status', 'open' );
+	}
 }
 
 /**
@@ -1280,52 +1250,43 @@ function give_set_form_closed_status($form_id)
  *
  * @since 2.19.0 Prevent divide by zero issue in goal percentage calculation logic.
  *
- * @since 2.1.0
- *
  * @param int $form_id Form ID.
+ *
+ * @since 2.1.0
  *
  * @return string
  */
-function give_admin_form_goal_stats($form_id)
-{
-    $html = '';
-    $goal_stats = give_goal_progress_stats($form_id);
-    $percent_complete = $goal_stats['raw_goal'] ? round(
-                                                      ($goal_stats['raw_actual'] / $goal_stats['raw_goal']),
-                                                      3
-                                                  ) * 100 : 0;
+function give_admin_form_goal_stats( $form_id ) {
 
-    $html .= sprintf(
-        '<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">
+	$html             = '';
+	$goal_stats       = give_goal_progress_stats( $form_id );
+	$percent_complete = $goal_stats['raw_goal'] ? round( ( $goal_stats['raw_actual'] / $goal_stats['raw_goal'] ), 3 ) * 100 : 0;
+
+	$html .= sprintf(
+		'<div class="give-admin-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%1$s">
 <span style="width:%1$s%%;"></span>
 </div>',
-        esc_attr($goal_stats['progress'])
-    );
+		esc_attr( $goal_stats['progress'] )
+	);
 
-    $html .= sprintf(
-        ('percentage' !== $goal_stats['format']) ?
-            '<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s ' :
-            '<div class="give-goal-text"><a href="%3$s">%1$s </a>',
-        ('percentage' !== $goal_stats['format']) ? $goal_stats['actual'] : $percent_complete . '%',
-        ('percentage' !== $goal_stats['format']) ? __('of', 'give') : '',
-        esc_url(admin_url("post.php?post={$form_id}&action=edit&give_tab=donation_goal_options")),
-        $goal_stats['goal'],
-        ('donors' === $goal_stats['format'] ? __('donors', 'give') : ('donation' === $goal_stats['format'] ? __(
-            'donations',
-            'give'
-        ) : ''))
-    );
+	$html .= sprintf(
+		( 'percentage' !== $goal_stats['format'] ) ?
+			'<div class="give-goal-text"><span>%1$s</span> %2$s <a href="%3$s">%4$s</a> %5$s ' :
+			'<div class="give-goal-text"><a href="%3$s">%1$s </a>',
+		( 'percentage' !== $goal_stats['format'] ) ? $goal_stats['actual'] : $percent_complete . '%',
+		( 'percentage' !== $goal_stats['format'] ) ? __( 'of', 'give' ) : '',
+		esc_url( admin_url( "post.php?post={$form_id}&action=edit&give_tab=donation_goal_options" ) ),
+		$goal_stats['goal'],
+		( 'donors' === $goal_stats['format'] ? __( 'donors', 'give' ) : ( 'donation' === $goal_stats['format'] ? __( 'donations', 'give' ) : '' ) )
+	);
 
-    if ($goal_stats['raw_actual'] >= $goal_stats['raw_goal']) {
-        $html .= sprintf(
-            '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>',
-            __('Goal achieved', 'give')
-        );
-    }
+	if ( $goal_stats['raw_actual'] >= $goal_stats['raw_goal'] ) {
+		$html .= sprintf( '<span class="give-admin-goal-achieved"><span class="dashicons dashicons-star-filled"></span> %s</span>', __( 'Goal achieved', 'give' ) );
+	}
 
-    $html .= '</div>';
+	$html .= '</div>';
 
-    return $html;
+	return $html;
 }
 
 /**
@@ -1337,46 +1298,43 @@ function give_admin_form_goal_stats($form_id)
  *
  * @return null | array
  */
-function give_form_get_default_level($form_id)
-{
-    $default_level = null;
+function give_form_get_default_level( $form_id ) {
+	$default_level = null;
 
-    // If donation form has variable prices.
-    if (give_has_variable_prices($form_id)) {
-        /**
-         * Filter the variable pricing
-         *
-         * @since          1.0
-         *
-         * @param array $prices Array of variable prices.
-         * @param int   $form   Form ID.
-         *
-         * @deprecated     2.2 Use give_get_donation_levels filter instead of give_form_variable_prices.
-         *                 Check Give_Donate_Form::get_prices().
-         *
-         */
-        $prices = apply_filters('give_form_variable_prices', give_get_variable_prices($form_id), $form_id);
+	// If donation form has variable prices.
+	if ( give_has_variable_prices( $form_id ) ) {
+		/**
+		 * Filter the variable pricing
+		 *
+		 * @since      1.0
+		 * @deprecated 2.2 Use give_get_donation_levels filter instead of give_form_variable_prices.
+		 *                 Check Give_Donate_Form::get_prices().
+		 *
+		 * @param array $prices Array of variable prices.
+		 * @param int   $form   Form ID.
+		 */
+		$prices = apply_filters( 'give_form_variable_prices', give_get_variable_prices( $form_id ), $form_id );
 
-        // Go through each of the level and get the default level id.
-        foreach ($prices as $level) {
-            if (
-                isset($level['_give_default'])
-                && $level['_give_default'] === 'default'
-            ) {
-                $default_level = $level;
-            }
-        }
-    }
+		// Go through each of the level and get the default level id.
+		foreach ( $prices as $level ) {
+			if (
+				isset( $level['_give_default'] )
+				&& $level['_give_default'] === 'default'
+			) {
+				$default_level = $level;
+			}
+		}
+	}
 
-    /**
-     * Filter the default donation level id.
-     *
-     * @since 2.2.0
-     *
-     * @param array   $default_level Default level price data.
-     * @param integer $form_id       Donation form ID.
-     */
-    return apply_filters('give_form_get_default_level', $default_level, $form_id);
+	/**
+	 * Filter the default donation level id.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param array   $default_level Default level price data.
+	 * @param integer $form_id       Donation form ID.
+	 */
+	return apply_filters( 'give_form_get_default_level', $default_level, $form_id );
 }
 
 /**
@@ -1389,153 +1347,144 @@ function give_form_get_default_level($form_id)
  *
  * @return boolean
  */
-function give_is_default_level_id($price_or_level_id, $form_id = 0)
-{
-    $is_default = false;
+function give_is_default_level_id( $price_or_level_id, $form_id = 0 ) {
+	$is_default = false;
 
-    if (
-        ! empty($form_id)
-        && is_numeric($price_or_level_id)
-    ) {
-        // Get default level id.
-        $form_price_data = give_form_get_default_level($form_id);
+	if (
+		! empty( $form_id )
+		&& is_numeric( $price_or_level_id )
+	) {
+		// Get default level id.
+		$form_price_data = give_form_get_default_level( $form_id );
 
-        $is_default = ! is_null($form_price_data) && ($price_or_level_id === absint(
-                    $form_price_data['_give_id']['level_id']
-                ));
-    }
+		$is_default = ! is_null( $form_price_data ) && ( $price_or_level_id === absint( $form_price_data['_give_id']['level_id'] ) );
+	}
 
-    $is_default = false === $is_default && is_array($price_or_level_id) ?
-        (isset($price_or_level_id['_give_default']) && $price_or_level_id['_give_default'] === 'default')
-        : $is_default;
+	$is_default = false === $is_default && is_array( $price_or_level_id ) ?
+		( isset( $price_or_level_id['_give_default'] ) && $price_or_level_id['_give_default'] === 'default' )
+		: $is_default;
 
-    /**
-     * Allow developers to modify the default level id checks.
-     *
-     * @since 2.2.0
-     *
-     * @param bool          $is_default        True if it is default price level id otherwise false.
-     * @param array|integer $price_or_level_id Price Data.
-     */
-    return apply_filters('give_is_default_level_id', $is_default, $price_or_level_id);
+	/**
+	 * Allow developers to modify the default level id checks.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param bool          $is_default        True if it is default price level id otherwise false.
+	 * @param array|integer $price_or_level_id Price Data.
+	 */
+	return apply_filters( 'give_is_default_level_id', $is_default, $price_or_level_id );
 }
 
 
 /**
  * Get Name Title Prefixes (a.k.a. Salutation) value.
  *
- * @since 2.2.0
- *
  * @param int $form_id Donation Form ID.
+ *
+ * @since 2.2.0
  *
  * @return array
  */
-function give_get_name_title_prefixes($form_id = 0)
-{
-    $name_title_prefix = give_is_name_title_prefix_enabled($form_id);
-    $title_prefixes = give_get_option('title_prefixes', give_get_default_title_prefixes());
+function give_get_name_title_prefixes( $form_id = 0 ) {
 
-    // If form id exists, then fetch form specific title prefixes.
-    if (intval($form_id) > 0 && $name_title_prefix) {
-        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
-        if ('global' !== $form_title_prefix) {
-            $form_title_prefixes = give_get_meta(
-                $form_id,
-                '_give_title_prefixes',
-                true,
-                give_get_default_title_prefixes()
-            );
+	$name_title_prefix = give_is_name_title_prefix_enabled( $form_id );
+	$title_prefixes    = give_get_option( 'title_prefixes', give_get_default_title_prefixes() );
 
-            // Check whether the form based title prefixes exists or not.
-            if (is_array($form_title_prefixes) && count($form_title_prefixes) > 0) {
-                $title_prefixes = $form_title_prefixes;
-            }
-        }
-    }
+	// If form id exists, then fetch form specific title prefixes.
+	if ( intval( $form_id ) > 0 && $name_title_prefix ) {
 
-    return array_filter((array)$title_prefixes);
+		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
+		if ( 'global' !== $form_title_prefix ) {
+			$form_title_prefixes = give_get_meta( $form_id, '_give_title_prefixes', true, give_get_default_title_prefixes() );
+
+			// Check whether the form based title prefixes exists or not.
+			if ( is_array( $form_title_prefixes ) && count( $form_title_prefixes ) > 0 ) {
+				$title_prefixes = $form_title_prefixes;
+			}
+		}
+	}
+
+	return array_filter( (array) $title_prefixes );
 }
 
 /**
  * Check whether the name title prefix is enabled or not.
  *
- * @since 2.2.0
- *
+ * @param int    $form_id Donation Form ID.
  * @param string $status  Status to set status based on option value.
  *
- * @param int    $form_id Donation Form ID.
+ * @since 2.2.0
  *
  * @return bool
  */
-function give_is_name_title_prefix_enabled($form_id = 0, $status = '')
-{
-    if (empty($status)) {
-        $status = ['required', 'optional'];
-    } else {
-        $status = [$status];
-    }
+function give_is_name_title_prefix_enabled( $form_id = 0, $status = '' ) {
+	if ( empty( $status ) ) {
+		$status = [ 'required', 'optional' ];
+	} else {
+		$status = [ $status ];
+	}
 
-    $title_prefix_status = give_is_setting_enabled(give_get_option('name_title_prefix'), $status);
+	$title_prefix_status = give_is_setting_enabled( give_get_option( 'name_title_prefix' ), $status );
 
-    if (intval($form_id) > 0) {
-        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
+	if ( intval( $form_id ) > 0 ) {
+		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
 
-        if ('disabled' === $form_title_prefix) {
-            $title_prefix_status = false;
-        } elseif (in_array($form_title_prefix, $status, true)) {
-            $title_prefix_status = give_is_setting_enabled($form_title_prefix, $status);
-        }
-    }
+		if ( 'disabled' === $form_title_prefix ) {
+			$title_prefix_status = false;
+		} elseif ( in_array( $form_title_prefix, $status, true ) ) {
+			$title_prefix_status = give_is_setting_enabled( $form_title_prefix, $status );
+		}
+	}
 
-    return $title_prefix_status;
+	return $title_prefix_status;
+
 }
 
 /**
  * Get Donor Name with Title Prefix
  *
- * @since 2.2.0
- *
  * @param int|Give_Donor $donor Donor Information.
+ *
+ * @since 2.2.0
  *
  * @return object
  */
-function give_get_name_with_title_prefixes($donor)
-{
-    // Prepare Give_Donor object, if $donor is numeric.
-    if (is_numeric($donor)) {
-        $donor = new Give_Donor($donor);
-    }
+function give_get_name_with_title_prefixes( $donor ) {
 
-    $title_prefix = Give()->donor_meta->get_meta($donor->id, '_give_donor_title_prefix', true);
+	// Prepare Give_Donor object, if $donor is numeric.
+	if ( is_numeric( $donor ) ) {
+		$donor = new Give_Donor( $donor );
+	}
 
-    // Update Donor name, if non empty title prefix.
-    if ( ! empty($title_prefix)) {
-        $donor->name = give_get_donor_name_with_title_prefixes($title_prefix, $donor->name);
-    }
+	$title_prefix = Give()->donor_meta->get_meta( $donor->id, '_give_donor_title_prefix', true );
 
-    return $donor;
+	// Update Donor name, if non empty title prefix.
+	if ( ! empty( $title_prefix ) ) {
+		$donor->name = give_get_donor_name_with_title_prefixes( $title_prefix, $donor->name );
+	}
+
+	return $donor;
 }
 
 /**
  * This function will generate donor name with title prefix if it is required.
  *
- * @since 2.2.0
- *
+ * @param string $title_prefix Title Prefix of Donor
  * @param string $name         Donor Name.
  *
- * @param string $title_prefix Title Prefix of Donor
+ * @since 2.2.0
  *
  * @return string
  */
-function give_get_donor_name_with_title_prefixes($title_prefix, $name)
-{
-    $donor_name = $name;
+function give_get_donor_name_with_title_prefixes( $title_prefix, $name ) {
 
-    if ( ! empty($title_prefix) && ! empty($name)) {
-        $donor_name = "{$title_prefix} {$name}";
-    }
+	$donor_name = $name;
 
-    return trim($donor_name);
+	if ( ! empty( $title_prefix ) && ! empty( $name ) ) {
+		$donor_name = "{$title_prefix} {$name}";
+	}
+
+	return trim( $donor_name );
 }
 
 /**
@@ -1545,54 +1494,53 @@ function give_get_donor_name_with_title_prefixes($title_prefix, $name)
  *
  * @return array
  */
-function give_get_default_title_prefixes()
-{
-    /**
-     * Filter the data
-     * Set default title prefixes.
-     *
-     * @since 2.2.0
-     */
-    return apply_filters(
-        'give_get_default_title_prefixes',
-        [
-            'Mr.'  => __('Mr.', 'give'),
-            'Mrs.' => __('Mrs.', 'give'),
-            'Ms.'  => __('Ms.', 'give'),
-        ]
-    );
+function give_get_default_title_prefixes() {
+	/**
+	 * Filter the data
+	 * Set default title prefixes.
+	 *
+	 * @since 2.2.0
+	 */
+	return apply_filters(
+		'give_get_default_title_prefixes',
+		[
+			'Mr.'  => __( 'Mr.', 'give' ),
+			'Mrs.' => __( 'Mrs.', 'give' ),
+			'Ms.'  => __( 'Ms.', 'give' ),
+		]
+	);
 }
 
 /**
  * This function will check whether the name title prefix field is required or not.
  *
- * @since 2.2.0
- *
  * @param int $form_id Donation Form ID.
+ *
+ * @since 2.2.0
  *
  * @return bool
  */
-function give_is_name_title_prefix_required($form_id = 0)
-{
-    // Bail out, if name title prefix is not enabled.
-    if ( ! give_is_name_title_prefix_enabled($form_id)) {
-        return false;
-    }
+function give_is_name_title_prefix_required( $form_id = 0 ) {
 
-    $status = ['optional'];
-    $is_optional = give_is_setting_enabled(give_get_option('name_title_prefix'), $status);
+	// Bail out, if name title prefix is not enabled.
+	if ( ! give_is_name_title_prefix_enabled( $form_id ) ) {
+		return false;
+	}
 
-    if (intval($form_id) > 0) {
-        $form_title_prefix = give_get_meta($form_id, '_give_name_title_prefix', true);
+	$status      = [ 'optional' ];
+	$is_optional = give_is_setting_enabled( give_get_option( 'name_title_prefix' ), $status );
 
-        if ('required' === $form_title_prefix) {
-            $is_optional = false;
-        } elseif ('optional' === $form_title_prefix) {
-            $is_optional = true;
-        }
-    }
+	if ( intval( $form_id ) > 0 ) {
+		$form_title_prefix = give_get_meta( $form_id, '_give_name_title_prefix', true );
 
-    return ( ! $is_optional);
+		if ( 'required' === $form_title_prefix ) {
+			$is_optional = false;
+		} elseif ( 'optional' === $form_title_prefix ) {
+			$is_optional = true;
+		}
+	}
+
+	return ( ! $is_optional );
 }
 
 /**
@@ -1604,26 +1552,26 @@ function give_is_name_title_prefix_required($form_id = 0)
  *
  * @return void
  */
-function give_handle_form_meta_on_delete($id)
-{
-    global $wpdb;
+function give_handle_form_meta_on_delete( $id ) {
 
-    $form = get_post($id);
-    $get_data = give_clean($_GET);
+	global $wpdb;
 
-    if (
-        'give_forms' === $form->post_type &&
-        'trash' === $form->post_status &&
-        (
-            (isset($get_data['action']) && 'delete' === $get_data['action']) ||
-            ! empty($get_data['delete_all'])
-        )
-    ) {
-        $wpdb->query($wpdb->prepare("DELETE FROM {$wpdb->formmeta} WHERE form_id = '%d'", $form->ID));
-    }
+	$form     = get_post( $id );
+	$get_data = give_clean( $_GET );
+
+	if (
+		'give_forms' === $form->post_type &&
+		'trash' === $form->post_status &&
+		(
+			( isset( $get_data['action'] ) && 'delete' === $get_data['action'] ) ||
+			! empty( $get_data['delete_all'] )
+		)
+	) {
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->formmeta} WHERE form_id = '%d'", $form->ID ) );
+	}
 }
 
-add_action('before_delete_post', 'give_handle_form_meta_on_delete', 10, 1);
+add_action( 'before_delete_post', 'give_handle_form_meta_on_delete', 10, 1 );
 
 
 /**
@@ -1634,26 +1582,25 @@ add_action('before_delete_post', 'give_handle_form_meta_on_delete', 10, 1);
  *
  * @return array
  */
-function give_get_default_form_shortcode_args()
-{
-    $default = [
-        'id'                    => '',
-        'show_title'            => true,
-        'show_goal'             => true,
-        'show_content'          => '',
-        'float_labels'          => '',
+function give_get_default_form_shortcode_args() {
+	$default = [
+		'id'                    => '',
+		'show_title'            => true,
+		'show_goal'             => true,
+		'show_content'          => '',
+		'float_labels'          => '',
         'display_style'         => '',
-        'continue_button_title' => '',
+        'continue_button_title' => __('Donate now', 'give'),
 
-        // This attribute belong to form template functionality.
-        // You can use this attribute to set modal open button background color.
-        'button_color'          => '#28C77B',
-    ];
+		// This attribute belong to form template functionality.
+		// You can use this attribute to set modal open button background color.
+		'button_color'          => '#28C77B',
+	];
 
-    /**
-     * Fire the filter
-     */
-    $default = apply_filters('give_get_default_form_shortcode_args', $default);
+	/**
+	 * Fire the filter
+	 */
+	$default = apply_filters( 'give_get_default_form_shortcode_args', $default );
 
-    return $default;
+	return $default;
 }

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -1590,7 +1590,7 @@ function give_get_default_form_shortcode_args() {
 		'show_content'          => '',
 		'float_labels'          => '',
         'display_style'         => '',
-        'continue_button_title' => __('Donate now', 'give'),
+        'continue_button_title' => '',
 
 		// This attribute belong to form template functionality.
 		// You can use this attribute to set modal open button background color.

--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -40,9 +40,7 @@ class BlockRenderController
 
         $viewUrl = $this->getViewUrl($donationForm, $embedId);
         $formUrl = esc_url(add_query_arg(['p' => $blockAttributes->formId], site_url('?post_type=give_forms')));
-
-        $formUrl = add_query_arg(['p' => $blockAttributes->formId], site_url('?post_type=give_forms'));
-
+        
         /**
          * Note: iframe-resizer uses querySelectorAll so using a data attribute makes the most sense to target.
          * It will also generate a dynamic ID - so when we have multiple embeds on a page there will be no conflict.

--- a/src/DonationForms/Blocks/DonationFormBlock/DataTransferObjects/BlockAttributes.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/DataTransferObjects/BlockAttributes.php
@@ -26,6 +26,7 @@ class BlockAttributes implements Arrayable
     public $openFormButton;
 
     /**
+     * @unreleased add v3 default for form button.
      * @since 3.0.0
      */
     public static function fromArray(array $array): BlockAttributes
@@ -35,7 +36,7 @@ class BlockAttributes implements Arrayable
         $self->formId = !empty($array['formId']) ? (int)$array['formId'] : null;
         $self->blockId = !empty($array['blockId']) ? (string)$array['blockId'] : null;
         $self->formFormat = !empty($array['formFormat']) ? (string)$array['formFormat'] : null;
-        $self->openFormButton = !empty($array['openFormButton']) ? (string)$array['openFormButton'] : null;
+        $self->openFormButton = !empty($array['openFormButton']) ? (string)$array['openFormButton'] : __('Donate now', 'give');
 
         return $self;
     }


### PR DESCRIPTION
Resolves #7150  / [GIVE-145]

## Description
This PR removes the static default value for `continue_button_title` in the shortcode args, so that form meta can be used as the default for legacy forms. We still require a default value for v3 forms, so one has been added to the `BlockAttributes` class.

Also I found a duplicate line for `$formUrl` in the `BlockRenderController` that I removed. It was an oversight while merging [Feature: include shortcode & block control support for v3 forms #7082](https://github.com/impress-org/givewp/pull/7082/files#diff-6afdb6343e85db42452a2debf534303d64d06709fd43e3119b0670f89a2fabae)  and [Feature: Embed Donation Form button #7080 ](https://github.com/impress-org/givewp/pull/7080)

## Affects
Legacy Forms, shortcode, block

## Visuals

https://github.com/impress-org/givewp/assets/75056371/e38b77da-c795-4d71-a0a3-bf3e5c0f54d3

## Testing Instructions
- Create a legacy form template
- Select reveal on form display options
- Update Continue button
- View form on frontend & confirm that the button label changes
- Create a shortcode - without explicitly setting continue button
- View form on frontend & confirm that the button label changes
- Retest with a v3 form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-145]: https://stellarwp.atlassian.net/browse/GIVE-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ