### PR TITLE
Refactor: Change unlimited capacity concept from 0 to null

### DIFF
--- a/src/EventTickets/DataTransferObjects/EventTicketTypeData.php
+++ b/src/EventTickets/DataTransferObjects/EventTicketTypeData.php
@@ -69,7 +69,7 @@ final class EventTicketTypeData
         $self->price = $ticketType->price->formatToMinorAmount();
         $self->capacity = $ticketType->capacity;
         $self->salesCount = $ticketType->eventTickets()->count();
-        $self->ticketsAvailable = $self->capacity - $self->salesCount;
+        $self->ticketsAvailable = ! is_null($self->capacity) ? $self->capacity - $self->salesCount : null;
 
         return $self;
     }

--- a/src/EventTickets/ListTable/Columns/SalesCountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesCountColumn.php
@@ -43,13 +43,23 @@ class SalesCountColumn extends ModelColumn
      */
     public function getCellValue($model): string
     {
+        $ticketTypes = $model->ticketTypes()->getAll() ?? [];
         $soldTicketsCount = $model->eventTickets()->count() ?? 0;
-        $capacity = array_reduce($model->ticketTypes()->getAll() ?? [], function (int $carry, $ticketType) {
-            return $carry + $ticketType->capacity;
-        }, 0);
+
+        $hasUnlimitedCapacity = array_filter($ticketTypes, function ($ticketType) {
+            return is_null($ticketType->capacity);
+        });
+
+        if ( ! empty($hasUnlimitedCapacity)) {
+            $capacity = __('Unlimited', 'give');
+        } else {
+            $capacity = array_reduce($ticketTypes, function (int $carry, $ticketType) {
+                return $carry + $ticketType->capacity;
+            }, 0);
+        }
 
         return sprintf(
-            __('%1$d out of %2$d', 'give'),
+            __('%1$d of %2$s', 'give'),
             $soldTicketsCount,
             $capacity
         );

--- a/src/EventTickets/Models/EventTicketType.php
+++ b/src/EventTickets/Models/EventTicketType.php
@@ -141,7 +141,7 @@ class EventTicketType extends Model implements ModelCrud /*, ModelHasFactory */
             'title' => $object->title,
             'description' => $object->description,
             'price' => new Money($object->price, give_get_currency()),
-            'capacity' => (int)$object->capacity,
+            'capacity' => ! is_null($object->capacity) ? (int)$object->capacity : null,
             'createdAt' => Temporal::toDateTime($object->created_at),
             'updatedAt' => Temporal::toDateTime($object->updated_at),
         ]);

--- a/src/EventTickets/Repositories/EventTicketTypeRepository.php
+++ b/src/EventTickets/Repositories/EventTicketTypeRepository.php
@@ -26,7 +26,6 @@ class EventTicketTypeRepository
         'eventId',
         'title',
         'price',
-        'capacity',
     ];
 
     /**

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -62,9 +62,13 @@ class CreateEventTicketType implements RestRoute
                     ],
                     'capacity' => [
                         'type' => 'integer',
-                        'required' => true,
-                        'sanitize_callback' => 'absint',
-                        'validate_callback' => 'rest_is_integer',
+                        'required' => false,
+                        'sanitize_callback' => function ($value) {
+                            return $value === 'null' ? null : absint($value);
+                        },
+                        'validate_callback' => function ($value) {
+                            return $value === 'null' || rest_is_integer($value);
+                        },
                     ],
                 ],
             ]

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -61,8 +61,12 @@ class UpdateEventTicketType implements RestRoute
                     'capacity' => [
                         'type' => 'integer',
                         'required' => false,
-                        'sanitize_callback' => 'absint',
-                        'validate_callback' => 'rest_is_integer',
+                        'sanitize_callback' => function ($value) {
+                            return $value === 'null' ? null : absint($value);
+                        },
+                        'validate_callback' => function ($value) {
+                            return $value === 'null' || rest_is_integer($value);
+                        },
                     ],
                 ],
             ]

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
@@ -10,13 +10,9 @@ export function TicketTypesRowActions({tickets, openEditModal}) {
         const ticket = tickets.find((ticket) => ticket.id === row.id);
 
         const handleEditClick = () => {
-            const {id, title, description, price, capacity} = ticket;
             openEditModal({
-                id,
-                title,
-                description,
-                price: price / 100,
-                capacity,
+                ...ticket,
+                price: ticket?.price / 100,
             });
         };
 

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -78,7 +78,7 @@ export default function TicketTypesSection() {
             count: sprintf(
                 __('%d of %s', 'give'),
                 ticketType.salesCount,
-                ticketType.capacity > 0 ? ticketType.capacity : __('Unlimited', 'give')
+                ticketType.capacity ?? __('Unlimited', 'give')
             ),
             price: ticketType.price > 0 ? amountFormatter.format(ticketType.price / 100) : __('Free', 'give'),
         };

--- a/src/EventTickets/resources/admin/components/FormModal/ErrorMessages.tsx
+++ b/src/EventTickets/resources/admin/components/FormModal/ErrorMessages.tsx
@@ -7,11 +7,14 @@ import {FieldError, FieldErrors} from 'react-hook-form';
  */
 export default function ErrorMessages({errors}: ErrorMessagesProps) {
     if (!(Object.values(errors).length > 0)) return null;
+    const filteredErrors = Object.values(errors).filter((error) => !error?.message);
+
+    if (filteredErrors.length === 0) return null;
 
     return (
         <>
             <ul className="givewp-event-tickets__form-errors">
-                {Object.values(errors).map((error: FieldError, key) => (
+                {filteredErrors.map((error: FieldError, key) => (
                     <li key={key}>{error?.message}</li>
                 ))}
             </ul>

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
@@ -27,15 +27,15 @@ export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, e
         reset({
             title: ticketData?.title || '',
             description: ticketData?.description || '',
-            price: ticketData?.price || null,
-            capacity: ticketData?.capacity || null,
+            price: ticketData?.price > 0 ? ticketData?.price : null,
+            capacity: ticketData?.capacity !== null ? ticketData?.capacity : null,
         });
     }, [ticketData, reset]);
 
     const onSubmit: SubmitHandler<Inputs> = async (data) => {
         try {
             data.price = data.price * 100;
-            data.capacity = data.capacity || 0;
+            data.capacity = data?.capacity || null;
 
             const endpoint = ticketData?.id ? `/ticket-type/${ticketData.id}` : `/event/${eventId}/ticket-types`;
             const response = await API.fetchWithArgs(endpoint, data, 'POST');
@@ -74,14 +74,14 @@ export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, e
             <div className="givewp-event-tickets__form-row givewp-event-tickets__form-row--half">
                 <div className="givewp-event-tickets__form-column">
                     <label htmlFor="price">{__('Price', 'give')}</label>
-                    <input type="number" {...register('price')} />
+                    <input type="number" {...register('price')} min={0} />
                     <span>
                         {__('Leave empty for', 'give')} <strong>{__('free', 'give')}</strong>
                     </span>
                 </div>
                 <div className="givewp-event-tickets__form-column">
                     <label htmlFor="capacity">{__('Capacity', 'give')}</label>
-                    <input type="number" {...register('capacity')} />
+                    <input type="number" {...register('capacity')} min={ticketData?.salesCount ?? 0} />
                     <span>
                         {__('Leave empty for', 'give')} <strong>{__('unlimited', 'give')}</strong>
                     </span>

--- a/src/EventTickets/resources/components/EventTicketsListItem.tsx
+++ b/src/EventTickets/resources/components/EventTicketsListItem.tsx
@@ -7,6 +7,8 @@ export default function EventTicketsListItem({ticketType, currency, currencyRate
     const formatter = useCurrencyFormatter(currency);
     const ticketPrice =
         ticketType.price > 0 ? formatter.format((Number(ticketType.price) * currencyRate) / 100) : __('Free', 'give');
+    const remainingTickets =
+        ticketType.ticketsAvailable !== null ? ticketType.ticketsAvailable - selectedTickets : null;
 
     const handleButtonClick = (quantity) => (e) => {
         e.preventDefault();
@@ -21,18 +23,26 @@ export default function EventTicketsListItem({ticketType, currency, currencyRate
                 <p>{ticketType.description}</p>
             </div>
             <div className={'givewp-event-tickets__tickets__ticket__quantity'}>
-                <div className={'givewp-event-tickets__tickets__ticket__quantity__input'}>
-                    <button onClick={handleButtonClick(selectedTickets - 1)}>
-                        <Icon icon={minus} />
-                    </button>
-                    <input type="text" value={selectedTickets} />
-                    <button onClick={handleButtonClick(selectedTickets + 1)}>
-                        <Icon icon={plus} />
-                    </button>
-                </div>
-                <p className={'givewp-event-tickets__tickets__ticket__quantity__availability'}>
-                    {ticketType.ticketsAvailable - selectedTickets} {__('remaining', 'give')}
-                </p>
+                {remainingTickets === null || remainingTickets > 0 ? (
+                    <>
+                        <div className={'givewp-event-tickets__tickets__ticket__quantity__input'}>
+                            <button onClick={handleButtonClick(selectedTickets - 1)}>
+                                <Icon icon={minus} />
+                            </button>
+                            <input type="text" value={selectedTickets} />
+                            <button onClick={handleButtonClick(selectedTickets + 1)}>
+                                <Icon icon={plus} />
+                            </button>
+                        </div>
+                        {remainingTickets > 0 && (
+                            <p className={'givewp-event-tickets__tickets__ticket__quantity__availability'}>
+                                {remainingTickets} {__('remaining', 'give')}
+                            </p>
+                        )}
+                    </>
+                ) : (
+                    <p>{__('Sold out', 'give')}</p>
+                )}
             </div>
         </div>
     );

--- a/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
@@ -51,7 +51,7 @@ export default function EventTicketsListHOC({name, ticketTypes, ticketsLabel}: E
             selectedQuantity = 0;
         }
 
-        if (selectedQuantity > ticketsAvailable) {
+        if (ticketsAvailable > 0 && selectedQuantity > ticketsAvailable) {
             selectedQuantity = ticketsAvailable;
         }
 

--- a/src/EventTickets/resources/templates/EventTickets/styles.scss
+++ b/src/EventTickets/resources/templates/EventTickets/styles.scss
@@ -140,6 +140,7 @@
                         display: flex;
                         height: 1.25rem;
                         line-height: 1.25rem;
+                        margin: 0;
                         padding: 0;
                         width: 1.25rem;
 
@@ -161,6 +162,7 @@
                         font-size: 1rem !important;
                         font-weight: 600 !important;
                         height: 2.25rem;
+                        margin: 0;
                         padding: var(--givewp-spacing-3) var(--givewp-spacing-2);
                         text-align: center;
                     }


### PR DESCRIPTION
Resolves [GIVE-435]

## Description

Before this pull request, we used to save 0 for the capacity field if left empty. Moving forward, we will store it as null.

This PR includes many changes to support nullable capacity:
-  TicketType Model now verifies null before converting to an integer.
-  TicketTypeRepository no longer requires capacity for validation during insert/update.
-  Create/Update Ticket Type routes now accept null or an integer for capacity, without requiring the argument.
-  SalesCount and SalesAmount columns on Events table now display "Unlimited" if any ticket type has a nullable capacity.
-  Ticket Type edit form now preserves the capacity value without attempting to convert it.
-  Ticket Type table on Event details page now handles null to display "Unlimited."
-  Ticket Type data being passed to the field template will now return either null or a number for the `ticketsAvailable` prop.
-  Field template checks for null or a number greater than 0 for `ticketsAvailable` before showing the quantity input; otherwise, it displays a simple "Sold Out" label.
-  Field template now only shows remaining tickets when the ticket type's capacity is not unlimited.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

