### PR TITLE
Feature: add form featured image migration step

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -90,7 +90,9 @@ class FormMetaDecorator extends FormModelDecorator
     {
         $template = $this->getFormTemplate();
 
-        return give_get_meta($this->form->id, "_give_{$template}_form_template_settings", true);
+        $templateSettings = give_get_meta($this->form->id, "_give_{$template}_form_template_settings", true);
+
+        return is_array($templateSettings) ? $templateSettings : [];
     }
 
     public function isDonationGoalEnabled(): bool

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -781,7 +781,7 @@ class FormMetaDecorator extends FormModelDecorator
             // Legacy Template or Sequoia Template without the ['introduction']['image'] setting
             $featuredImage = get_the_post_thumbnail_url($this->form->id, 'full');
         } else {
-            $featuredImage = '';
+            $featuredImage = null;
         }
 
         return $featuredImage;

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -5,6 +5,7 @@ namespace Give\FormMigration;
 use Give\DonationForms\V2\Models\DonationForm;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\FormMigration\Contracts\FormModelDecorator;
+use Give\Helpers\Form\Template as FormTemplateUtils;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
 use Give_Email_Notification_Util;
 
@@ -760,5 +761,18 @@ class FormMetaDecorator extends FormModelDecorator
     public function getGiftAidDeclarationForm(): string
     {
         return $this->getMeta('give_gift_aid_declaration_form');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getFormFeaturedImage(): string
+    {
+        $formId = $this->form->id;
+        $templateOptions = FormTemplateUtils::getOptions($formId);
+
+        return ! empty($templateOptions['introduction']['image']) ?
+            $templateOptions['introduction']['image'] :
+            get_the_post_thumbnail_url($formId, 'full');
     }
 }

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -49,6 +49,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Steps\Mailchimp::class,
                 Steps\FundsAndDesignations::class,
                 Steps\GiftAid::class,
+                Steps\FormFeaturedImage::class,
             ]);
         });
     }

--- a/src/FormMigration/Steps/FormFeaturedImage.php
+++ b/src/FormMigration/Steps/FormFeaturedImage.php
@@ -16,7 +16,9 @@ class FormFeaturedImage extends FormMigrationStep
     {
         if ($formV2FeaturedImage = $this->formV2->getFormFeaturedImage()) {
             $this->formV3->settings->designSettingsImageUrl = $formV2FeaturedImage;
-            $this->formV3->settings->designSettingsImageStyle = 'center';
+            if ('sequoia' === $this->formV2->getFormTemplate()) {
+                $this->formV3->settings->designSettingsImageStyle = 'center';
+            }
         }
     }
 }

--- a/src/FormMigration/Steps/FormFeaturedImage.php
+++ b/src/FormMigration/Steps/FormFeaturedImage.php
@@ -16,6 +16,7 @@ class FormFeaturedImage extends FormMigrationStep
     {
         if ($formV2FeaturedImage = $this->formV2->getFormFeaturedImage()) {
             $this->formV3->settings->designSettingsImageUrl = $formV2FeaturedImage;
+            $this->formV3->settings->designSettingsImageStyle = 'center';
         }
     }
 }

--- a/src/FormMigration/Steps/FormFeaturedImage.php
+++ b/src/FormMigration/Steps/FormFeaturedImage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Give\FormMigration\Steps;
+
+use Give\FormMigration\Contracts\FormMigrationStep;
+
+/**
+ * @unreleased
+ */
+class FormFeaturedImage extends FormMigrationStep
+{
+    /**
+     * @unreleased
+     */
+    public function process()
+    {
+        if ($formV2FeaturedImage = $this->formV2->getFormFeaturedImage()) {
+            $this->formV3->settings->designSettingsImageUrl = $formV2FeaturedImage;
+        }
+    }
+}

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -258,7 +258,10 @@ class TestFormMetaDecorator extends TestCase {
      */
     private function uploadTestImage()
     {
-        $filename = (GIVE_PLUGIN_DIR . 'assets/dist/images/give-placeholder.jpg');
+        $filename = GIVE_PLUGIN_DIR . 'assets/dist/images/give-placeholder.jpg';
+
+        $this->assertFileExists($filename);
+
         $contents = file_get_contents($filename);
         $upload = wp_upload_bits(basename($filename), null, $contents);
 

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -258,7 +258,7 @@ class TestFormMetaDecorator extends TestCase {
      */
     private function uploadTestImage()
     {
-        $filename = (DIR_TESTDATA . '/images/test-image.jpg');
+        $filename = (GIVE_PLUGIN_DIR . 'assets/dist/images/give-placeholder.jpg');
         $contents = file_get_contents($filename);
         $upload = wp_upload_bits(basename($filename), null, $contents);
 

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -245,7 +245,7 @@ class TestFormMetaDecorator extends TestCase {
         // Test 1 - The featured image from the WP default setting is NOT set
         $this->assertEmpty($formMetaDecorator->getFormFeaturedImage());
 
-        // Test 3 - The featured image from the WP default setting is set
+        // Test 2 - The featured image from the WP default setting is set
         $thumbnailId = $this->uploadTestImage();
         set_post_thumbnail($formV2->id, $thumbnailId);
         $this->assertNotEmpty($formMetaDecorator->getFormFeaturedImage());

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -258,9 +258,7 @@ class TestFormMetaDecorator extends TestCase {
      */
     private function uploadTestImage()
     {
-        $filename = GIVE_PLUGIN_DIR . 'assets/dist/images/give-placeholder.jpg';
-
-        $this->assertFileExists($filename);
+        $filename = GIVE_PLUGIN_DIR . 'assets/src/images/give-placeholder.jpg';
 
         $contents = file_get_contents($filename);
         $upload = wp_upload_bits(basename($filename), null, $contents);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-348]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds header image migrations for the v2 form templates. Each template uses different data as the headerImage based on the available settings. The default behavior of the designSettingsImageStyle is set to background when an image supplied, so setting an image style is not necessary unless you want to update it.

### Legacy template
- Uses the featured image as the default

### MultiStep template
- Uses the `introduction` image as the default
- Uses the featured image from the WP default setting as a fallback 
- Sets the image style to `center` as this most closely resembles the current way it is displayed on v2 forms

### Classic template 
- Uses the `headerBackgroundImage` as the default
- It does NOT use the featured image from the WP default setting as a fallback 


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

All 3 form templates during the migration process.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

In the below attached screenshots you can see that the `Classic` template doesn't use the featured image from the WP default setting as a fallback:


![classic-template-settings](https://github.com/impress-org/givewp/assets/16308864/70726588-4fa6-433e-bc6f-4c190c67003f)

![image](https://github.com/impress-org/givewp/assets/16308864/64886b12-b7d6-48ac-8bc3-51156b28d22e)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a v2 form for each of the 3 form templates

**Legacy**

1. Set a featured image and migrate to a v3 form, the featured image previously set should be visible with the _background_ image style in the header

**MultiStep**

1. Set a featured image and migrate to a v3 form, the featured image previously set should be visible with the _center_ image style
2. Set the `introduction` image and migrate to a v3 form, the image previously set should be visible with the _center_ image style
3. Set both the `introduction` image and a featured image, the `introduction` image previously set should be visible with the _center_ image style

**Classic** 

1. Set a featured image and migrate to a v3 form, the featured image previously set should _NOT_ be visible in the header **(this template doesn't use the featured image from the WP default setting as a fallback)**
2. Set a `headerBackgroundImage` and migrate to a v3 form, the header image previously set should be visible with the _background_ image style in the header


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-348]: https://stellarwp.atlassian.net/browse/GIVE-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ