### PR TITLE
Refactor: truncate event description on events list table

### DIFF
--- a/src/EventTickets/ListTable/Columns/DescriptionColumn.php
+++ b/src/EventTickets/ListTable/Columns/DescriptionColumn.php
@@ -37,12 +37,20 @@ class DescriptionColumn extends ModelColumn
     /**
      * @inheritDoc
      *
+     * @unreleased Truncate description to 200 characters
      * @since 3.6.0
      *
      * @param Event $model
      */
     public function getCellValue($model): string
     {
-        return wpautop($model->description);
+        $maxChars = 200;
+        $truncatedDescription = mb_substr($model->description, 0, $maxChars);
+
+        if (mb_strlen($model->description) > $maxChars) {
+            $truncatedDescription .= '...';
+        }
+
+        return wpautop($truncatedDescription);
     }
 }

--- a/src/EventTickets/ListTable/Columns/DescriptionColumn.php
+++ b/src/EventTickets/ListTable/Columns/DescriptionColumn.php
@@ -51,6 +51,6 @@ class DescriptionColumn extends ModelColumn
             $truncatedDescription .= '...';
         }
 
-        return wpautop($truncatedDescription);
+        return sprintf('<div class="event-description">%s</div>', wpautop($truncatedDescription));
     }
 }

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/SectionTable/SectionTable.module.scss
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/SectionTable/SectionTable.module.scss
@@ -102,6 +102,7 @@
 
     &.description {
         font-weight: 400;
+        line-height: 1.43;
     }
 }
 

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsListTable.module.scss
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsListTable.module.scss
@@ -1,3 +1,26 @@
+.listTable {
+    :global {
+        table {
+            tbody {
+                tr {
+                    td {
+                        &:nth-child(4) {
+                            p {
+                                display: -webkit-box;
+                                -webkit-line-clamp: 2;
+                                -webkit-box-orient: vertical;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}
+
 .container {
     text-align: center;
     color: #424242;

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsListTable.module.scss
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsListTable.module.scss
@@ -1,25 +1,17 @@
 .listTable {
     :global {
-        table {
-            tbody {
-                tr {
-                    td {
-                        &:nth-child(4) {
-                            p {
-                                display: -webkit-box;
-                                -webkit-line-clamp: 2;
-                                -webkit-box-orient: vertical;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                            }
-                        }
-                    }
-                }
-
+        .event-description {
+            p {
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
         }
     }
 }
+
 
 .container {
     text-align: center;
@@ -42,7 +34,7 @@
     }
 
     .helpMessage {
-        font-size:0.875rem;
+        font-size: 0.875rem;
         font-weight: 400;
         line-height: 1.57;
     }

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/index.tsx
@@ -78,9 +78,15 @@ const ListTableBlankSlate = () => {
     );
 };
 
+/**
+ * EventTicketsListTable
+ *
+ * @unreleased Add wrapper class for the EventTicketsListTable
+ * @since 3.6.0
+ */
 export default function EventTicketsListTable() {
     return (
-        <>
+        <div className={styles.listTable}>
             <Feedback />
             <ListTablePage
                 title={__('Events', 'give')}
@@ -94,6 +100,6 @@ export default function EventTicketsListTable() {
             >
                 <CreateEventModal />
             </ListTablePage>
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
Resolves [GIVE-465]

## Description
This pull request truncates long event descriptions in the events list table by using the still new `line-clamp` property in CSS to restrict them to 2 lines. Additionally, a maximum of 200 characters is set as a fallback to ensure the description length is limited.

## Affects

Event List Table

## Visuals
![CleanShot 2024-03-13 at 19 33 30](https://github.com/impress-org/givewp/assets/3921017/0f6ea1ee-c9c7-426e-bc54-fa1d5cf9413c)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-465]: https://stellarwp.atlassian.net/browse/GIVE-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ