### PR TITLE
Fix: allow users to type into the state/county field input

### DIFF
--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -43,6 +43,7 @@ async function getStates(url, country) {
 /**
  * This component is used to dynamically update the state field based on the country value
  *
+ * @unreleased Set current state value to the state input field
  * @since 3.0.0
  */
 function StateFieldContainer({

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -182,16 +182,13 @@ function StateFieldContainer({
             <label>
                 <Label label={stateLabel ?? __('State', 'give')} required={stateRequired} />
 
-                {statesLoading ? (
-                    <input type="text" disabled={true} value={__('Loading...', 'give')} />
-                ) : (
-                    <input
-                        type="text"
-                        value={state}
-                        onChange={updateStateValue}
-                        aria-invalid={fieldError ? 'true' : 'false'}
-                    />
-                )}
+                <input
+                    type="text"
+                    onChange={updateStateValue}
+                    aria-invalid={fieldError ? 'true' : 'false'}
+                    placeholder={statesLoading ? __('Loading...', 'give') : ''}
+                    disabled={statesLoading}
+                />
 
                 <HiddenStateField />
 

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -65,6 +65,7 @@ function StateFieldContainer({
     const {errors} = useFormState();
     const {setValue, clearErrors} = useFormContext();
     const country = useWatch({name: 'country'});
+    const state = useWatch({name: 'state'});
     const [states, setStates] = useState<State[]>([]);
     const [statesLoading, setStatesLoading] = useState<boolean>(false);
     const [stateLabel, setStateLabel] = useState<string>('State');
@@ -93,7 +94,7 @@ function StateFieldContainer({
             .then((data) => {
                 if (data.ok) {
                     setStatesLoading(false);
-                    setValue('state', null);
+                    setValue('state', '');
 
                     return data.json();
                 }
@@ -185,7 +186,7 @@ function StateFieldContainer({
                 ) : (
                     <input
                         type="text"
-                        value={''}
+                        value={state}
                         onChange={updateStateValue}
                         aria-invalid={fieldError ? 'true' : 'false'}
                     />

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -1,8 +1,8 @@
-import type {BillingAddressProps} from '@givewp/forms/propTypes';
-import {FC, useEffect, useState} from 'react';
-import {__} from '@wordpress/i18n';
-import {ErrorMessage} from '@hookform/error-message';
-import {useCallback} from '@wordpress/element';
+import type { BillingAddressProps } from "@givewp/forms/propTypes";
+import { FC, useEffect, useState } from "react";
+import { __ } from "@wordpress/i18n";
+import { ErrorMessage } from "@hookform/error-message";
+import { useCallback } from "@wordpress/element";
 
 /**
  * @since 3.0.0
@@ -66,7 +66,6 @@ function StateFieldContainer({
     const {errors} = useFormState();
     const {setValue, clearErrors} = useFormContext();
     const country = useWatch({name: 'country'});
-    const state = useWatch({name: 'state'});
     const [states, setStates] = useState<State[]>([]);
     const [statesLoading, setStatesLoading] = useState<boolean>(false);
     const [stateLabel, setStateLabel] = useState<string>('State');


### PR DESCRIPTION
Fix necessary for [GIVE-12]

## Description

While working on Gift Aid 3.0 compatibility, we encountered an issue with the `State` field (referred to as `County` for Gift Aid in the United Kingdom). The problem is that users are unable to enter any text in this field. In the case of countries like the USA, the state field is a dropdown menu with available options and it works correctly. However, for countries like the UK, it should be a text input, and that's where the error occurs.

Upon further investigation, I discovered that the text input had a fixed value of `''` and did not update when typing.

This pull request resolves the issue by making the value of the field dynamic, updating according to the current value of the `state` state.

## Affects

Billing Address block

## Visuals

|![CleanShot 2023-12-26 at 18 09 34](https://github.com/impress-org/givewp/assets/3921017/aa660f70-4f89-4035-a7f6-9409404f800c)|![CleanShot 2023-12-26 at 18 10 24](https://github.com/impress-org/givewp/assets/3921017/41e09e1a-65c8-42cb-921e-ca5827a4739b)|
|----|----|


## Testing Instructions

1. Add a v3 form
2. Add the Billing Address block
3. Open the form
4. Select United Kingdom in the country field
5. Type into the County field

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-12]: https://stellarwp.atlassian.net/browse/GIVE-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ