### PR TITLE
Feature: add Two Panel (steps) option to Form design drop-down

### DIFF
--- a/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
+++ b/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Give\DonationForms\FormDesigns\ClassicFormDesign;
+namespace Give\DonationForms\FormDesigns\TwoColumnFormDesign;
 
 use Give\Framework\FormDesigns\FormDesign;
 
@@ -9,6 +9,8 @@ use Give\Framework\FormDesigns\FormDesign;
  */
 class TwoColumnFormDesign extends FormDesign
 {
+    protected $isMultiStep = true;
+
     /**
      * @unreleased
      */

--- a/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
+++ b/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Give\DonationForms\FormDesigns\ClassicFormDesign;
+
+use Give\Framework\FormDesigns\FormDesign;
+
+/**
+ * @unreleased
+ */
+class TwoColumnFormDesign extends FormDesign
+{
+    /**
+     * @unreleased
+     */
+    public static function id(): string
+    {
+        return 'two-column';
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function name(): string
+    {
+        return __('Two column', 'give');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function css(): string
+    {
+        return GIVE_PLUGIN_URL . 'build/twoColumnFormDesignCss.css';
+    }
+}

--- a/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
+++ b/src/DonationForms/FormDesigns/TwoColumnFormDesign/TwoColumnFormDesign.php
@@ -24,7 +24,7 @@ class TwoColumnFormDesign extends FormDesign
      */
     public static function name(): string
     {
-        return __('Two column', 'give');
+        return __('Two-Column', 'give');
     }
 
     /**

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/TwoPanelStepsFormLayout.php
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/TwoPanelStepsFormLayout.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Give\DonationForms\FormDesigns\TwoColumnFormDesign;
+namespace Give\DonationForms\FormDesigns\TwoPanelStepsFormLayout;
 
 use Give\Framework\FormDesigns\FormDesign;
 
 /**
  * @unreleased
  */
-class TwoColumnFormDesign extends FormDesign
+class TwoPanelStepsFormLayout extends FormDesign
 {
     protected $isMultiStep = true;
 
@@ -16,7 +16,7 @@ class TwoColumnFormDesign extends FormDesign
      */
     public static function id(): string
     {
-        return 'two-column';
+        return 'two-panel-steps';
     }
 
     /**
@@ -24,7 +24,7 @@ class TwoColumnFormDesign extends FormDesign
      */
     public static function name(): string
     {
-        return __('Two-Column', 'give');
+        return __('Two Panel (Steps)', 'give');
     }
 
     /**
@@ -32,6 +32,6 @@ class TwoColumnFormDesign extends FormDesign
      */
     public function css(): string
     {
-        return GIVE_PLUGIN_URL . 'build/twoColumnFormDesignCss.css';
+        return GIVE_PLUGIN_URL . 'build/twoPanelStepsFormLayoutCss.css';
     }
 }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -14,7 +14,7 @@ use Give\DonationForms\DataTransferObjects\DonationConfirmationReceiptViewRouteD
 use Give\DonationForms\DataTransferObjects\DonationFormPreviewRouteData;
 use Give\DonationForms\DataTransferObjects\DonationFormViewRouteData;
 use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
-use Give\DonationForms\FormDesigns\TwoColumnFormDesign\TwoColumnFormDesign;
+use Give\DonationForms\FormDesigns\TwoPanelStepsFormLayout\TwoPanelStepsFormLayout;
 use Give\DonationForms\FormDesigns\MultiStepFormDesign\MultiStepFormDesign;
 use Give\DonationForms\FormPage\TemplateHandler;
 use Give\DonationForms\Migrations\CleanMultipleSlashesOnDB;
@@ -162,7 +162,7 @@ class ServiceProvider implements ServiceProviderInterface
             try {
                 $formDesignRegistrar->registerDesign(ClassicFormDesign::class);
                 $formDesignRegistrar->registerDesign(MultiStepFormDesign::class);
-                $formDesignRegistrar->registerDesign(TwoColumnFormDesign::class);
+                $formDesignRegistrar->registerDesign(TwoPanelStepsFormLayout::class);
             } catch (Exception $e) {
                 Log::error('Error registering form designs', [
                     'message' => $e->getMessage(),

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -14,7 +14,7 @@ use Give\DonationForms\DataTransferObjects\DonationConfirmationReceiptViewRouteD
 use Give\DonationForms\DataTransferObjects\DonationFormPreviewRouteData;
 use Give\DonationForms\DataTransferObjects\DonationFormViewRouteData;
 use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
-use Give\DonationForms\FormDesigns\ClassicFormDesign\TwoColumnFormDesign;
+use Give\DonationForms\FormDesigns\TwoColumnFormDesign\TwoColumnFormDesign;
 use Give\DonationForms\FormDesigns\MultiStepFormDesign\MultiStepFormDesign;
 use Give\DonationForms\FormPage\TemplateHandler;
 use Give\DonationForms\Migrations\CleanMultipleSlashesOnDB;

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -14,6 +14,7 @@ use Give\DonationForms\DataTransferObjects\DonationConfirmationReceiptViewRouteD
 use Give\DonationForms\DataTransferObjects\DonationFormPreviewRouteData;
 use Give\DonationForms\DataTransferObjects\DonationFormViewRouteData;
 use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
+use Give\DonationForms\FormDesigns\ClassicFormDesign\TwoColumnFormDesign;
 use Give\DonationForms\FormDesigns\MultiStepFormDesign\MultiStepFormDesign;
 use Give\DonationForms\FormPage\TemplateHandler;
 use Give\DonationForms\Migrations\CleanMultipleSlashesOnDB;
@@ -161,6 +162,7 @@ class ServiceProvider implements ServiceProviderInterface
             try {
                 $formDesignRegistrar->registerDesign(ClassicFormDesign::class);
                 $formDesignRegistrar->registerDesign(MultiStepFormDesign::class);
+                $formDesignRegistrar->registerDesign(TwoColumnFormDesign::class);
             } catch (Exception $e) {
                 Log::error('Error registering form designs', [
                     'message' => $e->getMessage(),

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -51,7 +51,7 @@ module.exports = {
         classicFormDesignCss: srcPath('DonationForms/FormDesigns/ClassicFormDesign/css/main.scss'),
         classicFormDesignJs: srcPath('DonationForms/FormDesigns/ClassicFormDesign/js/main.ts'),
         multiStepFormDesignCss: srcPath('DonationForms/FormDesigns/MultiStepFormDesign/css/main.scss'),
-        twoColumnFormDesignCss: srcPath('DonationForms/FormDesigns/TwoColumnFormDesign/css/main.scss'),
+        twoPanelStepsFormLayoutCss: srcPath('DonationForms/FormDesigns/twoPanelStepsFormLayout/css/main.scss'),
         donationConfirmationReceiptApp: srcPath('DonationForms/resources/receipt/DonationConfirmationReceiptApp.tsx'),
         baseFormDesignCss: srcPath('DonationForms/resources/styles/base.scss'),
         formBuilderApp: srcPath('FormBuilder/resources/js/form-builder/src/index.tsx'),

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -51,6 +51,7 @@ module.exports = {
         classicFormDesignCss: srcPath('DonationForms/FormDesigns/ClassicFormDesign/css/main.scss'),
         classicFormDesignJs: srcPath('DonationForms/FormDesigns/ClassicFormDesign/js/main.ts'),
         multiStepFormDesignCss: srcPath('DonationForms/FormDesigns/MultiStepFormDesign/css/main.scss'),
+        twoColumnFormDesignCss: srcPath('DonationForms/FormDesigns/TwoColumnFormDesign/css/main.scss'),
         donationConfirmationReceiptApp: srcPath('DonationForms/resources/receipt/DonationConfirmationReceiptApp.tsx'),
         baseFormDesignCss: srcPath('DonationForms/resources/styles/base.scss'),
         formBuilderApp: srcPath('FormBuilder/resources/js/form-builder/src/index.tsx'),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-153]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a new "Two Panel (steps)" option to the form layout dropdown list.  Currently this does not include any styles, just the option and is equivalent to multi-step.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Form design dropdown

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1032" alt="Screenshot 2024-01-09 at 2 12 58 PM" src="https://github.com/impress-org/givewp/assets/10138447/088ceb73-1a60-4569-8e3c-0a6c8c336f14">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Try selecting "Two Panel (steps)" from the form design list.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-153]: https://stellarwp.atlassian.net/browse/GIVE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ