### PR TITLE
Fix: avoid errors on add/remove a sub-site in a WP multisite

### DIFF
--- a/give.php
+++ b/give.php
@@ -497,13 +497,14 @@ final class Give
      *
      * Runs on plugin activation and performs initial setup.
      *
+     * @since 3.1.3  test in give_install() if installing in WP multisite
      * @since 2.33.3 set network_wide parameter to true, enabling installing in WP multisite
      * @since 1.0.0
      */
     public function install()
     {
         $this->loadServiceProviders();
-        give_install(true);
+        give_install(is_plugin_active_for_network(GIVE_PLUGIN_BASENAME));
     }
 
     /**

--- a/give.php
+++ b/give.php
@@ -497,7 +497,7 @@ final class Give
      *
      * Runs on plugin activation and performs initial setup.
      *
-     * @since 3.1.3  test in give_install() if installing in WP multisite
+     * @unreleased check if installing in WP multisite
      * @since 2.33.3 set network_wide parameter to true, enabling installing in WP multisite
      * @since 1.0.0
      */

--- a/includes/install.php
+++ b/includes/install.php
@@ -210,6 +210,7 @@ add_action('wpmu_new_blog', 'give_on_create_blog', 10, 6);
 /**
  * Drop Give's custom tables when a mu site is deleted.
  *
+ * @unlreased updated implementation to query all give_* tables
  * @since  1.4.3
  *
  * @param array $tables The tables to drop.
@@ -219,19 +220,20 @@ add_action('wpmu_new_blog', 'give_on_create_blog', 10, 6);
  */
 function give_wpmu_drop_tables($tables, $blog_id)
 {
-    switch_to_blog($blog_id);
-    $custom_tables = __give_get_tables();
+    global $wpdb;
 
-    /* @var Give_DB $table */
-    foreach ($custom_tables as $table) {
-        if ($table->installed()) {
-            $tables[] = $table->table_name;
-        }
+    switch_to_blog($blog_id);
+
+    $prefix = $wpdb->prefix . 'give_%';
+    $giveTables = $wpdb->get_col("SHOW TABLES LIKE '{$prefix}'");
+
+    foreach ($giveTables as $table) {
+        $tables[] = $table;
     }
 
     restore_current_blog();
 
-    return $tables;
+    return array_unique($tables);
 }
 
 add_filter('wpmu_drop_tables', 'give_wpmu_drop_tables', 10, 2);

--- a/includes/install.php
+++ b/includes/install.php
@@ -210,7 +210,7 @@ add_action('wpmu_new_blog', 'give_on_create_blog', 10, 6);
 /**
  * Drop Give's custom tables when a mu site is deleted.
  *
- * @unlreased updated implementation to query all give_* tables
+ * @unreleased updated implementation to query all give_* tables
  * @since  1.4.3
  *
  * @param array $tables The tables to drop.

--- a/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -27,7 +27,7 @@ class SetPayPalStandardGatewayId extends Migration
         $gateways = $give_settings['gateways'];
         $updateSettings = false;
 
-        if (array_key_exists('paypal-standard', $gateways)) {
+        if (is_array($gateways) && array_key_exists('paypal-standard', $gateways)) {
             unset($gateways['paypal-standard']);
             $gateways['paypal'] = '1';
             $give_settings['gateways'] = $gateways;

--- a/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
+++ b/src/PaymentGateways/Gateways/PayPalStandard/Migrations/SetPayPalStandardGatewayId.php
@@ -19,6 +19,8 @@ class SetPayPalStandardGatewayId extends Migration
 
     /**
      * @inheritdoc
+     *
+     * @unreleased confirm $gateways is an array
      */
     public function run()
     {


### PR DESCRIPTION
Resolves [GIVE-119]

## Description

This epic fixes errors reported by @Genevieve-K when adding/removing sub-sites in a WP multisite install.

Include the following PRs:
- https://github.com/impress-org/givewp/pull/7113
- https://github.com/impress-org/givewp/pull/7120
- https://github.com/impress-org/givewp/pull/7162

## Affects

WP Multisite installs

## Testing Instructions

1. Create a new multisite install
2. Add a new sub-site
3. Enable Give for the entire network
4. Confirm Give tables were properly created for all sites
5. Remove the recently created sub-site
6. Confirm all Give tables for that sub-site were removed
7. Create a new sub-site
8. Confirm Give tables were properly created for this new sub-site
9. Confirm no fatal errors happened

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-119]: https://stellarwp.atlassian.net/browse/GIVE-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ