### PR TITLE
Fix: modal form redirect compatibility with offsite gateways

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -40,12 +40,13 @@ class BlockRenderController
 
         $viewUrl = $this->getViewUrl($donationForm, $embedId);
         $formUrl = esc_url(add_query_arg(['p' => $blockAttributes->formId], site_url('?post_type=give_forms')));
-        
+        $formViewUrl = $this->getFormViewUrl($donationForm);
+
         /**
          * Note: iframe-resizer uses querySelectorAll so using a data attribute makes the most sense to target.
          * It will also generate a dynamic ID - so when we have multiple embeds on a page there will be no conflict.
          */
-        return "<div class='root-data-givewp-embed' data-form-url='$formUrl' data-src='$viewUrl' data-givewp-embed-id='$embedId' data-form-format='$blockAttributes->formFormat' data-open-form-button='$blockAttributes->openFormButton'></div>";
+        return "<div class='root-data-givewp-embed' data-form-url='$formUrl' data-form-view-url='$formViewUrl' data-src='$viewUrl' data-givewp-embed-id='$embedId' data-form-format='$blockAttributes->formFormat' data-open-form-button='$blockAttributes->openFormButton'></div>";
     }
 
     /**
@@ -83,6 +84,14 @@ class BlockRenderController
             return (new GenerateDonationConfirmationReceiptViewRouteUrl())($receiptId);
         }
 
+        return $this->getFormViewUrl($donationForm);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getFormViewUrl(DonationForm $donationForm): string
+    {
         return (new GenerateDonationFormViewRouteUrl())($donationForm->id);
     }
 

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -3,32 +3,37 @@ import IframeResizer from 'iframe-resizer-react';
 import {createPortal} from 'react-dom';
 
 import '../../editor/styles/index.scss';
-import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';
+import {useCallback} from 'react';
 
 type ModalFormProps = {
     dataSrc: string;
     embedId: string;
     openFormButton: string;
+    openByDefault?: boolean;
+    isFormRedirect: boolean;
+    formViewUrl: string;
 };
 
 /**
  * @unreleased
- */
-const inlineRedirectRoutes = ['donation-confirmation-receipt-view'];
-
-/**
  * @since 3.2.0 include types. update BEM classnames.
  * @since 3.0.0
  */
-export default function ModalForm({dataSrc, embedId, openFormButton}: ModalFormProps) {
-    const redirectUrl = new URL(dataSrc);
-    const redirectUrlParams = new URLSearchParams(redirectUrl.search);
-    const shouldRedirectInline = isRouteInlineRedirect(redirectUrlParams, inlineRedirectRoutes);
-    const [isOpen, setIsOpen] = useState(shouldRedirectInline);
+export default function ModalForm({dataSrc, embedId, openFormButton, openByDefault, isFormRedirect, formViewUrl}: ModalFormProps) {
+    const [isOpen, setIsOpen] = useState(openByDefault || isFormRedirect);
     const modalRef = useRef(null);
+    const [dataSrcUrl, setDataSrcUrl] = useState(dataSrc);
+
+    const resetDataSrcUrl = () => {
+         if (!isOpen && isFormRedirect) {
+            setDataSrcUrl(formViewUrl);
+        }
+    };
 
     const toggleModal = () => {
         setIsOpen(!isOpen);
+
+        resetDataSrcUrl();
     };
 
     useEffect(() => {
@@ -65,7 +70,7 @@ export default function ModalForm({dataSrc, embedId, openFormButton}: ModalFormP
                         </button>
                         <IframeResizer
                             id={embedId}
-                            src={dataSrc}
+                            src={dataSrcUrl}
                             checkOrigin={false}
                             style={{
                                 width: '32.5rem',

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useRef, useState} from '@wordpress/element';
 import IframeResizer from 'iframe-resizer-react';
 import {createPortal} from 'react-dom';
-import getWindowData from '@givewp/forms/app/utilities/getWindowData';
 
 import '../../editor/styles/index.scss';
 import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -1,8 +1,10 @@
 import {useEffect, useRef, useState} from '@wordpress/element';
 import IframeResizer from 'iframe-resizer-react';
 import {createPortal} from 'react-dom';
+import getWindowData from '@givewp/forms/app/utilities/getWindowData';
 
 import '../../editor/styles/index.scss';
+import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';
 
 type ModalFormProps = {
     dataSrc: string;
@@ -11,11 +13,19 @@ type ModalFormProps = {
 };
 
 /**
+ * @unreleased
+ */
+const inlineRedirectRoutes = ['donation-confirmation-receipt-view'];
+
+/**
  * @since 3.2.0 include types. update BEM classnames.
  * @since 3.0.0
  */
 export default function ModalForm({dataSrc, embedId, openFormButton}: ModalFormProps) {
-    const [isOpen, setIsOpen] = useState(false);
+    const redirectUrl = new URL(dataSrc);
+    const redirectUrlParams = new URLSearchParams(redirectUrl.search);
+    const shouldRedirectInline = isRouteInlineRedirect(redirectUrlParams, inlineRedirectRoutes);
+    const [isOpen, setIsOpen] = useState(shouldRedirectInline);
     const modalRef = useRef(null);
 
     const toggleModal = () => {

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -3,6 +3,7 @@ import ModalForm from './Components/ModalForm';
 import IframeResizer from 'iframe-resizer-react';
 
 import '../editor/styles/index.scss';
+import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';
 
 /**
  * @since 3.2.1 Revert the display style value of "fullForm" to "onpage".
@@ -14,13 +15,32 @@ type DonationFormBlockAppProps = {
     embedId: string;
     openFormButton: string;
     formUrl: string;
+    formViewUrl: string;
 };
 
 /**
+ * @unreleased
+ */
+const inlineRedirectRoutes = ['donation-confirmation-receipt-view'];
+
+/**
+ * @unreleased
+ */
+const isRedirect = (url: string) => {
+    const redirectUrl = new URL(url);
+    const redirectUrlParams = new URLSearchParams(redirectUrl.search);
+
+    return isRouteInlineRedirect(redirectUrlParams, inlineRedirectRoutes);
+}
+
+/**
+ * @unreleased add logic for inline redirects.
  * @since 3.2.0 replace form format reveal with new tab.
  * @since 3.0.0
  */
-function DonationFormBlockApp({formFormat, dataSrc, embedId, openFormButton, formUrl}: DonationFormBlockAppProps) {
+function DonationFormBlockApp({formFormat, dataSrc, embedId, openFormButton, formUrl, formViewUrl}: DonationFormBlockAppProps) {
+    const isFormRedirect = isRedirect(dataSrc);
+
     if (formFormat === 'newTab') {
         return (
             <a className={'givewp-donation-form-link'} href={formUrl} target={'_blank'} rel={'noopener noreferrer'}>
@@ -30,7 +50,7 @@ function DonationFormBlockApp({formFormat, dataSrc, embedId, openFormButton, for
     }
 
     if (formFormat === 'modal' || formFormat === 'reveal') {
-        return <ModalForm openFormButton={openFormButton} dataSrc={dataSrc} embedId={embedId} />;
+        return <ModalForm openFormButton={openFormButton} dataSrc={dataSrc} embedId={embedId} openByDefault={isFormRedirect} isFormRedirect={isFormRedirect} formViewUrl={formViewUrl} />;
     }
 
     return (
@@ -55,6 +75,7 @@ roots.forEach((root) => {
     const formFormat = root.getAttribute('data-form-format');
     const openFormButton = root.getAttribute('data-open-form-button');
     const formUrl = root.getAttribute('data-form-url');
+    const formViewUrl = root.getAttribute('data-form-view-url');
 
     if (createRoot) {
         createRoot(root).render(
@@ -64,6 +85,7 @@ roots.forEach((root) => {
                 dataSrc={dataSrc}
                 embedId={embedId}
                 formUrl={formUrl}
+                formViewUrl={formViewUrl}
             />
         );
     } else {
@@ -74,6 +96,7 @@ roots.forEach((root) => {
                 dataSrc={dataSrc}
                 embedId={embedId}
                 formUrl={formUrl}
+                formViewUrl={formViewUrl}
             />,
             root
         );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-258]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This ensures when using an offsite gateway and the modal display for donation form blocks using v3 forms - the confirmation page is displayed in place of the modal form when returning to the website origin.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The modal form

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="852" alt="Screenshot 2024-01-25 at 2 11 21 PM" src="https://github.com/impress-org/givewp/assets/10138447/e1dd32b3-73bb-4393-adfc-f1a3513db366">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a v3 form
- Enable paypal standard & stripe payment element
- Create a page with the donation form block
- Select "modal" from display settings
- Go through donation form inside modal using paypal standard and then stripe payment element
- It should redirect back to the page when complete showing the confirmation receipt inside the model
- When you close the modal you should be able to click the donate button again and get a fresh form
- (note) refreshing the page will result in the confirmation page showing up again.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-258]: https://stellarwp.atlassian.net/browse/GIVE-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ