### PR TITLE
Feature: add badges to field template

### DIFF
--- a/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
+++ b/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
@@ -14,6 +14,7 @@ use Give\Framework\Support\ValueObjects\Money;
 class ConvertEventTicketsBlockToFieldsApi
 {
     /**
+     * @unreleased Set event end date and time.
      * @since 3.6.0
      *
      * @throws EmptyNameException

--- a/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
+++ b/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
@@ -3,11 +3,9 @@
 namespace Give\EventTickets\Actions;
 
 use Give\Donations\Models\Donation;
-use Give\EventTickets\DataTransferObjects\TicketPurchaseData;
 use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
+use Give\EventTickets\DataTransferObjects\TicketPurchaseData;
 use Give\EventTickets\Fields\EventTickets;
-use Give\EventTickets\Models\EventTicket;
-use Give\EventTickets\Models\EventTicketType;
 use Give\EventTickets\Repositories\EventRepository;
 use Give\Framework\Blocks\BlockModel;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
@@ -33,6 +31,7 @@ class ConvertEventTicketsBlockToFieldsApi
                 $eventTicketsField
                     ->title($event->title)
                     ->startDateTime($event->startDateTime->format('Y-m-d H:i:s'))
+                    ->endDateTime($event->startDateTime->format('Y-m-d H:i:s'))
                     ->description($event->description)
                     ->ticketTypes($ticketTypes);
 

--- a/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
+++ b/src/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApi.php
@@ -31,7 +31,7 @@ class ConvertEventTicketsBlockToFieldsApi
                 $eventTicketsField
                     ->title($event->title)
                     ->startDateTime($event->startDateTime->format('Y-m-d H:i:s'))
-                    ->endDateTime($event->startDateTime->format('Y-m-d H:i:s'))
+                    ->endDateTime($event->endDateTime->format('Y-m-d H:i:s'))
                     ->description($event->description)
                     ->ticketTypes($ticketTypes);
 

--- a/src/EventTickets/Fields/EventTickets.php
+++ b/src/EventTickets/Fields/EventTickets.php
@@ -7,8 +7,9 @@ use Give\Framework\FieldsAPI\Field;
 class EventTickets extends Field
 {
     protected $title;
-    protected $startDateTime;
     protected $description;
+    protected $startDateTime;
+    protected $endDateTime;
     protected $ticketTypes = [];
 
     const TYPE = 'eventTickets';
@@ -50,6 +51,24 @@ class EventTickets extends Field
     /**
      * @since 3.6.0
      */
+    public function getEndDateTime(): string
+    {
+        return $this->endDateTime;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function endDateTime(string $date): EventTickets
+    {
+        $this->endDateTime = $date;
+
+        return $this;
+    }
+
+    /**
+     * @since 3.6.0
+     */
     public function getDescription(): string
     {
         return $this->description;
@@ -81,28 +100,4 @@ class EventTickets extends Field
         return $this;
     }
 
-    /**
-     * @since 3.6.0
-     */
-    public function getTicketsLabel(): string
-    {
-        return apply_filters(
-            'givewp_event_tickets_block/tickets_label',
-            __('Select Tickets', 'give')
-        );
-    }
-
-    /**
-     * @since 3.6.0
-     */
-    public function getSoldOutMessage(): string
-    {
-        return apply_filters(
-            'givewp_event_tickets_block/sold_out_message',
-            __(
-                'Thank you for supporting our cause. Our fundraising event tickets are officially sold out. You can still contribute by making a donation.',
-                'give'
-            )
-        );
-    }
 }

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
@@ -4,6 +4,7 @@ import EventTicketsList from '../../../components/EventTicketsList';
 import {getWindowData} from '@givewp/form-builder/common';
 
 /**
+ * @unreleased Hide tickets once the event has ended.
  * @since 3.6.0
  */
 export default function BlockPlaceholder({attributes}) {

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
@@ -15,23 +15,25 @@ export default function BlockPlaceholder({attributes}) {
         return null;
     }
 
+    const startDateTimeObj = new Date(event.startDateTime);
+    const endDateTimeObj = new Date(event.endDateTime);
+    const hasEnded = endDateTimeObj < new Date();
+
     return (
         <div className={'givewp-event-tickets-block__placeholder'}>
             <div className={'givewp-event-tickets'}>
-                <EventTicketsHeader
-                    title={event.title}
-                    startDateTime={new Date(event.startDateTime)}
-                    endDateTime={new Date(event.endDateTime)}
-                />
+                <EventTicketsHeader title={event.title} startDateTime={startDateTimeObj} endDateTime={endDateTimeObj} />
 
                 {event.description && <EventTicketsDescription description={event.description} />}
 
-                <EventTicketsList
-                    ticketTypes={event.ticketTypes}
-                    ticketsLabel={ticketsLabel}
-                    currency={currency}
-                    currencyRate={1}
-                />
+                {!hasEnded && (
+                    <EventTicketsList
+                        ticketTypes={event.ticketTypes}
+                        ticketsLabel={ticketsLabel}
+                        currency={currency}
+                        currencyRate={1}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
@@ -18,7 +18,11 @@ export default function BlockPlaceholder({attributes}) {
     return (
         <div className={'givewp-event-tickets-block__placeholder'}>
             <div className={'givewp-event-tickets'}>
-                <EventTicketsHeader title={event.title} startDateTime={new Date(event.startDateTime)} />
+                <EventTicketsHeader
+                    title={event.title}
+                    startDateTime={new Date(event.startDateTime)}
+                    endDateTime={new Date(event.endDateTime)}
+                />
 
                 {event.description && <EventTicketsDescription description={event.description} />}
 

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/styles.scss
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/styles.scss
@@ -65,14 +65,23 @@
         padding: var(--givewp-spacing-2);
 
         &__header {
+            background: none;
             padding: 0;
 
-            &::before {
-                display: none;
-            }
-
             &__date {
+                background-color: var(--givewp-grey-25);
                 color: var(--givewp-grey-900);
+            }
+        }
+
+        &__tickets {
+            &__ticket {
+                &__quantity {
+                    &__sold-out {
+                        background-color: var(--givewp-grey-25);
+                        color: var(--givewp-grey-900);
+                    }
+                }
             }
         }
     }

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/types.ts
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/types.ts
@@ -3,8 +3,9 @@ import {TicketType} from '../../components/types';
 export type EventSettings = {
     id: number;
     title: string;
-    startDateTime: Date;
     description: string;
+    startDateTime: Date;
+    endDateTime: Date;
     ticketTypes: TicketType[];
 };
 

--- a/src/EventTickets/resources/components/EventTicketsHeader.tsx
+++ b/src/EventTickets/resources/components/EventTicketsHeader.tsx
@@ -11,8 +11,6 @@ export default function EventTicketsHeader({title, startDateTime, endDateTime}) 
     const month = format(startDateTime, 'MMM');
     const hasEnded = endDateTime < new Date();
 
-    console.log(endDateTime);
-
     return (
         <div className={'givewp-event-tickets__header'}>
             <div className={'givewp-event-tickets__header__date'}>

--- a/src/EventTickets/resources/components/EventTicketsHeader.tsx
+++ b/src/EventTickets/resources/components/EventTicketsHeader.tsx
@@ -1,6 +1,10 @@
 import {__} from '@wordpress/i18n';
 import {format} from 'date-fns';
 
+/**
+ * @unreleased Show "ENDED" badge once the event has ended.
+ * @since 3.6.0
+ */
 export default function EventTicketsHeader({title, startDateTime, endDateTime}) {
     const fullDate = format(startDateTime, 'EEEE, MMMM do, hh:mmaaa');
     const day = format(startDateTime, 'dd');

--- a/src/EventTickets/resources/components/EventTicketsHeader.tsx
+++ b/src/EventTickets/resources/components/EventTicketsHeader.tsx
@@ -1,9 +1,13 @@
+import {__} from '@wordpress/i18n';
 import {format} from 'date-fns';
 
-export default function EventTicketsHeader({title, startDateTime}) {
+export default function EventTicketsHeader({title, startDateTime, endDateTime}) {
     const fullDate = format(startDateTime, 'EEEE, MMMM do, hh:mmaaa');
     const day = format(startDateTime, 'dd');
     const month = format(startDateTime, 'MMM');
+    const hasEnded = endDateTime < new Date();
+
+    console.log(endDateTime);
 
     return (
         <div className={'givewp-event-tickets__header'}>
@@ -12,6 +16,12 @@ export default function EventTicketsHeader({title, startDateTime}) {
             </div>
             <h4 className={'givewp-event-tickets__header__title'}>{title}</h4>
             <p className={'givewp-event-tickets__header__full-date'}>{fullDate}</p>
+
+            {hasEnded && (
+                <div className={'givewp-event-tickets__header__ended'}>
+                    <span>{__('Ended', 'give')}</span>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/EventTickets/resources/components/EventTicketsListItem.tsx
+++ b/src/EventTickets/resources/components/EventTicketsListItem.tsx
@@ -38,7 +38,9 @@ export default function EventTicketsListItem({ticketType, currency, currencyRate
                         </p>
                     </>
                 ) : (
-                    <span>{__('Sold out', 'give')}</span>
+                    <span className={'givewp-event-tickets__tickets__ticket__quantity__sold-out'}>
+                        {__('Sold out', 'give')}
+                    </span>
                 )}
             </div>
         </div>

--- a/src/EventTickets/resources/components/types.ts
+++ b/src/EventTickets/resources/components/types.ts
@@ -4,11 +4,11 @@ export type Event = {
     id: number;
     name: string;
     title: string;
-    startDateTime: Date;
     description: string;
+    startDateTime: Date;
+    endDateTime: Date;
     ticketTypes: TicketType[];
     ticketsLabel: string;
-    soldOutMessage: string;
 };
 
 export type TicketType = {

--- a/src/EventTickets/resources/templates/EventTickets/index.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/index.tsx
@@ -9,15 +9,19 @@ export default function EventTicketsField({
     name,
     id,
     title,
-    startDateTime,
     description,
+    startDateTime,
+    endDateTime,
     ticketTypes,
     ticketsLabel,
-    soldOutMessage,
 }: Event) {
     return (
         <div className={'givewp-event-tickets'}>
-            <EventTicketsHeader title={title} startDateTime={new Date(startDateTime)} />
+            <EventTicketsHeader
+                title={title}
+                startDateTime={new Date(startDateTime)}
+                endDateTime={new Date(endDateTime)}
+            />
 
             {description && <EventTicketsDescription description={description} />}
 

--- a/src/EventTickets/resources/templates/EventTickets/index.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/index.tsx
@@ -5,9 +5,12 @@ import {Event} from '../../components/types';
 
 import './styles.scss';
 
+/**
+ * @unreleased Hide tickets once the event has ended.
+ * @since 3.6.0
+ */
 export default function EventTicketsField({
     name,
-    id,
     title,
     description,
     startDateTime,

--- a/src/EventTickets/resources/templates/EventTickets/index.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/index.tsx
@@ -15,17 +15,17 @@ export default function EventTicketsField({
     ticketTypes,
     ticketsLabel,
 }: Event) {
+    const startDateTimeObj = new Date(startDateTime);
+    const endDateTimeObj = new Date(endDateTime);
+    const hasEnded = endDateTimeObj < new Date();
+
     return (
         <div className={'givewp-event-tickets'}>
-            <EventTicketsHeader
-                title={title}
-                startDateTime={new Date(startDateTime)}
-                endDateTime={new Date(endDateTime)}
-            />
+            <EventTicketsHeader title={title} startDateTime={startDateTimeObj} endDateTime={endDateTimeObj} />
 
             {description && <EventTicketsDescription description={description} />}
 
-            <EventTicketsListHOC name={name} ticketTypes={ticketTypes} ticketsLabel={ticketsLabel} />
+            {!hasEnded && <EventTicketsListHOC name={name} ticketTypes={ticketTypes} ticketsLabel={ticketsLabel} />}
         </div>
     );
 }

--- a/src/EventTickets/resources/templates/EventTickets/styles.scss
+++ b/src/EventTickets/resources/templates/EventTickets/styles.scss
@@ -1,6 +1,7 @@
 .givewp-event-tickets {
 
     &__header {
+        background-color: color-mix(in lab, var(--givewp-primary-color) 15%, white);
         color: var(--givewp-grey-900);
         column-gap: var(--givewp-spacing-2);
         display: grid;
@@ -10,21 +11,9 @@
         position: relative;
         z-index: 1;
 
-        &::before {
-            background-color: var(--givewp-primary-color);
-            content: "";
-            height: 100%;
-            left: 0;
-            opacity: 0.1;
-            position: absolute;
-            top: 0;
-            width: 100%;
-            z-index: -1;
-        }
-
         &__date {
             align-items: center;
-            background-color: var(--givewp-grey-25);
+            background-color: var(--givewp-grey-5);
             border-radius: var(--givewp-rounded-4);
             color: var(--givewp-primary-color);
             display: flex;
@@ -173,6 +162,16 @@
                     font-size: 0.75rem;
                     line-height: 1.5;
                     margin: 0;
+                }
+
+                &__sold-out {
+                    background-color: color-mix(in lab, var(--givewp-primary-color) 15%, white);
+                    border-radius: var(--givewp-rounded-4);
+                    color: var(--givewp-primary-color);
+                    font-size: 0.75rem;
+                    font-weight: 600;
+                    line-height: 1.5;
+                    padding: var(--givewp-spacing-1) var(--givewp-spacing-2);
                 }
             }
         }

--- a/src/EventTickets/resources/templates/EventTickets/styles.scss
+++ b/src/EventTickets/resources/templates/EventTickets/styles.scss
@@ -51,6 +51,24 @@
             line-height: 1.5;
             margin: 0;
         }
+
+        &__ended {
+            align-items: center;
+            display: flex;
+            grid-column: 3 / 4;
+            grid-row: 1 / 3;
+
+            span {
+                background-color: var(--givewp-primary-color);
+                border-radius: var(--givewp-rounded-4);
+                color: var(--givewp-shades-white);
+                font-size: 0.75rem;
+                font-weight: 600;
+                line-height: 1.5;
+                padding: var(--givewp-spacing-1) var(--givewp-spacing-2);
+                text-transform: uppercase;
+            }
+        }
     }
 
     &__description {

--- a/tests/Unit/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApiTest.php
+++ b/tests/Unit/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApiTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Give\Tests\Unit\EventTickets\Actions;
+
+use Exception;
+use Give\DonationForms\Models\DonationForm;
+use Give\EventTickets\Actions\ConvertEventTicketsBlockToFieldsApi;
+use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
+use Give\EventTickets\Fields\EventTickets;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicketType;
+use Give\Framework\Blocks\BlockModel;
+use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ */
+class ConvertEventTicketsBlockToFieldsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     * @throws EmptyNameException
+     * @throws Exception
+     */
+    public function testBlockToFieldConversionMatchesAttributes(): void
+    {
+        $event = Event::factory()->create();
+        $ticketType = EventTicketType::factory()->create(['eventId' => $event->id]);
+
+        $block = BlockModel::make([
+            'name' => 'givewp/event-tickets',
+            'attributes' => [
+                'eventId' => $event->id,
+            ],
+        ]);
+
+        $donationForm = DonationForm::factory()->create();
+
+        $action = give(ConvertEventTicketsBlockToFieldsApi::class);
+        /** @var EventTickets $field */
+        $field = $action($block, $donationForm->id);
+
+        $this->assertEquals('event-tickets-1', $field->getName());
+        $this->assertEquals('eventTickets', $field->getType());
+        $this->assertEquals('field', $field->getNodeType());
+
+        $expectedAttributes = [
+            'title' => $event->title,
+            'startDateTime' => $event->startDateTime->format('Y-m-d H:i:s'),
+            'endDateTime' => $event->endDateTime->format('Y-m-d H:i:s'),
+            'description' => $event->description,
+            'ticketTypes' => [EventTicketTypeData::make($ticketType)->toArray()],
+        ];
+
+        $fieldAttributes = $field->jsonSerialize();
+
+        foreach ($expectedAttributes as $key => $value) {
+            $this->assertEquals($value, $fieldAttributes[$key]);
+        }
+    }
+}

--- a/tests/Unit/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApiTest.php
+++ b/tests/Unit/EventTickets/Actions/ConvertEventTicketsBlockToFieldsApiTest.php
@@ -7,7 +7,6 @@ use Give\DonationForms\Models\DonationForm;
 use Give\EventTickets\Actions\ConvertEventTicketsBlockToFieldsApi;
 use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
 use Give\EventTickets\Fields\EventTickets;
-use Give\EventTickets\Models\Event;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Blocks\BlockModel;
 use Give\Framework\FieldsAPI\Exceptions\EmptyNameException;
@@ -28,8 +27,8 @@ class ConvertEventTicketsBlockToFieldsApiTest extends TestCase
      */
     public function testBlockToFieldConversionMatchesAttributes(): void
     {
-        $event = Event::factory()->create();
-        $ticketType = EventTicketType::factory()->create(['eventId' => $event->id]);
+        $ticketType = EventTicketType::factory()->create();
+        $event = $ticketType->event;
 
         $block = BlockModel::make([
             'name' => 'givewp/event-tickets',


### PR DESCRIPTION
Resolves [GIVE-353]

## Description
This pull request adds some badges to the EventTickets template. The <kbd>**Sold Out**</kbd> badge appears on each line for tickets when none are available. The <kbd>**ENDED**</kbd> badge is displayed in the header once the event end date has passed. Under these conditions, no tickets are shown for sale.

## Affects

EventTickets template

## Visuals
![CleanShot 2024-03-14 at 20 38 22](https://github.com/impress-org/givewp/assets/3921017/5a8a9ab3-a4a7-444f-9ee6-af3ecc46571f)
![CleanShot 2024-03-14 at 20 29 25](https://github.com/impress-org/givewp/assets/3921017/c57e295d-7e79-4051-9061-e2f3bb3ba75f)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-353]: https://stellarwp.atlassian.net/browse/GIVE-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ