### PR TITLE
Feature: Scaffold Field and Converter

### DIFF
--- a/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
+++ b/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
@@ -1,0 +1,53 @@
+<?php
+namespace Give\EventTickets\Actions;
+
+use Give\Donations\Models\Donation;
+use Give\EventTickets\Fields\EventTickets;
+use Give\Framework\Blocks\BlockModel;
+use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
+
+class ConvertEventTicketsBlockToFieldsApi
+{
+    /**
+     * @unreleased
+     *
+     * @throws EmptyNameException
+     */
+    public function __invoke(BlockModel $block, int $formId)
+    {
+        return EventTickets::make('eventTickets')
+            ->tap(function (EventTickets $eventTicketsField) use ($block, $formId) {
+
+                $eventTicketsField
+                    ->title('Event 1')
+                    ->date('2024-01-10 10:00')
+                    ->description('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.')
+                    ->tickets([
+                        [
+                            'id' => 1,
+                            'name' => 'Standard',
+                            'price' => 50,
+                            'quantity' => 5,
+                            'description' => 'Standard ticket description goes here',
+                        ],
+                        [
+                            'id' => 2,
+                            'name' => 'VIP',
+                            'price' => 100,
+                            'quantity' => 5,
+                            'description' => 'VIP ticket description goes here',
+                        ],
+                    ]);
+
+                $eventTicketsField->scope(function (EventTickets $field, $value, Donation $donation) {
+                    if (empty($value)) {
+                        return;
+                    }
+
+                    // (new UpdateDonationWithEventTickets())($value, $donation, $field);
+                });
+
+                return $eventTicketsField;
+            });
+    }
+}

--- a/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
+++ b/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
@@ -15,7 +15,7 @@ class ConvertEventTicketsBlockToFieldsApi
      */
     public function __invoke(BlockModel $block, int $formId)
     {
-        return EventTickets::make('eventTickets')
+        return EventTickets::make($block->getShortName() . '-' . $block->getAttribute('eventId'))
             ->tap(function (EventTickets $eventTicketsField) use ($block, $formId) {
 
                 $eventTicketsField

--- a/src/EventTickets/Fields/EventTickets.php
+++ b/src/EventTickets/Fields/EventTickets.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Give\EventTickets\Fields;
+
+use Give\Framework\FieldsAPI\Field;
+
+class EventTickets extends Field
+{
+    protected $title;
+    protected $date;
+    protected $description;
+    protected $tickets = [];
+
+    const TYPE = 'eventTickets';
+
+    /**
+     * @unreleased
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function title(string $title): EventTickets
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getDate(): string
+    {
+        return $this->date;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function date(string $date): EventTickets
+    {
+        $this->date = $date;
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function description(string $description): EventTickets
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getTickets(): array
+    {
+        return $this->tickets;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function tickets(array $tickets): EventTickets
+    {
+        $this->tickets = $tickets;
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getTicketsLabel(): string
+    {
+        return apply_filters(
+            'givewp_event_tickets_block/tickets_label',
+            __('Select Tickets', 'give')
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getSoldOutMessage(): string
+    {
+        return apply_filters(
+            'givewp_event_tickets_block/sold_out_message',
+            __(
+                'Thank you for supporting our cause. Our fundraising event tickets are officially sold out. You can still contribute by making a donation.',
+                'give'
+            )
+        );
+    }
+}

--- a/src/EventTickets/Hooks/DonationFormBlockRender.php
+++ b/src/EventTickets/Hooks/DonationFormBlockRender.php
@@ -1,0 +1,31 @@
+<?php
+namespace Give\EventTickets\Hooks;
+
+use Give\EventTickets\Actions\ConvertEventTicketsBlockToFieldsApi;
+use Give\EventTickets\Fields\EventTickets;
+use Give\Framework\Blocks\BlockModel;
+use Give\Framework\FieldsAPI\Contracts\Node;
+use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
+
+/**
+ * Class DonationFormBlockRender
+ *
+ * @unreleased
+ */
+class DonationFormBlockRender
+{
+    /**
+     * Renders the EventTickets field for the donation form block.
+     *
+     * @param Node|null $node The node instance.
+     * @param BlockModel $block The block model instance.
+     * @param int $blockIndex The index of the block.
+     *
+     * @return EventTickets The EventTickets field instance.
+     * @throws EmptyNameException
+     */
+    public function __invoke($node, BlockModel $block, int $blockIndex, int $formId): EventTickets
+    {
+        return (give(ConvertEventTicketsBlockToFieldsApi::class))($block, $formId);
+    }
+}

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -2,12 +2,13 @@
 
 namespace Give\EventTickets;
 
-use Give\Framework\Migrations\MigrationsRegister;
-use Give\Helpers\Hooks;
-use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give\EventTickets\Hooks\DonationFormBlockRender;
 use Give\EventTickets\Repositories\EventRepository;
 use Give\EventTickets\Repositories\EventTicketRepository;
 use Give\EventTickets\Repositories\EventTicketTypeRepository;
+use Give\Framework\Migrations\MigrationsRegister;
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
 /**
  * @unreleased
@@ -44,6 +45,13 @@ class ServiceProvider implements ServiceProviderInterface
 
         Hooks::addAction('givewp_form_builder_enqueue_scripts', Actions\EnqueueFormBuilderScripts::class);
         Hooks::addAction('givewp_donation_form_enqueue_scripts', Actions\EnqueueDonationFormScripts::class);
+        Hooks::addFilter(
+            'givewp_donation_form_block_render_givewp/event-tickets',
+            DonationFormBlockRender::class,
+            '__invoke',
+            10,
+            4
+        );
 
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');


### PR DESCRIPTION
## Description

This pull-request adds a initial structure for the EventTickets Field and a converter with hardcoded values, allowing us to start testing the field template and how it integrates with the donation form.

## Testing Instructions
Use the following snippet to programmatically add a EventTickets field to the form.
```php
add_action('givewp_donation_form_schema', static function (DonationForm $form) {
	$field = \Give\EventTickets\Fields\EventTickets::make('event_tickets');

	$form->insertAfter('email', $field);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

