### PR TITLE
Feature: Add endpoint for creating an event

### DIFF
--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\API\RestRoute;
+use Give\EventTickets\Models\Event;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @unreleased
+ */
+class CreateEvent implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'events-tickets/events';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'POST',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => function () {
+                        return current_user_can( 'manage_options' );
+                    }
+                ],
+                'args' => [
+                    'title' => [
+                        'type' => 'string',
+                        'required' => true,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'description' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'startDateTime' => [
+                        'type' => 'string',
+                        'format' => 'date-time', // @link https://datatracker.ietf.org/doc/html/rfc3339#section-5.8
+                        'required' => true,
+                        'validate_callback' => 'rest_parse_date',
+                        'sanitize_callback' => function ($value) {
+                            return new \DateTime($value);
+                        },
+                    ],
+                    'endDateTime' => [
+                        'type' => 'string',
+                        'format' => 'date-time', // @link https://datatracker.ietf.org/doc/html/rfc3339#section-5.8
+                        'required' => false,
+                        'validate_callback' => 'rest_parse_date',
+                        'sanitize_callback' => function ($value) {
+                            return new \DateTime($value);
+                        },
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return WP_REST_Response
+     *
+     */
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $event = Event::create([
+            'title' => $request->get_param('title'),
+            'description' => $request->get_param('description'),
+            'startDateTime' => $request->get_param('startDateTime'),
+            'endDateTime' => $request->get_param('endDateTime'),
+        ]);
+
+        return new WP_REST_Response($event->toArray(), 201);
+    }
+}

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -53,6 +53,7 @@ class ServiceProvider implements ServiceProviderInterface
             4
         );
 
+        Hooks::addAction('rest_api_init', Routes\CreateEvent::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-356](https://stellarwp.atlassian.net/browse/GIVE-356?atlOrigin=eyJpIjoiYTI5YjhlOWNmODU3NDMyNDg5NDg1ZmJmY2Y2Y2MwMDAiLCJwIjoiaiJ9)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new WP Rest Route for creating a new event as a POST request.

## Visuals

 ![image](https://github.com/impress-org/givewp/assets/10858303/a5ad1957-a9a2-4044-b250-4159f1aff972) 

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make a POST request to `/wp-json/give-api/v2/events-tickets/events` passing the `title` (string) and `startDateTime` (string as date-time, see RFC3339) and confirm a `201 Created` response.

[GIVE-356]: https://stellarwp.atlassian.net/browse/GIVE-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ