### PR TITLE
Feature: update confirmation page detail values to allow html

### DIFF
--- a/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
@@ -17,6 +17,7 @@ const SecureBadge = () => {
 
 /**
  *
+ * @unreleased updated to render value using Interweave
  * @since 3.0.0
  */
 const Details = ({id, heading, details}: {id: string; heading: string; details: ReceiptDetail[]}) =>

--- a/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
@@ -27,9 +27,7 @@ const Details = ({id, heading, details}: {id: string; heading: string; details: 
                 {details.map(({label, value}, index) => (
                     <div key={index} className={`details-row details-row--${label.toLowerCase().replace(' ', '-')}`}>
                         <dt className="detail">{label}</dt>
-                        <dd className="value" data-value={value}>
-                            {value}
-                        </dd>
+                        <Interweave className="value" tagName="dd" data-value={value} content={value} />
                     </div>
                 ))}
             </dl>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: [GIVE-291]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This will allow html to be added to the confirmation page for more flexibility.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Confirmation page detail values will be rendered properly if supplied a string of html.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="829" alt="Screenshot 2024-01-31 at 4 51 44 PM" src="https://github.com/impress-org/givewp/assets/10138447/8ea4f991-5883-4ec6-b4b3-95cda84ae927">



<img width="837" alt="Screenshot 2024-01-31 at 4 54 28 PM" src="https://github.com/impress-org/givewp/assets/10138447/9a257651-8e2f-49c0-bc94-bac0860f2e6f">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/7733974060

Programmatically return an html value for receipt:

```
add_action('givewp_donation_form_schema', static function (Give\Framework\FieldsAPI\DonationForm $form) {
    $field = Give\Framework\FieldsAPI\Text::make('favoriteColor')
            ->label('Your favorite color:')
            ->defaultValue('Blue')
            ->metaKey('_favorite_color')
            ->showInReceipt()
            ->receiptValue(function (Give\Framework\FieldsAPI\Text $field, Give\Donations\Models\Donation $donation) {
                $favoriteColor = give_get_meta($donation->id,'_favorite_color', true);
                
                return sprintf('<strong style="color: %s">%s</strong>', esc_html($favoriteColor), esc_html($favoriteColor));
            });
    $form->insertAfter('email', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-291]: https://stellarwp.atlassian.net/browse/GIVE-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ