### PR TITLE
Fix: gift aid step should exclude long text heading in favor of modal header

### DIFF
--- a/src/FormMigration/Steps/GiftAid.php
+++ b/src/FormMigration/Steps/GiftAid.php
@@ -32,7 +32,7 @@ class GiftAid extends FormMigrationStep
             'longExplanationEnabled' => $this->formV2->getGiftAidLongExplanationEnabled(),
             'linkText' => __('Tell me more', 'give-gift-aid'),
             'modalHeader' => __('What is Gift Aid?', 'give-gift-aid'),
-            'longExplanation' => $this->formV2->getGiftAidLongExplanation(),
+            'longExplanation' => str_replace(__('What is Gift Aid?', 'give-gift-aid'), '', $this->formV2->getGiftAidLongExplanation()),
             'checkboxLabel' => $this->formV2->getGiftAidCheckboxLabel(),
             'agreementText' => $this->formV2->getGiftAidAgreementText(),
             'declarationForm' => $this->formV2->getGiftAidDeclarationForm(),
@@ -42,6 +42,7 @@ class GiftAid extends FormMigrationStep
             'name' => 'givewp-gift-aid/gift-aid',
             'attributes' => $giftAidSettings,
         ]);
+
         $this->fieldBlocks->insertAfter('givewp/donation-amount', $giftAidBlock);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

When migrating forms with gift aid, we need to modify the existing long text if it has the same heading as the modal header

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

