### PR TITLE
Feature: Add endpoint for creating a ticket type for an event

### DIFF
--- a/src/EventTickets/DataTransferObjects/EventTicketTypeData.php
+++ b/src/EventTickets/DataTransferObjects/EventTicketTypeData.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Give\EventTickets\DataTransferObjects;
+
+use Give\EventTickets\Models\EventTicketType;
+
+final class EventTicketTypeData
+{
+
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $eventId;
+
+    /**
+     * @unreleased
+     * @var string
+     */
+    public $title;
+
+    /**
+     * @unreleased
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $price;
+
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $capacity;
+
+    public static function make(EventTicketType $ticketType)
+    {
+        $self = new self();
+
+        $self->id = $ticketType->id;
+        $self->eventId = $ticketType->eventId;
+        $self->title = $ticketType->title;
+        $self->description = $ticketType->description;
+        $self->price = $ticketType->price->formatToMinorAmount();
+        $self->capacity = $ticketType->capacity;
+
+        return $self;
+    }
+}

--- a/src/EventTickets/Repositories/EventTicketTypeRepository.php
+++ b/src/EventTickets/Repositories/EventTicketTypeRepository.php
@@ -68,8 +68,8 @@ class EventTicketTypeRepository
                     'description' => $eventTicketType->description,
                     'price' => $eventTicketType->price->formatToMinorAmount(),
                     'max_available' => $eventTicketType->maxAvailable,
-                    'created_at' => $createdDateTime,
-                    'updated_at' => $createdDateTime,
+                    'created_at' => $createdDateTime->format('Y-m-d H:i:s'),
+                    'updated_at' => $createdDateTime->format('Y-m-d H:i:s'),
                 ]);
 
             $eventTicketType->id = DB::last_insert_id();
@@ -80,6 +80,9 @@ class EventTicketTypeRepository
 
             throw new $exception('Failed creating an event ticket type');
         }
+
+        $eventTicketType->createdAt = $createdDateTime;
+        $eventTicketType->updatedAt = $createdDateTime;
 
         DB::query('COMMIT');
 

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -3,6 +3,7 @@
 namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
+use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
 use Give\EventTickets\Models\Event;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Support\ValueObjects\Money;
@@ -86,6 +87,6 @@ class CreateEventTicketType implements RestRoute
             'capacity' => $request->get_param('capacity'),
         ]);
 
-        return new WP_REST_Response($ticketType->toArray(), 201);
+        return new WP_REST_Response(EventTicketTypeData::make($ticketType), 201);
     }
 }

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -42,7 +42,7 @@ class CreateEventTicketType implements RestRoute
                         },
                         'required' => true,
                     ],
-                    'label' => [
+                    'title' => [
                         'type' => 'string',
                         'required' => true,
                         'sanitize_callback' => 'sanitize_text_field',
@@ -80,7 +80,7 @@ class CreateEventTicketType implements RestRoute
     {
         $ticketType = EventTicketType::create([
             'eventId' => $request->get_param('event_id'),
-            'label' => $request->get_param('label'),
+            'title' => $request->get_param('title'),
             'description' => $request->get_param('description'),
             'price' => new Money($request->get_param('price'), give_get_currency()),
             'maxAvailable' => $request->get_param('capacity'),

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\API\RestRoute;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicketType;
+use Give\Framework\Support\ValueObjects\Money;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @unreleased
+ */
+class CreateEventTicketType implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'events-tickets/event/(?P<event_id>\d+)/ticket-types';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'POST',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => function () {
+                        return current_user_can( 'manage_options' );
+                    }
+                ],
+                'args' => [
+                    'event_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return Event::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                    'label' => [
+                        'type' => 'string',
+                        'required' => true,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'description' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'price' => [
+                        'type' => 'integer',
+                        'required' => true,
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => 'rest_is_integer',
+                        'description' => 'This price to purchase a ticket in the minor amount of the currency. For example, 1000 for $10.00.',
+                    ],
+                    'capacity' => [
+                        'type' => 'integer',
+                        'required' => true,
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => 'rest_is_integer',
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return WP_REST_Response
+     *
+     */
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $ticketType = EventTicketType::create([
+            'eventId' => $request->get_param('event_id'),
+            'label' => $request->get_param('label'),
+            'description' => $request->get_param('description'),
+            'price' => new Money($request->get_param('price'), give_get_currency()),
+            'maxAvailable' => $request->get_param('capacity'),
+        ]);
+
+        return new WP_REST_Response($ticketType->toArray(), 201);
+    }
+}

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -83,7 +83,7 @@ class CreateEventTicketType implements RestRoute
             'title' => $request->get_param('title'),
             'description' => $request->get_param('description'),
             'price' => new Money($request->get_param('price'), give_get_currency()),
-            'maxAvailable' => $request->get_param('capacity'),
+            'capacity' => $request->get_param('capacity'),
         ]);
 
         return new WP_REST_Response($ticketType->toArray(), 201);

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -53,6 +53,7 @@ class ServiceProvider implements ServiceProviderInterface
             4
         );
 
+        Hooks::addAction('rest_api_init', Routes\CreateEventTicketType::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-365](https://stellarwp.atlassian.net/browse/GIVE-365)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new WP Rest Route for creating a new ticket type for an event as a POST request.

Note: This also resolves a small bug with the `created_at` and `updated_at` timestamps when creating a Ticket Type.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/70b7583b-a0ed-4df0-ada3-a37f9620b8cc)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make a POST request to `/wp-json/give-api/v2/events-tickets/event/{event_id}/ticket-types` passing the `label` (string), `description` (string), `price` (int), and `capacity` (int) and confirm a `201 Created` response.

[GIVE-365]: https://stellarwp.atlassian.net/browse/GIVE-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ