### PR TITLE
Feature: add filter to add stripe elements appearance options

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -82,6 +82,7 @@ class StripePaymentElementGateway extends PaymentGateway
         $stripeConnectedAccountKey = $this->getStripeConnectedAccountKey($formId);
 
         return [
+            'formId' => $formId,
             'stripeKey' => $stripePublishableKey,
             'stripeConnectedAccountId' => $stripeConnectedAccountKey,
         ];

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -98,7 +98,7 @@ const stripePaymentElementGateway: StripeGateway = {
             throw new Error('Stripe gateway settings are missing.  Check your Stripe settings.');
         }
 
-        appearanceOptions = applyFilters('give_stripe_elements_appearance_options', {}, formId) as object;
+        appearanceOptions = applyFilters('givewp_stripe_elements_appearance_options', {}, formId) as object;
 
         /**
          * Create the Stripe object and pass our api keys

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -6,7 +6,6 @@ import {
     StripePaymentElementChangeEvent,
 } from '@stripe/stripe-js';
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js';
-import {useMemo} from '@wordpress/element';
 import {applyFilters} from '@wordpress/hooks';
 import type {Gateway, GatewaySettings} from '@givewp/forms/types';
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -98,7 +98,7 @@ const stripePaymentElementGateway: StripeGateway = {
             throw new Error('Stripe gateway settings are missing.  Check your Stripe settings.');
         }
 
-        appearanceOptions = applyFilters('givewp_stripe_payment_elements_appearance_options', {}, formId) as object;
+        appearanceOptions = applyFilters('givewp_stripe_payment_element_appearance_options', {}, formId) as object;
 
         /**
          * Create the Stripe object and pass our api keys

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -73,7 +73,10 @@ const StripeFields = ({gateway}) => {
     );
 };
 
+let appearanceOptions = {};
+
 interface StripeSettings extends GatewaySettings {
+    formId: number;
     stripeKey: string;
     stripeConnectAccountId: string;
     stripeClientSecret: string;
@@ -90,11 +93,13 @@ interface StripeGateway extends Gateway {
 const stripePaymentElementGateway: StripeGateway = {
     id: 'stripe_payment_element',
     initialize() {
-        const {stripeKey, stripeConnectedAccountId} = this.settings;
+        const {stripeKey, stripeConnectedAccountId, formId} = this.settings;
 
         if (!stripeKey || !stripeConnectedAccountId) {
             throw new Error('Stripe gateway settings are missing.  Check your Stripe settings.');
         }
+
+        appearanceOptions = applyFilters('give_stripe_elements_appearance_options', {}, formId) as object;
 
         /**
          * Create the Stripe object and pass our api keys
@@ -168,22 +173,12 @@ const stripePaymentElementGateway: StripeGateway = {
         const donationAmount = useWatch({name: 'amount'});
         const stripeAmount = dollarsToCents(donationAmount, donationCurrency.toString().toUpperCase());
 
-        const stripeElementOptions: StripeElementsOptionsMode = useMemo(() => {
-            const appearanceOptions = applyFilters(
-                'give_stripe_elements_appearance_options',
-                {},
-                donationType,
-                donationCurrency,
-                stripeAmount
-            ) as object;
-
-            return {
-                mode: donationType === 'subscription' ? 'subscription' : 'payment',
-                amount: stripeAmount,
-                currency: donationCurrency.toLowerCase(),
-                appearance: appearanceOptions,
-            };
-        }, [donationType, donationCurrency, stripeAmount]);
+        const stripeElementOptions: StripeElementsOptionsMode = {
+            mode: donationType === 'subscription' ? 'subscription' : 'payment',
+            amount: stripeAmount,
+            currency: donationCurrency.toLowerCase(),
+            appearance: appearanceOptions,
+        };
 
         return (
             <Elements stripe={stripePromise} options={stripeElementOptions}>

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -6,6 +6,8 @@ import {
     StripePaymentElementChangeEvent,
 } from '@stripe/stripe-js';
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js';
+import {useMemo} from '@wordpress/element';
+import {applyFilters} from '@wordpress/hooks';
 import type {Gateway, GatewaySettings} from '@givewp/forms/types';
 
 let stripePromise = null;
@@ -166,11 +168,22 @@ const stripePaymentElementGateway: StripeGateway = {
         const donationAmount = useWatch({name: 'amount'});
         const stripeAmount = dollarsToCents(donationAmount, donationCurrency.toString().toUpperCase());
 
-        const stripeElementOptions: StripeElementsOptionsMode = {
-            mode: donationType === 'subscription' ? 'subscription' : 'payment',
-            amount: stripeAmount,
-            currency: donationCurrency.toLowerCase(),
-        };
+        const stripeElementOptions: StripeElementsOptionsMode = useMemo(() => {
+            const appearanceOptions = applyFilters(
+                'give_stripe_elements_appearance_options',
+                {},
+                donationType,
+                donationCurrency,
+                stripeAmount
+            ) as object;
+
+            return {
+                mode: donationType === 'subscription' ? 'subscription' : 'payment',
+                amount: stripeAmount,
+                currency: donationCurrency.toLowerCase(),
+                appearance: appearanceOptions,
+            };
+        }, [donationType, donationCurrency, stripeAmount]);
 
         return (
             <Elements stripe={stripePromise} options={stripeElementOptions}>

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -98,7 +98,7 @@ const stripePaymentElementGateway: StripeGateway = {
             throw new Error('Stripe gateway settings are missing.  Check your Stripe settings.');
         }
 
-        appearanceOptions = applyFilters('givewp_stripe_elements_appearance_options', {}, formId) as object;
+        appearanceOptions = applyFilters('givewp_stripe_payment_elements_appearance_options', {}, formId) as object;
 
         /**
          * Create the Stripe object and pass our api keys

--- a/tests/Feature/Gateways/Stripe/StripePaymentElement/TestStripePaymentElementGateway.php
+++ b/tests/Feature/Gateways/Stripe/StripePaymentElement/TestStripePaymentElementGateway.php
@@ -50,6 +50,7 @@ class TestStripePaymentElementGateway extends TestCase
         $settings = $mockGateway->formSettings($form->id);
 
         $this->assertSame($settings, [
+            'formId' => $form->id,
             'stripeKey' => $stripePublishableKey,
             'stripeConnectedAccountId' => $stripeConnectedAccountKey,
         ]);


### PR DESCRIPTION
## Description

The only way to modify the appearance of the Stripe Elements gateway fields is through a JS script. There's currently no way to do this as the Stripe options are hard-coded.

This PR adds a filter to add appearance options to the Stripe options. I started with a more general filter, but decided to limit the scope as that's all I really need, and we want to be careful about folks messing with the options otherwise.

This also doesn't provide a non-programmatic way of adjusting the fields. Especially since Stripe provides themes, I think it makes sense to surface this in the Design Settings in the future, but it's more than I need now and these two options aren't mutually exclusive.

## Affects

The Stripe Elements fields as rendered in v3 forms

## Visuals

<img width="524" alt="image" src="https://github.com/impress-org/givewp/assets/2024145/c1f5c9e8-8896-4314-b19a-8bfd24f8606d">


## Testing Instructions

I used the following PHP snippet to test it out:
```php
add_action('givewp_donation_form_enqueue_scripts', function () {
    $addFilterScript = <<<JS
wp.hooks.addFilter("give_stripe_elements_appearance_options", 'testplugin', function() {
    return {
        theme: 'night'
    };
});
JS;

    wp_add_inline_script(
        'givewp-donation-form-registrars',
        $addFilterScript,
        'before'
    );
}, 1000, 1);

```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

