### PR TITLE
Fix: prevent generic block attributes from overriding intentional required rule

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.4.0
+ * Version: 3.4.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -403,7 +403,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.4.0');
+            define('GIVE_VERSION', '3.4.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.4.1: February 13th, 2024 =
+* Fix: Resolved an issue with the default email block that ensures it is always a required field in the donation form. 
+
 = 3.4.0: February 8th, 2024 =
 * Fix: Resolved several issues with the billing address block including dynamically requiring certain fields and allowing state/county field input
 * Fix: Resolved an issue with multi step form layout where the title was missing on the first step when show header was disabled

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -102,7 +102,6 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @unlreased add `givewp_donation_form_block_converted_to_node` action hook
      * @since 3.0.0
      *
      * @return Node|null

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -367,7 +367,7 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
-     * @unreleased updated to be field specific and prevent overwriting of existing values
+     * @since 3.4.1 updated to be field specific and prevent overwriting of existing values
      * @since 3.0.0
      */
     protected function mapGenericBlockAttributesToField(BlockModel $block, Field $field): Node

--- a/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationFormBlocksToFieldsApi.php
@@ -21,6 +21,7 @@ use Give\Framework\FieldsAPI\Email;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
 use Give\Framework\FieldsAPI\Exceptions\NameCollisionException;
 use Give\Framework\FieldsAPI\Exceptions\TypeNotSupported;
+use Give\Framework\FieldsAPI\Field;
 use Give\Framework\FieldsAPI\Name;
 use Give\Framework\FieldsAPI\Paragraph;
 use Give\Framework\FieldsAPI\PaymentGateways;
@@ -43,14 +44,14 @@ class ConvertDonationFormBlocksToFieldsApi
      */
     protected $currency;
     /**
-     * @var array {blockClientId: {node: Node, block: BlockModel}}
+     * @var array{blockClientId: {node: Node, block: BlockModel}}
      */
     protected $blockNodeRelationships = [];
 
     /**
      * @since 3.0.0
      *
-     * @return array {DonationForm, array {blockClientId: {node: Node, block: BlockModel}}}
+     * @return array{form: DonationForm, array{clientId: string{node: Node, block: BlockModel}}}
      * @throws TypeNotSupported|NameCollisionException
      */
     public function __invoke(BlockCollection $blocks, int $formId): array
@@ -112,15 +113,17 @@ class ConvertDonationFormBlocksToFieldsApi
     {
         $node = $this->createNodeFromBlockWithUniqueAttributes($block, $blockIndex);
 
-        if ($node instanceof Node) {
-            $node = $this->mapGenericBlockAttributesToNode($block, $node);
-
-            $this->mapBlockToNodeRelationships($block, $node);
-
-            return $node;
+        if (!$node instanceof Node) {
+            return null;
         }
 
-        return null;
+        if ($node instanceof Field) {
+            $node = $this->mapGenericBlockAttributesToField($block, $node);
+        }
+
+         $this->mapBlockToNodeRelationships($block, $node);
+
+        return $node;
     }
 
     /**
@@ -365,36 +368,35 @@ class ConvertDonationFormBlocksToFieldsApi
     }
 
     /**
+     * @unreleased updated to be field specific and prevent overwriting of existing values
      * @since 3.0.0
      */
-    protected function mapGenericBlockAttributesToNode(BlockModel $block, Node $node): Node
+    protected function mapGenericBlockAttributesToField(BlockModel $block, Field $field): Node
     {
-        if ('field' === $node->getNodeType()) {
-            // Label
-            if ($block->hasAttribute('label')) {
-                $node->label($block->getAttribute('label'));
-            }
-
-            // Placeholder
-            if ($block->hasAttribute('placeholder')) {
-                $node->placeholder($block->getAttribute('placeholder'));
-            }
-
-            // Required
-            if ($block->hasAttribute('isRequired')) {
-                $node->required($block->getAttribute('isRequired'));
-            }
-
-            if ($block->hasAttribute('displayInAdmin') && $block->getAttribute('displayInAdmin')) {
-                $node->showInAdmin($block->getAttribute('displayInAdmin'));
-            }
-
-            if ($block->hasAttribute('displayInReceipt') && $block->getAttribute('displayInReceipt')) {
-                $node->showInReceipt($block->getAttribute('displayInReceipt'));
-            }
+        // Label
+        if ($block->hasAttribute('label') && method_exists($field, 'label')) {
+            $field->label($block->getAttribute('label'));
         }
 
-        return $node;
+        // Placeholder
+        if ($block->hasAttribute('placeholder') && method_exists($field, 'placeholder')) {
+            $field->placeholder($block->getAttribute('placeholder'));
+        }
+
+        // Required
+        if ($block->hasAttribute('isRequired') && method_exists($field, 'required') && !$field->isRequired()) {
+            $field->required($block->getAttribute('isRequired'));
+        }
+
+        if ($block->hasAttribute('displayInAdmin') && $block->getAttribute('displayInAdmin')) {
+            $field->showInAdmin($block->getAttribute('displayInAdmin'));
+        }
+
+        if ($block->hasAttribute('displayInReceipt') && $block->getAttribute('displayInReceipt')) {
+            $field->showInReceipt($block->getAttribute('displayInReceipt'));
+        }
+
+        return $field;
     }
 
     /**

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
@@ -7,7 +7,7 @@ import {Path, SVG} from '@wordpress/components';
 import {BlockEditProps} from '@wordpress/blocks';
 
 /**
- * @unreleased updated default required attribute to be true on block and edit component
+ * @since 3.4.1 updated default required attribute to be true on block and edit component
  * @since 3.0.0
  */
 const settings: FieldBlock['settings'] = {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/email/settings.tsx
@@ -4,7 +4,12 @@ import defaultSettings from '../settings';
 import FieldSettings from '@givewp/form-builder/blocks/fields/settings/Edit';
 import {FieldBlock} from '@givewp/form-builder/types';
 import {Path, SVG} from '@wordpress/components';
+import {BlockEditProps} from '@wordpress/blocks';
 
+/**
+ * @unreleased updated default required attribute to be true on block and edit component
+ * @since 3.0.0
+ */
 const settings: FieldBlock['settings'] = {
     ...defaultSettings,
     title: __('Email', 'give'),
@@ -16,6 +21,11 @@ const settings: FieldBlock['settings'] = {
         ...defaultSettings.attributes,
         label: {
             default: __('Email Address'),
+        },
+        isRequired: {
+            type: 'boolean',
+            source: 'attribute',
+            default: true,
         },
     },
     icon: () => (
@@ -31,7 +41,7 @@ const settings: FieldBlock['settings'] = {
         />
     ),
 
-    edit: (props) => <FieldSettings showRequired={false} {...props} />,
+    edit: (props: BlockEditProps<any>) => <FieldSettings showRequired={false} {...props} attributes={{...props.attributes, isRequired: true}} />,
 };
 
 export default settings;

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationFormBlocksToFieldsApi.php
@@ -156,7 +156,7 @@ final class TestConvertDonationFormBlocksToFieldsApi extends TestCase
                     'isValid' => true,
                     'attributes' => [
                         'label' => 'GiveWP Custom Block',
-                        'required' => false,
+                        'isRequired' => false,
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-330]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The mapping of generic block attributes was overriding the intentional use of the core email required rule.  This guided me toward making sure if a field is specifying a required rule up front, we do not want to let the generic attributes override them. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The core email field (always visually & functionally required now)
- Minor updates to the block conversation process as it relates to mapping generic block attributes

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="889" alt="Screenshot 2024-02-13 at 10 20 16 AM" src="https://github.com/impress-org/givewp/assets/10138447/eff9ec43-58a8-489a-bd9c-0c6343d9e54e">


<img width="760" alt="Screenshot 2024-02-13 at 10 20 01 AM" src="https://github.com/impress-org/givewp/assets/10138447/eff231b3-ceeb-4faa-ba81-a154470bbc21">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/7890132090

- Create a v3 form
- Remove the default email block
- Add a new core email block
- Make sure it appears to be required
- Publish form and test it out to make sure its required.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-330]: https://stellarwp.atlassian.net/browse/GIVE-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ