### PR TITLE
Refactor: add options to force State, City, and Zip fields to be required in the billing address block

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -310,6 +310,15 @@ class ConvertDonationFormBlocksToFieldsApi
             ->setGroupLabel(
                 $block->getAttribute('groupLabel')
             )
+            ->setStateAlwaysRequired(
+                $block->getAttribute('stateAlwaysRequired') ?? false
+            )
+            ->setCityAlwaysRequired(
+                $block->getAttribute('cityAlwaysRequired') ?? false
+            )
+            ->setZipAlwaysRequired(
+                $block->getAttribute('zipAlwaysRequired') ?? false
+            )
             ->tap(function ($group) use ($block, $countryList) {
                 $group->getNodeByName('country')
                     ->label($block->getAttribute('countryLabel'))

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -300,6 +300,10 @@ class ConvertDonationFormBlocksToFieldsApi
             $countryList[] = [$value, $label];
         }
 
+        $stateAlwaysRequired = $block->getAttribute('stateAlwaysRequired') ?? false;
+        $cityAlwaysRequired = $block->getAttribute('cityAlwaysRequired') ?? false;
+        $zipAlwaysRequired = $block->getAttribute('zipAlwaysRequired') ?? false;
+
         return BillingAddress::make('billingAddress')
             ->setApiUrl(
                 give_get_ajax_url([
@@ -311,15 +315,19 @@ class ConvertDonationFormBlocksToFieldsApi
                 $block->getAttribute('groupLabel')
             )
             ->setStateAlwaysRequired(
-                $block->getAttribute('stateAlwaysRequired') ?? false
+                $stateAlwaysRequired
             )
             ->setCityAlwaysRequired(
-                $block->getAttribute('cityAlwaysRequired') ?? false
+                $cityAlwaysRequired
             )
-            ->setZipAlwaysRequired(
-                $block->getAttribute('zipAlwaysRequired') ?? false
-            )
-            ->tap(function ($group) use ($block, $countryList) {
+            ->setZipAlwaysRequired($zipAlwaysRequired)
+            ->tap(function ($group) use (
+                $block,
+                $countryList,
+                $stateAlwaysRequired,
+                $cityAlwaysRequired,
+                $zipAlwaysRequired
+            ) {
                 $group->getNodeByName('country')
                     ->label($block->getAttribute('countryLabel'))
                     ->options(...$countryList)
@@ -339,16 +347,16 @@ class ConvertDonationFormBlocksToFieldsApi
                 $group->getNodeByName('city')
                     ->label($block->getAttribute('cityLabel'))
                     ->placeholder($block->getAttribute('cityPlaceholder'))
-                    ->rules('max:255', new BillingAddressCityRule());
+                    ->rules('max:255', $cityAlwaysRequired ? 'required' : new BillingAddressCityRule());
 
                 $group->getNodeByName('state')
                     ->label($block->getAttribute('stateLabel'))
-                    ->rules('max:255', new BillingAddressStateRule());
+                    ->rules('max:255', $stateAlwaysRequired ? 'required' : new BillingAddressStateRule());
 
                 $group->getNodeByName('zip')
                     ->label($block->getAttribute('zipLabel'))
                     ->placeholder($block->getAttribute('zipPlaceholder'))
-                    ->rules('max:255', new BillingAddressZipRule());
+                    ->rules('max:255', $zipAlwaysRequired ? 'required' : new BillingAddressZipRule());
             });
     }
 

--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -90,6 +90,9 @@ export interface BillingAddressProps extends GroupProps {
         zip: FC<Partial<FieldProps> | {}>;
     };
     apiUrl: string;
+    stateAlwaysRequired: boolean;
+    cityAlwaysRequired: boolean;
+    zipAlwaysRequired: boolean;
 }
 
 export interface DonationAmountProps extends GroupProps {

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -1,8 +1,8 @@
-import type { BillingAddressProps } from "@givewp/forms/propTypes";
-import { FC, useEffect, useState } from "react";
-import { __ } from "@wordpress/i18n";
-import { ErrorMessage } from "@hookform/error-message";
-import { useCallback } from "@wordpress/element";
+import type {BillingAddressProps} from '@givewp/forms/propTypes';
+import {FC, useEffect, useState} from 'react';
+import {__} from '@wordpress/i18n';
+import {ErrorMessage} from '@hookform/error-message';
+import {useCallback} from '@wordpress/element';
 
 /**
  * @since 3.0.0
@@ -52,12 +52,14 @@ function StateFieldContainer({
     setCityRequired,
     setZipRequired,
     nodeName,
+    stateAlwaysRequired,
 }: {
     apiUrl: string;
     state: FC;
     setCityRequired: Function;
     setZipRequired: Function;
     nodeName: string;
+    stateAlwaysRequired: boolean;
 }) {
     const Label = window.givewp.form.templates.layouts.fieldLabel;
     const FieldError = window.givewp.form.templates.layouts.fieldError;
@@ -136,7 +138,7 @@ function StateFieldContainer({
              */
             <NodeWrapper nodeType="fields" type="select" htmlTag="div" name="state">
                 <label>
-                    <Label label={stateLabel} required={stateRequired} />
+                    <Label label={stateLabel} required={stateAlwaysRequired ? stateAlwaysRequired : stateRequired} />
 
                     <select
                         onChange={updateStateValue}
@@ -179,7 +181,10 @@ function StateFieldContainer({
          */
         <NodeWrapper nodeType="fields" type="text" htmlTag="div" name="state">
             <label>
-                <Label label={stateLabel ?? __('State', 'give')} required={stateRequired} />
+                <Label
+                    label={stateLabel ?? __('State', 'give')}
+                    required={stateAlwaysRequired ? stateAlwaysRequired : stateRequired}
+                />
 
                 <input
                     type="text"
@@ -208,6 +213,9 @@ export default function BillingAddress({
     groupLabel,
     nodeComponents: {country: Country, address1: Address1, address2: Address2, city: City, state, zip: Zip},
     apiUrl,
+    stateAlwaysRequired,
+    cityAlwaysRequired,
+    zipAlwaysRequired,
     name,
 }: BillingAddressProps) {
     // these are necessary to set the required indicator on the city and zip field labels
@@ -222,15 +230,16 @@ export default function BillingAddress({
                 <Country />
                 <Address1 />
                 <Address2 />
-                <City validationRules={{required: cityRequired}} />
+                <City validationRules={{required: cityAlwaysRequired ? cityAlwaysRequired : cityRequired}} />
                 <StateFieldContainer
                     apiUrl={apiUrl}
                     state={state}
                     setCityRequired={setCityRequired}
                     setZipRequired={setZipRequired}
                     nodeName={name}
+                    stateAlwaysRequired={stateAlwaysRequired}
                 />
-                <Zip validationRules={{required: zipRequired}} />
+                <Zip validationRules={{required: zipAlwaysRequired ? zipAlwaysRequired : zipRequired}} />
             </fieldset>
         </>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
@@ -37,10 +37,13 @@ export default function Edit({
         requireAddress2,
         cityLabel,
         cityPlaceholder,
+        alwaysRequireCity,
         stateLabel,
         statePlaceholder,
+        alwaysRequireState,
         zipLabel,
         zipPlaceholder,
+        alwaysRequireZip,
     },
     setAttributes,
 }: BlockEditProps<any>) {
@@ -101,8 +104,8 @@ export default function Edit({
                     <TextControl
                         label={cityLabel}
                         placeholder={cityPlaceholder}
-                        required={true}
-                        className={'give-is-required'}
+                        required={alwaysRequireCity}
+                        className={`${alwaysRequireCity ? 'give-is-required' : ''}`}
                         readOnly
                         value={cityPlaceholder}
                         onChange={null}
@@ -112,8 +115,8 @@ export default function Edit({
                     <TextControl
                         label={stateLabel}
                         placeholder={statePlaceholder}
-                        required={true}
-                        className={'give-is-required'}
+                        required={alwaysRequireState}
+                        className={`${alwaysRequireState ? 'give-is-required' : ''}`}
                         value={statePlaceholder}
                         onChange={null}
                         readOnly
@@ -123,8 +126,8 @@ export default function Edit({
                     <TextControl
                         label={zipLabel}
                         placeholder={zipPlaceholder}
-                        required={true}
-                        className={'give-is-required'}
+                        required={alwaysRequireZip}
+                        className={`${alwaysRequireZip ? 'give-is-required' : ''}`}
                         value={zipPlaceholder}
                         onChange={null}
                         readOnly
@@ -191,6 +194,19 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
+                <PanelBody title={__('State/Province/Country', 'give')} initialOpen={true}>
+                    <PanelRow>
+                        <ToggleControl
+                            label={__('Always Required', 'give')}
+                            checked={alwaysRequireState}
+                            onChange={() => setAttributes({alwaysRequireState: !alwaysRequireState})}
+                            help={__(
+                                'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
+                                'give'
+                            )}
+                        />
+                    </PanelRow>
+                </PanelBody>
                 <PanelBody title={__('City', 'give')} initialOpen={true}>
                     <PanelRow>
                         <TextControl
@@ -204,6 +220,17 @@ export default function Edit({
                             label={__('Placeholder')}
                             value={cityPlaceholder}
                             onChange={(value) => setAttributes({cityPlaceholder: value})}
+                        />
+                    </PanelRow>
+                    <PanelRow>
+                        <ToggleControl
+                            label={__('Always Required', 'give')}
+                            checked={alwaysRequireCity}
+                            onChange={() => setAttributes({alwaysRequireCity: !alwaysRequireCity})}
+                            help={__(
+                                'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
+                                'give'
+                            )}
                         />
                     </PanelRow>
                 </PanelBody>
@@ -220,6 +247,17 @@ export default function Edit({
                             label={__('Placeholder')}
                             value={zipPlaceholder}
                             onChange={(value) => setAttributes({zipPlaceholder: value})}
+                        />
+                    </PanelRow>
+                    <PanelRow>
+                        <ToggleControl
+                            label={__('Always Required', 'give')}
+                            checked={alwaysRequireZip}
+                            onChange={() => setAttributes({alwaysRequireZip: !alwaysRequireZip})}
+                            help={__(
+                                'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
+                                'give'
+                            )}
                         />
                     </PanelRow>
                 </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
@@ -37,13 +37,13 @@ export default function Edit({
         requireAddress2,
         cityLabel,
         cityPlaceholder,
-        alwaysRequireCity,
+        cityAlwaysRequired,
         stateLabel,
         statePlaceholder,
-        alwaysRequireState,
+        stateAlwaysRequired,
         zipLabel,
         zipPlaceholder,
-        alwaysRequireZip,
+        zipAlwaysRequired,
     },
     setAttributes,
 }: BlockEditProps<any>) {
@@ -104,8 +104,8 @@ export default function Edit({
                     <TextControl
                         label={cityLabel}
                         placeholder={cityPlaceholder}
-                        required={alwaysRequireCity}
-                        className={`${alwaysRequireCity ? 'give-is-required' : ''}`}
+                        required={cityAlwaysRequired}
+                        className={`${cityAlwaysRequired ? 'give-is-required' : ''}`}
                         readOnly
                         value={cityPlaceholder}
                         onChange={null}
@@ -115,8 +115,8 @@ export default function Edit({
                     <TextControl
                         label={stateLabel}
                         placeholder={statePlaceholder}
-                        required={alwaysRequireState}
-                        className={`${alwaysRequireState ? 'give-is-required' : ''}`}
+                        required={stateAlwaysRequired}
+                        className={`${stateAlwaysRequired ? 'give-is-required' : ''}`}
                         value={statePlaceholder}
                         onChange={null}
                         readOnly
@@ -126,8 +126,8 @@ export default function Edit({
                     <TextControl
                         label={zipLabel}
                         placeholder={zipPlaceholder}
-                        required={alwaysRequireZip}
-                        className={`${alwaysRequireZip ? 'give-is-required' : ''}`}
+                        required={zipAlwaysRequired}
+                        className={`${zipAlwaysRequired ? 'give-is-required' : ''}`}
                         value={zipPlaceholder}
                         onChange={null}
                         readOnly
@@ -198,8 +198,8 @@ export default function Edit({
                     <PanelRow>
                         <ToggleControl
                             label={__('Always Required', 'give')}
-                            checked={alwaysRequireState}
-                            onChange={() => setAttributes({alwaysRequireState: !alwaysRequireState})}
+                            checked={stateAlwaysRequired}
+                            onChange={() => setAttributes({stateAlwaysRequired: !stateAlwaysRequired})}
                             help={__(
                                 'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
                                 'give'
@@ -225,8 +225,8 @@ export default function Edit({
                     <PanelRow>
                         <ToggleControl
                             label={__('Always Required', 'give')}
-                            checked={alwaysRequireCity}
-                            onChange={() => setAttributes({alwaysRequireCity: !alwaysRequireCity})}
+                            checked={cityAlwaysRequired}
+                            onChange={() => setAttributes({cityAlwaysRequired: !cityAlwaysRequired})}
                             help={__(
                                 'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
                                 'give'
@@ -252,8 +252,8 @@ export default function Edit({
                     <PanelRow>
                         <ToggleControl
                             label={__('Always Required', 'give')}
-                            checked={alwaysRequireZip}
-                            onChange={() => setAttributes({alwaysRequireZip: !alwaysRequireZip})}
+                            checked={zipAlwaysRequired}
+                            onChange={() => setAttributes({zipAlwaysRequired: !zipAlwaysRequired})}
                             help={__(
                                 'Do you want to force this field always to be required? When disabled, it will be enabled according to the Country selection.',
                                 'give'

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
@@ -63,7 +63,7 @@ const settings: FieldBlock['settings'] = {
             source: 'attribute',
             default: __('City', 'give'),
         },
-        alwaysRequireCity: {
+        cityAlwaysRequired: {
             type: 'boolean',
             default: false,
         },
@@ -77,7 +77,7 @@ const settings: FieldBlock['settings'] = {
             source: 'attribute',
             default: __('This changes by country selection...', 'give'),
         },
-        alwaysRequireState: {
+        stateAlwaysRequired: {
             type: 'boolean',
             default: false,
         },
@@ -91,7 +91,7 @@ const settings: FieldBlock['settings'] = {
             source: 'attribute',
             default: __('Zip/Postal Code', 'give'),
         },
-        alwaysRequireZip: {
+        zipAlwaysRequired: {
             type: 'boolean',
             default: false,
         },

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/settings.tsx
@@ -63,6 +63,10 @@ const settings: FieldBlock['settings'] = {
             source: 'attribute',
             default: __('City', 'give'),
         },
+        alwaysRequireCity: {
+            type: 'boolean',
+            default: false,
+        },
         stateLabel: {
             type: 'string',
             source: 'attribute',
@@ -73,6 +77,10 @@ const settings: FieldBlock['settings'] = {
             source: 'attribute',
             default: __('This changes by country selection...', 'give'),
         },
+        alwaysRequireState: {
+            type: 'boolean',
+            default: false,
+        },
         zipLabel: {
             type: 'string',
             source: 'attribute',
@@ -82,6 +90,10 @@ const settings: FieldBlock['settings'] = {
             type: 'string',
             source: 'attribute',
             default: __('Zip/Postal Code', 'give'),
+        },
+        alwaysRequireZip: {
+            type: 'boolean',
+            default: false,
         },
     },
     edit: Edit,

--- a/src/Framework/FieldsAPI/BillingAddress.php
+++ b/src/Framework/FieldsAPI/BillingAddress.php
@@ -22,6 +22,21 @@ class BillingAddress extends Group
     public $groupLabel;
 
     /**
+     * @unreleased
+     */
+    public $stateAlwaysRequired;
+
+    /**
+     * @unreleased
+     */
+    public $cityAlwaysRequired;
+
+    /**
+     * @unreleased
+     */
+    public $zipAlwaysRequired;
+
+    /**
      * @since 3.0.0
      */
     public function setApiUrl(string $url): BillingAddress
@@ -37,6 +52,36 @@ class BillingAddress extends Group
     public function setGroupLabel(string $groupLabel): BillingAddress
     {
         $this->groupLabel = $groupLabel;
+
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function setStateAlwaysRequired(bool $stateAlwaysRequired): BillingAddress
+    {
+        $this->stateAlwaysRequired = $stateAlwaysRequired;
+
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function setCityAlwaysRequired(bool $cityAlwaysRequired): BillingAddress
+    {
+        $this->cityAlwaysRequired = $cityAlwaysRequired;
+
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function setZipAlwaysRequired(bool $zipAlwaysRequired): BillingAddress
+    {
+        $this->zipAlwaysRequired = $zipAlwaysRequired;
 
         return $this;
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-238]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements new options in the billing address block to force always be required the State, City, and Zip fields.

Why?

The 2Checkout gateway needs the billing address block to finish a donation and the State, City, and Zip fields are required by the 2Checkout API.

However, the billing address block sets these fields as required only for countries that require it.

This way, we need an option to force these fields to always be required. So, we can prevent invalid responses from the 2Checkout API when users try to finish a donation without informing the State, City, and Zip fields.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The billing address block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![billing-addres-block-always-required-attributes](https://github.com/impress-org/givewp/assets/16308864/f4ad9cfa-5401-4949-bf65-e7ba85928662)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-238]: https://stellarwp.atlassian.net/browse/GIVE-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ