### PR TITLE
Fix: Prevent error in Event Field when Currency Switcher is disabled

### DIFF
--- a/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
@@ -13,7 +13,7 @@ export default function EventTicketsListHOC({name, ticketTypes, ticketsLabel}: E
     const currencySettings = currencySwitcherSettings.find((setting) => setting.id === currency);
     const currencyRate = (currencySettings?.exchangeRate ?? Number('1.00')) || 1;
     const currencyFormatter = useCurrencyFormatter(currency, {
-        minimumFractionDigits: currencySettings.exchangeRateFractionDigits,
+        minimumFractionDigits: currencySettings?.exchangeRateFractionDigits,
     });
     const donationSummary = useDonationSummary();
 


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a `null` check before accessing a property of the Currency Settings, which may not be defined when Currency Switcher is disabled.


## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before |
| --- |
| ![image](https://github.com/impress-org/givewp/assets/10858303/50fbabfe-8f5f-407d-b579-fd68d2ce9ba4) |

| After |
| --- |
| ![image](https://github.com/impress-org/givewp/assets/10858303/972a2f9f-8b98-4f37-9df0-1f3ee937e0e0) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Disable Currency Switcher and load the donation form.