### PR TITLE
Feature: Add endpoint for updating an event 

### DIFF
--- a/src/EventTickets/Repositories/EventRepository.php
+++ b/src/EventTickets/Repositories/EventRepository.php
@@ -103,10 +103,11 @@ class EventRepository
             DB::table('give_events')
                 ->where('id', $event->id)
                 ->update([
+                    'title' => $event->title,
                     'description' => $event->description,
                     'start_datetime' => $event->startDateTime->format('Y-m-d H:i:s'),
-                    'end_datetime' => $event->end_datetime ? $event->end_datetime->format('Y-m-d H:i:s') : null,
-                    'ticket_close_datetime' => $event->ticket_close_datetime ? $event->ticket_close_datetime->format(
+                    'end_datetime' => $event->endDateTime ? $event->endDateTime->format('Y-m-d H:i:s') : null,
+                    'ticket_close_datetime' => $event->ticketCloseDateTime ? $event->ticketCloseDateTime->format(
                         'Y-m-d H:i:s'
                     ) : null,
                     'updated_at' => $updatedDateTime->format('Y-m-d H:i:s'),

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\API\RestRoute;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicket;
+use Give\Framework\Models\Model;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @unreleased
+ */
+class UpdateEvent implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'events-tickets/event/(?P<event_id>\d+)';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'GET',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => '__return_true',
+                ],
+                'args' => [
+                    'event_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return Event::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                    'title' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'description' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'startDateTime' => [
+                        'type' => 'string',
+                        'format' => 'date-time', // @link https://datatracker.ietf.org/doc/html/rfc3339#section-5.8
+                        'required' => false,
+                        'validate_callback' => 'rest_parse_date',
+                        'sanitize_callback' => function ($value) {
+                            return new \DateTime($value);
+                        },
+                    ],
+                    'endDateTime' => [
+                        'type' => 'string',
+                        'format' => 'date-time', // @link https://datatracker.ietf.org/doc/html/rfc3339#section-5.8
+                        'required' => false,
+                        'validate_callback' => 'rest_parse_date',
+                        'sanitize_callback' => function ($value) {
+                            return new \DateTime($value);
+                        },
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return WP_REST_Response
+     *
+     */
+    public function handleRequest(WP_REST_Request $request)
+    {
+        $event = Event::find($request->get_param('event_id'));
+
+        foreach(['title', 'description', 'startDateTime', 'endDateTime'] as $param) {
+            if ($request->has_param($param)) {
+                $event->setAttribute($param, $request->get_param($param));
+            }
+        }
+
+        $event->save();
+
+        return new WP_REST_Response();
+    }
+}

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -4,10 +4,9 @@ namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
 use Give\EventTickets\Models\Event;
-use Give\EventTickets\Models\EventTicket;
-use Give\Framework\Models\Model;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * @unreleased
@@ -27,7 +26,7 @@ class UpdateEvent implements RestRoute
             $this->endpoint,
             [
                 [
-                    'methods' => 'GET',
+                    'methods' => WP_REST_Server::EDITABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => '__return_true',
                 ],

--- a/tests/Unit/EventTickets/Routes/UpdateEventTest.php
+++ b/tests/Unit/EventTickets/Routes/UpdateEventTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Give\Tests\Unit\EventTickets\Routes;
+
+use Exception;
+use Give\Donations\Endpoints\ListDonations;
+use Give\Donations\ListTable\DonationsListTable;
+use Give\Donations\Models\Donation;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Routes\GetEventsListTable;
+use Give\EventTickets\Routes\UpdateEvent;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class UpdateEventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    protected function getMockRequest($eventId): WP_REST_Request
+    {
+        $request = new WP_REST_Request(
+            WP_REST_Server::EDITABLE,
+            "/give-api/v2/event-tickets/event/$eventId"
+        );
+
+        $request->set_param('event_id', $eventId);
+
+        return $request;
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testShouldUpdateEventTitle()
+    {
+        $event = Event::factory()->create([
+            'title' => 'Old Title',
+        ]);
+
+        $mockRequest = $this->getMockRequest($event->id);
+        $mockRequest->set_param('title', 'New Title');
+        $response = (new UpdateEvent())->handleRequest($mockRequest);
+
+        $this->assertEquals('New Title', Event::find($event->id)->title);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves GIVE-359

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new WP Rest Route for updating an event as a POST, PUT, or PATCH request.

Note: This also resolves a small bug with the `title`, `endDateTime`, and `ticketCloseDateTime` properties when updating an Event.