### PR TITLE
refactor: accommodate header image for 2-panel layout

### DIFF
--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -10,10 +10,6 @@
     padding: 0;
     width: 100%;
 
-    @media screen and (max-width: 79rem) {
-        --two-panel-header-width: 35rem;
-    }
-
     @media screen and (max-width: 71.5rem) {
         border: solid 1px var(--givewp-grey-25);
         border-radius: var(--givewp-rounded-8);

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_container.scss
@@ -5,7 +5,7 @@
     gap: var(--givewp-spacing-2);
     display: flex;
     flex-direction: row;
-    margin: 0.5rem auto;
+    margin: auto;
     max-width: calc(var(--two-panel-header-width) + 35.5rem);
     padding: 0;
     width: 100%;

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
@@ -1,7 +1,6 @@
 .givewp-layouts {
     &-header {
         max-width: var(--two-panel-header-width);
-        padding: var(--givewp-spacing-6);
         text-align: center;
         width: 100%;
 

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_header.scss
@@ -18,5 +18,28 @@
     &-headerDescription {
         margin-bottom: var(--givewp-spacing-10);
     }
+
+    .givewp-layouts-header__templates-ms {
+        padding-bottom: 2rem;
+
+        &--background {
+            .givewp-layouts-header__content {
+                position: static;
+                margin-bottom: 0;
+            }
+
+            .givewp-layouts-headerImage {
+
+                img {
+                    position: absolute;
+                    left: 0;
+                    bottom: 0;
+                    height: 100%;
+                    min-height: 100%;
+                    border-radius: var(--givewp-rounded-8);
+                }
+            }
+        }
+    }
 }
 

--- a/src/DonationForms/resources/app/form/Header.tsx
+++ b/src/DonationForms/resources/app/form/Header.tsx
@@ -3,6 +3,7 @@ import {withTemplateWrapper} from '../templates';
 import type {GoalType} from '@givewp/forms/propTypes';
 import amountFormatter from '@givewp/forms/app/utilities/amountFormatter';
 import DonationFormErrorBoundary from '@givewp/forms/app/errors/boundaries/DonationFormErrorBoundary';
+import type {Form as DonationForm} from '@givewp/forms/types';
 
 const formTemplates = window.givewp.form.templates;
 
@@ -16,7 +17,7 @@ const HeaderImageTemplate = withTemplateWrapper(formTemplates.layouts.headerImag
 /**
  * @since 3.0.0
  */
-export default function Header({form}) {
+export default function Header({form}: {form: DonationForm}) {
     const formatGoalAmount = useCallback((amount: number) => {
         return amountFormatter(form.currency, {
             maximumFractionDigits: 0,
@@ -26,6 +27,7 @@ export default function Header({form}) {
     return (
         <DonationFormErrorBoundary>
             <HeaderTemplate
+                isMultiStep={form.design.isMultiStep}
                 HeaderImage={() =>
                     form.settings?.designSettingsImageUrl && (
                         <HeaderImageTemplate

--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -179,6 +179,7 @@ export interface HeaderProps {
     Title: FC<HeaderTitleProps | {}>;
     Description: FC<HeaderDescriptionProps | {}>;
     Goal: FC<GoalProps | {}>;
+    isMultiStep: boolean
 }
 
 export interface HeaderImageProps {

--- a/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
@@ -6,85 +6,85 @@ import cx from 'classnames';
  * @since 3.0.0
  */
 export default function Header({ HeaderImage, Title, Description, Goal, isMultiStep }: HeaderProps) {
-  const { designSettingsImageStyle, designSettingsImageUrl } = window.givewp.form.hooks.useDonationFormSettings();
+    const { designSettingsImageStyle, designSettingsImageUrl } = window.givewp.form.hooks.useDonationFormSettings();
 
-  if (!designSettingsImageUrl) {
+    if (!designSettingsImageUrl) {
+        return (
+            <div className={
+                cx({
+                        'givewp-layouts-header__templates': !isMultiStep,
+                        'givewp-layouts-header__templates-ms': isMultiStep
+                    }
+                )}>
+                <Title />
+                <Description />
+                <Goal />
+            </div>
+        );
+    }
+
     return (
-      <div className={
-        cx({
-            'givewp-layouts-header__templates': !isMultiStep,
-            'givewp-layouts-header__templates-ms': isMultiStep
-          }
-        )}>
-        <Title />
-        <Description />
-        <Goal />
-      </div>
+        <div
+            className={cx({
+                'givewp-layouts-header__templates': !isMultiStep,
+                [`givewp-layouts-header__templates--${designSettingsImageStyle}`]: !isMultiStep,
+                'givewp-layouts-header__templates-ms': isMultiStep,
+                [`givewp-layouts-header__templates-ms--${designSettingsImageStyle}`]: isMultiStep
+            })}
+        >
+            <HeaderImageTemplates
+                imagePosition={designSettingsImageStyle}
+                HeaderImage={HeaderImage}
+                Title={Title}
+                Description={Description}
+                Goal={Goal}
+            />
+        </div>
     );
-  }
-
-  return (
-    <div
-      className={cx({
-        'givewp-layouts-header__templates': !isMultiStep,
-        [`givewp-layouts-header__templates--${designSettingsImageStyle}`]: !isMultiStep,
-        'givewp-layouts-header__templates-ms': isMultiStep,
-        [`givewp-layouts-header__templates-ms--${designSettingsImageStyle}`]: isMultiStep
-      })}
-    >
-      <HeaderImageTemplates
-        imagePosition={designSettingsImageStyle}
-        HeaderImage={HeaderImage}
-        Title={Title}
-        Description={Description}
-        Goal={Goal}
-      />
-    </div>
-  );
 }
 
 function HeaderImageTemplates({ imagePosition, HeaderImage, Title, Description, Goal }) {
-  switch (imagePosition) {
-    case 'background':
-      return (
-        <>
-          <div className={'givewp-layouts-header__content'}>
-            <HeaderImage />
-            <Title />
-            <Description />
-          </div>
-          <div className={'givewp-layouts-header__goal'}>
-            <Goal />
-          </div>
-        </>
-      );
-    case 'above':
-      return (
-        <>
-          <HeaderImage />
-          <div className={'givewp-layouts-header__content'}>
-            <Title />
-            <Description />
-            <Goal />
-          </div>
-        </>
-      );
-    case 'center':
-      return (
-        <>
-          <Title />
-          <Description />
-          <HeaderImage />
-          <Goal />
-        </>
-      );
-    default:
-      return (
-        <>
-          <Title />
-          <Description />
-          <Goal />
-        </>
-      );
-  }
+    switch (imagePosition) {
+        case 'background':
+            return (
+                <>
+                    <div className={'givewp-layouts-header__content'}>
+                        <HeaderImage />
+                        <Title />
+                        <Description />
+                    </div>
+                    <div className={'givewp-layouts-header__goal'}>
+                        <Goal />
+                    </div>
+                </>
+            );
+        case 'above':
+            return (
+                <>
+                    <HeaderImage />
+                    <div className={'givewp-layouts-header__content'}>
+                        <Title />
+                        <Description />
+                        <Goal />
+                    </div>
+                </>
+            );
+        case 'center':
+            return (
+                <>
+                    <Title />
+                    <Description />
+                    <HeaderImage />
+                    <Goal />
+                </>
+            );
+        default:
+            return (
+                <>
+                    <Title />
+                    <Description />
+                    <Goal />
+                </>
+            );
+    }
 }

--- a/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/Header.tsx
@@ -1,79 +1,90 @@
 import type {HeaderProps} from '@givewp/forms/propTypes';
+import cx from 'classnames';
 
 /**
  * @unreleased add HeaderImage
  * @since 3.0.0
  */
-export default function Header({HeaderImage, Title, Description, Goal}: HeaderProps) {
-    const {designSettingsImageStyle, designSettingsImageUrl} = window.givewp.form.hooks.useDonationFormSettings();
+export default function Header({ HeaderImage, Title, Description, Goal, isMultiStep }: HeaderProps) {
+  const { designSettingsImageStyle, designSettingsImageUrl } = window.givewp.form.hooks.useDonationFormSettings();
 
-    if (!designSettingsImageUrl) {
-        return (
-            <div className={`givewp-layouts-header__templates-ms`}>
-                <Title />
-                <Description />
-                <Goal />
-            </div>
-        );
-    }
-
+  if (!designSettingsImageUrl) {
     return (
-        <div
-            className={`givewp-layouts-header__templates-ms givewp-layouts-header__templates-ms--${designSettingsImageStyle}`}
-        >
-            <HeaderImageTemplates
-                imagePosition={designSettingsImageStyle}
-                HeaderImage={HeaderImage}
-                Title={Title}
-                Description={Description}
-                Goal={Goal}
-            />
-        </div>
+      <div className={
+        cx({
+            'givewp-layouts-header__templates': !isMultiStep,
+            'givewp-layouts-header__templates-ms': isMultiStep
+          }
+        )}>
+        <Title />
+        <Description />
+        <Goal />
+      </div>
     );
+  }
+
+  return (
+    <div
+      className={cx({
+        'givewp-layouts-header__templates': !isMultiStep,
+        [`givewp-layouts-header__templates--${designSettingsImageStyle}`]: !isMultiStep,
+        'givewp-layouts-header__templates-ms': isMultiStep,
+        [`givewp-layouts-header__templates-ms--${designSettingsImageStyle}`]: isMultiStep
+      })}
+    >
+      <HeaderImageTemplates
+        imagePosition={designSettingsImageStyle}
+        HeaderImage={HeaderImage}
+        Title={Title}
+        Description={Description}
+        Goal={Goal}
+      />
+    </div>
+  );
 }
 
-function HeaderImageTemplates({imagePosition, HeaderImage, Title, Description, Goal}) {
-    switch (imagePosition) {
-        case 'background':
-            return (
-                <>
-                    <div className={'givewp-layouts-header__content'}>
-                        <HeaderImage />
-                        <Title />
-                        <Description />
-                    </div>
-                    <div className={'givewp-layouts-header__goal'}>
-                        <Goal />
-                    </div>
-                </>
-            );
-        case 'above':
-            return (
-                <>
-                    <HeaderImage />
-                    <div className={'givewp-layouts-header__content'}>
-                        <Title />
-                        <Description />
-                        <Goal />
-                    </div>
-                </>
-            );
-        case 'center':
-            return (
-                <>
-                    <Title />
-                    <Description />
-                    <HeaderImage />
-                    <Goal />
-                </>
-            );
-        default:
-            return (
-                <>
-                    <Title />
-                    <Description />
-                    <Goal />
-                </>
-            );
-    }
+function HeaderImageTemplates({ imagePosition, HeaderImage, Title, Description, Goal }) {
+  switch (imagePosition) {
+    case 'background':
+      return (
+        <>
+          <div className={'givewp-layouts-header__content'}>
+            <HeaderImage />
+            <Title />
+            <Description />
+          </div>
+          <div className={'givewp-layouts-header__goal'}>
+            <Goal />
+          </div>
+        </>
+      );
+    case 'above':
+      return (
+        <>
+          <HeaderImage />
+          <div className={'givewp-layouts-header__content'}>
+            <Title />
+            <Description />
+            <Goal />
+          </div>
+        </>
+      );
+    case 'center':
+      return (
+        <>
+          <Title />
+          <Description />
+          <HeaderImage />
+          <Goal />
+        </>
+      );
+    default:
+      return (
+        <>
+          <Title />
+          <Description />
+          <Goal />
+        </>
+      );
+  }
 }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -98,7 +98,7 @@
                     }
 
                     .givewp-layouts-goal {
-                        margin-top: -1.35rem;
+                        margin-top: -1.25rem;
                     }
                 }
             }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -107,8 +107,9 @@
 }
 
 /* Multi Step */
-.givewp-donation-form__steps-body {
+.givewp-donation-form__steps-body, .givewp-donation-form > .givewp-layouts-header {
     padding: 0;
+    background: #fff;
 
     .givewp-layouts-multiStepForm, .givewp-layouts-header__templates-ms {
         padding: 2rem 2rem 0 2rem;
@@ -216,3 +217,9 @@
     }
 }
 
+/* Two-Panel */
+.givewp-donation-form > .givewp-layouts-header {
+    .givewp-layouts-header__templates-ms {
+        padding-bottom: 2rem;
+    }
+}

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -25,8 +25,8 @@
                     img {
                         object-fit: cover;
                         min-width: 100%;
-                        border-top-left-radius: 0.5rem;
-                        border-top-right-radius: 0.5rem;
+                        border-top-left-radius: var(--givewp-rounded-8);
+                        border-top-right-radius: var(--givewp-rounded-8);
                     }
                 }
             }
@@ -134,8 +134,8 @@
             img {
                 object-fit: cover;
                 min-width: 100%;
-                border-top-left-radius: 0.5rem;
-                border-top-right-radius: 0.5rem;
+                border-top-left-radius: var(--givewp-rounded-8);
+                border-top-right-radius: var(--givewp-rounded-8);
             }
         }
 
@@ -237,6 +237,7 @@
                     bottom: 0;
                     height: 100%;
                     min-height: 100%;
+                    border-radius: var(--givewp-rounded-8);
                 }
             }
         }

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -207,7 +207,7 @@
             .givewp-layouts-headerImage {
                 img {
                     border-radius: var(--givewp-rounded-4);
-
+                    max-height: 320px;
                 }
             }
 

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -218,28 +218,3 @@
     }
 }
 
-/* Two-Panel */
-.givewp-donation-form > .givewp-layouts-header {
-    .givewp-layouts-header__templates-ms {
-        padding-bottom: 2rem;
-
-        &--background {
-            .givewp-layouts-header__content {
-                position: static;
-                margin-bottom: 0;
-            }
-
-            .givewp-layouts-headerImage {
-
-                img {
-                    position: absolute;
-                    left: 0;
-                    bottom: 0;
-                    height: 100%;
-                    min-height: 100%;
-                    border-radius: var(--givewp-rounded-8);
-                }
-            }
-        }
-    }
-}

--- a/src/DonationForms/resources/styles/design-settings/image.scss
+++ b/src/DonationForms/resources/styles/design-settings/image.scss
@@ -126,13 +126,6 @@
         }
     }
 
-    .givewp-layouts-headerTitle {
-        color: var(--givewp-grey-900);
-    }
-
-    .givewp-layouts-headerDescription {
-        color: var(--givewp-grey-700);
-    }
 
     .givewp-layouts-header__templates-ms {
         .givewp-layouts-headerImage {
@@ -144,6 +137,14 @@
                 border-top-left-radius: 0.5rem;
                 border-top-right-radius: 0.5rem;
             }
+        }
+
+        .givewp-layouts-headerTitle {
+            color: var(--givewp-grey-900);
+        }
+
+        .givewp-layouts-headerDescription {
+            color: var(--givewp-grey-700);
         }
 
 
@@ -168,7 +169,7 @@
             }
 
 
-            div:not(.givewp-layouts-headerImage), aside {
+            div:not(.givewp-layouts-headerImage, .givewp-layouts-header__content), aside {
                 position: relative;
                 z-index: 999;
             }
@@ -221,5 +222,23 @@
 .givewp-donation-form > .givewp-layouts-header {
     .givewp-layouts-header__templates-ms {
         padding-bottom: 2rem;
+
+        &--background {
+            .givewp-layouts-header__content {
+                position: static;
+                margin-bottom: 0;
+            }
+
+            .givewp-layouts-headerImage {
+
+                img {
+                    position: absolute;
+                    left: 0;
+                    bottom: 0;
+                    height: 100%;
+                    min-height: 100%;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves [GIVE-150]

## Description

This PR includes the necessary changes to accommodate the header image while using the 2-panel layout.

Additional changes include:
- Remove margin from container that was clipping the border-radius on the form.
- Remove media max-width on the header panel as it was applying in the canvas but not on the frontend resulting in inconsistent views.
- Replace border-radius in design settings stylesheet with `--givewp-rounded-8`

## Affects

HeaderImage design setting

## Visuals

https://github.com/impress-org/givewp/assets/75056371/51874de2-7377-46ce-9ed7-253db0e6c016

## Testing Instructions
- Create a form in the visual form builder
- Set layout to two-panel
- Upload a header image
-  Test all 3 image styles
- Toggle the various header settings to ensure the layout does not break
- Verify previous layouts do not break

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-150]: https://stellarwp.atlassian.net/browse/GIVE-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ