### PR TITLE
Feature: add ability to delete ticket types

### DIFF
--- a/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
+++ b/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
@@ -70,6 +70,10 @@ class EnqueueFormBuilderScripts
         }
 
         foreach ($ticketTypes as $ticketType) {
+            if ( ! isset($eventData[$ticketType->eventId])) {
+                continue;
+            }
+
             $eventData[$ticketType->eventId]['ticketTypes'][] = EventTicketTypeData::make($ticketType)->toArray();
         }
 

--- a/src/EventTickets/Routes/DeleteEventTicketType.php
+++ b/src/EventTickets/Routes/DeleteEventTicketType.php
@@ -5,6 +5,7 @@ namespace Give\EventTickets\Routes;
 use Give\API\RestRoute;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Exceptions\Primitives\Exception;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -29,7 +30,7 @@ class DeleteEventTicketType implements RestRoute
                 [
                     'methods' => WP_REST_Server::DELETABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => [$this, 'permissionsCheck'],
                 ],
                 'args' => [
                     'ticket_type_id' => [
@@ -65,5 +66,19 @@ class DeleteEventTicketType implements RestRoute
         $ticketType->delete();
 
         return new WP_REST_Response();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return bool|WP_Error
+     */
+    public function permissionsCheck()
+    {
+        return current_user_can('delete_posts') ?: new WP_Error(
+            'rest_forbidden',
+            esc_html__("You don't have permission to delete Event Ticket Types", 'give'),
+            ['status' => is_user_logged_in() ? 403 : 401]
+        );
     }
 }

--- a/src/EventTickets/Routes/DeleteEventTicketType.php
+++ b/src/EventTickets/Routes/DeleteEventTicketType.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Give\EventTickets\Routes;
+
+use Give\API\RestRoute;
+use Give\EventTickets\Models\EventTicketType;
+use Give\Framework\Exceptions\Primitives\Exception;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @unreleased
+ */
+class DeleteEventTicketType implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'events-tickets/ticket-type/(?P<ticket_type_id>\d+)';
+
+    /**
+     * @inheritDoc
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => WP_REST_Server::DELETABLE,
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => '__return_true',
+                ],
+                'args' => [
+                    'ticket_type_id' => [
+                        'type' => 'integer',
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => function ($eventId) {
+                            return EventTicketType::find($eventId);
+                        },
+                        'required' => true,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function handleRequest(WP_REST_Request $request): WP_REST_Response
+    {
+        $ticketType = EventTicketType::find($request->get_param('ticket_type_id'));
+
+        $salesCount = $ticketType->eventTickets()->count();
+
+        if ($salesCount > 0) {
+            return new WP_REST_Response([
+                'message' => __('This ticket type has been sold and cannot be deleted.', 'give'),
+            ], 400);
+        }
+
+        $ticketType->delete();
+
+        return new WP_REST_Response();
+    }
+}

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -75,6 +75,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('rest_api_init', Routes\CreateEvent::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\CreateEventTicketType::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\DeleteEventsListTable::class, 'registerRoute');
+        Hooks::addAction('rest_api_init', Routes\DeleteEventTicketType::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEvents::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetEventForms::class, 'registerRoute');

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
@@ -5,7 +5,7 @@ import EventTicketsApi from '../../api';
 const apiSettings = window.GiveEventTicketsDetails;
 const eventTicketsApi = new EventTicketsApi(apiSettings);
 
-export function TicketTypesRowActions({tickets, openEditModal}) {
+export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
     return (row) => {
         const ticket = tickets.find((ticket) => ticket.id === row.id);
 
@@ -20,15 +20,14 @@ export function TicketTypesRowActions({tickets, openEditModal}) {
             });
         };
 
-        const deleteItem = async (selected) =>
-            eventTicketsApi.fetchWithArgs('/event/ticket-type/' + ticket.id, {}, 'DELETE');
+        const deleteItem = async (selected) => eventTicketsApi.fetchWithArgs('/ticket-type/' + ticket.id, {}, 'DELETE');
 
         const confirmModal = async () => {
             const confirmDelete = confirm(sprintf(__('Really delete ticket #%d?', 'give'), ticket.id));
 
             if (confirmDelete) {
                 if (await deleteItem(ticket.id)) {
-                    // Refresh data
+                    setTickets((tickets) => tickets.filter((t) => t.id !== ticket.id));
                 }
             }
         };
@@ -36,13 +35,15 @@ export function TicketTypesRowActions({tickets, openEditModal}) {
         return (
             <>
                 <RowAction onClick={handleEditClick} displayText={__('Edit', 'give')} />
-                <RowAction
-                    onClick={confirmModal}
-                    actionId={ticket.id}
-                    displayText={__('Delete', 'give')}
-                    hiddenText={ticket.title}
-                    highlight
-                />
+                {ticket.salesCount === 0 && (
+                    <RowAction
+                        onClick={confirmModal}
+                        actionId={ticket.id}
+                        displayText={__('Delete', 'give')}
+                        hiddenText={ticket.title}
+                        highlight
+                    />
+                )}
             </>
         );
     };

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
@@ -23,6 +23,11 @@ export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
         const deleteItem = async (selected) => eventTicketsApi.fetchWithArgs('/ticket-type/' + ticket.id, {}, 'DELETE');
 
         const confirmModal = async () => {
+            if (ticket.salesCount > 0) {
+                alert(__('This ticket type cannot be deleted because it has donations associated with it.', 'give'));
+                return;
+            }
+
             const confirmDelete = confirm(sprintf(__('Really delete ticket #%d?', 'give'), ticket.id));
 
             if (confirmDelete) {
@@ -35,7 +40,6 @@ export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
         return (
             <>
                 <RowAction onClick={handleEditClick} displayText={__('Edit', 'give')} />
-                {ticket.salesCount === 0 && (
                     <RowAction
                         onClick={confirmModal}
                         actionId={ticket.id}
@@ -43,7 +47,6 @@ export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
                         hiddenText={ticket.title}
                         highlight
                     />
-                )}
             </>
         );
     };

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -98,7 +98,11 @@ export default function TicketTypesSection() {
                         tableHeaders={tableHeaders}
                         data={formattedData}
                         blankSlate={<BlankSlate openModal={openModal} />}
-                        rowActions={TicketTypesRowActions({tickets: data, openEditModal: openModal})}
+                        rowActions={TicketTypesRowActions({
+                            tickets: data,
+                            setTickets: setData,
+                            openEditModal: openModal,
+                        })}
                     />
                     <TicketTypeFormModal
                         apiSettings={{apiRoot, apiNonce}}

--- a/src/EventTickets/resources/admin/components/api.ts
+++ b/src/EventTickets/resources/admin/components/api.ts
@@ -19,11 +19,20 @@ export default class EventTicketsApi {
             method: method,
             signal: signal,
             headers: this.headers,
-        }).then((res) => {
-            if (!res.ok) {
-                throw new Error();
-            }
-            return res.json();
-        });
+        })
+            .then((res) => {
+                if (!res.ok) {
+                    throw new Error();
+                }
+                return res.text();
+            })
+            .then((text) => {
+                try {
+                    return text ? JSON.parse(text) : {};
+                } catch (error) {
+                    console.error('Failed to parse JSON:', error);
+                    return {};
+                }
+            });
     };
 }


### PR DESCRIPTION
Resolves [GIVE-441]

## Description

This PR implements the ability to delete ticket types from the event details page unless they have tickets generated from them.

### To do:
In the future, add an informative modal to explain why the event cannot be deleted.

## Visuals
![CleanShot 2024-03-11 at 22 24 16](https://github.com/impress-org/givewp/assets/3921017/a90efb29-618b-47ce-956a-75886ffcf8dc)
![CleanShot 2024-03-12 at 14 56 33](https://github.com/impress-org/givewp/assets/3921017/9ba90205-5cfd-40bf-82e1-79441352c238)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-441]: https://stellarwp.atlassian.net/browse/GIVE-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ