### PR TITLE
Feature: add header image migrations

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -761,4 +761,12 @@ class FormMetaDecorator extends FormModelDecorator
     {
         return $this->getMeta('give_gift_aid_declaration_form');
     }
+
+    /**
+     * @unreleased
+     */
+    public function getFeaturedImage(): string
+    {
+        return wp_get_attachment_image_src($this->getMeta('_thumbnail_id'), 'full')[0] ?? '';
+    }
 }

--- a/src/FormMigration/Steps/FormTemplate/ClassicTemplateSettings.php
+++ b/src/FormMigration/Steps/FormTemplate/ClassicTemplateSettings.php
@@ -54,6 +54,8 @@ class ClassicTemplateSettings extends FormMigrationStep
             ->__invoke(new DesignHeaderSettings($displayHeader, $mainHeading, $description));
 
         $this->formV3->settings->primaryColor = $primaryColor;
+        $this->formV3->settings->designSettingsImageUrl =
+            !empty($headerBackgroundImage) ? $headerBackgroundImage : $this->formV2->getFeaturedImage();
 
         // @note What do we do with `secondaryColor` in v3 (which is not a feature of v2)?
     }

--- a/src/FormMigration/Steps/FormTemplate/LegacyTemplateSettings.php
+++ b/src/FormMigration/Steps/FormTemplate/LegacyTemplateSettings.php
@@ -19,6 +19,7 @@ class LegacyTemplateSettings extends FormMigrationStep
         ] = $this->formV2->getFormTemplateSettings();
 
         $this->displaySettings($displaySettings);
+        $this->formV3->settings->designSettingsImageUrl = $this->formV2->getFeaturedImage();
     }
 
     protected function displaySettings($settings)

--- a/src/FormMigration/Steps/FormTemplate/SequoiaTemplateSettings.php
+++ b/src/FormMigration/Steps/FormTemplate/SequoiaTemplateSettings.php
@@ -66,9 +66,8 @@ class SequoiaTemplateSettings extends FormMigrationStep
             ->__invoke(new DesignHeaderSettings($enabled, $headline, $description));
 
         $this->formV3->settings->multiStepFirstButtonText = $donateLabel;
-
-        // @note `image` is not supported in v3 forms (defers to the Form Design).
-
+        $this->formV3->settings->designSettingsImageUrl = !empty($image) ? $image : $this->formV2->getFeaturedImage();
+        $this->formV3->settings->designSettingsImageStyle = 'center';
     }
 
     protected function paymentAmount($settings)


### PR DESCRIPTION
## Description

This PR adds header image migrations for each of the v2 form templates. Each template uses different data as the headerImage based on the available settings. The default behavior of the designSettingsImageStyle is set to background when an image supplied, so setting an image style is not necessary unless you want to update it.

### Classic template 
- uses the headerBackgroundImage
- defaults to the Featured Image 

### MultiStep template
- uses the "introduction" image
- defaults to the Featured Image 
- sets the image style to `center` as this most closely resembles the current way it is displayed on v2 forms

### Legacy template
- uses the Featured Image

## Affects
All 3 form templates during migration process.

## Visuals


## Testing Instructions
Create a v2 form for each of the 3 form templates

Classic: 
- set a headerBackgroundImage and migrate to a v3 form, the header image perviously set should be visible with the background image style in the header
- set a featured image and migrate to a v3 form, the featured image previously set should be visible with the background image style in the header
- set both headerBackgroundImage and featured image, he header image perviously set sshould be visible with the background image style in the header

MultiStep
- set the "introduction" image and migrate to a v3 form, the image perviously set should be visible with the center image style
- set a featured image and migrate to a v3 form, the featured image previously set should be visible with the center image style 
- set both the "introduction" image and a featured image, the "introduction" image perviously set should be visible with the center image style

Legacy
- set a featured image and migrate to a v3 form, the featured image previously set should be visible with the background image style in the header

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

