### PR TITLE
Refactor: Update deep link for create event modal

### DIFF
--- a/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
+++ b/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
@@ -28,7 +28,7 @@ class EnqueueFormBuilderScripts
             'eventTicketsBlockSettings',
             [
                 'events' => $this->getEvents(),
-                'createEventUrl' => admin_url('edit.php?post_type=give_forms&page=give-event-tickets&id=new'),
+                'createEventUrl' => admin_url('edit.php?post_type=give_forms&page=give-event-tickets&new=event'),
                 'listEventsUrl' => admin_url('edit.php?post_type=give_forms&page=give-event-tickets'),
                 'ticketsLabel' => apply_filters(
                     'givewp_event_tickets_block/tickets_label',

--- a/src/EventTickets/resources/admin/components/CreateEventModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/CreateEventModal/index.tsx
@@ -12,9 +12,9 @@ import FormModal from '../FormModal';
  */
 const autoOpenModal = () => {
     const queryParams = new URLSearchParams(window.location.search);
-    const id = queryParams.get('id');
+    const newParam = queryParams.get('new');
 
-    return id === 'new';
+    return newParam === 'event';
 };
 
 /**

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
@@ -72,7 +72,7 @@ const ListTableBlankSlate = () => {
             <p className={styles.helpMessage}>{__('Don’t worry, let’s help you setup your first event.', 'give')}</p>
             <p>
                 <a
-                    href={`${window.GiveEventTickets.adminUrl}edit.php?post_type=give_forms&page=give-event-tickets&id=new`}
+                    href={`${window.GiveEventTickets.adminUrl}edit.php?post_type=give_forms&page=give-event-tickets&new=event`}
                     className={`button button-primary ${styles.button}`}
                 >
                     {__('Create event', 'give')}

--- a/src/EventTickets/resources/admin/event-details.tsx
+++ b/src/EventTickets/resources/admin/event-details.tsx
@@ -2,4 +2,5 @@ import {createRoot} from 'react-dom/client';
 
 const container = document.getElementById('give-admin-event-tickets-root');
 const root = createRoot(container!);
+// @ts-ignore
 root.render(<p>Event Details: {window.GiveEventTickets?.event?.title}</p>);


### PR DESCRIPTION
## Description

This pull request updates our code to include recent changes made to the query parameters. The deep link to automatically trigger the create event modal is now `edit.php?post_type=give_forms&page=give-event-tickets&new=event`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

