### PR TITLE
Feature: Add routes for Event Details page list tables

### DIFF
--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -542,6 +542,21 @@ class DonationRepository
     }
 
     /**
+     * @unreleased
+     */
+    public function getAllDonationIdsByFormId(int $formId)
+    {
+        return array_column(
+            DB::table('give_donationmeta')
+                ->select('donation_id')
+                ->where('meta_key', DonationMetaKeys::FORM_ID)
+                ->where('meta_value', $formId)
+                ->getAll(),
+            'donation_id'
+        );
+    }
+
+    /**
      * @since 2.23.1 Fixed order by property, see https://github.com/impress-org/givewp/pull/6559
      * @since 2.21.2
      *

--- a/src/EventTickets/Routes/GetEventFormsListTable.php
+++ b/src/EventTickets/Routes/GetEventFormsListTable.php
@@ -194,6 +194,7 @@ class GetEventFormsListTable
 
     private function formatColumns(DonationForm $form): array
     {
+        $formEditLink = get_edit_post_link($form->id);
         $donationIds = give()->donations->getAllDonationIdsByFormId($form->id) ?? [];
         $soldTicketsCount = count($donationIds) > 0
             ? EventTicket::query()
@@ -204,7 +205,7 @@ class GetEventFormsListTable
 
         return [
             'id' => $form->id,
-            'title' => "<a href='{get_edit_link($form->id)}'>{$form->title}</a>",
+            'title' => "<a href='{$formEditLink}'>{$form->title}</a>",
             'count' => "<span>{$soldTicketsCount}</span>",
         ];
     }

--- a/src/EventTickets/Routes/GetEventFormsListTable.php
+++ b/src/EventTickets/Routes/GetEventFormsListTable.php
@@ -205,7 +205,7 @@ class GetEventFormsListTable
         return [
             'id' => $form->id,
             'title' => "<a href='{get_edit_link($form->id)}'>{$form->title}</a>",
-            'count' => $soldTicketsCount,
+            'count' => "<span>{$soldTicketsCount}</span>",
         ];
     }
 }

--- a/src/EventTickets/Routes/GetEventFormsListTable.php
+++ b/src/EventTickets/Routes/GetEventFormsListTable.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicket;
+use Give\Framework\QueryBuilder\QueryBuilder;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @unreleased
+ */
+class GetEventFormsListTable
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'events-tickets/event/(?P<event_id>\d+)/forms/list-table';
+
+    /**
+     * @var WP_REST_Request
+     */
+    protected $request;
+
+    /**
+     * @inheritDoc
+     *
+     * @unreleased
+     */
+    public function registerRoute(): void
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => [$this, 'permissionsCheck'],
+                ],
+                'args' => [
+                    'event_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return Event::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                    'page' => [
+                        'type' => 'integer',
+                        'default' => 1,
+                        'minimum' => 1
+                    ],
+                    'perPage' => [
+                        'type' => 'integer',
+                        'default' => 30,
+                        'minimum' => 1
+                    ],
+                    'sortColumn' => [
+                        'type' => 'string',
+                        'default' => 'id',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'sortDirection' => [
+                        'type' => 'string',
+                        'default' => 'asc',
+                        'enum' => ['asc', 'desc'],
+                    ],
+                    'locale' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'default' => get_locale(),
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        $this->request = $request;
+
+        $forms = $this->getEventForms();
+        $formsCount = $this->getEventFormsCount();
+        $pageCount = (int)ceil($formsCount / $request->get_param('perPage'));
+
+        $items = $this->prepareItems($forms);
+
+        return new WP_REST_Response(
+            [
+                'items' => $items,
+                'totalItems' => $formsCount,
+                'totalPages' => $pageCount
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getEventForms(): array
+    {
+        $page = $this->request->get_param('page');
+        $perPage = $this->request->get_param('perPage');
+        $sortColumns = ['id'];
+        $sortDirection = $this->request->get_param('sortDirection') ?: 'asc';
+
+        $query = DonationForm::query();
+        $query = $this->getWhereConditions($query);
+
+        foreach ($sortColumns as $sortColumn) {
+            $query->orderBy($sortColumn, $sortDirection);
+        }
+
+        $query->limit($perPage)
+            ->offset(($page - 1) * $perPage);
+
+        $forms = $query->getAll();
+
+        if (!$forms) {
+            return [];
+        }
+
+        return $forms;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getEventFormsCount(): int
+    {
+        $query = DonationForm::query();
+        $query = $this->getWhereConditions($query);
+
+        return $query->count();
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getWhereConditions(QueryBuilder $query): QueryBuilder
+    {
+        $eventIdPattern = sprintf('"eventId":%s', $this->request->get_param('event_id'));
+
+        $query->whereLike('give_formmeta_attach_meta_fields.meta_value', '%"name":"givewp/event-tickets"%')
+            ->where(function ($query) use ($eventIdPattern) {
+                $query->whereLike(
+                    'give_formmeta_attach_meta_fields.meta_value',
+                    "%$eventIdPattern}%"
+                ) // When the eventId is the only block attribute.
+                ->orWhereLike(
+                    'give_formmeta_attach_meta_fields.meta_value',
+                    "%$eventIdPattern,%"
+                ); // When the eventId is the NOT only block attribute.
+            });
+
+        return $query;
+    }
+
+
+        /**
+     * @unreleased
+     *
+     * @return bool|\WP_Error
+     */
+    public function permissionsCheck()
+    {
+        return current_user_can('edit_posts')?: new \WP_Error(
+            'rest_forbidden',
+            esc_html__("You don't have permission to view Events", 'give'),
+            ['status' => is_user_logged_in() ? 403 : 401]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    private function prepareItems(array $forms): array
+    {
+        return array_map(
+            function (DonationForm $form) {
+                return $this->formatColumns($form);
+            },
+            $forms
+        );
+    }
+
+    private function formatColumns(DonationForm $form): array
+    {
+        $donationIds = give()->donations->getAllDonationIdsByFormId($form->id) ?? [];
+        $soldTicketsCount = count($donationIds) > 0
+            ? EventTicket::query()
+                ->where('event_id', $this->request->get_param('event_id'))
+                ->whereIn('donation_id', $donationIds)
+                ->count()
+            : 0;
+
+        return [
+            'id' => $form->id,
+            'title' => "<a href='{get_edit_link($form->id)}'>{$form->title}</a>",
+            'count' => $soldTicketsCount,
+        ];
+    }
+}

--- a/src/EventTickets/Routes/GetEventFormsListTable.php
+++ b/src/EventTickets/Routes/GetEventFormsListTable.php
@@ -165,7 +165,7 @@ class GetEventFormsListTable
     }
 
 
-        /**
+    /**
      * @unreleased
      *
      * @return bool|\WP_Error

--- a/src/EventTickets/Routes/GetEventTicketTypesListTable.php
+++ b/src/EventTickets/Routes/GetEventTicketTypesListTable.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicketType;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @unreleased
+ */
+class GetEventTicketTypesListTable
+{
+    /**
+     * @var string
+     */
+    protected $endpoint = 'events-tickets/event/(?P<event_id>\d+)/ticket-types/list-table';
+
+    /**
+     * @var WP_REST_Request
+     */
+    protected $request;
+
+    /**
+     * @inheritDoc
+     *
+     * @unreleased
+     */
+    public function registerRoute(): void
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => [$this, 'permissionsCheck'],
+                ],
+                'args' => [
+                    'event_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return Event::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                    'page' => [
+                        'type' => 'integer',
+                        'default' => 1,
+                        'minimum' => 1
+                    ],
+                    'perPage' => [
+                        'type' => 'integer',
+                        'default' => 30,
+                        'minimum' => 1
+                    ],
+                    'sortColumn' => [
+                        'type' => 'string',
+                        'default' => 'id',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                    'sortDirection' => [
+                        'type' => 'string',
+                        'default' => 'asc',
+                        'enum' => ['asc', 'desc'],
+                    ],
+                    'locale' => [
+                        'type' => 'string',
+                        'required' => false,
+                        'default' => get_locale(),
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        $this->request = $request;
+
+        $eventTicketTypes = $this->getEventTicketTypes();
+        $eventTicketTypesCount = $this->getTotalEventTicketTypesCount();
+        $pageCount = (int)ceil($eventTicketTypesCount / $request->get_param('perPage'));
+
+        $items = $this->prepareItems($eventTicketTypes, $this->request->get_param('locale') ?? '');
+
+        return new WP_REST_Response(
+            [
+                'items' => $items,
+                'totalItems' => $eventTicketTypesCount,
+                'totalPages' => $pageCount
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getEventTicketTypes(): array
+    {
+        $page = $this->request->get_param('page');
+        $perPage = $this->request->get_param('perPage');
+        $sortColumns = ['id'];
+        $sortDirection = $this->request->get_param('sortDirection') ?: 'desc';
+
+        $query = EventTicketType::findByEvent($this->request->get_param('event_id'));
+
+        foreach ($sortColumns as $sortColumn) {
+            $query->orderBy($sortColumn, $sortDirection);
+        }
+
+        $query->limit($perPage)
+            ->offset(($page - 1) * $perPage);
+
+        $eventTicketTypes = $query->getAll();
+
+        if (!$eventTicketTypes) {
+            return [];
+        }
+
+        return $eventTicketTypes;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getTotalEventTicketTypesCount(): int
+    {
+        $query = EventTicketType::findByEvent($this->request->get_param('event_id'));
+
+        return $query->count();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return bool|\WP_Error
+     */
+    public function permissionsCheck()
+    {
+        return current_user_can('edit_posts')?: new \WP_Error(
+            'rest_forbidden',
+            esc_html__("You don't have permission to view Events", 'give'),
+            ['status' => is_user_logged_in() ? 403 : 401]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    private function prepareItems(array $eventTicketTypes, $locale): array
+    {
+        return array_map(
+            function (EventTicketType $eventTicketType) use ($locale) {
+                return $this->formatColumns($eventTicketType, $locale);
+            },
+            $eventTicketTypes
+        );
+    }
+
+    private function formatColumns(EventTicketType $eventTicketType, string $locale): array
+    {
+        $soldTicketsCount = $eventTicketType->eventTickets()->count() ?? 0;
+        $countString = sprintf(
+            __('%1$d of %2$d', 'give'),
+            $soldTicketsCount,
+            $eventTicketType->capacity
+        );
+
+        return [
+            'id' => $eventTicketType->id,
+            'title' => $eventTicketType->title,
+            'count' => $countString,
+            'price' => $eventTicketType->price->formatToLocale($locale),
+        ];
+    }
+}

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -78,6 +78,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventForms::class, 'registerRoute');
+        Hooks::addAction('rest_api_init', Routes\GetEventFormsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTicketTypes::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTicketTypesListTable::class, 'registerRoute');

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -3,8 +3,6 @@
 namespace Give\EventTickets;
 
 use Give\BetaFeatures\Facades\FeatureFlag;
-use Give\EventTickets\Actions\EnqueueEventDetailsScripts;
-use Give\EventTickets\Actions\EnqueueListTableScripts;
 use Give\EventTickets\Actions\RegisterEventsMenuItem;
 use Give\EventTickets\Actions\RenderDonationFormBlock;
 use Give\EventTickets\Repositories\EventRepository;
@@ -82,6 +80,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('rest_api_init', Routes\GetEventForms::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTickets::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTicketTypes::class, 'registerRoute');
+        Hooks::addAction('rest_api_init', Routes\GetEventTicketTypesListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventTicketTypeTickets::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\UpdateEvent::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\UpdateEventTicketType::class, 'registerRoute');


### PR DESCRIPTION
Resolves #

## Description

This PR adds two new routes that are gonna be used on Event Details page: `GetEventTicketTypesListTable` and `GetEventFormsListTable`.

_Tests yet to be included._

## Testing Instructions

### `GetEventTicketTypesListTable`
`events-tickets/event/1/ticket-types/list-table`

### `GetEventFormsListTable`
`events-tickets/event/1/forms/list-table`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

