### PR TITLE
Refactor: create responsive previews in the form builder

### DIFF
--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -10,7 +10,7 @@
     padding: 0;
     width: 100%;
 
-    @media screen and (max-width: 71.5rem) {
+    @media screen and (max-width: 53.5rem) {
         border: solid 1px var(--givewp-grey-25);
         border-radius: var(--givewp-rounded-8);
         box-shadow: var(--givewp-shadow-sm);

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -7,7 +7,7 @@
     flex-direction: row;
     margin: auto;
     max-width: calc(var(--two-panel-header-width) + 35.5rem);
-    padding: 0;
+    padding: 0 .5rem;
     width: 100%;
 
     @media screen and (max-width: 53.5rem) {

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/schema-steps.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/steps/schema-steps.tsx
@@ -4,7 +4,7 @@ import Placement from '@givewp/form-builder/components/onboarding/steps/types/pl
 const schemaSteps = [
     {
         id: 'schema-canvas',
-        attachTo: {element: '#form-blocks-canvas', on: 'right-start' as Placement},
+        attachTo: {element: '#form-blocks-canvas > div', on: 'right-start' as Placement},
         title: __('Canvas', 'give'),
         text: __('Add, reorder, and edit blocks and sections here to make up your form.', 'give'),
     },

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -35,7 +35,7 @@
 }
 
 .interface-interface-skeleton__content {
-    height: 100vh;
+    height: calc(100vh - 60px);
     width: 100%;
     margin: auto;
     padding: 100px 0; /* Leave room for toolbar above first block. */

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -35,7 +35,6 @@
 }
 
 .interface-interface-skeleton__content {
-    display: block;
     height: 100vh;
     width: 100%;
     margin: auto;
@@ -44,8 +43,13 @@
     box-sizing: border-box;
 
     .givewp-form-builder__design-tab & {
+        display: block;
         width: 100%;
-        max-width: 1200px;
+    }
+
+    #form-blocks-canvas {
+        display: flex;
+        justify-content: center;
     }
 
     @media screen and (max-width: 782px) {

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -35,8 +35,10 @@
 }
 
 .interface-interface-skeleton__content {
-    width: 720px;
-    margin: 0 auto auto;
+    display: block;
+    height: 100vh;
+    width: 100%;
+    margin: auto;
     padding: 100px 0; /* Leave room for toolbar above first block. */
     flex-grow: unset;
     box-sizing: border-box;

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -213,6 +213,8 @@
     gap: 2rem;
 
     .block-editor-block-list__block {
+        max-width: 720px;
+
         &:not([contenteditable]):focus::after {
             box-shadow: none;
         }

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -13,7 +13,7 @@
 }
 
 .interface-interface-skeleton__body {
-    width: 100%;
+    width: calc(100% - var(--givewp-sidebar-width));
     background-color: var(--givewp-gray-10);
 }
 
@@ -296,3 +296,6 @@
     }
 }
 
+.givewp-form-settings__editor .interface-interface-skeleton {
+    width: 100%;
+}

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -214,6 +214,7 @@
 
     .block-editor-block-list__block {
         max-width: 720px;
+        padding: 0 0.5rem;
 
         &:not([contenteditable]):focus::after {
             box-shadow: none;

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -13,8 +13,9 @@
 }
 
 .interface-interface-skeleton__body {
-    width: calc(100% - var(--givewp-sidebar-width));
+    width: 100%;
     background-color: var(--givewp-gray-10);
+    overflow: hidden;
 }
 
 .interface-interface-skeleton__secondary-sidebar {

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -44,13 +44,10 @@
     //color: slategray;
     height: calc(100vh - 60px); // Account for header height above sidebar
     //overflow: hidden; // The Inspector Popout needs to be visible.
-    position: fixed !important; // !important override added when migrated to WordPress - not sure why this is necessary...
-    top: 60px; // Account for header @todo move this to layout, not in the component.
     overflow-y: scroll;
 
-    &.givewp-next-gen-sidebar-primary {
-        right: 0;
 
+    &.givewp-next-gen-sidebar-primary {
         .block-editor-block-inspector {
             > h2 {
                 border-bottom: 1px solid #e0e0e0;
@@ -68,10 +65,6 @@
                 padding: var(--givewp-spacing-4);
             }
         }
-    }
-
-    &.givewp-next-gen-sidebar-secondary {
-        left: 0;
     }
 
     &__inner {
@@ -249,7 +242,7 @@
         }
     }
 
-    &_visibility{
+    &_visibility {
         font-size: 0.75rem;
         line-height: 1.4;
         margin-top: -8px;
@@ -309,7 +302,8 @@
             fill: #000;
             stroke: #fff;
         }
-    };
+    }
+;
 }
 
 .iti {

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -42,7 +42,7 @@
     border: 1px solid lightgray;
     bottom: 0;
     //color: slategray;
-    height: calc(100vh - 60px); // Account for header height above sidebar
+    height: calc(100vh - 65px); // Account for header height above sidebar
     //overflow: hidden; // The Inspector Popout needs to be visible.
     overflow-y: scroll;
 


### PR DESCRIPTION
Resolves [GIVE-268]

## Description
This pull request (PR) introduces enhancements to achieve a width-responsive preview in the form builder by removing the sidebars from their fixed positioning. This creates a more similar experience as the WP block editor.

Changes include:
`interface-interface-skeleton__content`
- Set height to allow content to be scrolled
- Set overflow-y to allow content to scroll

`.interface-interface-skeleton__body`
- Hide overflow so entire body does not scroll

`.givewp-next-gen-sidebar`
- remove fixed positioning

## Affects
The visual form builder sidebars

## Visuals

https://github.com/impress-org/givewp/assets/75056371/e9903e49-b03f-4da5-a965-738c5cd7838a

## Testing Instructions
- Toggle the sidebars on each form builder section'Build', 'Design' & 'Settings', the content section should expand and retract accordingly.
- Each sidebar should be scrollable.
- The preview content should be scrollable.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-268]: https://stellarwp.atlassian.net/browse/GIVE-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ