### PR TITLE
Fix: replace field template enqueueing method

### DIFF
--- a/src/EventTickets/Actions/EnqueueDonationFormScripts.php
+++ b/src/EventTickets/Actions/EnqueueDonationFormScripts.php
@@ -2,8 +2,6 @@
 
 namespace Give\EventTickets\Actions;
 
-use Give\Framework\EnqueueScript;
-
 /**
  * @unreleased
  */
@@ -13,13 +11,13 @@ class EnqueueDonationFormScripts
     {
         $scriptAsset = require GIVE_PLUGIN_DIR . 'build/eventTicketsTemplate.asset.php';
 
-        (new EnqueueScript(
+        wp_enqueue_script(
             'givewp-event-tickets-template',
-            'build/eventTicketsTemplate.js',
-            GIVE_PLUGIN_DIR,
-            GIVE_PLUGIN_URL,
-            'give'
-        ))->enqueue();
+            GIVE_PLUGIN_URL . 'build/eventTicketsTemplate.js',
+            $scriptAsset['dependencies'],
+            false,
+            true
+        );
 
         wp_enqueue_style(
             'givewp-event-tickets-template',


### PR DESCRIPTION
## Description

When testing the Events block in a multi-step form, the block was not being rendered. After investigating, I saw that Fee Recovery (that works) uses `wp_enqueue_script` instead of our `EnqueueScript` class. This PR then replaces how the field template scripts are enqueued.

## Visuals
![image](https://github.com/impress-org/givewp/assets/3921017/711b1754-f692-4944-9452-0d9ce41e99f9)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

