### PR TITLE
Handle the Stripe connect redirect on specific pages

### DIFF
--- a/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
+++ b/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
@@ -162,7 +162,7 @@ class NewStripeAccountOnBoardingController
      *
      * @unreleased
      */
-    protected function canProcessRequestOnCurrentPage($url): bool
+    protected function canProcessRequestOnCurrentPage(string $url): bool
     {
         // Check if request is from edit.php or post.php page.
         if (false === strpos($url, 'wp-admin/post.php') && false === strpos($url, 'wp-admin/edit.php')) {

--- a/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
+++ b/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
@@ -30,11 +30,24 @@ class NewStripeAccountOnBoardingController
     }
 
     /**
+     * @unreleased Handle Stripe connect account on-boarding redirect on specific pages.
+     *             Admin redirect to following page:
+     *             1. GiveWP stripe settings page.
+     *             2. Legacy donation form edit form.
      * @since 2.13.0
      */
     public function __invoke()
     {
         if (!current_user_can('manage_give_settings')) {
+            return;
+        }
+
+        $isDonationFormPage = isset($_GET['give_tab']) && $_GET['give_tab'] !== 'stripe_form_account_options';
+        $isSettingPage = isset($_GET['tab'], $_GET['tab'])
+                         && Give_Admin_Settings::is_setting_page('gateways', 'stripe-settings');
+
+        // Exit if admin is not redirect to the GiveWP settings page or donation form page.
+        if (! $isDonationFormPage && ! $isSettingPage) {
             return;
         }
 

--- a/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
+++ b/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
@@ -33,7 +33,7 @@ class NewStripeAccountOnBoardingController
      * @unreleased Handle Stripe connect account on-boarding redirect on specific pages.
      *             Admin redirect to following page:
      *             1. GiveWP stripe settings page.
-     *             2. Legacy donation form edit form.
+     *             2. V2 donation form edit form.
      * @since 2.13.0
      */
     public function __invoke()

--- a/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
+++ b/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
@@ -42,8 +42,12 @@ class NewStripeAccountOnBoardingController
             return;
         }
 
-        $isDonationFormPage = isset($_GET['give_tab']) && $_GET['give_tab'] !== 'stripe_form_account_options';
-        $isSettingPage = isset($_GET['tab'], $_GET['tab'])
+        $isDonationFormPage = isset($_GET['give_tab'], $_GET['post_type'])
+                              && $_GET['post_type'] === 'give_forms'
+                              && $_GET['give_tab'] !== 'stripe_form_account_options';
+        $isSettingPage = isset($_GET['post_type'], $_GET['page'], $_GET['tab'], $_GET['section'])
+                         && $_GET['post_type'] === 'give_forms'
+                         && $_GET['page'] === 'give-settings'
                          && Give_Admin_Settings::is_setting_page('gateways', 'stripe-settings');
 
         // Exit if admin is not redirect to the GiveWP settings page or donation form page.

--- a/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
+++ b/src/PaymentGateways/Stripe/Controllers/NewStripeAccountOnBoardingController.php
@@ -168,8 +168,7 @@ class NewStripeAccountOnBoardingController
         $isDonationFormPage = isset($_GET['give_tab'], $_GET['post_type'])
                               && $_GET['post_type'] === 'give_forms'
                               && $_GET['give_tab'] !== 'stripe_form_account_options';
-        $isSettingPage = isset($_GET['post_type'], $_GET['page'], $_GET['tab'], $_GET['section'])
-                         && $_GET['post_type'] === 'give_forms'
+        $isSettingPage = isset($_GET['page'], $_GET['tab'], $_GET['section'])
                          && $_GET['page'] === 'give-settings'
                          && Give_Admin_Settings::is_setting_page('gateways', 'stripe-settings');
 

--- a/tests/Feature/Controllers/NewStripeAccountOnBoardingControllerTest.php
+++ b/tests/Feature/Controllers/NewStripeAccountOnBoardingControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Give\Tests\Feature\Controllers;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Models\Donation;
+use Give\PaymentGateways\Stripe\Controllers\NewStripeAccountOnBoardingController;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class NewStripeAccountOnBoardingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var NewStripeAccountOnBoardingController
+     */
+    private $newStripeAccountOnBoardingController;
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->newStripeAccountOnBoardingController = give(NewStripeAccountOnBoardingController::class);
+        $this->canProcessRequestOnCurrentPageMethod = (new \ReflectionObject(
+            $this->newStripeAccountOnBoardingController
+        ))->getMethod('canProcessRequestOnCurrentPage');
+        $this->canProcessRequestOnCurrentPageMethod->setAccessible(true);
+    }
+
+    public function testShouldReturnTrueForV2DonationFomEditPage(): void
+    {
+        /** @var DonationForm $form */
+        $form = DonationForm::factory()->create();
+        $url = "wp-admin/post.php?post=$form->id&action=edit&give_tab=stripe_form_account_options";
+        $result = $this->canProcessRequestOnCurrentPageMethod->invokeArgs(
+            $this->newStripeAccountOnBoardingController,
+            [$url]
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testShouldReturnTrueGlobalStripeSettingPage(): void
+    {
+        $url = 'wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=stripe-settings';
+        $result = $this->canProcessRequestOnCurrentPageMethod->invokeArgs(
+            $this->newStripeAccountOnBoardingController,
+            [$url]
+        );
+        $this->assertTrue($result);
+    }
+
+    public function testShouldReturnFalseOtherPage(): void
+    {
+        $url = 'wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=paypal-settings';
+        $result = $this->canProcessRequestOnCurrentPageMethod->invokeArgs(
+            $this->newStripeAccountOnBoardingController,
+            [$url]
+        );
+        $this->assertFalse($result);
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+        $url = "wp-admin/post.php?post=$donation->id&action=edit&give_tab=stripe_form_account_options";
+        $result = $this->canProcessRequestOnCurrentPageMethod->invokeArgs(
+            $this->newStripeAccountOnBoardingController,
+            [$url]
+        );
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
Based on the query param, we are handling the Stripe redirect from the connect gateway server. We should limit handling to specific pages to prevent conflict.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] Admin should be able to connect the Stripe account from the Stripe setting page.
- [ ] Admin should be able to connect the Stripe account from the v2 donation edit page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

