### PR TITLE
Fix: adjust styles for Two-Panel (Steps) and Design Selector modal

### DIFF
--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -1,20 +1,38 @@
+@mixin responsive-styles {
+    border: solid 1px var(--givewp-grey-25);
+    border-radius: var(--givewp-rounded-8);
+    box-shadow: var(--givewp-shadow-sm);
+    flex-direction: column;
+    gap: 0;
+    max-width: 35rem;
+}
+
 .givewp-donation-form {
+    --two-panel-header-width: 42.5rem;
+
     align-items: flex-start;
     gap: var(--givewp-spacing-2);
     display: flex;
     flex-direction: row;
     margin: 0.5rem auto;
-    max-width: 70.5rem;
+    max-width: calc(var(--two-panel-header-width) + 35.5rem);
     padding: 0;
     width: 100%;
 
-    @media screen and (max-width: 71.5rem) {
-        border: solid 1px var(--givewp-grey-25);
-        border-radius: var(--givewp-rounded-8);
-        box-shadow: var(--givewp-shadow-sm);
-        flex-direction: column;
-        gap: 0;
-        max-width: 35rem;
+    &:not(&--preview) {
+        @media screen and (max-width: 79rem) {
+            @include responsive-styles;
+        }
+    }
+
+    &:is(&--preview) {
+        @media screen and (max-width: 71.5rem) {
+            @include responsive-styles;
+        }
+
+        @media screen and (max-width: 79rem) {
+            --two-panel-header-width: 35rem;
+        }
     }
 
     @media screen and (max-width: 36rem) {

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -1,12 +1,3 @@
-@mixin responsive-styles {
-    border: solid 1px var(--givewp-grey-25);
-    border-radius: var(--givewp-rounded-8);
-    box-shadow: var(--givewp-shadow-sm);
-    flex-direction: column;
-    gap: 0;
-    max-width: 35rem;
-}
-
 .givewp-donation-form {
     --two-panel-header-width: 42.5rem;
 
@@ -19,20 +10,17 @@
     padding: 0;
     width: 100%;
 
-    &:not(&--preview) {
-        @media screen and (max-width: 79rem) {
-            @include responsive-styles;
-        }
+    @media screen and (max-width: 79rem) {
+        --two-panel-header-width: 35rem;
     }
 
-    &:is(&--preview) {
-        @media screen and (max-width: 71.5rem) {
-            @include responsive-styles;
-        }
-
-        @media screen and (max-width: 79rem) {
-            --two-panel-header-width: 35rem;
-        }
+    @media screen and (max-width: 71.5rem) {
+        border: solid 1px var(--givewp-grey-25);
+        border-radius: var(--givewp-rounded-8);
+        box-shadow: var(--givewp-shadow-sm);
+        flex-direction: column;
+        gap: 0;
+        max-width: 35rem;
     }
 
     @media screen and (max-width: 36rem) {

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
@@ -1,12 +1,24 @@
+@mixin responsive-styles {
+    border: solid 1px var(--givewp-grey-25);
+    border-radius: var(--givewp-rounded-8);
+    box-shadow: var(--givewp-shadow-sm);
+}
+
 .givewp-layouts {
     &-header {
+        max-width: var(--two-panel-header-width);
         padding: var(--givewp-spacing-6);
         text-align: center;
+        width: 100%;
 
-        @media screen and (min-width: 71.5rem) {
-            border: solid 1px var(--givewp-grey-25);
-            border-radius: var(--givewp-rounded-8);
-            box-shadow: var(--givewp-shadow-sm);
+        @media screen and (min-width: 79rem) {
+            @include responsive-styles;
+        }
+
+        .givewp-donation-form--preview & {
+            @media screen and (min-width: 71.5rem) {
+                @include responsive-styles;
+            }
         }
     }
 
@@ -18,3 +30,4 @@
         margin-bottom: var(--givewp-spacing-10);
     }
 }
+

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
@@ -1,9 +1,3 @@
-@mixin responsive-styles {
-    border: solid 1px var(--givewp-grey-25);
-    border-radius: var(--givewp-rounded-8);
-    box-shadow: var(--givewp-shadow-sm);
-}
-
 .givewp-layouts {
     &-header {
         max-width: var(--two-panel-header-width);
@@ -11,14 +5,10 @@
         text-align: center;
         width: 100%;
 
-        @media screen and (min-width: 79rem) {
-            @include responsive-styles;
-        }
-
-        .givewp-donation-form--preview & {
-            @media screen and (min-width: 71.5rem) {
-                @include responsive-styles;
-            }
+        @media screen and (min-width: 71.5rem) {
+            border: solid 1px var(--givewp-grey-25);
+            border-radius: var(--givewp-rounded-8);
+            box-shadow: var(--givewp-shadow-sm);
         }
     }
 

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
@@ -1,7 +1,19 @@
-.givewp-donation-form__steps {
-    @media screen and (max-width: 71.5rem) {
-        border-radius: 0;
-        box-shadow: none;
+@mixin responsive-styles {
+    border-radius: 0;
+    box-shadow: none;
+}
+
+.givewp-donation-form {
+    &:not(&--preview) .givewp-donation-form__steps {
+        @media screen and (max-width: 79rem) {
+            @include responsive-styles;
+        }
+    }
+
+    &:is(&--preview) .givewp-donation-form__steps {
+        @media screen and (max-width: 71.5rem) {
+            @include responsive-styles;
+        }
     }
 }
 
@@ -14,3 +26,4 @@
         gap: var(--givewp-spacing-6);
     }
 }
+

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
@@ -1,19 +1,7 @@
-@mixin responsive-styles {
-    border-radius: 0;
-    box-shadow: none;
-}
-
-.givewp-donation-form {
-    &:not(&--preview) .givewp-donation-form__steps {
-        @media screen and (max-width: 79rem) {
-            @include responsive-styles;
-        }
-    }
-
-    &:is(&--preview) .givewp-donation-form__steps {
-        @media screen and (max-width: 71.5rem) {
-            @include responsive-styles;
-        }
+.givewp-donation-form__steps {
+    @media screen and (max-width: 71.5rem) {
+        border-radius: 0;
+        box-shadow: none;
     }
 }
 

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -1,6 +1,6 @@
-import {ReactNode} from "react";
-import PreviousButton from "@givewp/forms/app/form/MultiStepForm/components/PreviousButton";
-import {__} from "@wordpress/i18n";
+import {ReactNode} from 'react';
+import PreviousButton from '@givewp/forms/app/form/MultiStepForm/components/PreviousButton';
+import {__} from '@wordpress/i18n';
 import {useDonationFormMultiStepState} from '@givewp/forms/app/form/MultiStepForm/store';
 import {useDonationFormSettings} from '@givewp/forms/app/store/form-settings';
 import {StepObject} from '@givewp/forms/app/form/MultiStepForm/types';
@@ -10,29 +10,28 @@ import getCurrentStepObject from '@givewp/forms/app/form/MultiStepForm/utilities
  * @unreleased updated with steps props and showStepsHeader conditional
  * @since 3.0.0
  */
-export default function StepsWrapper({steps, children}: {steps: StepObject[], children: ReactNode }) {
+export default function StepsWrapper({steps, children}: {steps: StepObject[]; children: ReactNode}) {
     const {currentStep} = useDonationFormMultiStepState();
     const {showHeader: hasFirstStep} = useDonationFormSettings();
     const currentStepObject = getCurrentStepObject(steps, currentStep);
 
-    const showProgress = !hasFirstStep || currentStep > 0;
     const totalSteps = hasFirstStep ? steps.length : steps.length - 1;
     const showStepsHeader = !hasFirstStep || currentStepObject.title !== null;
 
     return (
         <div className="givewp-donation-form__steps">
-          {showStepsHeader && (
-            <div className="givewp-donation-form__steps-header">
-                <div className="givewp-donation-form__steps-header-previous">
-                    <PreviousButton>{__('Previous', 'give')}</PreviousButton>
-                </div>
-                <div className="givewp-donation-form__steps-header-title">
-                    <p className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</p>
-                </div>
-            </div>
-            )}
-            {showProgress && (
-                <progress className="givewp-donation-form__steps-progress" value={currentStep} max={totalSteps} />
+            {showStepsHeader && (
+                <>
+                    <div className="givewp-donation-form__steps-header">
+                        <div className="givewp-donation-form__steps-header-previous">
+                            <PreviousButton>{__('Previous', 'give')}</PreviousButton>
+                        </div>
+                        <div className="givewp-donation-form__steps-header-title">
+                            <p className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</p>
+                        </div>
+                    </div>
+                    <progress className="givewp-donation-form__steps-progress" value={currentStep} max={totalSteps} />
+                </>
             )}
             <div className="givewp-donation-form__steps-body">{children}</div>
             <div className="givewp-donation-form__steps-footer">

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -35,7 +35,7 @@
 
 .interface-interface-skeleton__content {
     width: 720px;
-    margin: auto;
+    margin: 0 auto auto;
     padding: 100px 0; /* Leave room for toolbar above first block. */
     flex-grow: unset;
     box-sizing: border-box;

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_onboarding.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_onboarding.scss
@@ -86,6 +86,7 @@
 
     .givewp-design-selector--header {
         font-size: 1rem;
+        text-align: center;
 
         h3 {
             font-size: 1.5rem;
@@ -152,7 +153,9 @@
     }
 
     .givewp-design-selector--button {
+        align-self: flex-end;
         width: 100%;
+        max-width: 22.5rem;
         justify-content: center;
         padding: var(--givewp-spacing-3) var(--givewp-spacing-8);
         min-height: var(--givewp-spacing-12);


### PR DESCRIPTION
## Description

This pull request adjusts styles related to the addition of the new Two-Panel (Steps) layout.

- the width of the header section in the Two-Panel (Steps) layout. The width is increased to 42.5rem, with a breakpoint at 71.5rem resizing it to 35rem, like what happens in the design preview tab;
- it resolves a glitch where the header appeared narrower when the description section was disabled;
- the design selector modal was changed, having header texts centered and its button right aligned.

## Affects

Two-Panel (Steps) layout and Design Selector modal

## Visuals

![give test_wp-admin_edit php_post_type=give_forms page=givewp-form-builder donationFormID=930](https://github.com/impress-org/givewp/assets/3921017/4641dd21-1faf-42ee-a5c4-57276a42d0ae)

![CleanShot 2024-01-18 at 15 59 18 2](https://github.com/impress-org/givewp/assets/3921017/8b170c0b-3553-4f20-878b-2f0f1608f456)

![give test_wp-admin_edit php_post_type=give_forms page=givewp-form-builder donationFormID=930 (1)](https://github.com/impress-org/givewp/assets/3921017/99955958-558b-453b-8342-050d962b3d87)

![give test_wp-admin_edit php_post_type=give_forms page=givewp-form-builder donationFormID=931](https://github.com/impress-org/givewp/assets/3921017/f4646ee3-0578-4aad-ba1f-a81ca636fad8)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

