### PR TITLE
Feature: Add eager loading of related models

### DIFF
--- a/src/Framework/Models/EagerLoader.php
+++ b/src/Framework/Models/EagerLoader.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Give\Framework\Models;
+
+use ReflectionClass;
+
+/**
+ * @unreleased
+ */
+class EagerLoader
+{
+    /**
+     * @unreleased
+     * @var string
+     */
+    protected $modelClass;
+
+    /**
+     * @unreleased
+     * @var string
+     */
+    protected $relationshipKey;
+
+    /**
+     * @unreleased
+     * @var ModelQueryBuilder
+     */
+    protected $modelQuery;
+
+    /**
+     * @unreleased
+     * @var ModelQueryBuilder
+     */
+    protected $eagerLoadedQuery;
+
+    /**
+     * @unreleased
+     * @var string
+     */
+    protected $foreignKey;
+
+    /**
+     * @var mixed
+     */
+    protected $foreignAttribute;
+
+    public function __construct($modelClass, $relationshipKey, $eagerLoadedModelClass, $foreignKey, $foreignAttribute = null)
+    {
+        $this->modelClass = $modelClass;
+        $this->modelQuery = $modelClass::query();
+        $this->relationshipKey = $relationshipKey;
+        $this->eagerLoadedQuery = $eagerLoadedModelClass::query();
+        $this->foreignKey = $foreignKey;
+        $this->foreignAttribute = $foreignAttribute ?? $foreignKey;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __call($name, $arguments)
+    {
+        $this->modelQuery->$name(...$arguments);
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     *
+     * This method wraps the `get()` method of the underlying ModelQueryBuilder.
+     * It uses the results to query the related models and pre-set the cachedRelations property.
+     */
+    public function get()
+    {
+        $model = $this->modelQuery->get();
+
+        $eagerLoadedModels = $this->eagerLoadedQuery
+            ->where($this->foreignKey, $model->id)
+            ->getAll();
+
+        $this->setEagerLoadedModels($model, $eagerLoadedModels);
+
+        return $model;
+    }
+
+    /**
+     * @unreleased
+     *
+     * This method wraps the `getAll()` method of the underlying ModelQueryBuilder.
+     * It uses the results to query the related models and pre-set the cachedRelations property.
+     */
+    public function getAll()
+    {
+        $models = $this->modelQuery->getAll();
+
+        $eagerLoadedModels = $this->eagerLoadedQuery
+            ->whereIn($this->foreignKey, array_column($models, 'id'))
+            ->getAll();
+
+        foreach($models as $model) {
+            $this->setEagerLoadedModels($model, array_filter($eagerLoadedModels, function($eagerLoadedModel) use ($model) {
+                return $eagerLoadedModel->{$this->foreignAttribute} === $model->id;
+            }));
+        }
+
+        return $models;
+    }
+
+    /**
+     * @unreleased
+     *
+     * The cachedRelations property is protected and cannot be accessed directly.
+     * This method uses reflection to set the cachedRelations property on the model.
+     */
+    protected function setEagerLoadedModels($model, $eagerLoadedModels): void
+    {
+        $modelClassReflection = new ReflectionClass($this->modelClass);
+        $cachedRelationsReflection = $modelClassReflection
+            ->getParentClass()
+            ->getProperty('cachedRelations');
+        $cachedRelationsReflection->setAccessible(true);
+
+        $cachedRelations = $cachedRelationsReflection->getValue($model);
+        $cachedRelations[$this->relationshipKey] = $eagerLoadedModels;
+
+        $cachedRelationsReflection->setValue($model, $cachedRelations);
+    }
+}

--- a/src/Framework/Models/EagerLoader.php
+++ b/src/Framework/Models/EagerLoader.php
@@ -2,24 +2,27 @@
 
 namespace Give\Framework\Models;
 
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use ReflectionClass;
 
 /**
+ * Eager load model relationships for more performant queries.
+ *
+ * As opposed to "lazy" loading, which queries the database for a relationship when it is accessed,
+ * "eager" loading queries the database for the relationship of all queried models, with a single query.
+ * This prevents a "N+1" problem, where a query is executed for each model, but using query optimization.
+ *
  * @unreleased
+ *
+ * @template M
  */
 class EagerLoader
 {
     /**
      * @unreleased
-     * @var string
+     * @var ReflectionClass<M>
      */
-    protected $modelClass;
-
-    /**
-     * @unreleased
-     * @var string
-     */
-    protected $relationshipKey;
+    protected $reflection;
 
     /**
      * @unreleased
@@ -37,6 +40,12 @@ class EagerLoader
      * @unreleased
      * @var string
      */
+    protected $relationshipKey;
+
+    /**
+     * @unreleased
+     * @var string
+     */
     protected $foreignKey;
 
     /**
@@ -44,9 +53,26 @@ class EagerLoader
      */
     protected $foreignAttribute;
 
-    public function __construct($modelClass, $relationshipKey, $eagerLoadedModelClass, $foreignKey, $foreignAttribute = null)
+    /**
+     * @unreleased
+     *
+     * @param class-string<M> $modelClass
+     * @param class-string<M> $eagerLoadedModelClass
+     * @param string $relationshipKey
+     * @param string $foreignKey
+     * @param string|null $foreignAttribute
+     */
+    public function __construct(string $modelClass, string $eagerLoadedModelClass, string $relationshipKey, string $foreignKey, string $foreignAttribute = null)
     {
-        $this->modelClass = $modelClass;
+        if (!is_subclass_of($modelClass, Model::class)) {
+            throw new InvalidArgumentException("$modelClass must be an instance of " . Model::class);
+        }
+
+        if (!is_subclass_of($eagerLoadedModelClass, Model::class)) {
+            throw new InvalidArgumentException("$eagerLoadedModelClass must be an instance of " . Model::class);
+        }
+
+        $this->reflection = new ReflectionClass($modelClass);
         $this->modelQuery = $modelClass::query();
         $this->relationshipKey = $relationshipKey;
         $this->eagerLoadedQuery = $eagerLoadedModelClass::query();
@@ -64,10 +90,12 @@ class EagerLoader
     }
 
     /**
-     * @unreleased
-     *
      * This method wraps the `get()` method of the underlying ModelQueryBuilder.
      * It uses the results to query the related models and pre-set the cachedRelations property.
+     *
+     * @unreleased
+     *
+     * @return M|null
      */
     public function get()
     {
@@ -83,10 +111,12 @@ class EagerLoader
     }
 
     /**
-     * @unreleased
-     *
      * This method wraps the `getAll()` method of the underlying ModelQueryBuilder.
      * It uses the results to query the related models and pre-set the cachedRelations property.
+     *
+     * @unreleased
+     *
+     * @return M[]|null
      */
     public function getAll()
     {
@@ -106,22 +136,24 @@ class EagerLoader
     }
 
     /**
-     * @unreleased
-     *
      * The cachedRelations property is protected and cannot be accessed directly.
      * This method uses reflection to set the cachedRelations property on the model.
+     *
+     * @unreleased
+     *
+     * @param Model $model
+     * @param array $eagerLoadedModels
      */
-    protected function setEagerLoadedModels($model, $eagerLoadedModels): void
+    protected function setEagerLoadedModels(Model $model, array $eagerLoadedModels): void
     {
-        $modelClassReflection = new ReflectionClass($this->modelClass);
-        $cachedRelationsReflection = $modelClassReflection
+        $property = $this->reflection
             ->getParentClass()
             ->getProperty('cachedRelations');
-        $cachedRelationsReflection->setAccessible(true);
+        $property->setAccessible(true);
 
-        $cachedRelations = $cachedRelationsReflection->getValue($model);
+        $cachedRelations = $property->getValue($model);
         $cachedRelations[$this->relationshipKey] = $eagerLoadedModels;
 
-        $cachedRelationsReflection->setValue($model, $cachedRelations);
+        $property->setValue($model, $cachedRelations);
     }
 }

--- a/tests/Unit/Framework/Models/TestEagerLoader.php
+++ b/tests/Unit/Framework/Models/TestEagerLoader.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Give\Tests\Unit\Framework\Models;
+
+use Give\Donors\Models\Donor;
+use Give\Framework\Models\EagerLoader;
+use Give\Subscriptions\Models\Subscription;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ */
+class TestEagerLoader extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp()
+    {
+        define('SAVEQUERIES', true);
+        parent::setUp();
+    }
+
+    public function testRelatedModelsAreEagerLoaded()
+    {
+        $this->refreshDatabase(); // Clear out any existing donors.
+
+        Subscription::factory()->create(); // Also creates an associated donor.
+        Subscription::factory()->create(); // Also creates an associated donor.
+
+        /**
+         * 4 queries are expected:
+         * 1. To get the donors
+         * 2. To get the donors additional emails
+         * 3. To get the first donor's subscriptions
+         * 4. To get the second donor's subscriptions
+         */
+        $this->assertQueryCount(4, function() {
+            foreach(Donor::query()->getAll() as $donor) {
+                $donor->subscriptions;
+            }
+        });
+
+        /**
+         * 3 queries are expected:
+         * 1. To get the donors
+         * 2. To get the donors additional emails
+         * 3. To get the subscriptions
+         */
+        $this->assertQueryCount(3, function() {
+            $eagerLoaderQuery = new EagerLoader(Donor::class, 'subscriptions', Subscription::class, 'customer_id', 'donorId');
+            $eagerLoaderQuery->getAll();
+        });
+    }
+
+    protected function assertQueryCount($expected, $callback)
+    {
+        global $wpdb;
+        $wpdb->queries = []; // Reset tracked queries.
+        $callback();
+        $this->assertEquals($expected, count($wpdb->queries));
+    }
+}

--- a/tests/Unit/Framework/Models/TestEagerLoader.php
+++ b/tests/Unit/Framework/Models/TestEagerLoader.php
@@ -48,7 +48,7 @@ class TestEagerLoader extends TestCase
          * 3. To get the subscriptions
          */
         $this->assertQueryCount(3, function() {
-            $eagerLoaderQuery = new EagerLoader(Donor::class, 'subscriptions', Subscription::class, 'customer_id', 'donorId');
+            $eagerLoaderQuery = new EagerLoader(Donor::class, Subscription::class, 'subscriptions', 'customer_id', 'donorId');
             $eagerLoaderQuery->getAll();
         });
     }


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR introduces a Eager Loader to support loading a models relationship with a single additional query (as opposed to an additional query per model).

Example:

```php
// Given 1 event this runs 2 queries.
// Given 10 events this runs 11 queries.
// Given 100 events this runs 101 queries.
$events = Event::query()->getAll();
foreach($events as $event);
    $events->tickets; // Additional query for each event
}
```

```php
// Given 1 events this runs 2 queries.
// Given 10 events this runs 2 queries
// Given 100 events  this runs 2 queries.
$events = Event::withTickets()->getAll();
foreach($events as $event);
    $events->tickets; // No additional query - already cached
}
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The existing `ModelQueryBuilder` is not affected. Instead the `EagerLoader` class decorates the underlying query builder instance.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```php
class Event extends Model
{
    protected $relationships = [
        'tickets' => Relationship::HAS_MANY,
    ];

    public static function withTickets()
    {
        return new EagerLoader(self::class, 'tickets', Ticket::class, 'event_id');
    }
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Add a `with*()` method to a Model class and query the model with an eager loaded relationship.