### PR TITLE
Refactor: Ensure event details row actions are always visible.

### DIFF
--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSection.module.scss
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSection.module.scss
@@ -1,0 +1,9 @@
+#eventSection {
+    table {
+        td:first-child {
+            > div {
+                opacity: 1;
+            }
+        }
+    }
+}

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -5,6 +5,7 @@ import EventFormModal from '../../EventFormModal';
 import locale from '../../../../date-fns-locale';
 import SectionTable from '../SectionTable';
 import {EventSectionRowActions} from './EventSectionRowActions';
+import styles from './EventSection.module.scss';
 
 const dateFormat = _x("MM/dd/yyyy 'at' h:mmaaa", 'Date format for event details page', 'give');
 
@@ -41,7 +42,7 @@ export default function EventSection({setUpdateErrors}) {
     ];
 
     return (
-        <section>
+        <section id={styles.eventSection}>
             <h2>{__('Event', 'give')}</h2>
             <SectionTable
                 tableHeaders={tableHeaders}


### PR DESCRIPTION
Resolves [GIVE-265]

## Description

This PR implements a CSS to keep row actions always visible in the Event details table.

## Affects

Tables on the Event details page

## Visuals
![CleanShot 2024-03-11 at 19 29 19](https://github.com/impress-org/givewp/assets/3921017/c6f80e58-e949-4556-a4c7-cd57eff258c4)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-265]: https://stellarwp.atlassian.net/browse/GIVE-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ