### PR TITLE
Feature: prevent some events from being deleted

### DIFF
--- a/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
@@ -22,7 +22,7 @@ class SalesAmountColumn extends ModelColumn
      */
     public static function getId(): string
     {
-        return 'sales-amount';
+        return 'salesAmount';
     }
 
     /**

--- a/src/EventTickets/ListTable/Columns/SalesCountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesCountColumn.php
@@ -21,7 +21,7 @@ class SalesCountColumn extends ModelColumn
      */
     public static function getId(): string
     {
-        return 'sales-count';
+        return 'salesCount';
     }
 
     /**

--- a/src/EventTickets/Routes/DeleteEventsListTable.php
+++ b/src/EventTickets/Routes/DeleteEventsListTable.php
@@ -73,6 +73,13 @@ class DeleteEventsListTable
         $successes = [];
 
         foreach ($ids as $id) {
+            $soldTicketsCount = give(EventRepository::class)->getById($id)->eventTickets()->count() ?? 0;
+
+            if ($soldTicketsCount > 0) {
+                $errors[] = $id;
+                continue;
+            }
+            
             $eventDeleted = give(EventRepository::class)->getById($id)->delete();
             $eventDeleted ? $successes[] = $id : $errors[] = $id;
         }

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
@@ -11,6 +11,8 @@ export function EventTicketsRowActions({item, setUpdateErrors, parameters}) {
     const showConfirmModal = useContext(ShowConfirmModalContext);
     const {mutate} = useSWRConfig();
 
+    const salesCount = parseInt(item?.salesCount?.match(/^\d+/)[0], 10);
+
     const fetchAndUpdateErrors = async (parameters, endpoint, id, method) => {
         const response = await eventTicketsApi.fetchWithArgs(endpoint, {ids: [id]}, method);
         setUpdateErrors(response);
@@ -32,13 +34,15 @@ export function EventTicketsRowActions({item, setUpdateErrors, parameters}) {
                 href={`edit.php?post_type=give_forms&page=give-event-tickets&id=${item.id}`}
                 displayText={__('Edit', 'give')}
             />
-            <RowAction
-                onClick={confirmModal}
-                actionId={item.id}
-                displayText={__('Delete', 'give')}
-                hiddenText={item.title}
-                highlight
-            />
+            {salesCount === 0 && (
+                <RowAction
+                    onClick={confirmModal}
+                    actionId={item.id}
+                    displayText={__('Delete', 'give')}
+                    hiddenText={item.title}
+                    highlight
+                />
+            )}
         </>
     );
 }

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
@@ -25,6 +25,11 @@ export function EventTicketsRowActions({item, setUpdateErrors, parameters}) {
     const confirmDelete = (selected) => <p>{sprintf(__('Really delete event #%d?', 'give'), item.id)}</p>;
 
     const confirmModal = (event) => {
+        if (salesCount > 0) {
+            alert(__('This event cannot be deleted because it has donations associated with it.', 'give'));
+            return;
+        }
+        
         showConfirmModal(__('Delete', 'give'), confirmDelete, deleteItem, 'danger');
     };
 
@@ -34,15 +39,13 @@ export function EventTicketsRowActions({item, setUpdateErrors, parameters}) {
                 href={`edit.php?post_type=give_forms&page=give-event-tickets&id=${item.id}`}
                 displayText={__('Edit', 'give')}
             />
-            {salesCount === 0 && (
-                <RowAction
-                    onClick={confirmModal}
-                    actionId={item.id}
-                    displayText={__('Delete', 'give')}
-                    hiddenText={item.title}
-                    highlight
-                />
-            )}
+            <RowAction
+                onClick={confirmModal}
+                actionId={item.id}
+                displayText={__('Delete', 'give')}
+                hiddenText={item.title}
+                highlight
+            />
         </>
     );
 }


### PR DESCRIPTION
Resolves [GIVE-422]

## Description

This PR adds an initial implementation for preventing events that has tickets generated from being deleted. Two main actions has been taken: (1) Added an alert when clicking the delete button and (2) added a validation to the API route to ignore those events with tickets.

### To do:
In the future, add an informative modal to explain why the event cannot be deleted.

## Visuals
![CleanShot 2024-03-11 at 21 37 06](https://github.com/impress-org/givewp/assets/3921017/cb2e27d7-023e-47fe-ac38-1cc46325f33b)
![CleanShot 2024-03-12 at 15 00 09](https://github.com/impress-org/givewp/assets/3921017/26aae209-3bba-4dff-b020-f019392a7da4)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-422]: https://stellarwp.atlassian.net/browse/GIVE-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ