### PR TITLE
Fix: prevent fatal error during form migration

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.3.0
+ * Version: 3.3.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -403,7 +403,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.3.0');
+            define('GIVE_VERSION', '3.3.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,7 +262,10 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
-= 3.3.0: Jan 10th, 2024 =
+= 3.3.1: January 23rd, 2024 =
+* Fix: Resolved an issue checking for the GiveWP Funds and Designations add-on information during form migrations  
+
+= 3.3.0: January 10th, 2024 =
 * Happy new year!
 * Fix: Resolved an issue where some migrated forms were being duplicated
 * Fix: Resolved an issue with the donor export filter by donation form

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -5,7 +5,6 @@ namespace Give\FormMigration;
 use Give\DonationForms\V2\Models\DonationForm;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\FormMigration\Contracts\FormModelDecorator;
-use Give\Log\Log;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
 use Give_Email_Notification_Util;
 
@@ -599,6 +598,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased changed how is checked if the form has funds
      * @since 3.3.0
      */
     public function hasFunds(): bool
@@ -609,6 +609,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased changed how is checked if the form has fund options
      * @since 3.3.0
      */
     public function hasFundOptions(): bool

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -598,7 +598,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
-     * @unreleased changed how is checked if the form has funds
+     * @since 3.3.1 changed how is checked if the form has funds
      * @since 3.3.0
      */
     public function hasFunds(): bool
@@ -609,7 +609,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
-     * @unreleased changed how is checked if the form has fund options
+     * @since 3.3.1 changed how is checked if the form has fund options
      * @since 3.3.0
      */
     public function hasFundOptions(): bool

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -605,7 +605,7 @@ class FormMetaDecorator extends FormModelDecorator
     {
         $fundsAndDesignationsAttributes = $this->getFundsAndDesignationsAttributes();
 
-        return count($fundsAndDesignationsAttributes['fund']) > 0;
+        return !empty($fundsAndDesignationsAttributes['fund']);
     }
 
     /**
@@ -615,7 +615,7 @@ class FormMetaDecorator extends FormModelDecorator
     {
         $fundsAndDesignationsAttributes = $this->getFundsAndDesignationsAttributes();
 
-        return count($fundsAndDesignationsAttributes['options']) > 0;
+        return !empty($fundsAndDesignationsAttributes['options']);
     }
 
     /**


### PR DESCRIPTION
Resolves [GIVE-243]

## Description

After version 3.3.0, form migrations began to fail with a fatal error. Upon investigation, I discovered that under certain conditions, the conditionals for executing the Funds & Designations step were attempting to count the elements of a nullable variable, resulting in the fatal error.

This pull request resolves the issue by replacing the `count` function with an `!empty` check. This fix will work for both nullable variables (returning false) and arrays.

## Affects

Form Migrations

## Testing Instructions

1. Create a v2 form
2. Migrate it

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-243]: https://stellarwp.atlassian.net/browse/GIVE-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ