### PR TITLE
Fix: Remove prefixed phpstan class

### DIFF
--- a/src/ServiceProviders/LegacyServiceProvider.php
+++ b/src/ServiceProviders/LegacyServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Give\ServiceProviders;
 
-use _PHPStan_9a6ded56a\Nette\Neon\Exception;
 use Closure;
 use Give\PaymentGateways\Gateways\Stripe\LegacyStripeAdapter;
 use Give\Route\Form;


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This has apparently been here for a while, but hasn't caused an issue because it is only declared in a `use` statement. But for some reason, an Event Tickets PR is starting to throw an error during static analysis.
