### PR TITLE
Feature: add `HeaderImage` to multistep template

### DIFF
--- a/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
+++ b/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_header.scss
@@ -6,11 +6,9 @@
 
     &-headerTitle {
         margin-bottom: var(--givewp-spacing-3);
-        color: var(--givewp-grey-900);
     }
 
     &-headerDescription {
         margin-bottom: var(--givewp-spacing-10);
-        color: var(--givewp-grey-700);
     }
 }

--- a/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
@@ -1,14 +1,79 @@
 import type {HeaderProps} from '@givewp/forms/propTypes';
 
 /**
+ * @unreleased add HeaderImage
  * @since 3.0.0
  */
 export default function Header({HeaderImage, Title, Description, Goal}: HeaderProps) {
+    const {designSettingsImageStyle, designSettingsImageUrl} = window.givewp.form.hooks.useDonationFormSettings();
+
+    if (!designSettingsImageUrl) {
+        return (
+            <div className={`givewp-layouts-header__templates-ms`}>
+                <Title />
+                <Description />
+                <Goal />
+            </div>
+        );
+    }
+
     return (
-        <>
-            <Title />
-            <Description />
-            <Goal />
-        </>
+        <div
+            className={`givewp-layouts-header__templates-ms givewp-layouts-header__templates-ms--${designSettingsImageStyle}`}
+        >
+            <HeaderImageTemplates
+                imagePosition={designSettingsImageStyle}
+                HeaderImage={HeaderImage}
+                Title={Title}
+                Description={Description}
+                Goal={Goal}
+            />
+        </div>
     );
+}
+
+function HeaderImageTemplates({imagePosition, HeaderImage, Title, Description, Goal}) {
+    switch (imagePosition) {
+        case 'background':
+            return (
+                <>
+                    <div className={'givewp-layouts-header__content'}>
+                        <HeaderImage />
+                        <Title />
+                        <Description />
+                    </div>
+                    <div className={'givewp-layouts-header__goal'}>
+                        <Goal />
+                    </div>
+                </>
+            );
+        case 'above':
+            return (
+                <>
+                    <HeaderImage />
+                    <div className={'givewp-layouts-header__content'}>
+                        <Title />
+                        <Description />
+                        <Goal />
+                    </div>
+                </>
+            );
+        case 'center':
+            return (
+                <>
+                    <Title />
+                    <Description />
+                    <HeaderImage />
+                    <Goal />
+                </>
+            );
+        default:
+            return (
+                <>
+                    <Title />
+                    <Description />
+                    <Goal />
+                </>
+            );
+    }
 }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -119,6 +119,12 @@
         margin: 0 auto;
     }
 
+    .givewp-layouts-multiStepForm__form {
+        .givewp-donation-form__steps-button-next {
+            width: 100%;
+        }
+    }
+
     .givewp-layouts-headerTitle {
         color: var(--givewp-grey-900);
     }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -1,3 +1,4 @@
+/* Classic */
 .givewp-donation-form {
     .givewp-layouts {
         &-header {
@@ -104,3 +105,108 @@
         }
     }
 }
+
+/* Multi Step */
+.givewp-donation-form__steps-body {
+    padding: 0;
+
+    .givewp-layouts-multiStepForm, .givewp-layouts-header__templates-ms {
+        padding: 2rem 2rem 0 2rem;
+    }
+
+    .givewp-donation-form__steps-button-next {
+        width: calc(100% - 4rem);
+        margin: 0 auto;
+    }
+
+    .givewp-layouts-headerTitle {
+        color: var(--givewp-grey-900);
+    }
+
+    .givewp-layouts-headerDescription {
+        color: var(--givewp-grey-700);
+    }
+
+    .givewp-layouts-header__templates-ms {
+        .givewp-layouts-headerImage {
+            width: 100%;
+
+            img {
+                object-fit: cover;
+                min-width: 100%;
+                border-top-left-radius: 0.5rem;
+                border-top-right-radius: 0.5rem;
+            }
+        }
+
+
+        &--background {
+            padding: 0;
+
+            .givewp-layouts-header {
+                &__content {
+                    position: relative;
+                    padding: 2rem 2rem .5rem 2rem;
+                    margin-bottom: var(--givewp-spacing-4);
+
+                    .givewp-layouts-headerTitle h2, .givewp-layouts-headerDescription p {
+                        color: var(--givewp-shades-white);
+                    }
+
+                }
+
+                &__goal {
+                    padding: 0 2rem;
+                }
+            }
+
+
+            div:not(.givewp-layouts-headerImage), aside {
+                position: relative;
+                z-index: 999;
+            }
+
+            .givewp-layouts-headerImage {
+
+                img {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    height: 100%;
+                }
+            }
+        }
+
+        &--above {
+            padding: 0;
+
+            .givewp-layouts-header__content {
+                padding: 0 2rem;
+            }
+
+            .givewp-layouts-headerImage {
+                margin-bottom: var(--givewp-spacing-6);
+
+                img {
+                    height: 320px;
+                }
+            }
+        }
+
+        &--center {
+            padding: 2rem 2rem 0 2rem;
+
+            .givewp-layouts-headerImage {
+                img {
+                    border-radius: var(--givewp-rounded-4);
+
+                }
+            }
+
+            .givewp-layouts-goal {
+                margin-top: var(--givewp-spacing-1);
+            }
+        }
+    }
+}
+

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/index.tsx
@@ -34,8 +34,8 @@ export default function GeneralControls() {
                 formDesigns={formDesigns}
                 designId={designId}
             />
-            {design?.isMultiStep && <MultiStep dispatch={dispatch} publishSettings={publishSettings} />}
             <Header dispatch={dispatch} publishSettings={publishSettings} />
+            {design?.isMultiStep && <MultiStep dispatch={dispatch} publishSettings={publishSettings} />}
             <DonationGoal dispatch={dispatch} />
             {!design?.isMultiStep && <DonateButton dispatch={dispatch} publishSettings={publishSettings} />}
         </DesignSettings>

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/multi-step/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/multi-step/index.tsx
@@ -36,7 +36,7 @@ export default function MultiStep({dispatch, publishSettings}) {
             </PanelRow>
             <PanelRow>
                 <TextControl
-                    label={__('Button caption', 'give')}
+                    label={__('Donate Button', 'give')}
                     value={donateButtonCaption}
                     onChange={(donateButtonCaption) => {
                         dispatch(


### PR DESCRIPTION
## Description

This PR reintroduces the HeaderImage to the visual form builder for the Multistep Header template & moves the Header setting control above the Button control.  

Some of the HeaderImage styles require changes to the title and description color, as well as the padding applied to the header. To accommodate this Ive removed the color from theMultistepFormDesign stylesheet so that It can be updated by the HeaderImage styling. For multistep I removed the padding from `.givewp-donation-form__steps-body` so that the appropriate padding could be applied to each `.givewp-layouts-header__templates-ms` modifier. Because this also removes it from the other steps of the form it has also been reapplied to `.givewp-layouts-multiStepForm`. The Donate button is affected too, so changes were applied to allow it to calculate its width based on missing the padding difference.

The 3 HeaderImage styles:
Background
Center
Above

## Affects
Multistep forms in the visual form builder

## Visuals

https://github.com/impress-org/givewp/assets/75056371/23997c6c-3fc6-4cb4-bd2c-1a6ccf5331e5

## Testing Instructions
- Using the Classic template go to the form builder and add an image.
- Test all 3 styles and test that that the other header settings do not break the layout.
- Delete the image & also try changing the image.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

