### PR TITLE
Feature: fix form modal to page (and other styling)

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -44,6 +44,7 @@ export default function ModalForm({dataSrc, embedId, openFormButton}: ModalFormP
                             onClick={toggleModal}
                         >
                             <svg
+                                className="givewp-donation-form-modal__close__icon"
                                 xmlns="http://www.w3.org/2000/svg"
                                 viewBox="0 0 24 24"
                                 width="24"
@@ -51,7 +52,11 @@ export default function ModalForm({dataSrc, embedId, openFormButton}: ModalFormP
                                 aria-hidden="true"
                                 focusable="false"
                             >
-                                <path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
+                                <path
+                                    stroke="black"
+                                    strokeWidth="2"
+                                    d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
+                                ></path>
                             </svg>
                         </button>
                         <IframeResizer

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
@@ -74,6 +74,7 @@
         padding: 0 !important;
         border: none !important;
         background-color: transparent;
+        overflow: visible;
 
         &::backdrop {
             background-color: rgba(0, 0, 0, 0.6);
@@ -82,18 +83,23 @@
 
     &__close {
         position: absolute;
-        right: 3.5%;
-        top: 1.5%;
-        margin-right: auto;
+        right: 0;
+        top: 0.5rem;
+        margin-right: -2rem;
         padding: 0.5rem 0.5rem 0.25rem 0.5rem;
-        border: none !important;
-        background-color: transparent !important;
+        background-color: #ccc;
         cursor: pointer;
+        border: none !important;
+        border-radius: 50%;
+        transition: background-color 0.2s;
+
+        &__icon {
+            width: 1rem;
+            height: 1rem;
+        }
 
         &:hover {
-            path {
-                fill: #0073aa;
-            }
+            background-color: #bbb;
         }
     }
 }

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
@@ -1,128 +1,132 @@
 .givewp-donation-form-selector {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 2rem 4rem;
-  background: #f6f6f6;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem 4rem;
+    background: #f6f6f6;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 
-  &__select {
-    input[type="text"]:focus {
-      border-color: transparent;
-      box-shadow: 0 0 0 1px transparent;
-      outline: 2px solid transparent;
+    &__select {
+        input[type='text']:focus {
+            border-color: transparent;
+            box-shadow: 0 0 0 1px transparent;
+            outline: 2px solid transparent;
+        }
     }
-  }
 
-  &__logo {
-    align-self: center;
-  }
+    &__logo {
+        align-self: center;
+    }
 
-  &__open {
-    color: #fff;
-    background: #2271b1;
-    padding: .5rem 1rem;
+    &__open {
+        color: #fff;
+        background: #2271b1;
+        padding: 0.5rem 1rem;
+        cursor: pointer;
+        border: none;
+        border-radius: 5px;
+    }
+
+    &__submit {
+        width: 100%;
+        background-color: #27ae60;
+        color: #fff;
+        padding: 1rem;
+        border-radius: 5px;
+        font-weight: bold;
+        text-align: center;
+        outline: none;
+        border: 0;
+        transition: 0.2s;
+
+        &:disabled {
+            background-color: #e0e0e0;
+        }
+
+        &:hover:not(:disabled) {
+            cursor: pointer;
+            filter: brightness(1.2);
+        }
+    }
+}
+
+.givewp-donation-form-link,
+.givewp-donation-form-modal__open {
+    color: var(--givewp-secondary-color, #ffffff) !important;
+    background: var(--givewp-primary-color, #2271b1);
+    padding: 0.75rem 1.25rem !important;
     cursor: pointer;
     border: none;
     border-radius: 5px;
-  }
-
-  &__submit {
-    width: 100%;
-    background-color: #27ae60;
-    color: #fff;
-    padding: 1rem;
-    border-radius: 5px;
-    font-weight: bold;
-    text-align: center;
-    outline: none;
-    border: 0;
-    transition: 0.2s;
-
-    &:disabled {
-      background-color: #e0e0e0;
-    }
-
-    &:hover:not(:disabled) {
-      cursor: pointer;
-      filter: brightness(1.2);
-    }
-  }
-}
-
-.givewp-donation-form-link, .givewp-donation-form-modal__open {
-  color: var(--givewp-secondary-color, #ffffff) !important;
-  background: var(--givewp-primary-color, #2271b1);
-  padding: .75rem 1.25rem !important;
-  cursor: pointer;
-  border: none;
-  border-radius: 5px;
-  font-size: 1rem;
-  font-weight: 500 !important;
-  text-decoration: none !important;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;;
+    font-size: 1rem;
+    font-weight: 500 !important;
+    text-decoration: none !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue',
+    sans-serif;
 }
 
 .givewp-donation-form-modal {
-  border: none;
+    border: none;
 
-  &__dialog {
-    position: relative;
-    padding: 0 !important;
-    border: none !important;
-  }
+    &__dialog {
+        position: fixed;
+        padding: 0 !important;
+        border: none !important;
 
-  &__close {
-    position: absolute;
-    right: 3.5%;
-    top: 1.5%;
-    margin-right: auto;
-    padding: .5rem .5rem .25rem .5rem;
-    border: none !important;
-    background-color: transparent !important;
-    cursor: pointer;
-
-
-    &:hover {
-      path {
-        fill: #0073AA;
-      }
+        &::backdrop {
+            background-color: rgba(0, 0, 0, 0.5);
+        }
     }
-  }
+
+    &__close {
+        position: absolute;
+        right: 3.5%;
+        top: 1.5%;
+        margin-right: auto;
+        padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+        border: none !important;
+        background-color: transparent !important;
+        cursor: pointer;
+
+        &:hover {
+            path {
+                fill: #0073aa;
+            }
+        }
+    }
 }
 
 .components-modal__header {
-  padding-top: 0 !important;
-  padding-right: 1.5rem !important;
-  border-bottom: none !important;
+    padding-top: 0 !important;
+    padding-right: 1.5rem !important;
+    border-bottom: none !important;
 }
 
 .components-modal__content {
-  margin-top: 0 !important;
-  padding: 0 !important;
+    margin-top: 0 !important;
+    padding: 0 !important;
 }
 
 .components-input-control__label {
-  width: 100%;
+    width: 100%;
 }
 
 .wp-block-give-donation-form {
-  position: relative;
+    position: relative;
 
-  form[id*='give-form'] #give-gateway-radio-list > li input[type='radio'] {
-    display: inline-block;
-  }
+    form[id*='give-form'] #give-gateway-radio-list > li input[type='radio'] {
+        display: inline-block;
+    }
 
-  iframe {
-    pointer-events: none;
-    width: 100% !important;
-  }
+    iframe {
+        pointer-events: none;
+        width: 100% !important;
+    }
 }
 
 .give-change-donation-form-btn {
-  svg {
-    margin-top: 3px;
-  }
+    svg {
+        margin-top: 3px;
+    }
 }
-

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
@@ -73,9 +73,10 @@
         position: fixed;
         padding: 0 !important;
         border: none !important;
+        background-color: transparent;
 
         &::backdrop {
-            background-color: rgba(0, 0, 0, 0.5);
+            background-color: rgba(0, 0, 0, 0.6);
         }
     }
 

--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_layouts.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_layouts.scss
@@ -11,4 +11,11 @@
     border-radius: 0.5rem;
     box-shadow: var(--givewp-shadow-xs);
     background-color: #fff;
+    border: 1px solid var(--givewp-grey-25);
+    border-top: none;
+}
+
+.givewp-layouts-header {
+    border: 1px solid var(--givewp-grey-25);
+    border-bottom: none;
 }

--- a/src/DonationForms/resources/styles/_pico.scss
+++ b/src/DonationForms/resources/styles/_pico.scss
@@ -80,6 +80,10 @@ a:focus, [role=link]:focus {
   --background-color: transparent;
 }
 
+form {
+    margin: 0;
+}
+
 ul li {
   list-style: disc;
 }

--- a/src/DonationForms/resources/styles/elements/_multi-step-form.scss
+++ b/src/DonationForms/resources/styles/elements/_multi-step-form.scss
@@ -11,7 +11,8 @@
         border-radius: var(--givewp-rounded-8);
         color: var(--givewp-grey-700);
         background-color: var(--givewp-shades-white);
-        box-shadow: var(--givewp-shadow-sm);
+        box-shadow: var(--givewp-shadow-xs);
+        border: solid 1px var(--givewp-grey-25);
 
         &-header {
             position: relative;


### PR DESCRIPTION
## Description

This PR focuses on making styling improvements to the form modal display option. Most notably, the position of the dialog is no longer relative, but is instead fixed. This makes sure the modal is in the center of the page, regardless of the scroll position.

From there:
- the backdrop of the modal was too light, 10% opacity black, and has been increased to 50% opacity
- the background color for the modal was made transparent
- the box shadowing and bordering of the form have been corrected to the design (per Jeffrey's guidance)
- moved the close button outside of the form to not clash with various form background colors

## Affects

The form modal display mode styling

## Visuals

<img width="578" alt="image" src="https://github.com/impress-org/givewp/assets/2024145/c0d05792-72d5-45c0-8ecb-1e1443895835">




## Testing Instructions

1. Make a form
2. Embed the form on a page
3. Change the display mode to "modal"
4. Check out the form on the page and make sure it looks good!

## Pre-review Checklist

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

