### PR TITLE
Refactor: Remove delete row action from event details

### DIFF
--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/EventSectionRowActions.tsx
@@ -1,4 +1,4 @@
-import {__, sprintf} from '@wordpress/i18n';
+import {__} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';
 import EventTicketsApi from '../../api';
 
@@ -10,31 +10,8 @@ const eventTicketsApi = new EventTicketsApi(apiSettings);
  */
 export function EventSectionRowActions({event, openEditModal}) {
     return () => {
-        const deleteItem = async (itemId) =>
-            await eventTicketsApi.fetchWithArgs('/events/list-table', {ids: [itemId]}, 'DELETE');
-
-        const confirmModal = async () => {
-            const confirmDelete = confirm(sprintf(__('Really delete event #%d?', 'give'), event.id));
-
-            if (confirmDelete) {
-                if (await deleteItem(event.id)) {
-                    window.location.href =
-                        apiSettings.adminUrl + 'edit.php?post_type=give_forms&page=give-event-tickets';
-                }
-            }
-        };
-
         return (
-            <>
                 <RowAction onClick={openEditModal} displayText={__('Edit', 'give')} />
-                <RowAction
-                    onClick={confirmModal}
-                    actionId={event.id}
-                    displayText={__('Delete', 'give')}
-                    hiddenText={event.title}
-                    highlight
-                />
-            </>
         );
     };
 }


### PR DESCRIPTION
## Description

This PR removes the delete row action from the table in the Event Details page.

## Visuals
![CleanShot 2024-03-12 at 15 17 02](https://github.com/impress-org/givewp/assets/3921017/7588732c-aefe-4f43-8fb6-e70e5b8b4e3f)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

