### PR TITLE
Feature: Add Event Details page with Event Card

### DIFF
--- a/src/EventTickets/Actions/EnqueueEventDetailsScripts.php
+++ b/src/EventTickets/Actions/EnqueueEventDetailsScripts.php
@@ -3,7 +3,6 @@
 namespace Give\EventTickets\Actions;
 
 use Give\EventTickets\Models\Event;
-use Give\EventTickets\Repositories\EventRepository;
 use Give\Helpers\EnqueueScript;
 
 class EnqueueEventDetailsScripts
@@ -20,7 +19,7 @@ class EnqueueEventDetailsScripts
         EnqueueScript::make('give-admin-event-tickets-details', 'assets/dist/js/give-admin-event-tickets-details.js')
             ->loadInFooter()
             ->registerTranslations()
-            ->registerLocalizeData('GiveEventTickets', $data)->enqueue();
+            ->registerLocalizeData('GiveEventTicketsDetails', $data)->enqueue();
 
         wp_enqueue_style(
             'give-admin-ui-font',

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
@@ -1,0 +1,8 @@
+export default function DonationFormsSection() {
+    return (
+        <section>
+            <h1>Donation Forms Section</h1>
+            <p>Donation Forms List Table</p>
+        </section>
+    );
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
@@ -1,5 +1,8 @@
 import {__} from '@wordpress/i18n';
 
+/**
+ * @unreleased
+ */
 export default function DonationFormsSection() {
     return (
         <section>

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
@@ -1,7 +1,9 @@
+import {__} from '@wordpress/i18n';
+
 export default function DonationFormsSection() {
     return (
         <section>
-            <h1>Donation Forms Section</h1>
+            <h2>{__('Donation Forms', 'give')}</h2>
             <p>Donation Forms List Table</p>
         </section>
     );

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventDetailsPage.module.scss
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventDetailsPage.module.scss
@@ -1,0 +1,114 @@
+:global {
+    :root {
+        --give-primary-color: #69b868;
+    }
+
+    .post-type-give_forms #wpbody {
+        box-sizing: border-box;
+
+        & > a {
+            text-decoration: underline;
+        }
+    }
+
+    .post-type-give_forms #wpbody-content {
+        box-sizing: border-box;
+    }
+
+    .post-type-give_forms #wpbody::after {
+        all: revert;
+    }
+
+    .give-visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
+    }
+
+    #wpcontent {
+        padding: 0;
+    }
+}
+
+.page {
+    box-sizing: border-box;
+    color: #333;
+    font-family: Open Sans, system-ui, sans-serif;
+    font-size: 1rem;
+
+    *,
+    ::before,
+    ::after {
+        box-sizing: inherit;
+    }
+}
+
+.pageHeader {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background-color: #fff;
+    padding-block: 1em;
+    padding-inline: 1.5em;
+    border-bottom: 0.0625rem solid #dbdbdb;
+
+    & > * {
+        flex-shrink: 0;
+    }
+}
+
+.flexRow {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 1rem;
+
+    & > span {
+        padding-inline: 0.5rem;
+        padding-block: 0.185rem;
+        background: #f49420;
+        border-radius: 5px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04rem;
+        transform: translateY(0.075rem);
+        color: #ffffff;
+    }
+}
+
+.flexRow:not(:first-child) {
+    flex: 1;
+    justify-content: flex-end;
+}
+
+.pageTitle {
+    color: #424242;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.pageContent {
+    padding: 0 1.5em 1.5em 1.5em;
+}
+
+:global(#give-admin-event-tickets-root) {
+    .goToEventsListButton {
+        background: none;
+        border-radius: 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.43;
+        padding: var(--givewp-spacing-2) var(--givewp-spacing-4);
+        text-align: center;
+    }
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventDetailsPage.module.scss
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventDetailsPage.module.scss
@@ -99,6 +99,10 @@
 
 .pageContent {
     padding: 0 1.5em 1.5em 1.5em;
+
+    section {
+        margin-bottom: var(--givewp-spacing-14);
+    }
 }
 
 :global(#give-admin-event-tickets-root) {

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSection.module.scss
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSection.module.scss
@@ -1,0 +1,104 @@
+.tableGroup {
+    background-color: #fff;
+    border: 0.0625em solid #ddd;
+    border-radius: 0.3125em;
+    overflow: auto;
+    position: relative;
+    max-inline-size: 100%;
+    box-shadow: 0 0 0.5625em rgb(68 68 68 / 0.05);
+}
+
+.table {
+    border-radius: inherit;
+    border-spacing: 0;
+    inline-size: 100%;
+    table-layout: fixed;
+}
+
+.tableColumnHeader {
+    border-bottom: 0.0625em solid #ddd;
+    color: var(--givewp-grey-700);
+    font-size: 1rem;
+    padding: var(--givewp-spacing-5) var(--givewp-spacing-9);
+    text-align: start;
+    vertical-align: middle;
+}
+
+.tableContent {
+    overflow: auto;
+}
+
+.tableRow {
+    &:hover .tableRowActions {
+        opacity: 1;
+    }
+}
+
+.tableRowActions {
+    position: absolute;
+    inset-block-end: 1rem;
+
+    display: flex;
+    align-items: center;
+    column-gap: 1.25rem;
+    word-break: keep-all;
+    transition: opacity 150ms ease-in-out;
+
+    > * {
+        position: relative;
+        color: #0878b0;
+        font-weight: 400;
+        line-height: 1;
+        flex-shrink: 0;
+    }
+
+    > * + ::before {
+        position: absolute;
+        content: "";
+        inset-block: auto;
+        inset-inline-start: calc(-.6725rem);
+        block-size: 110%;
+        inline-size: 0.125rem;
+        background-color: #dedede;
+    }
+
+    > a {
+        text-decoration: none;
+    }
+
+    &:focus-within {
+        opacity: 1;
+    }
+}
+
+.tableCell {
+    color: var(--givewp-grey-700);
+    font-size: 0.875em;
+    font-weight: 600;
+    padding: var(--givewp-spacing-4) var(--givewp-spacing-9) var(--givewp-spacing-7);
+    position: relative;
+    vertical-align: middle;
+
+    & a {
+        text-decoration: none;
+
+        &:focus, &:hover, &:active {
+            text-decoration: underline;
+            transition: all 0.05s ease-in-out;
+        }
+    }
+
+    &.title {
+        line-height: 2rem;
+    }
+
+    &.description {
+        font-weight: 400;
+    }
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .tableRowActions {
+        opacity: 0;
+    }
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
@@ -7,6 +7,9 @@ const apiSettings = window.GiveEventTicketsDetails;
 apiSettings.apiRoot = apiSettings.apiRoot.replace('/list-table', '');
 const eventTicketsApi = new ListTableApi(apiSettings);
 
+/**
+ * @unreleased
+ */
 export function EventSectionRowActions({item, setUpdateErrors}) {
     const fetchAndUpdateErrors = async (endpoint, id, method) => {
         const response = await eventTicketsApi.fetchWithArgs(endpoint, {ids: [id]}, method);

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
@@ -1,0 +1,44 @@
+import {__, sprintf} from '@wordpress/i18n';
+import RowAction from '@givewp/components/ListTable/RowAction';
+import ListTableApi from '@givewp/components/ListTable/api';
+
+const apiSettings = window.GiveEventTicketsDetails;
+// Remove the /list-table from the apiRoot. This is a hack to make the API work while we don't refactor other list tables.
+apiSettings.apiRoot = apiSettings.apiRoot.replace('/list-table', '');
+const eventTicketsApi = new ListTableApi(apiSettings);
+
+export function EventSectionRowActions({item, setUpdateErrors}) {
+    const fetchAndUpdateErrors = async (endpoint, id, method) => {
+        const response = await eventTicketsApi.fetchWithArgs(endpoint, {ids: [id]}, method);
+        setUpdateErrors(response);
+        return response;
+    };
+
+    const deleteItem = async (itemId) => await fetchAndUpdateErrors('/list-table', itemId, 'DELETE');
+
+    const confirmModal = async () => {
+        const confirmDelete = confirm(sprintf(__('Really delete event #%d?', 'give'), item.id));
+
+        if (confirmDelete) {
+            if (await deleteItem(item.id)) {
+                window.location.href = window.GiveEventTicketsDetails.adminUrl + 'edit.php?post_type=give_forms&page=give-event-tickets';
+            }
+        }
+    }
+
+    return (
+        <>
+            <RowAction
+                onClick={() => {alert('Edit modal will be opened')}}
+                displayText={__('Edit', 'give')}
+            />
+            <RowAction
+                onClick={confirmModal}
+                actionId={item.id}
+                displayText={__('Delete', 'give')}
+                hiddenText={item.name}
+                highlight
+            />
+        </>
+    );
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -3,6 +3,9 @@ import {format} from 'date-fns';
 import styles from './EventSection.module.scss';
 import {EventSectionRowActions} from './EventSectionRowActions';
 
+/**
+ * @unreleased
+ */
 export default function EventSection({setUpdateErrors}) {
     const {event} = window.GiveEventTicketsDetails;
     const startDateTime = new Date(event.startDateTime.date);

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -2,6 +2,7 @@ import {__, _x} from '@wordpress/i18n';
 import {format} from 'date-fns';
 import styles from './EventSection.module.scss';
 import {EventSectionRowActions} from './EventSectionRowActions';
+import locale from '../../../../date-fns-locale';
 
 /**
  * @unreleased
@@ -22,8 +23,8 @@ export default function EventSection({setUpdateErrors}) {
     const tableContent = {
         title: event.title,
         description: event.description,
-        startDateTime: format(startDateTime, dateFormat),
-        endDateTime: format(endDateTime, dateFormat),
+        startDateTime: format(startDateTime, dateFormat, {locale}),
+        endDateTime: format(endDateTime, dateFormat, {locale}),
     };
 
     return (

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -1,0 +1,10 @@
+export default function EventSection() {
+    const {event} = window.GiveEventTickets;
+
+    return (
+        <section>
+            <h1>Event Section</h1>
+            <p>{event.title} Details</p>
+        </section>
+    );
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -1,10 +1,65 @@
-export default function EventSection() {
-    const {event} = window.GiveEventTickets;
+import {__, _x} from '@wordpress/i18n';
+import {format} from 'date-fns';
+import styles from './EventSection.module.scss';
+import {EventSectionRowActions} from './EventSectionRowActions';
+
+export default function EventSection({setUpdateErrors}) {
+    const {event} = window.GiveEventTicketsDetails;
+    const startDateTime = new Date(event.startDateTime.date);
+    const endDateTime = new Date(event.endDateTime.date);
+    const dateFormat = _x("MM/dd/yyyy 'at' h:mmaaa", 'Date format for event details page', 'give');
+
+    const tableHeaders = [
+        __('Event', 'give'),
+        __('Description', 'give'),
+        __('Start Date', 'give'),
+        __('End Date', 'give'),
+    ];
+
+    const tableContent = {
+        title: event.title,
+        description: event.description,
+        startDateTime: format(startDateTime, dateFormat),
+        endDateTime: format(endDateTime, dateFormat),
+    };
 
     return (
         <section>
-            <h1>Event Section</h1>
-            <p>{event.title} Details</p>
+            <h2>{__('Event', 'give')}</h2>
+            <div className={styles.tableGroup}>
+                <table className={styles.table}>
+                    <thead>
+                        <tr>
+                            {tableHeaders.map((text, key) => (
+                                <th className={styles.tableColumnHeader} key={key}>
+                                    {text}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr className={styles.tableRow}>
+                            {Object.keys(tableContent).map((key) => (
+                                <td className={`${styles.tableCell} ${styles[key] ?? ''}`} key={key}>
+                                    {tableContent[key]}
+                                    {key === 'title' && (
+                                        <div
+                                            role="group"
+                                            aria-label={__('Actions', 'give')}
+                                            className={styles.tableRowActions}
+                                        >
+                                            <EventSectionRowActions
+                                                item={{id: event.id, name: event.title}}
+                                                setUpdateErrors={setUpdateErrors}
+                                            />
+                                        </div>
+                                    )}
+                                </td>
+                            ))}
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </section>
     );
 }

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -1,5 +1,8 @@
 import {__} from '@wordpress/i18n';
 
+/**
+ * @unreleased
+ */
 export default function TicketTypesSection() {
     return (
         <section>

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -1,0 +1,8 @@
+export default function TicketTypesSection() {
+    return (
+        <section>
+            <h1>Ticket Types Section</h1>
+            <p>Ticket Types List Table</p>
+        </section>
+    );
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -1,7 +1,9 @@
+import {__} from '@wordpress/i18n';
+
 export default function TicketTypesSection() {
     return (
         <section>
-            <h1>Ticket Types Section</h1>
+            <h2>{__('Tickets', 'give')}</h2>
             <p>Ticket Types List Table</p>
         </section>
     );

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -3,6 +3,9 @@ import {__} from '@wordpress/i18n';
 import {GiveIcon} from '@givewp/components';
 import styles from './EventDetailsPage.module.scss';
 import {GiveEventTickets} from './types';
+import EventSection from './EventSection';
+import TicketTypesSection from './TicketTypesSection';
+import DonationFormsSection from './DonationFormsSection';
 
 declare global {
     interface Window {
@@ -29,7 +32,11 @@ export default function EventDetailsPage() {
                     </div>
                 </header>
                 <div className={cx('wp-header-end', 'hidden')} />
-                <div className={styles.pageContent}>{window.GiveEventTickets.event.title}</div>
+                <div className={styles.pageContent}>
+                    <EventSection />
+                    <TicketTypesSection />
+                    <DonationFormsSection />
+                </div>
             </article>
         </>
     );

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -2,14 +2,14 @@ import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import {GiveIcon} from '@givewp/components';
 import styles from './EventDetailsPage.module.scss';
-import {GiveEventTickets} from './types';
+import {GiveEventTicketsDetails} from './types';
 import EventSection from './EventSection';
 import TicketTypesSection from './TicketTypesSection';
 import DonationFormsSection from './DonationFormsSection';
 
 declare global {
     interface Window {
-        GiveEventTickets: GiveEventTickets;
+        GiveEventTicketsDetails: GiveEventTicketsDetails;
     }
 }
 
@@ -24,7 +24,7 @@ export default function EventDetailsPage() {
                     </div>
                     <div className={styles.flexRow}>
                         <a
-                            href={`${window.GiveEventTickets.adminUrl}edit.php?post_type=give_forms&page=give-event-tickets`}
+                            href={`${window.GiveEventTicketsDetails.adminUrl}edit.php?post_type=give_forms&page=give-event-tickets`}
                             className={`button button-secondary ${styles.goToEventsListButton}`}
                         >
                             {__('Go to events list', 'give')}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import {GiveIcon} from '@givewp/components';
@@ -14,6 +15,11 @@ declare global {
 }
 
 export default function EventDetailsPage() {
+    const [updateErrors, setUpdateErrors] = useState<{errors: Array<number>; successes: Array<number>}>({
+        errors: [],
+        successes: [],
+    });
+
     return (
         <>
             <article className={styles.page}>
@@ -33,7 +39,7 @@ export default function EventDetailsPage() {
                 </header>
                 <div className={cx('wp-header-end', 'hidden')} />
                 <div className={styles.pageContent}>
-                    <EventSection />
+                    <EventSection setUpdateErrors={setUpdateErrors} />
                     <TicketTypesSection />
                     <DonationFormsSection />
                 </div>

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -2,6 +2,13 @@ import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import {GiveIcon} from '@givewp/components';
 import styles from './EventDetailsPage.module.scss';
+import {GiveEventTickets} from './types';
+
+declare global {
+    interface Window {
+        GiveEventTickets: GiveEventTickets;
+    }
+}
 
 export default function EventDetailsPage() {
     return (

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -1,0 +1,29 @@
+import cx from 'classnames';
+import {__} from '@wordpress/i18n';
+import {GiveIcon} from '@givewp/components';
+import styles from './EventDetailsPage.module.scss';
+
+export default function EventDetailsPage() {
+    return (
+        <>
+            <article className={styles.page}>
+                <header className={styles.pageHeader}>
+                    <div className={styles.flexRow}>
+                        <GiveIcon size={'1.875rem'} />
+                        <h1 className={styles.pageTitle}>{__('Event details', 'give')}</h1>
+                    </div>
+                    <div className={styles.flexRow}>
+                        <a
+                            href={`${window.GiveEventTickets.adminUrl}edit.php?post_type=give_forms&page=give-event-tickets`}
+                            className={`button button-secondary ${styles.goToEventsListButton}`}
+                        >
+                            {__('Go to events list', 'give')}
+                        </a>
+                    </div>
+                </header>
+                <div className={cx('wp-header-end', 'hidden')} />
+                <div className={styles.pageContent}>{window.GiveEventTickets.event.title}</div>
+            </article>
+        </>
+    );
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
@@ -1,0 +1,14 @@
+export interface GiveEventTickets {
+    apiNonce: string;
+    apiRoot: string;
+    event: {
+        title: string;
+        description: string;
+        startDateTime: string;
+        endDateTime: string;
+        createdAt: string;
+        updatedAt: string;
+    };
+    adminUrl: string;
+    pluginUrl: string;
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
@@ -1,11 +1,20 @@
-export interface GiveEventTickets {
+export interface GiveEventTicketsDetails {
     apiNonce: string;
     apiRoot: string;
     event: {
+        id: number;
         title: string;
         description: string;
-        startDateTime: string;
-        endDateTime: string;
+        startDateTime: {
+            date: string;
+            timezone_type: number;
+            timezone: string;
+        };
+        endDateTime: {
+            date: string;
+            timezone_type: number;
+            timezone: string;
+        };
         createdAt: string;
         updatedAt: string;
     };

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
@@ -6,17 +6,12 @@ import {IdBadge} from '@givewp/components/ListTable/TableCell';
 import {Interweave} from 'interweave';
 import {EventTicketsRowActions} from './EventTicketsRowActions';
 import styles from './EventTicketsListTable.module.scss';
+import {GiveEventTickets} from './types';
 import CreateEventModal from '../CreateEventModal';
 
 declare global {
     interface Window {
-        GiveEventTickets: {
-            apiNonce: string;
-            apiRoot: string;
-            table: {columns: Array<object>};
-            adminUrl: string;
-            pluginUrl: string;
-        };
+        GiveEventTickets: GiveEventTickets;
     }
 }
 

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/types.ts
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/types.ts
@@ -1,0 +1,7 @@
+export interface GiveEventTickets {
+    apiNonce: string;
+    apiRoot: string;
+    table: { columns: Array<object> };
+    adminUrl: string;
+    pluginUrl: string;
+}

--- a/src/EventTickets/resources/admin/event-details.tsx
+++ b/src/EventTickets/resources/admin/event-details.tsx
@@ -1,5 +1,6 @@
 import {createRoot} from 'react-dom/client';
+import EventDetailsPage from './components/EventDetailsPage';
 
 const container = document.getElementById('give-admin-event-tickets-root');
 const root = createRoot(container!);
-root.render(<p>Event Details: {window.GiveEventTickets?.event?.title}</p>);
+root.render(<EventDetailsPage />);

--- a/src/EventTickets/resources/date-fns-locale.ts
+++ b/src/EventTickets/resources/date-fns-locale.ts
@@ -1,0 +1,8 @@
+import * as locales from 'date-fns/locale';
+
+const browserLanguage = navigator.language;
+const localizedCode = browserLanguage.replace('-', '');
+const genericCode = browserLanguage.split('-')[0];
+const locale = locales[localizedCode] ?? locales[genericCode] ?? locales.enUS;
+
+export default locale;


### PR DESCRIPTION
Resolves [GIVE-360]

## Description

This pull-request adds the basic structure for the Event Details page, including the event card and initial scaffold for the other sections.

#### To Do
- The Delete Confirmation Modal is currently part of the List Table and requires to be re-implemented here so to speed up development, I'm temporarily replacing it with a native `confirm` prompt.
- Ability to edit an event will be part of another PR.
- Global notifications area still to be implemented.
- Loader while processing an AJAX request still to be implemented.

## Visuals
![CleanShot 2024-02-29 at 17 19 04](https://github.com/impress-org/givewp/assets/3921017/b1d27900-f0d1-406b-a00b-0524498025b8)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-360]: https://stellarwp.atlassian.net/browse/GIVE-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ