### PR TITLE
New Feat: Admin List Tables - allow third party plugin to add filters

### DIFF
--- a/src/Views/Components/ListTable/Filters/index.tsx
+++ b/src/Views/Components/ListTable/Filters/index.tsx
@@ -51,9 +51,12 @@ export const Filter = ({filter, value = null, onChange, debouncedOnChange}) => {
 };
 
 // figure out what the initial filter state should be based on the filter configuration
-export const getInitialFilterState = (filters) => {
+export const getInitialFilterState = (filters, apiSettings) => {
     const state = {};
     const urlParams = new URLSearchParams(window.location.search);
+
+    // Allow third party extends filters
+    filters = wp.hooks.applyFilters(`give-${apiSettings.table.id}-list-table-filters`, filters);
     filters.map((filter) => {
         // if the search parameters contained a value for the filter, use that
         const filterQuery = decodeURI(urlParams.get(filter.name));

--- a/src/Views/Components/ListTable/ListTablePage/index.tsx
+++ b/src/Views/Components/ListTable/ListTablePage/index.tsx
@@ -84,7 +84,7 @@ export default function ListTablePage({
 }: ListTablePageProps) {
     const [page, setPage] = useState<number>(1);
     const [perPage, setPerPage] = useState<number>(30);
-    const [filters, setFilters] = useState(getInitialFilterState(filterSettings));
+    const [filters, setFilters] = useState(getInitialFilterState(filterSettings, apiSettings));
     const [modalContent, setModalContent] = useState<{confirm; action; label; type?: 'normal' | 'warning' | 'danger'}>({
         confirm: (selected) => {},
         action: (selected) => {},


### PR DESCRIPTION
## Description

My donations come from a limited number of donors.

Some of them have several email addresses and use them randomly.

I took care to merge the different accounts of each donor.

Thus, donors can access their entire donation history, regardless of the email address used to make these donations.

For my part, I want to be able to filter the list of donations in the back office according to a donor ID.

I found that the API endpoint is perfectly capable of handling this filter, it is simply missing in the React version of the donations view.

This PR aims to extend the flexibility of ListTable:

The Give\Donations\Endpoints\ListDonations class is extendable since version 3.4.0, so we can make the API capable of handling all kinds of filters.

With this modification, we can now add these filters to the native view.

## Affects

Admin List Tables

## Testing Instructions

Add some JS code on the front end page (via some snippet) : 

```js
document.addEventListener("DOMContentLoaded", () => {
    wp.hooks.addFilter('give-donations-list-table-filters', 'namespace', filters => {
        return [
            ...filters,
            {
                name: 'donor',
                type: 'search',
                text: 'Donor',
                ariaLabel: 'Search by Donor'
            },
        ];
    });
});
```

Go to back office > Give > Donations

New Field appears in filter fields : Donor. 
Type in it ID of a Donor.

And Tadaaa ! You can filter donation by donor id.

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

