### PR TITLE
Refactor: Add placeholder to event description field

### DIFF
--- a/assets/src/css/admin/settings.scss
+++ b/assets/src/css/admin/settings.scss
@@ -1070,10 +1070,25 @@ a.give-delete {
     display: none;
 }
 
+.give-subsubsub .givewp-feature-flag-notification-counter {
+    translate: 0 -0.125rem;
+    vertical-align: middle;
+}
+
 .give-admin-beta-features-message {
     background-color: #fff;
-    padding: 0.5rem;
+    padding: 1rem;
     border: 1px solid #F29718;
+    margin-bottom: 1.5rem;
+
+    .givewp-beta-icon {
+        margin-right: 0.25rem;
+    }
+
+    p {
+        line-height: 1.6;
+        margin: 0;
+    }
 }
 
 .give-admin-beta-features-feedback-link {

--- a/src/EventTickets/resources/admin/components/EventFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventFormModal/index.tsx
@@ -40,6 +40,7 @@ const removeTimezoneFromDateISOString = (date: string) => {
 /**
  * Event Form Modal component
  *
+ * @unreleased Added placeholder to event description field
  * @since 3.6.0
  */
 export default function EventFormModal({isOpen, handleClose, apiSettings, title, event}: EventModalProps) {
@@ -96,7 +97,11 @@ export default function EventFormModal({isOpen, handleClose, apiSettings, title,
             </div>
             <div className="givewp-event-tickets__form-row">
                 <label htmlFor="description">{__('Description', 'give')}</label>
-                <textarea {...register('description')} rows={4} />
+                <textarea
+                    {...register('description')}
+                    rows={4}
+                    placeholder={__('Briefly describe the details of your event', 'give')}
+                />
             </div>
             <div className="givewp-event-tickets__form-row givewp-event-tickets__form-row--half">
                 <div className="givewp-event-tickets__form-column">


### PR DESCRIPTION
Resolves [GIVE-399]

## Description

This PR adds a placeholder to the event description field in the Event Form Modal to help users understand its purpose.

## Affects

Create/Edit event modal

## Visuals
![CleanShot 2024-03-13 at 18 47 34](https://github.com/impress-org/givewp/assets/3921017/b7dc7d4a-52c3-4a3b-9852-82e76527f6af)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-399]: https://stellarwp.atlassian.net/browse/GIVE-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ