### PR TITLE
Refactor: Store ticket type price in the generated ticket

### DIFF
--- a/src/EventTickets/Actions/GenerateTicketsFromPurchaseData.php
+++ b/src/EventTickets/Actions/GenerateTicketsFromPurchaseData.php
@@ -26,6 +26,7 @@ class GenerateTicketsFromPurchaseData
     }
 
     /**
+     * @unreleased Add "amount" to the array of props
      * @since 3.6.0
      */
     public function __invoke(TicketPurchaseData $data)

--- a/src/EventTickets/Actions/GenerateTicketsFromPurchaseData.php
+++ b/src/EventTickets/Actions/GenerateTicketsFromPurchaseData.php
@@ -35,6 +35,7 @@ class GenerateTicketsFromPurchaseData
                 'eventId' => $data->ticketType->eventId,
                 'ticketTypeId' => $data->ticketType->id,
                 'donationId' => $this->donation->id,
+                'amount' => $data->ticketType->price,
             ]);
         }
     }

--- a/src/EventTickets/Factories/EventTicketFactory.php
+++ b/src/EventTickets/Factories/EventTicketFactory.php
@@ -12,15 +12,20 @@ use Give\Framework\Models\Factories\ModelFactory;
 class EventTicketFactory extends ModelFactory
 {
     /**
+     * @unreleased Add amount to the properties array using the price from the ticket type
      * @since 3.6.0
+     *
      * @throws Exception
      */
     public function definition(): array
     {
+        $ticketType = EventTicketType::factory()->create();
+
         return [
             'eventId' => Event::factory()->create()->id,
-            'ticketTypeId' => EventTicketType::factory()->create()->id,
+            'ticketTypeId' => $ticketType->id,
             'donationId' => Donation::factory()->create()->id,
+            'amount' => $ticketType->price,
             'createdAt' => new DateTime(),
             'updatedAt' => new DateTime(),
         ];

--- a/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
@@ -54,8 +54,8 @@ class SalesAmountColumn extends ModelColumn
 
         $salesTotal = array_reduce(
             $model->eventTickets()->getAll() ?? [],
-                function (Money $carry, $eventTicket) use ($ticketTypes) {
-                    return $carry->add($ticketTypes[$eventTicket->ticketTypeId]['price']);
+                function (Money $carry, $eventTicket) {
+                    return $carry->add($eventTicket->amount);
             },
             new Money(0, give_get_currency())
         );

--- a/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
@@ -47,9 +47,13 @@ class SalesAmountColumn extends ModelColumn
     {
         $ticketTypes = [];
         foreach ($model->ticketTypes()->getAll() ?? [] as $ticketType) {
+            $salesCount = $ticketType->eventTickets()->count();
+            $ticketsAvailable = $ticketType->capacity - $salesCount;
+
             $ticketTypes[$ticketType->id] = [
                 'price' => $ticketType->price,
                 'capacity' => $ticketType->capacity,
+                'ticketsAvailable' => $ticketsAvailable,
             ];
         }
 
@@ -61,8 +65,8 @@ class SalesAmountColumn extends ModelColumn
             new Money(0, give_get_currency())
         );
         $maxCapacitySales = array_reduce($ticketTypes, function (Money $carry, $ticketType) {
-            return $carry->add($ticketType['price']->multiply($ticketType['capacity']));
-        }, new Money(0, give_get_currency()));
+            return $carry->add($ticketType['price']->multiply($ticketType['ticketsAvailable']));
+        }, $salesTotal);
 
         $salesPercentage = $maxCapacitySales->formatToMinorAmount() > 0 ? max(
             min($salesTotal->formatToMinorAmount() / $maxCapacitySales->formatToMinorAmount(), 100),

--- a/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
+++ b/src/EventTickets/ListTable/Columns/SalesAmountColumn.php
@@ -38,6 +38,7 @@ class SalesAmountColumn extends ModelColumn
     /**
      * @inheritDoc
      *
+     * @unreleased Refactored to use event ticket amount instead of ticket type price
      * @since 3.6.0
      *
      * @param Event $model

--- a/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
+++ b/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Give\EventTickets\Migrations;
+
+use Give\Framework\Database\Exceptions\DatabaseQueryException;
+use Give\Framework\Migrations\Contracts\Migration;
+use Give\Framework\Migrations\Exceptions\DatabaseMigrationException;
+
+/**
+ * @unreleased
+ */
+class AddAmountColumnToEventTicketsTable extends Migration {
+    /**
+     * @inheritdoc
+     */
+    public static function id() {
+        return 'give-events-add-amount-column-to-events-tickets-table';
+    }
+
+    public static function title() {
+        return 'Add "amount" column to give_event_tickets table';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp() {
+        return strtotime( '2022-03-18 12:00:00' );
+    }
+
+    /**
+     * @inheritdoc
+     * @throws DatabaseMigrationException
+     */
+    public function run() {
+        global $wpdb;
+
+        $eventTicketsTable = $wpdb->give_event_tickets;
+        $eventTicketTypesTable = $wpdb->give_event_ticket_types;
+
+        $this->addAmountColumn($wpdb, $eventTicketsTable);
+        $this->migrateTicketPrices($wpdb, $eventTicketsTable, $eventTicketTypesTable);
+    }
+
+    /**
+     * @throws DatabaseMigrationException
+     */
+    private function addAmountColumn($wpdb, $eventTicketsTable) {
+        $sql = "ALTER TABLE $eventTicketsTable
+                ADD COLUMN amount INT UNSIGNED NOT NULL AFTER donation_id";
+
+        try {
+            $wpdb->query($sql);
+        } catch (DatabaseQueryException $exception) {
+            throw new DatabaseMigrationException( "An error occurred while adding the amount column to the $eventTicketsTable table", 0, $exception );
+        }
+    }
+
+    /**
+     * @throws DatabaseMigrationException
+     */
+    private function migrateTicketPrices($wpdb, $eventTicketsTable, $eventTicketTypesTable) {
+        $sql = "UPDATE $eventTicketsTable eventTickets
+                JOIN $eventTicketTypesTable evenTicketTypes
+                ON eventTickets.ticket_type_id = evenTicketTypes.id
+                SET eventTickets.amount = evenTicketTypes.price";
+
+        try {
+            $wpdb->query($sql);
+        } catch (DatabaseQueryException $exception) {
+            throw new DatabaseMigrationException( "An error occurred while migrating data to the amount column in the $eventTicketsTable table", 0, $exception );
+        }
+    }
+};

--- a/src/EventTickets/Models/EventTicket.php
+++ b/src/EventTickets/Models/EventTicket.php
@@ -15,6 +15,7 @@ use Give\Framework\Models\Model;
 use Give\Framework\Models\ModelQueryBuilder;
 use Give\Framework\Models\ValueObjects\Relationship;
 use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Framework\Support\ValueObjects\Money;
 
 /**
  * @since 3.6.0
@@ -23,12 +24,16 @@ class EventTicket extends Model implements ModelCrud /*, ModelHasFactory */
 {
     /**
      * @inheritdoc
+     *
+     * @unreleased Add amount to the properties array
+     * @since      3.6.0
      */
     protected $properties = [
         'id' => 'int', // @todo Maybe use UUID instead of auto-incrementing integer
         'eventId' => 'int',
         'ticketTypeId' => 'int',
         'donationId' => 'int',
+        'amount' => Money::class,
         'createdAt' => DateTime::class,
         'updatedAt' => DateTime::class,
     ];
@@ -144,7 +149,6 @@ class EventTicket extends Model implements ModelCrud /*, ModelHasFactory */
         return give(EventTicketTypeRepository::class)->queryById($this->ticketTypeId);
     }
 
-
     /**
      * @since 3.6.0
      *
@@ -156,6 +160,7 @@ class EventTicket extends Model implements ModelCrud /*, ModelHasFactory */
     }
 
     /**
+     * @unreleased Add amount to the properties array
      * @since 3.6.0
      *
      * @param object $object
@@ -167,6 +172,7 @@ class EventTicket extends Model implements ModelCrud /*, ModelHasFactory */
             'eventId' => (int)$object->event_id,
             'ticketTypeId' => (int)$object->ticket_type_id,
             'donationId' => (int)$object->donation_id,
+            'amount' => new Money($object->amount, give_get_currency()),
             'createdAt' => Temporal::toDateTime($object->created_at),
             'updatedAt' => Temporal::toDateTime($object->updated_at),
         ]);

--- a/src/EventTickets/Repositories/EventTicketRepository.php
+++ b/src/EventTickets/Repositories/EventTicketRepository.php
@@ -233,6 +233,7 @@ class EventTicketRepository
     }
 
     /**
+     * @unreleased Refactored to use event ticket amount instead of ticket type price
      * @since 3.6.0
      */
     public function getTotalByDonation(Donation $donation): Money
@@ -241,10 +242,8 @@ class EventTicketRepository
         $currency = $donation->amount->getCurrency();
 
         return array_reduce($eventTickets, static function (Money $carry, EventTicket $eventTicket) {
-            $ticketType = $eventTicket->ticketType()->get();
-
             return $carry->add(
-                $ticketType->price
+                $eventTicket->amount
             );
         }, new Money(0, $currency));
     }

--- a/src/EventTickets/Repositories/EventTicketRepository.php
+++ b/src/EventTickets/Repositories/EventTicketRepository.php
@@ -20,6 +20,7 @@ class EventTicketRepository
 {
 
     /**
+     * @unreleased Add "amount" column to the properties array
      * @since 3.6.0
      *
      * @var string[]
@@ -28,6 +29,7 @@ class EventTicketRepository
         'eventId',
         'ticketTypeId',
         'donationId',
+        'amount',
     ];
 
     /**
@@ -50,6 +52,7 @@ class EventTicketRepository
     }
 
     /**
+     * @unreleased Add "amount" column to the insert statement
      * @since 3.6.0
      *
      * @throws Exception|InvalidArgumentException
@@ -70,6 +73,7 @@ class EventTicketRepository
                     'event_id' => $eventTicket->eventId,
                     'ticket_type_id' => $eventTicket->ticketTypeId,
                     'donation_id' => $eventTicket->donationId,
+                    'amount' => $eventTicket->amount->formatToMinorAmount(),
                     'created_at' => $createdDateTime->format('Y-m-d H:i:s'),
                     'updated_at' => $createdDateTime->format('Y-m-d H:i:s'),
                 ]);
@@ -93,6 +97,7 @@ class EventTicketRepository
     }
 
     /**
+     * @unreleased Add "amount" column to the update statement
      * @since 3.6.0
      *
      * @throws Exception|InvalidArgumentException
@@ -115,6 +120,7 @@ class EventTicketRepository
                     'event_id' => $eventTicket->eventId,
                     'ticket_type_id' => $eventTicket->ticketTypeId,
                     'donation_id' => $eventTicket->donationId,
+                    'amount' => $eventTicket->amount->formatToMinorAmount(),
                     'updated_at' => $updatedDateTime->format('Y-m-d H:i:s'),
                 ]);
         } catch (Exception $exception) {
@@ -175,6 +181,8 @@ class EventTicketRepository
     }
 
     /**
+     * @unreleased Add "amount" column to the select statement
+     * @since      3.6.0
      * @return ModelQueryBuilder<EventTicket>
      */
     public function prepareQuery(): ModelQueryBuilder
@@ -187,6 +195,7 @@ class EventTicketRepository
                 'event_id',
                 'ticket_type_id',
                 'donation_id',
+                'amount',
                 'created_at',
                 'updated_at'
             );

--- a/src/EventTickets/ServiceProvider.php
+++ b/src/EventTickets/ServiceProvider.php
@@ -12,8 +12,6 @@ use Give\EventTickets\Repositories\EventRepository;
 use Give\EventTickets\Repositories\EventTicketRepository;
 use Give\EventTickets\Repositories\EventTicketTypeRepository;
 use Give\Framework\Migrations\MigrationsRegister;
-use Give\Framework\Receipts\DonationReceipt;
-use Give\Framework\Support\ValueObjects\Money;
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 
@@ -69,6 +67,7 @@ class ServiceProvider implements ServiceProviderInterface
             Migrations\CreateEventsTable::class,
             Migrations\CreateEventTicketTypesTable::class,
             Migrations\CreateEventTicketsTable::class,
+            Migrations\AddAmountColumnToEventTicketsTable::class,
         ]);
     }
 


### PR DESCRIPTION
Resolves [GIVE-475]

## Description

We were relying on the ticket type prices as the ticket amount but then realized they could change, affecting calculations. This pull request refactors the ticket entity by adding a new `amount` property.

Changes made:
-  Added a migration to include the amount column in the `give_event_tickets` table.
-  Added a migration to transfer price values to the new column.
-  Updated `EventTickets` model, repository, and factory to accommodate the amount property.
-  Updated `AddEventTicketsToDonationConfirmationPageDonationTotal` action to use the amount property.
-  Updated `GenerateTicketsFromPurchasedData` action to save the ticket price as the amount for the new ticket.
-  Updated the `SalesAmount` column in the `EventTicketsListTable` to calculate from the amount property, reflecting ticket price changes.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-475]: https://stellarwp.atlassian.net/browse/GIVE-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ