### PR TITLE
Feature: add text field styles to `FormDesignSettings`

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -5,13 +5,14 @@ namespace Give\DonationForms\Properties;
 use Give\DonationForms\ValueObjects\DesignSettingsImageStyle;
 use Give\DonationForms\ValueObjects\DesignSettingsLogoPosition;
 use Give\DonationForms\ValueObjects\DesignSettingsSectionStyle;
+use Give\DonationForms\ValueObjects\DesignSettingsTextFieldStyle;
 use Give\DonationForms\ValueObjects\DonationFormStatus;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\Framework\Support\Contracts\Arrayable;
 use Give\Framework\Support\Contracts\Jsonable;
 
 /**
- * @since 3.2.0 Remove addSlashesRecursive method
+ * @since      3.2.0 Remove addSlashesRecursive method
  * @since      3.0.0
  */
 class FormSettings implements Arrayable, Jsonable
@@ -185,7 +186,7 @@ class FormSettings implements Arrayable, Jsonable
      * @unreleased
      * @var string
      */
-    public  $designSettingsImageUrl;
+    public $designSettingsImageUrl;
 
     /**
      * @unreleased
@@ -212,6 +213,12 @@ class FormSettings implements Arrayable, Jsonable
     public $designSettingsSectionStyle;
 
     /**
+     * @unreleased
+     * @var string
+     */
+    public $designSettingsTextFieldStyle;
+
+    /**
      * @since 3.2.0 Added registrationNotification
      * @since 3.0.0
      */
@@ -231,7 +238,7 @@ class FormSettings implements Arrayable, Jsonable
         $self->donateButtonCaption = $array['donateButtonCaption'] ?? __('Donate now', 'give');
         $self->enableDonationGoal = $array['enableDonationGoal'] ?? false;
         $self->enableAutoClose = $array['enableAutoClose'] ?? false;
-        $self->goalType = !empty($array['goalType']) && GoalType::isValid($array['goalType']) ? new GoalType(
+        $self->goalType = ! empty($array['goalType']) && GoalType::isValid($array['goalType']) ? new GoalType(
             $array['goalType']
         ) : GoalType::AMOUNT();
         $self->designId = $array['designId'] ?? null;
@@ -253,7 +260,7 @@ class FormSettings implements Arrayable, Jsonable
             '{first_name}, your contribution means a lot and will be put to good use in making a difference. We’ve sent your donation receipt to {email}.',
             'give'
         );
-        $self->formStatus = !empty($array['formStatus']) ? new DonationFormStatus(
+        $self->formStatus = ! empty($array['formStatus']) ? new DonationFormStatus(
             $array['formStatus']
         ) : DonationFormStatus::DRAFT();
 
@@ -287,18 +294,22 @@ class FormSettings implements Arrayable, Jsonable
         ) ? $array['pdfSettings'] : [];
 
         $self->designSettingsImageUrl = $array['designSettingsImageUrl'] ?? '';
-        $self->designSettingsImageStyle = !empty($array['designSettingsImageStyle']) ? new DesignSettingsImageStyle(
+        $self->designSettingsImageStyle = ! empty($array['designSettingsImageStyle']) ? new DesignSettingsImageStyle(
             $array['designSettingsImageStyle']
         ) : DesignSettingsImageStyle::COVER();
 
         $self->designSettingsLogoUrl = $array['designSettingsLogoUrl'] ?? '';
-        $self->designSettingsLogoPosition = !empty($array['designSettingsLogoPosition']) ? new DesignSettingsLogoPosition(
+        $self->designSettingsLogoPosition = ! empty($array['designSettingsLogoPosition']) ? new DesignSettingsLogoPosition(
             $array['designSettingsLogoPosition']
         ) : DesignSettingsLogoPosition::LEFT();
 
-        $self->designSettingsSectionStyle = !empty($array['designSettingsSectionStyle']) ? new DesignSettingsSectionStyle(
+        $self->designSettingsSectionStyle = ! empty($array['designSettingsSectionStyle']) ? new DesignSettingsSectionStyle(
             $array['designSettingsSectionStyle']
         ) : DesignSettingsSectionStyle::DEFAULT();
+
+        $self->designSettingsTextFieldStyle = ! empty($array['designSettingsTextFieldStyle']) ? new DesignSettingsTextFieldStyle(
+            $array['designSettingsTextFieldStyle']
+        ) : DesignSettingsTextFieldStyle::DEFAULT();
 
         return $self;
     }

--- a/src/DonationForms/ValueObjects/DesignSettingsTextFieldStyle.php
+++ b/src/DonationForms/ValueObjects/DesignSettingsTextFieldStyle.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Give\DonationForms\ValueObjects;
+
+use Give\Framework\Support\ValueObjects\Enum;
+
+/**
+ * @unreleased
+ * @method static DesignSettingsTextFieldStyle DEFAULT()
+ * @method static DesignSettingsTextFieldStyle BOX()
+ * @method static DesignSettingsTextFieldStyle LINE()
+ * @method bool isDefault()
+ * @method bool isBox()
+ * @method bool isLine()
+ */
+class DesignSettingsTextFieldStyle extends Enum
+{
+    const DEFAULT = 'default';
+    const BOX = 'box';
+    const LINE = 'line';
+
+}

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -125,23 +125,23 @@ class DonationFormViewModel
      */
     private function getTotalCountValue(GoalType $goalType): ?int
     {
-      if ($goalType->isDonors()){
-        return $this->donationFormRepository->getTotalNumberOfDonors($this->donationFormId);
-      }
+        if ($goalType->isDonors()) {
+            return $this->donationFormRepository->getTotalNumberOfDonors($this->donationFormId);
+        }
 
-      if ($goalType->isDonations() || $goalType->isAmount()){
-        return $this->donationFormRepository->getTotalNumberOfDonations($this->donationFormId);
-      }
+        if ($goalType->isDonations() || $goalType->isAmount()) {
+            return $this->donationFormRepository->getTotalNumberOfDonations($this->donationFormId);
+        }
 
-      if ($goalType->isSubscriptions() || $goalType->isAmountFromSubscriptions()){
-        return $this->donationFormRepository->getTotalNumberOfSubscriptions($this->donationFormId);
-      }
+        if ($goalType->isSubscriptions() || $goalType->isAmountFromSubscriptions()) {
+            return $this->donationFormRepository->getTotalNumberOfSubscriptions($this->donationFormId);
+        }
 
-      if ($goalType->isDonorsFromSubscriptions()){
-        return $this->donationFormRepository->getTotalNumberOfDonorsFromSubscriptions($this->donationFormId);
-      }
+        if ($goalType->isDonorsFromSubscriptions()) {
+            return $this->donationFormRepository->getTotalNumberOfDonorsFromSubscriptions($this->donationFormId);
+        }
 
-      return 0;
+        return 0;
     }
 
     /**
@@ -149,19 +149,19 @@ class DonationFormViewModel
      */
     private function getCountLabel(GoalType $goalType): ?string
     {
-      if ($goalType->isDonors() || $goalType->isDonorsFromSubscriptions()){
-        return __('Donors', 'give');
-      }
+        if ($goalType->isDonors() || $goalType->isDonorsFromSubscriptions()) {
+            return __('Donors', 'give');
+        }
 
-      if ($goalType->isDonations() || $goalType->isAmount()){
-        return __('Donations', 'give');
-      }
+        if ($goalType->isDonations() || $goalType->isAmount()) {
+            return __('Donations', 'give');
+        }
 
-      if ($goalType->isSubscriptions() || $goalType->isAmountFromSubscriptions()){
-        return __('Recurring Donations', 'give');
-      }
+        if ($goalType->isSubscriptions() || $goalType->isAmountFromSubscriptions()) {
+            return __('Recurring Donations', 'give');
+        }
 
-      return __('Counted', 'give');
+        return __('Counted', 'give');
     }
 
     /**
@@ -169,11 +169,11 @@ class DonationFormViewModel
      */
     private function getTotalRevenue(GoalType $goalType)
     {
-      if ($goalType->isAmountFromSubscriptions()){
-        return $this->donationFormRepository->getTotalInitialAmountFromSubscriptions($this->donationFormId);
-      }
+        if ($goalType->isAmountFromSubscriptions()) {
+            return $this->donationFormRepository->getTotalInitialAmountFromSubscriptions($this->donationFormId);
+        }
 
-      return $this->donationFormRepository->getTotalRevenue($this->donationFormId);
+        return $this->donationFormRepository->getTotalRevenue($this->donationFormId);
     }
 
     /**
@@ -188,7 +188,7 @@ class DonationFormViewModel
         $totalCountLabel = $this->getCountLabel($goalType);
 
         return [
-            'totalRevenue' => $totalRevenue,
+            'totalRevenue'    => $totalRevenue,
             'totalCountValue' => $totalCountValue,
             'totalCountLabel' => $totalCountLabel,
         ];
@@ -213,25 +213,25 @@ class DonationFormViewModel
         $formDesign = $this->getFormDesign($this->designId());
 
         return [
-            'donateUrl' => $donateUrl,
-            'validateUrl' => $validateUrl,
-            'authUrl' => $authUrl,
+            'donateUrl'            => $donateUrl,
+            'validateUrl'          => $validateUrl,
+            'authUrl'              => $authUrl,
             'inlineRedirectRoutes' => [
                 'donation-confirmation-receipt-view',
             ],
-            'registeredGateways' => $formDataGateways,
-            'form' => array_merge($formApi->jsonSerialize(), [
+            'registeredGateways'   => $formDataGateways,
+            'form'                 => array_merge($formApi->jsonSerialize(), [
                 'settings' => $this->formSettings,
                 'currency' => $formApi->getDefaultCurrency(),
-                'goal' => $donationFormGoalData->toArray(),
-                'stats' => $this->formStatsData(),
-                'design' => $formDesign ? [
-                    'id' => $formDesign::id(),
-                    'name' => $formDesign::name(),
+                'goal'     => $donationFormGoalData->toArray(),
+                'stats'    => $this->formStatsData(),
+                'design'   => $formDesign ? [
+                    'id'          => $formDesign::id(),
+                    'name'        => $formDesign::name(),
                     'isMultiStep' => $formDesign->isMultiStep(),
                 ] : null,
             ]),
-            'previewMode' => $this->previewMode,
+            'previewMode'          => $this->previewMode,
         ];
     }
 
@@ -277,17 +277,19 @@ class DonationFormViewModel
             $classNames[] = 'givewp-donation-form--preview';
         }
 
-        if($this->formSettings->designSettingsImageUrl) {
+        if ($this->formSettings->designSettingsImageUrl) {
             $classNames[] = 'givewp-design-settings--image';
             $classNames[] = 'givewp-design-settings--image-style__' . $this->formSettings->designSettingsImageStyle;
         }
 
-        if($this->formSettings->designSettingsLogoUrl) {
+        if ($this->formSettings->designSettingsLogoUrl) {
             $classNames[] = 'givewp-design-settings--logo';
             $classNames[] = 'givewp-design-settings--logo-position__' . $this->formSettings->designSettingsLogoPosition;
         }
 
         $classNames[] = 'givewp-design-settings--section-style__' . $this->formSettings->designSettingsSectionStyle;
+
+        $classNames[] = 'givewp-design-settings--textField-style__' . $this->formSettings->designSettingsTextFieldStyle;
 
         ?>
 

--- a/src/DonationForms/resources/styles/base.scss
+++ b/src/DonationForms/resources/styles/base.scss
@@ -3,6 +3,7 @@
 @import "design-settings/image";
 @import "design-settings/logo";
 @import "design-settings/section";
+@import "design-settings/text-field";
 
 @layer base {
     @import "pico";

--- a/src/DonationForms/resources/styles/design-settings/text-field.scss
+++ b/src/DonationForms/resources/styles/design-settings/text-field.scss
@@ -1,0 +1,40 @@
+.givewp-design-settings--textField-style {
+    &__line {
+        .givewp-layouts-section {
+            input[type='text'], input[type='email'], select[name="honorific"], .givewp-fields-amount__input-container {
+                background: var(--givewp-grey-5, #FAFAFA);
+                color: var(--givewp-grey-400, #8C8C8C);
+                border-top: 0;
+                border-left: 0;
+                border-right: 0;
+                border-radius: 0;
+            }
+        }
+    }
+
+    &__box {
+        .givewp-layouts-section {
+            input[type='text'], input[type='email'],
+
+        , select [ name = "honorific" ] {
+            position: relative;
+            border: 1px solid var(--givewp-primary-color, #0B72D9);
+        }
+
+            .givewp-fields-text, .givewp-fields-select-honorific, .givewp-fields-email {
+                label > span {
+                    width: fit-content;
+                    padding: 0 .25rem;
+                    background: var(--givewp-shades-white);
+                    color: var(--givewp-primary-color, #0B72D9);
+                    transform: translate(.7rem, 1.05rem);
+                    z-index: 999;
+                }
+            }
+
+            #amount-custom {
+                border: red;
+            }
+        }
+    }
+}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/index.tsx
@@ -23,13 +23,18 @@ export default function GeneralControls() {
     const dispatch = useFormStateDispatch();
     const {publishSettings} = useDonationFormPubSub();
     const design = getDesign(designId);
-    
+
     return (
         <DesignSettings
             title={__('General', 'give')}
             description={__('These settings affect the basic appearance of the form', 'give')}
         >
-            <Layout dispatch={dispatch} formDesigns={formDesigns} designId={designId} />
+            <Layout
+                dispatch={dispatch}
+                publishSettings={publishSettings}
+                formDesigns={formDesigns}
+                designId={designId}
+            />
             {design?.isMultiStep && <MultiStep dispatch={dispatch} publishSettings={publishSettings} />}
             <Header dispatch={dispatch} publishSettings={publishSettings} />
             <DonationGoal dispatch={dispatch} />

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
@@ -1,8 +1,12 @@
 import {PanelBody, PanelRow, SelectControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
-import {setFormSettings} from '@givewp/form-builder/stores/form-state';
+import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-state';
 
-export default function Layout({dispatch, formDesigns, designId}) {
+export default function Layout({dispatch, publishSettings, formDesigns, designId}) {
+    const {
+        settings: {designSettingsTextFieldStyle},
+    } = useFormState();
+
     const designOptions = Object.values(formDesigns).map(({id, name}) => ({value: id, label: name}));
 
     return (
@@ -17,6 +21,21 @@ export default function Layout({dispatch, formDesigns, designId}) {
                         'Change the appearance of your donation form on your site. Each option has a different layout.',
                         'give'
                     )}
+                />
+            </PanelRow>
+            <PanelRow>
+                <SelectControl
+                    label={__('Input Field', 'give')}
+                    onChange={(designSettingsTextFieldStyle) => {
+                        dispatch(setFormSettings({designSettingsTextFieldStyle}));
+                        publishSettings({designSettingsTextFieldStyle});
+                    }}
+                    value={designSettingsTextFieldStyle}
+                    options={[
+                        {label: __('Default', 'give'), value: 'default'},
+                        {label: __('Box (inner-label)', 'give'), value: 'box'},
+                        {label: __('Line (inner-label)', 'give'), value: 'line'},
+                    ]}
                 />
             </PanelRow>
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -47,4 +47,5 @@ export type FormSettings = {
     designSettingsLogoUrl: string;
     designSettingsLogoPosition: string;
     designSettingsSectionStyle: string;
+    designSettingsTextFieldStyle: string;
 };


### PR DESCRIPTION
## Description

This PR introduces the text field control settings into the General `FormDesignControls`.
1. Box (inner-label)
2. Line (inner-label)

## Visuals

https://github.com/impress-org/givewp/assets/75056371/fe1af4e2-514a-41b2-8aae-af33b0929d5d

## Testing Instructions
- Test both of the TextField settings from within the General Setting controls. (View Visuals for instructions)

## Pre-review Checklist


-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

