### PR TITLE
Refactor: show quantity per ticket type in the donation summary

### DIFF
--- a/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
@@ -28,7 +28,7 @@ export default function EventTicketsListHOC({name, ticketTypes, ticketsLabel}: E
                 const itemPrice = ticket.price * quantity * currencyRate;
                 donationSummary.addItem({
                     id: `eventTickets-${ticketId}`,
-                    label: `Ticket (${ticket.title})`,
+                    label: `Ticket (${ticket.title}) x${quantity}`,
                     value: itemPrice > 0 ? currencyFormatter.format(itemPrice / 100) : __('Free', 'give'),
                 });
                 amount += itemPrice;


### PR DESCRIPTION
Resolves [GIVE-436]

## Description

This PR adds the quantity per ticket type to the string shown in the Donation Summary.

## Visuals
![CleanShot 2024-03-12 at 12 08 44](https://github.com/impress-org/givewp/assets/3921017/807c1990-397a-44e5-b711-39636c44cd32)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-436]: https://stellarwp.atlassian.net/browse/GIVE-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ