### PR TITLE
Refactor: remove ticket close date prop from Event

### DIFF
--- a/src/EventTickets/Factories/EventFactory.php
+++ b/src/EventTickets/Factories/EventFactory.php
@@ -19,7 +19,6 @@ class EventFactory extends ModelFactory
             'description' => $this->faker->paragraph(),
             'startDateTime' => $startDateTime,
             'endDateTime' => $startDateTime->modify('+1 hour'),
-            'ticketCloseDateTime' => null,
             'createdAt' => new DateTime(),
             'updatedAt' => new DateTime(),
         ];

--- a/src/EventTickets/Migrations/CreateEventsTable.php
+++ b/src/EventTickets/Migrations/CreateEventsTable.php
@@ -45,7 +45,6 @@ class CreateEventsTable extends Migration {
 			description TEXT NULL,
 			start_datetime DATETIME NULL,
 			end_datetime DATETIME NULL,
-			ticket_close_datetime DATETIME NULL,
             created_at DATETIME NOT NULL,
 			updated_at DATETIME NOT NULL,
 			PRIMARY KEY  (id)

--- a/src/EventTickets/Models/Event.php
+++ b/src/EventTickets/Models/Event.php
@@ -29,7 +29,6 @@ class Event extends Model implements ModelCrud /*, ModelHasFactory */
         'description' => 'string',
         'startDateTime' => DateTime::class,
         'endDateTime' => DateTime::class,
-        'ticketCloseDateTime' => DateTime::class,
         'createdAt' => DateTime::class,
         'updatedAt' => DateTime::class,
     ];
@@ -136,9 +135,6 @@ class Event extends Model implements ModelCrud /*, ModelHasFactory */
             'description' => (string)$object->description,
             'startDateTime' => $object->start_datetime ? Temporal::toDateTime($object->start_datetime) : null,
             'endDateTime' => $object->end_datetime ? Temporal::toDateTime($object->end_datetime) : null,
-            'ticketCloseDateTime' => $object->ticket_close_datetime ? Temporal::toDateTime(
-                $object->ticket_close_datetime
-            ) : null,
             'createdAt' => Temporal::toDateTime($object->created_at),
             'updatedAt' => Temporal::toDateTime($object->updated_at),
         ]);

--- a/src/EventTickets/Repositories/EventRepository.php
+++ b/src/EventTickets/Repositories/EventRepository.php
@@ -59,9 +59,6 @@ class EventRepository
                     'description' => $event->description,
                     'start_datetime' => $event->startDateTime->format('Y-m-d H:i:s'),
                     'end_datetime' => $event->endDateTime ? $event->endDateTime->format('Y-m-d H:i:s') : null,
-                    'ticket_close_datetime' => $event->ticketCloseDateTime ? $event->ticketCloseDateTime->format(
-                        'Y-m-d H:i:s'
-                    ) : null,
                     'created_at' => $createdDateTime->format('Y-m-d H:i:s'),
                     'updated_at' => $createdDateTime->format('Y-m-d H:i:s'),
                 ]);
@@ -184,7 +181,6 @@ class EventRepository
                 'description',
                 'start_datetime',
                 'end_datetime',
-                'ticket_close_datetime',
                 'created_at',
                 'updated_at'
             );


### PR DESCRIPTION
## Description

This pull-request removes the `ticket_close_datetime` column from Events. In the future, event availability may be controlled at the Ticket Type level. An event with no tickets available will be presented as *Sold Out*;

## Affects

Events

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

