### PR TITLE
Refactor: Add attendee name to ticket endpoint

### DIFF
--- a/src/EventTickets/Actions/AttachAttendeeNamesToTicketData.php
+++ b/src/EventTickets/Actions/AttachAttendeeNamesToTicketData.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Give\EventTickets\Actions;
+
+use Give\EventTickets\Models\EventTicket;
+use Give\Framework\QueryBuilder\QueryBuilder;
+
+/**
+ * @unreleased
+ */
+class AttachAttendeeNamesToTicketData
+{
+    /**
+     * @unreleased
+     * @var array
+     */
+    protected $attendeeNameLookup;
+
+    /**
+     * @unreleased
+     * @param EventTicket[] $tickets
+     */
+    public function __construct(array $tickets)
+    {
+        $this->attendeeNameLookup = array_reduce($this->getAttendeeDataForTickets($tickets), function($lookup, $data) {
+            $lookup[$data->donationId] = $data->attendee;
+            return $lookup;
+        }, []);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function __invoke(EventTicket $ticket): array
+    {
+        return array_merge($ticket->toArray(), [
+            'attendee' => $this->attendeeNameLookup[$ticket->donationId] ?? null,
+        ]);
+    }
+
+    /**
+     * This query relates donors names to tickets through donations.
+     *
+     * @unreleased
+     *
+     * @param EventTicket[] $tickets
+     */
+    protected function getAttendeeDataForTickets(array $tickets): array
+    {
+        return (new QueryBuilder)
+            ->from('posts', 'Donation')
+            ->select(
+                ['Donation.ID', 'donationId'],
+                ['Donor.name', 'attendee']
+            )
+            ->join(function($builder) {
+                $builder
+                    ->leftJoin('give_donationmeta', $tableAlias = 'DonationDonorId' )
+                    ->on('Donation.ID', "DonationDonorId.donation_id")
+                    ->andOn("DonationDonorId.meta_key", '_give_payment_donor_id', true);
+            })
+            ->join(function($builder) {
+                $builder
+                    ->leftJoin('give_donors', $tableAlias = 'Donor' )
+                    ->on('DonationDonorId.meta_value', "Donor.id");
+            })
+            ->where('post_type', 'give_payment')
+            ->whereIn('Donation.ID', array_column($tickets, 'donationId'))
+            ->getAll();
+    }
+}

--- a/src/EventTickets/Routes/GetEventTickets.php
+++ b/src/EventTickets/Routes/GetEventTickets.php
@@ -3,9 +3,12 @@
 namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
+use Give\Donations\Models\Donation;
+use Give\EventTickets\Actions\AttachAttendeeNamesToTicketData;
 use Give\EventTickets\Models\Event;
 use Give\EventTickets\Models\EventTicket;
 use Give\Framework\Models\Model;
+use Give\Framework\QueryBuilder\QueryBuilder;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -74,9 +77,7 @@ class GetEventTickets implements RestRoute
 
         return new WP_REST_Response(
             array_map(
-                function (Model $model) {
-                    return $model->toArray();
-                },
+                new AttachAttendeeNamesToTicketData($tickets),
                 $tickets
             )
         );

--- a/tests/Unit/EventTickets/Routes/GetEventTicketsTest.php
+++ b/tests/Unit/EventTickets/Routes/GetEventTicketsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Give\Tests\Unit\EventTickets\Routes;
+
+use Exception;
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Endpoints\ListDonations;
+use Give\Donations\ListTable\DonationsListTable;
+use Give\Donations\Models\Donation;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicket;
+use Give\EventTickets\Routes\GetEventForms;
+use Give\EventTickets\Routes\GetEventsListTable;
+use Give\EventTickets\Routes\GetEventTickets;
+use Give\Framework\Blocks\BlockCollection;
+use Give\Framework\Blocks\BlockModel;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+class GetEventTicketsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    protected function getMockRequest(int $eventId): WP_REST_Request
+    {
+        $request = new WP_REST_Request(
+            WP_REST_Server::READABLE,
+            "/give-api/v2/events-tickets/event/$eventId/tickets"
+        );
+        $request->set_param('event_id', $eventId);
+
+        return $request;
+    }
+
+    public function testTicketHasAttendeeName()
+    {
+        $ticket = EventTicket::factory()->create();
+
+        $response = (new GetEventTickets)->handleRequest(
+            $this->getMockRequest($ticket->event->id)
+        );
+
+        $this->assertEquals($ticket->donation->donor->name, $response->data[0]['attendee']);
+    }
+
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-395](https://stellarwp.atlassian.net/browse/GIVE-395)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the attendee name to tickets returned by the `events-tickets/event/{event_id}/tickets` endpoint.

Attendee names are donor names of the donation associated with tickets.

[GIVE-395]: https://stellarwp.atlassian.net/browse/GIVE-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ