### PR TITLE
refactor: use TextWrapper to create "center"  header-image 

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_header.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_header.scss
@@ -54,10 +54,8 @@
     }
 
     &__center {
-        .givewp-layouts-goal {
-            margin-top: 320px;
-            position: relative;
-            border-radius: 0;
+        .givewp-form-secure-badge {
+            margin-bottom: 320px;
         }
 
         .givewp-layouts-header {
@@ -67,4 +65,3 @@
         }
     }
 }
-

--- a/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
+++ b/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
@@ -158,9 +158,21 @@
             padding-top: 1.5rem;
         }
 
-        .givewp-layouts-goal {
-            position: relative;
-            margin-top: calc(350px + var(--givewp-spacing-2));
+        .givewp-layouts-headerTextWrapper {
+            margin-bottom: 340px;
+        }
+
+        .givewp-layouts-headerTextWrapper::before {
+            content: '';
+            position: absolute;
+            top: 115%;
+            left: 0;
+            width: 100%;
+            height: 315px;
+
+            background-image: var(--givewp-design-settings-background-image);
+            background-position: 50%;
+            background-size: cover;
             border-radius: 0.5rem;
         }
     }

--- a/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
+++ b/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
@@ -154,12 +154,17 @@
     }
 
     &__center {
+        .givewp-layouts-headerDescription {
+            margin-bottom: 0;
+        }
+
         .givewp-donation-form__steps-body {
             padding-top: 1.5rem;
         }
 
         .givewp-layouts-headerTextWrapper {
             margin-bottom: 340px;
+            border: 1px solid transparent;
         }
 
         .givewp-layouts-headerTextWrapper::before {

--- a/src/DonationForms/resources/registrars/templates/layouts/HeaderTextWrapper.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/HeaderTextWrapper.tsx
@@ -5,7 +5,9 @@ export default function HeaderTextWrapper({children}) {
     const {designSettingsImageStyle} = window.givewp.form.hooks.useDonationFormSettings();
 
     // @note The `cover` design setting requires the header title and description to be wrapped in a div.
-    return 'cover' == designSettingsImageStyle
-        ? <div className="givewp-layouts givewp-layouts-headerTextWrapper">{children}</div>
-        : <>{children}</>
+    return 'cover' == designSettingsImageStyle || 'center' == designSettingsImageStyle ? (
+        <div className="givewp-layouts givewp-layouts-headerTextWrapper">{children}</div>
+    ) : (
+        <>{children}</>
+    );
 }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -99,10 +99,15 @@
             }
         }
 
-        .givewp-layouts-goal::after {
-            content: "";
+        .givewp-layouts-headerTextWrapper {
+            position: relative;
+            width: 100%;
+        }
+
+        .givewp-layouts-headerTextWrapper::before {
+            content: '';
             position: absolute;
-            top: -320px;
+            bottom: -390px;
             left: 0;
             width: 100%;
             height: 315px;


### PR DESCRIPTION
## Description

This PR changes the element used to create the pseudo header-image for center style. It previously used the donation goal element however if the donation goal was toggled off, it would fail to render the header image. Because no other common elements live in the header that we can use to create the header image pseudo element Ive update the text wrapper so that it may be used.

## Affects

Header image

## Visuals

https://github.com/impress-org/givewp/assets/75056371/b11a2185-447c-49fe-b565-f054d667f31a

## Testing Instructions
- Use the center style for the header image and disable donation goal. The header image should still be visible.
- Test for both multistep and classic.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

