### PR TITLE
Refactor: Co-location submenu scripts with render

### DIFF
--- a/src/EventTickets/Actions/EnqueueEventDetailsScripts.php
+++ b/src/EventTickets/Actions/EnqueueEventDetailsScripts.php
@@ -2,23 +2,14 @@
 
 namespace Give\EventTickets\Actions;
 
+use Give\EventTickets\Models\Event;
 use Give\EventTickets\Repositories\EventRepository;
 use Give\Helpers\EnqueueScript;
 
 class EnqueueEventDetailsScripts
 {
-    public function __invoke()
+    public function __invoke(Event $event)
     {
-        if (!$this->isShowing()) {
-            return;
-        }
-
-        $event = give(EventRepository::class)->getById((int) $_GET['id']);
-
-        if (!$event) {
-            wp_die(__('Event not found', 'give-event-tickets'), 404);
-        }
-
         $data = [
             'apiRoot' => esc_url_raw(rest_url('give-api/v2/events-tickets/events')),
             'apiNonce' => wp_create_nonce('wp_rest'),
@@ -39,15 +30,5 @@ class EnqueueEventDetailsScripts
         );
 
         wp_enqueue_style('givewp-design-system-foundation');
-    }
-
-    /**
-     * Helper function to determine if current page is Give Event Tickets admin page
-     *
-     * @unreleased
-     */
-    private function isShowing(): bool
-    {
-        return isset($_GET['page']) && $_GET['page'] === 'give-event-tickets' && ! isset($_GET['view']) && isset($_GET['id']) && $_GET['id'] > 0;
     }
 }

--- a/src/EventTickets/Actions/EnqueueListTableScripts.php
+++ b/src/EventTickets/Actions/EnqueueListTableScripts.php
@@ -9,10 +9,6 @@ class EnqueueListTableScripts
 {
     public function __invoke()
     {
-        if (!$this->isShowing()) {
-            return;
-        }
-
         $data = [
             'apiRoot' => esc_url_raw(rest_url('give-api/v2/events-tickets/events/list-table')),
             'apiNonce' => wp_create_nonce('wp_rest'),
@@ -35,15 +31,5 @@ class EnqueueListTableScripts
         );
 
         wp_enqueue_style('givewp-design-system-foundation');
-    }
-
-    /**
-     * Helper function to determine if current page is Give Event Tickets admin page
-     *
-     * @unreleased
-     */
-    private function isShowing(): bool
-    {
-        return isset($_GET['page']) && $_GET['page'] === 'give-event-tickets' && ! isset($_GET['view']) && ( ! isset($_GET['id']) || $_GET['id'] === 'new');
     }
 }

--- a/src/EventTickets/Actions/RegisterEventsMenuItem.php
+++ b/src/EventTickets/Actions/RegisterEventsMenuItem.php
@@ -2,6 +2,9 @@
 
 namespace Give\EventTickets\Actions;
 
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Repositories\EventRepository;
+
 /**
  * @unreleased
  */
@@ -26,6 +29,18 @@ class RegisterEventsMenuItem
      */
     public function render()
     {
+        if(isset($_GET['id'])) {
+            $event = Event::find(absint($_GET['id']));
+
+            if (!$event) {
+                wp_die(__('Event not found', 'give-event-tickets'), 404);
+            }
+
+            give(EnqueueEventDetailsScripts::class)($event);
+        } else {
+            give(EnqueueListTableScripts::class)();
+        }
+
         echo '<div id="give-admin-event-tickets-root"></div>';
     }
 }

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -53,7 +53,7 @@ class ServiceProvider implements ServiceProviderInterface
 
         $this->registerMigrations();
         $this->registerRoutes();
-        $this->registerEventTicketsAdminPage();
+        $this->registerMenus();
         $this->registerFormExtension();
     }
 
@@ -87,11 +87,9 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * @unreleased
      */
-    private function registerEventTicketsAdminPage(): void
+    private function registerMenus(): void
     {
         Hooks::addAction('admin_menu', RegisterEventsMenuItem::class, '__invoke', 15);
-        Hooks::addAction('admin_enqueue_scripts', EnqueueListTableScripts::class);
-        Hooks::addAction('admin_enqueue_scripts', EnqueueEventDetailsScripts::class);
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR co-locates submenu scripts with the render method.

The benefit here is that the logic of which script is getting enqueued is in a single place with the render of the submenu, which is where you would look to debug an issue - as opposed to having multiple enqueue actions that may or may not enqueue a script.

This also greatly simplifies the `isShowing()` logic, since most of the check is no longer necessary. 

And the enqueue actions themselves are now only responsible for enqueuing scripts and styles - and not responsible for determining if the script should or should not be enqueued.