### PR TITLE
Fix: ensure `showInReceipt` is compatible with all fields including use of `metaKey`

### DIFF
--- a/src/Framework/FieldsAPI/Field.php
+++ b/src/Framework/FieldsAPI/Field.php
@@ -2,12 +2,14 @@
 
 namespace Give\Framework\FieldsAPI;
 
+use Give\Framework\FieldsAPI\Concerns\HasLabel;
 use Give\Framework\FieldsAPI\Contracts\Node;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
 use Give\Framework\FieldsAPI\ValueObjects\PersistenceScope;
 use Give\Vendors\StellarWP\Validation\Concerns\HasValidationRules;
 
 /**
+ * @unreleased add HasLabel
  * @since 2.27.3 add ShowInAdmin, ShowInReceipt, StoreAsMeta
  * @since      2.17.0 allow fields to be macroable
  * @since      2.12.0
@@ -27,6 +29,7 @@ abstract class Field implements Node
     use Concerns\TapNode;
     use Concerns\ShowInAdmin;
     use Concerns\ShowInReceipt;
+    use Concerns\HasLabel;
     use Concerns\HasVisibilityConditions {
         Concerns\HasVisibilityConditions::__construct as private __visibilityConditionsConstruct;
     }

--- a/src/Framework/FieldsAPI/Field.php
+++ b/src/Framework/FieldsAPI/Field.php
@@ -2,14 +2,12 @@
 
 namespace Give\Framework\FieldsAPI;
 
-use Give\Framework\FieldsAPI\Concerns\HasLabel;
 use Give\Framework\FieldsAPI\Contracts\Node;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
 use Give\Framework\FieldsAPI\ValueObjects\PersistenceScope;
 use Give\Vendors\StellarWP\Validation\Concerns\HasValidationRules;
 
 /**
- * @unreleased add HasLabel
  * @since 2.27.3 add ShowInAdmin, ShowInReceipt, StoreAsMeta
  * @since      2.17.0 allow fields to be macroable
  * @since      2.12.0
@@ -29,7 +27,6 @@ abstract class Field implements Node
     use Concerns\TapNode;
     use Concerns\ShowInAdmin;
     use Concerns\ShowInReceipt;
-    use Concerns\HasLabel;
     use Concerns\HasVisibilityConditions {
         Concerns\HasVisibilityConditions::__construct as private __visibilityConditionsConstruct;
     }

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -32,6 +32,7 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
+     * @unreleased updated to check for metaKey first and then fallback to name
      * @since 3.3.0 updated conditional to check for scopes and added support for retrieving values programmatically with Fields API
      * @since 3.0.0
      */
@@ -64,17 +65,17 @@ class GenerateConfirmationPageReceipt
                     ]);
                 }
             } elseif ($field->getScope()->isDonor()) {
-                if (!metadata_exists('donor', $donation->donor->id, $field->getName())) {
+                if (!metadata_exists('donor', $donation->donor->id,$field->getMetaKey() ?? $field->getName())) {
                     continue;
                 }
 
-                $value = give()->donor_meta->get_meta($donation->donor->id, $field->getName(), true);
+                $value = give()->donor_meta->get_meta($donation->donor->id, $field->getMetaKey() ?? $field->getName(), true);
             } elseif ($field->getScope()->isDonation()) {
-                if (!metadata_exists('donation', $donation->id, $field->getName())) {
+                if (!metadata_exists('donation', $donation->id, $field->getMetaKey() ?? $field->getName())) {
                     continue;
                 }
 
-                $value = give()->payment_meta->get_meta($donation->id, $field->getName(), true);
+                $value = give()->payment_meta->get_meta($donation->id, $field->getMetaKey() ?? $field->getName(), true);
             } else {
                 $value = null;
             }

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -51,7 +51,7 @@ class GenerateConfirmationPageReceipt
 
         $receiptDetails = [];
         foreach ($customFields as $field) {
-            /** @var Field|HasName $field */
+            /** @var Field|HasLabel|HasName $field */
             if ($field->hasReceiptValue()) {
                 try {
                     $value = $field->isReceiptValueCallback() ? $field->getReceiptValue()($field, $donation) : null;
@@ -87,11 +87,9 @@ class GenerateConfirmationPageReceipt
                 $donation
             );
 
-            $defaultLabel = method_exists($field, 'getLabel') ? $field->getLabel() : null;
-
             $label = apply_filters(
                 sprintf("givewp_donation_confirmation_page_field_label_for_%s", $field->getName()),
-                $field->hasReceiptLabel() ? $field->getReceiptLabel() : $defaultLabel,
+                $field->hasReceiptLabel() ? $field->getReceiptLabel() : $field->getLabel(),
                 $field,
                 $donation
             );

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -51,7 +51,7 @@ class GenerateConfirmationPageReceipt
 
         $receiptDetails = [];
         foreach ($customFields as $field) {
-            /** @var Field|HasLabel|HasName $field */
+            /** @var Field|HasName $field */
             if ($field->hasReceiptValue()) {
                 try {
                     $value = $field->isReceiptValueCallback() ? $field->getReceiptValue()($field, $donation) : null;
@@ -87,9 +87,11 @@ class GenerateConfirmationPageReceipt
                 $donation
             );
 
+            $defaultLabel = method_exists($field, 'getLabel') ? $field->getLabel() : null;
+
             $label = apply_filters(
                 sprintf("givewp_donation_confirmation_page_field_label_for_%s", $field->getName()),
-                $field->hasReceiptLabel() ? $field->getReceiptLabel() : $field->getLabel(),
+                $field->hasReceiptLabel() ? $field->getReceiptLabel() : $defaultLabel,
                 $field,
                 $donation
             );

--- a/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
+++ b/tests/Unit/Framework/Receipts/TestGenerateConfirmationPageReceipt.php
@@ -295,4 +295,49 @@ class TestGenerateConfirmationPageReceipt extends TestCase
             $receipt->additionalDetails->toArray()
         );
     }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldAddCustomFieldsUsingMetaKayToAdditionalDetails(): void
+    {
+        $field = Text::make('favoriteColor')
+            ->label('Your favorite color:')
+            ->defaultValue('Blue')
+            ->metaKey('_favorite_color')
+            ->showInReceipt()
+        ;
+
+         add_action('givewp_donation_form_schema', static function (\Give\Framework\FieldsAPI\DonationForm $form) use ($field) {
+            $form->insertAfter('email', $field);
+        });
+
+        /** @var DonationForm $donationForm */
+        $donationForm = DonationForm::factory()->create();
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'formId' => $donationForm->id
+        ]);
+
+        give_update_payment_meta($donation->id, '_favorite_color', 'Blue');
+
+        $initialReceipt = new DonationReceipt($donation);
+
+        $receipt = (new GenerateConfirmationPageReceipt())($initialReceipt);
+
+        $additionalDetails = new ReceiptDetailCollection();
+
+        $additionalDetails->addDetail(
+            new ReceiptDetail(
+                __('Your favorite color:', 'give'),
+                'Blue'
+            )
+        );
+
+        $this->assertContains(
+            $additionalDetails->toArray()[0],
+            $receipt->additionalDetails->toArray()
+        );
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-279]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- The v3 confirmation page should respect when custom fields use `->metaKey()` in conjunction with `->showInReceipt()` to display their value.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
- Fields that use both `->metaKey()` and `->showInReceipt()`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="838" alt="Screenshot 2024-01-29 at 4 57 19 PM" src="https://github.com/impress-org/givewp/assets/10138447/48f41cb1-33cb-4c83-b33c-77125f0d2e3e">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

zip: https://github.com/impress-org/givewp/actions/runs/7742785302

- You can use the following code snippet
- After donating, the confirmation page should display the above screenshot

```
add_action('givewp_donation_form_schema', static function (Give\Framework\FieldsAPI\DonationForm $form) {
    $field = Give\Framework\FieldsAPI\Text::make('favoriteColor')
            ->label('Your favorite color:')
            ->defaultValue('Blue')
            ->metaKey('_favorite_color')
            ->showInReceipt();
    $form->insertAfter('email', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-279]: https://stellarwp.atlassian.net/browse/GIVE-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ