### PR TITLE
Feature: link attendee's name to donor profile in the event details page

### DIFF
--- a/src/EventTickets/Actions/AttachAttendeeDataToTicketData.php
+++ b/src/EventTickets/Actions/AttachAttendeeDataToTicketData.php
@@ -28,7 +28,7 @@ class AttachAttendeeDataToTicketData
             $lookup[$data->donationId] = [
                 'name' => $data->attendeeName,
                 'email' => $data->attendeeEmail,
-                'donorUrl' => $data->donorIr ? admin_url(
+                'donorUrl' => $data->donorId ? admin_url(
                     "edit.php?post_type=give_forms&page=give-donors&view=overview&id=$data->donorId"
                 ) : null,
             ];

--- a/src/EventTickets/Actions/AttachAttendeeDataToTicketData.php
+++ b/src/EventTickets/Actions/AttachAttendeeDataToTicketData.php
@@ -17,13 +17,21 @@ class AttachAttendeeDataToTicketData
     protected $attendeeDataLookup;
 
     /**
+     * @unreleased Add donorUrl to the attendee data
      * @since 3.6.0
+     *
      * @param EventTicket[] $tickets
      */
     public function __construct(array $tickets)
     {
         $this->attendeeDataLookup = array_reduce($this->getAttendeeDataForTickets($tickets), function ($lookup, $data) {
-            $lookup[$data->donationId] = ['name' => $data->attendeeName, 'email' => $data->attendeeEmail];
+            $lookup[$data->donationId] = [
+                'name' => $data->attendeeName,
+                'email' => $data->attendeeEmail,
+                'donorUrl' => $data->donorIr ? admin_url(
+                    "edit.php?post_type=give_forms&page=give-donors&view=overview&id=$data->donorId"
+                ) : null,
+            ];
             return $lookup;
         }, []);
     }
@@ -55,6 +63,7 @@ class AttachAttendeeDataToTicketData
             ->from('posts', 'Donation')
             ->select(
                 ['Donation.ID', 'donationId'],
+                ['Donor.id', 'donorId'],
                 ['Donor.name', 'attendeeName'],
                 ['Donor.email', 'attendeeEmail']
             )

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/AttendeesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/AttendeesSection/index.tsx
@@ -23,6 +23,10 @@ const BlankSlate = () => {
     );
 };
 
+/**
+ * @unreleased Link attendee name to donor profile
+ * @since 3.6.0
+ */
 export default function AttendeesSection() {
     const {
         event: {ticketTypes, tickets},
@@ -43,7 +47,11 @@ export default function AttendeesSection() {
     const formattedData = data.map((ticket) => {
         return {
             ...ticket,
-            attendeeName: ticket.attendee.name,
+            attendeeName: ticket.attendee.donorUrl ? (
+                <a href={ticket.attendee.donorUrl}>{ticket.attendee.name}</a>
+            ) : (
+                ticket.attendee.name
+            ),
             attendeeEmail: ticket.attendee.email,
             ticketType: getTicketTypeById(ticket.ticketTypeId),
             date: format(new Date(ticket.createdAt.date), dateFormat, {locale}),

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/types.ts
@@ -49,6 +49,7 @@ export type Ticket = {
     attendee: {
         name: string;
         email: string;
+        donorUrl: string;
     };
     createdAt: {
         date: string;


### PR DESCRIPTION
Resolves [GIVE-467]

## Description
This pull request links the attendee's name to the donor profile in the event details page, when a donor id is available for the donation.

## Affects

Attendees list

## Visuals
![CleanShot 2024-03-13 at 19 50 29](https://github.com/impress-org/givewp/assets/3921017/2350a426-7c6c-4c19-bdc3-5e6a64338edc)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-467]: https://stellarwp.atlassian.net/browse/GIVE-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ