### PR TITLE
Refactor: control items visibility in the gateways block trough a new filter

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
@@ -1,6 +1,7 @@
 import {ReactNode} from 'react';
 import {BlockEditProps} from '@wordpress/blocks';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
+import {Gateway} from '@givewp/form-builder/types';
 
 const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
     return (
@@ -18,6 +19,15 @@ const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
 };
 
 export default function Edit(props: BlockEditProps<any>) {
+    // @ts-ignore
+    const isPerFormGatewaysActive = Boolean(window.perFormGatewaysFormBuilder);
+    const {perFormGateways, useDefaultGateways} = props.attributes;
+    const isGatewayEnabled = (gateway: Gateway) =>
+        isPerFormGatewaysActive && perFormGateways && !useDefaultGateways
+            ? gateway.enabled &&
+              Boolean(perFormGateways.filter((perFormGateway) => perFormGateway.key === gateway.id).length)
+            : gateway.enabled;
+
     const {gateways} = getFormBuilderWindowData();
 
     return (
@@ -33,7 +43,7 @@ export default function Edit(props: BlockEditProps<any>) {
         >
             <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
                 {gateways
-                    .filter((gateway) => gateway.enabled)
+                    .filter((gateway) => isGatewayEnabled(gateway))
                     .map((gateway) => (
                         <GatewayItem
                             key={gateway.id}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
@@ -2,6 +2,7 @@ import {ReactNode} from 'react';
 import {BlockEditProps} from '@wordpress/blocks';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 import {Gateway} from '@givewp/form-builder/types';
+import {applyFilters} from '@wordpress/hooks';
 
 const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
     return (
@@ -19,14 +20,11 @@ const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
 };
 
 export default function Edit(props: BlockEditProps<any>) {
-    // @ts-ignore
-    const isPerFormGatewaysActive = Boolean(window.perFormGatewaysFormBuilder);
-    const {perFormGateways, useDefaultGateways} = props.attributes;
-    const isGatewayEnabled = (gateway: Gateway) =>
-        isPerFormGatewaysActive && perFormGateways && !useDefaultGateways
-            ? gateway.enabled &&
-              Boolean(perFormGateways.filter((perFormGateway) => perFormGateway.key === gateway.id).length)
-            : gateway.enabled;
+    const isGatewayEnabled = (gateway: Gateway) => {
+        let enabled = applyFilters('givewp_form_builder_enabled_payment_gateway_' + gateway.id, [gateway.enabled]);
+        enabled = typeof enabled === 'undefined' ? true : enabled[0];
+        return enabled;
+    };
 
     const {gateways} = getFormBuilderWindowData();
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
@@ -1,7 +1,6 @@
 import {ReactNode} from 'react';
 import {BlockEditProps} from '@wordpress/blocks';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
-import {Gateway} from '@givewp/form-builder/types';
 import {applyFilters} from '@wordpress/hooks';
 
 const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
@@ -20,12 +19,6 @@ const GatewayItem = ({label, icon}: {label: string; icon: ReactNode}) => {
 };
 
 export default function Edit(props: BlockEditProps<any>) {
-    const isGatewayEnabled = (gateway: Gateway) => {
-        let enabled = applyFilters('givewp_form_builder_enabled_payment_gateway_' + gateway.id, [gateway.enabled]);
-        enabled = typeof enabled === 'undefined' ? true : enabled[0];
-        return enabled;
-    };
-
     const {gateways} = getFormBuilderWindowData();
 
     return (
@@ -41,7 +34,13 @@ export default function Edit(props: BlockEditProps<any>) {
         >
             <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
                 {gateways
-                    .filter((gateway) => isGatewayEnabled(gateway))
+                    .filter((gateway) =>
+                        applyFilters(
+                            `givewp_form_builder_payment_gateway_enabled_${gateway.id}`,
+                            gateway.enabled,
+                            gateway
+                        )
+                    )
                     .map((gateway) => (
                         <GatewayItem
                             key={gateway.id}

--- a/src/FormMigration/Steps/PerFormGateways.php
+++ b/src/FormMigration/Steps/PerFormGateways.php
@@ -23,8 +23,9 @@ class PerFormGateways extends FormMigrationStep
             foreach ($perFormGateways as $key => $checked) {
                 if (in_array($key, $compatibleGateways)) {
                     $gateways[] = [
-                        'key' => $key,
+                        'id' => $key,
                         'label' => give_get_gateway_checkout_label($key),
+                        'value' => $key,
                         'checked' => (bool)$checked,
                     ];
                 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-251]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new filter to the payment gateway block which allows us to set if a specific gateway is enabled or not in the list of gateways displayed in the form builder.

It's useful for addons that need to handle the items of the gateway list like the Per Form Gateways addon which uses this new filter here: https://github.com/impress-org/give-per-form-gateways/pull/12

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Payment Gateway block.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Follow the instructions of this PR: https://github.com/impress-org/give-per-form-gateways/pull/12

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-251]: https://stellarwp.atlassian.net/browse/GIVE-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ