### PR TITLE
Fix: Update nonce validation to match when translated

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -812,7 +812,7 @@ class Give_Payment_History_Table extends WP_List_Table {
             return;
         }
 
-        give_validate_nonce($_GET['_wpnonce'] ?? '', 'bulk-forms');
+        give_validate_nonce($_GET['_wpnonce'] ?? '', 'bulk-'.$this->_args['plural']);
 
         foreach ($ids as $id) {
 			// Detect when a bulk action is being triggered.

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -136,9 +136,9 @@ class Give_Payment_History_Table extends WP_List_Table {
 		// Set parent defaults.
 		parent::__construct(
 			[
-				'singular' => give_get_forms_label_singular(),    // Singular name of the listed records.
-				'plural'   => give_get_forms_label_plural(),      // Plural name of the listed records.
-				'ajax'     => false,                              // Does this table support ajax?
+				'singular' => 'form',    // Singular name of the listed records.
+				'plural'   => 'forms',   // Plural name of the listed records.
+				'ajax'     => false,     // Does this table support ajax?
 			]
 		);
 
@@ -812,7 +812,7 @@ class Give_Payment_History_Table extends WP_List_Table {
             return;
         }
 
-        give_validate_nonce($_GET['_wpnonce'] ?? '', 'bulk-'.$this->_args['plural']);
+        give_validate_nonce($_GET['_wpnonce'] ?? '', 'bulk-forms');
 
         foreach ($ids as $id) {
 			// Detect when a bulk action is being triggered.


### PR DESCRIPTION
As an administrator, I would like to update donations with a bulk action. The result is:  
`We're unable to recognize your session. Please refresh the screen to try again; otherwise contact your website administrator for assistance. `

The nonce verification failed.
In class-wp-list-table.php, the nonce is created from `'bulk-' . $this->_args['plural']`. In French this plural is "formulaires". And the verification uses `'bulk-forms'`.

## Testing Instructions
Test bulk actions  in other languages as English
