### PR TITLE
Display PayPal Donations methods in legacy form template in modal view

### DIFF
--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -36,9 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
            return;
         }
 
-        setRecurringFieldTrackerToReloadPaypalSDK($form);
-        setFormCurrencyTrackerToReloadPaypalSDK($form);
-        setupGatewayLoadEventToRenderPaymentMethods($form);
+        trackDonorActivityToRerenderPaymentMethods($form);
     });
 
     // Attach tracking events to forms displays in modal.
@@ -58,9 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     setupPaymentMethod($form);
                 }
 
-                setRecurringFieldTrackerToReloadPaypalSDK($form);
-                setFormCurrencyTrackerToReloadPaypalSDK($form);
-                setupGatewayLoadEventToRenderPaymentMethods($form);
+                trackDonorActivityToRerenderPaymentMethods($form);
+
                 window.clearInterval(timer);
             }, 100);
         });
@@ -76,6 +73,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
         return false;
     });
+
+    /**
+     * Track donor activity to rerender payment methods.
+     *
+     * @unreleased
+     * @param {Element} $form Form selector.
+     */
+    function trackDonorActivityToRerenderPaymentMethods($form){
+        setRecurringFieldTrackerToReloadPaypalSDK($form);
+        setFormCurrencyTrackerToReloadPaypalSDK($form);
+        setupGatewayLoadEventToRenderPaymentMethods($form);
+    }
 
     /**
      * Setup recurring field tracker to reload paypal sdk.
@@ -138,6 +147,12 @@ document.addEventListener('DOMContentLoaded', () => {
         // Setup payment methods for all forms, except those displays in modal.
         $formWraps.forEach($formWrap => {
             const $form = $formWrap.querySelector('.give-form');
+
+            // If form displays in model do not setup payment methods.
+            // Payment methods will be setup on button click, after form loads in model.
+            if( $formWrap.classList.contains('give-display-button-only') || $formWrap.classList.contains('give-display-modal') ) {
+                return;
+            }
 
             if( $form ) {
                 setup($form);

--- a/assets/src/js/frontend/paypal-commerce/index.js
+++ b/assets/src/js/frontend/paypal-commerce/index.js
@@ -42,14 +42,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Attach tracking events to forms displays in modal.
-    jQuery('.give-form-wrap.give-display-button-only button.give-btn-modal,.give-form-wrap.give-display-modal button.give-btn-modal')
+    jQuery('.give-form-wrap.give-display-button-only button.give-btn-modal, .give-form-wrap.give-display-modal button.give-btn-modal')
         .on('click', function () {
 
             // Wait for modal to open and form to load in modal.
             const timer = window.setInterval(() => {
                 const $form = document.querySelector('.mfp-content form.give-form');
 
-                if ($form) {
+                if (! $form) {
                    return;
                 }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-352]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
This resolves the PayPal Donations and Legacy donation form template modal view compatibility issue.


## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
<img width="1007" alt="image" src="https://github.com/impress-org/givewp/assets/1784821/02d25427-78f0-416b-bd37-8090bdeeb799">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
- [ ] PayPal donations method should render in Legacy donation form template modal view
- [ ] This pull request should not cause a side effect with other donation form templates.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-352]: https://stellarwp.atlassian.net/browse/GIVE-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ