### PR TITLE
Fix: Update Stripe statement descriptor usage per API changes

### DIFF
--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -842,7 +842,7 @@ function give_stripe_is_source_type( $id, $type = 'src' ) {
 /**
  * This helper function is used to process Stripe payments.
  *
- * @unreleased switch to using statement_descriptor_suffix per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
+ * @unreleased remove descriptor as Stripe automatically adds it, per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
  * @since 2.33.0 no longer store the payment intent secret
  * @since 2.5.0
  *

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -930,7 +930,7 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 					'amount'               => $stripe_gateway->format_amount( $donation_data['price'] ),
 					'currency'             => give_get_currency( $form_id ),
 					'payment_method_types' => [ 'card' ],
-					'statement_descriptor' => give_stripe_get_statement_descriptor(),
+                    'statement_descriptor_suffix' => give_stripe_get_statement_descriptor(),
 					'description'          => give_payment_gateway_donation_summary( $donation_data ),
 					'metadata'             => $stripe_gateway->prepare_metadata( $donation_id ),
 					'customer'             => $stripe_customer_id,

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -931,7 +931,6 @@ function give_stripe_process_payment( $donation_data, $stripe_gateway ) {
 					'amount'               => $stripe_gateway->format_amount( $donation_data['price'] ),
 					'currency'             => give_get_currency( $form_id ),
 					'payment_method_types' => [ 'card' ],
-                    'statement_descriptor_suffix' => give_stripe_get_statement_descriptor(),
 					'description'          => give_payment_gateway_donation_summary( $donation_data ),
 					'metadata'             => $stripe_gateway->prepare_metadata( $donation_id ),
 					'customer'             => $stripe_customer_id,

--- a/includes/gateways/stripe/includes/give-stripe-helpers.php
+++ b/includes/gateways/stripe/includes/give-stripe-helpers.php
@@ -842,6 +842,7 @@ function give_stripe_is_source_type( $id, $type = 'src' ) {
 /**
  * This helper function is used to process Stripe payments.
  *
+ * @unreleased switch to using statement_descriptor_suffix per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
  * @since 2.33.0 no longer store the payment intent secret
  * @since 2.5.0
  *

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
@@ -27,7 +27,7 @@ class CreatePaymentIntent
     }
 
     /**
-     * @unreleased switch to using statement_descriptor_suffix per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
+     * @unreleased remove descriptor as Stripe automatically adds it, per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
      * @since 2.33.0 no longer store the payment intent secret
      * @since 2.19.0
      *

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
@@ -51,7 +51,6 @@ class CreatePaymentIntent
                 'amount' => $donation->amount->formatToMinorAmount(),
                 'currency' => $donation->amount->getCurrency(),
                 'payment_method_types' => ['card'],
-                'statement_descriptor_suffix' => give_stripe_get_statement_descriptor(),
                 'description' => $donationSummary->getSummaryWithDonor(),
                 'metadata' => give_stripe_prepare_metadata($donation->id),
                 'customer' => $giveStripeCustomer->get_id(),

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
@@ -27,6 +27,7 @@ class CreatePaymentIntent
     }
 
     /**
+     * @unreleased switch to using statement_descriptor_suffix per Stripe API changes (https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges)
      * @since 2.33.0 no longer store the payment intent secret
      * @since 2.19.0
      *

--- a/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
+++ b/src/PaymentGateways/Gateways/Stripe/Actions/CreatePaymentIntent.php
@@ -50,7 +50,7 @@ class CreatePaymentIntent
                 'amount' => $donation->amount->formatToMinorAmount(),
                 'currency' => $donation->amount->getCurrency(),
                 'payment_method_types' => ['card'],
-                'statement_descriptor' => give_stripe_get_statement_descriptor(),
+                'statement_descriptor_suffix' => give_stripe_get_statement_descriptor(),
                 'description' => $donationSummary->getSummaryWithDonor(),
                 'metadata' => give_stripe_prepare_metadata($donation->id),
                 'customer' => $giveStripeCustomer->get_id(),


### PR DESCRIPTION
## Description

Stripe made changes to how statement descriptors are used in Payment Intents for cards: https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges 

This breaking change affects new Stripe accounts, but prevents donations from working, as such it’s high priority.

Note: I did not change the descriptor for anything other than Payment Intents with `card` as the `payment_method_types` as that's the only scenario affected by the change.

## Affects

Donations processing a credit card using Stripe

## Testing Instructions

1. Test a v2 form using a credit card with Stripe
2. Test a v3 form using a credit card with Stripe

In both cases, check the descriptor in the Stripe dashboard to make sure it's present and looks good.

## Pre-review Checklist

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

