### PR TITLE
Feature: Add endpoint for event forms

### DIFF
--- a/src/EventTickets/Routes/GetEventForms.php
+++ b/src/EventTickets/Routes/GetEventForms.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\API\RestRoute;
+use Give\DonationForms\Models\DonationForm;
+use Give\EventTickets\Models\Event;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @unreleased
+ */
+class GetEventForms implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'events-tickets/event/(?P<event_id>\d+)/forms';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'GET',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => '__return_true',
+                ],
+                'args' => [
+                    'event_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return Event::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                    'page' => [
+                        'validate_callback' => function ($param) {
+                            return filter_var($param, FILTER_VALIDATE_INT);
+                        },
+                        'default' => 1,
+                    ],
+                    'per_page' => [
+                        'validate_callback' => function ($param) {
+                            return filter_var($param, FILTER_VALIDATE_INT);
+                        },
+                        'default' => 10,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return WP_REST_Response
+     *
+     */
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $eventIdPattern = sprintf('"eventId":%s', $request->get_param('event_id'));
+
+        $forms = DonationForm::query()
+            ->whereLike('give_formmeta_attach_meta_fields.meta_value', '%"name":"givewp/event-tickets"%')
+            ->whereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern}%") // When the eventId is the only block attribute.
+            ->orWhereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern,%") // When the eventId is the NOT only block attribute.
+            ->paginate(
+                $request->get_param('per_page'),
+                $request->get_param('page')
+            );
+
+        return new WP_REST_Response(array_column($forms->getAll() ?? [], 'id'));
+    }
+}

--- a/src/EventTickets/Routes/GetEventForms.php
+++ b/src/EventTickets/Routes/GetEventForms.php
@@ -68,8 +68,10 @@ class GetEventForms implements RestRoute
 
         $forms = DonationForm::query()
             ->whereLike('give_formmeta_attach_meta_fields.meta_value', '%"name":"givewp/event-tickets"%')
-            ->whereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern}%") // When the eventId is the only block attribute.
-            ->orWhereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern,%") // When the eventId is the NOT only block attribute.
+            ->where(function($query) use ($eventIdPattern) {
+                $query->whereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern}%") // When the eventId is the only block attribute.
+                    ->orWhereLike('give_formmeta_attach_meta_fields.meta_value', "%$eventIdPattern,%"); // When the eventId is the NOT only block attribute.
+            })
             ->paginate(
                 $request->get_param('per_page'),
                 $request->get_param('page')

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -53,6 +53,7 @@ class ServiceProvider implements ServiceProviderInterface
             4
         );
 
+        Hooks::addAction('rest_api_init', Routes\GetEventForms::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');

--- a/tests/Unit/EventTickets/Routes/GetEventFormsTest.php
+++ b/tests/Unit/EventTickets/Routes/GetEventFormsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Give\Tests\Unit\EventTickets\Routes;
+
+use Exception;
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Endpoints\ListDonations;
+use Give\Donations\ListTable\DonationsListTable;
+use Give\Donations\Models\Donation;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Routes\GetEventForms;
+use Give\EventTickets\Routes\GetEventsListTable;
+use Give\Framework\Blocks\BlockCollection;
+use Give\Framework\Blocks\BlockModel;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class GetEventFormsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    protected function getMockRequest(int $eventId): WP_REST_Request
+    {
+        $request = new WP_REST_Request(
+            WP_REST_Server::READABLE,
+            "/give-api/v2/events-tickets/event/$eventId/forms"
+        );
+        $request->set_param('event_id', $eventId);
+        return $request;
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResponseContainsRelatedForm()
+    {
+        $event = Event::factory()->create();
+        $form = DonationForm::factory()->create();
+
+        $form->blocks->insertAfter('givewp/donation-amount', BlockModel::make([
+            'name' => 'givewp/event-tickets',
+            'attributes' => [
+                'eventId' => $event->id,
+            ],
+        ]));
+        $form->save();
+
+        $response = (new GetEventForms())->handleRequest(
+            $this->getMockRequest($event->id)
+        );
+
+        $this->assertContains($form->id, $response->data);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResponseContainsNoRelatedForm()
+    {
+        $event = Event::factory()->create();
+
+        $response = (new GetEventForms())->handleRequest(
+            $this->getMockRequest($event->id)
+        );
+
+        $this->assertEmpty($response->data);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testResponseContainsRelatedFormWithoutCollision()
+    {
+        $this->refreshDatabase();
+        $event = Event::factory()->create();
+        $form = DonationForm::factory()->create();
+        $form->blocks->insertAfter('givewp/donation-amount', BlockModel::make([
+            'name' => 'givewp/event-tickets',
+            'attributes' => [
+                'eventId' => $event->id,
+            ],
+        ]));
+        $form->save();
+
+        $event2 = Event::factory()->create();
+        // Create possible collision in JSON search, ie 1 vs 11.
+        $collisionId = (int) ($event->id . $event->id);
+        Event::query()
+            ->where('id', $event2->id)
+            ->update(['id' => $collisionId]);
+        $event2 = Event::find($collisionId);
+
+        $form2 = DonationForm::factory()->create();
+        $form2->blocks->insertAfter('givewp/donation-amount', BlockModel::make([
+            'name' => 'givewp/event-tickets',
+            'attributes' => [
+                'eventId' => $event2->id,
+            ],
+        ]));
+        $form2->save();
+
+        $response = (new GetEventForms())->handleRequest(
+            $this->getMockRequest($event->id)
+        );
+
+        $this->assertContains($form->id, $response->data);
+        $this->assertNotContains($form2->id, $response->data);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-363](https://stellarwp.atlassian.net/browse/GIVE-363)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new WP Rest Route for listing forms related to an event as a GET request.

Note: A event related form is identified by the contents of the JSON `formBuilderFields` column. JSON related MySQL functionality is not introduced until `MySQL 5.7`, but GiveWP supports back to `MySQL 5.5`. For this reason, this endpoint uses `whereLike` queries to determine if a form contains an event block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/10858303/c2f954c7-0682-4426-8342-3f9bdbb45c6f)


[GIVE-363]: https://stellarwp.atlassian.net/browse/GIVE-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ