### PR TITLE
Fix: WP edit bulk action

### DIFF
--- a/src/FormBuilder/Routes/EditFormRoute.php
+++ b/src/FormBuilder/Routes/EditFormRoute.php
@@ -19,10 +19,12 @@ class EditFormRoute
     public function __invoke()
     {
         if (isset($_GET['post'], $_GET['action']) && 'edit' === $_GET['action']) {
-            $post = get_post(abs($_GET['post']));
-            if ('give_forms' === $post->post_type && Utils::isV3Form($post->ID)) {
-                wp_redirect(FormBuilderRouteBuilder::makeEditFormRoute($post->ID));
-                exit();
+            if ( ! is_array($_GET['post'])) {
+                $post = get_post(abs($_GET['post']));
+                if ('give_forms' === $post->post_type && Utils::isV3Form($post->ID)) {
+                    wp_redirect(FormBuilderRouteBuilder::makeEditFormRoute($post->ID));
+                    exit();
+                }
             }
         }
     }

--- a/src/FormBuilder/Routes/EditFormRoute.php
+++ b/src/FormBuilder/Routes/EditFormRoute.php
@@ -19,6 +19,8 @@ class EditFormRoute
     public function __invoke()
     {
         if (isset($_GET['post'], $_GET['action']) && 'edit' === $_GET['action']) {
+            // This conditional will be also triggered by WP edit bulk action
+            // WP sends an array of IDs so if that is the case here, we can skip this
             if ( ! is_array($_GET['post'])) {
                 $post = get_post(abs($_GET['post']));
                 if ('give_forms' === $post->post_type && Utils::isV3Form($post->ID)) {


### PR DESCRIPTION
## Description

This PR resolves the issue that happens when using edit bulk action to edit WP posts or pages. The problem was that our action to get the v3 form edit URL was also triggered by the WP edit bulk action. Since WP sends an array of IDs for edit bulk action and we don't need that, the issue is resolved by adding a conditional check where we check if the `$_GET['post']` variable is an array.

## Affects

WP edit bulk action for posts, pages, etc.

## Testing Instructions

Go to posts or pages, select them all, and try to edit them using the edit bulk action. Everything should work as expected. Also, keep an eye on the error log. Servers that run PHP8 will throw an error, so make sure you test this on a server that runs PHP8. 

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

