### PR TITLE
Fix: Remove superfluous allow_url_fopen check to avoid critical error from falsy value

### DIFF
--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -207,12 +207,14 @@ $give_updates = Give_Updates::get_instance();
 				$tls_check = wp_remote_get( 'https://www.howsmyssl.com/a/check' );
 			}
 
-			if ( ! is_wp_error( $tls_check ) ) {
-				$tls_check = json_decode( wp_remote_retrieve_body( $tls_check ), false );
+            if ( ! $tls_check ) {
+                echo __( 'Please enable' ) . ' <b>allow_url_fopen</b> ' . __( 'in your php.ini file to determine this value.' );
+            } else if ( ! is_wp_error( $tls_check ) ) {
+                $tls_check = json_decode( wp_remote_retrieve_body( $tls_check ), false );
 
-				/* translators: %s: SSL connection response */
-				printf( __( 'Connection uses %s', 'give' ), esc_html( $tls_check->tls_version ) );
-			}
+                /* translators: %s: SSL connection response */
+                printf( __( 'Connection uses %s', 'give' ), esc_html( $tls_check->tls_version ) );
+            }
 			?>
 		</td>
 	</tr>
@@ -221,9 +223,11 @@ $give_updates = Give_Updates::get_instance();
 		<td class="help"><?php echo Give()->tooltips->render_help( __( 'The server\'s connection as rated by https://www.howsmyssl.com/', 'give' ) ); ?></td>
 		<td>
 			<?php
-			if ( ! is_wp_error( $tls_check ) ) {
-				esc_html_e( property_exists( $tls_check, 'rating' ) ? $tls_check->rating : $tls_check->tls_version, 'give' );
-			}
+            if ( ! $tls_check ) {
+                echo __( 'Please enable' ) . ' <b>allow_url_fopen</b> ' . __( 'in your php.ini file to determine this value.' );
+            } else if ( ! is_wp_error( $tls_check ) ) {
+                esc_html_e( property_exists( $tls_check, 'rating' ) ? $tls_check->rating : $tls_check->tls_version, 'give' );
+            }
 			?>
 		</td>
 	</tr>

--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -200,16 +200,10 @@ $give_updates = Give_Updates::get_instance();
 		<td class="help"><?php echo Give()->tooltips->render_help( __( 'Most payment gateway APIs only support connections using the TLS 1.2 security protocol.', 'give' ) ); ?></td>
 		<td>
 			<?php
-			$tls_check = false;
-
 			// Get the SSL status.
-			if ( ini_get( 'allow_url_fopen' ) ) {
-				$tls_check = wp_remote_get( 'https://www.howsmyssl.com/a/check' );
-			}
+            $tls_check = wp_remote_get( 'https://www.howsmyssl.com/a/check' );
 
-            if ( ! $tls_check ) {
-                echo __( 'Please enable' ) . ' <b>allow_url_fopen</b> ' . __( 'in your php.ini file to determine this value.' );
-            } else if ( ! is_wp_error( $tls_check ) ) {
+            if ( ! is_wp_error( $tls_check ) ) {
                 $tls_check = json_decode( wp_remote_retrieve_body( $tls_check ), false );
 
                 /* translators: %s: SSL connection response */
@@ -223,9 +217,7 @@ $give_updates = Give_Updates::get_instance();
 		<td class="help"><?php echo Give()->tooltips->render_help( __( 'The server\'s connection as rated by https://www.howsmyssl.com/', 'give' ) ); ?></td>
 		<td>
 			<?php
-            if ( ! $tls_check ) {
-                echo __( 'Please enable' ) . ' <b>allow_url_fopen</b> ' . __( 'in your php.ini file to determine this value.' );
-            } else if ( ! is_wp_error( $tls_check ) ) {
+            if ( ! is_wp_error( $tls_check ) ) {
                 esc_html_e( property_exists( $tls_check, 'rating' ) ? $tls_check->rating : $tls_check->tls_version, 'give' );
             }
 			?>


### PR DESCRIPTION
## Issue
On PHP >= 8.0, when `allow_url_fopen` is `0`, a critical error blocks the rest of the page loading on the System Info page after the TLS values.

On Tools > System Info:
"TSL Connection" shows "Connection uses" (blank)
"TLS Rating" shows "There has been a critical error on this website..."

## Description
If the config value is false, `$tls_check` remains false, and then `json_decode()` fails, returning `null`. Then `property_exists()` is called with the null value, which triggers the critical error.

I've simply added checks to see if `$tls_check` is false, and if so, display text prompting the user to enable `allow_url_fopen` instead of attempting to decode the non-existent body text.

I considered attempting to use cURL as a fallback if the user has it enabled but figured this may be overkill. Also I think the fallback message is appropriate but we may want to amend the wording.

## Affects
Avoids error on System Info page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

