### PR TITLE
Fix: PayPal Donations does not work with switch currency on V3 Forms

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-= 3.6.1: March 21th, 2024 =
+= 3.6.1: March 21st, 2024 =
 * Fix: Resolved an issue with PayPal donations and currency switcher on donation forms using the visual form builder
 
 = 3.6.0: March 13th, 2024 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 3.6.1: March 21th, 2024 =
+* Fix: Resolved an issue with PayPal donations and currency switcher on donation forms using the visual form builder
+
 = 3.6.0: March 13th, 2024 =
 * New: Introduced a new beta feature called "Event Tickets" that is open for feedback! If enabled, you can create events and sell tickets on your donation forms.
 * New: Added a new form builder layout called "Two Panel" that offers a side-by-side appearance and a multi-step donation experience.

--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.6.0
+ * Version: 3.6.1
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -404,7 +404,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.6.0');
+            define('GIVE_VERSION', '3.6.1');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -262,7 +262,7 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
-= 3.6.1: March 21th, 2024 =
+= 3.6.1: March 21st, 2024 =
 * Fix: Resolved an issue with PayPal donations and currency switcher on donation forms using the visual form builder
 
 = 3.6.0: March 13th, 2024 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.2
-Stable tag: 3.6.0
+Stable tag: 3.6.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.6.1: March 21th, 2024 =
+* Fix: Resolved an issue with PayPal donations and currency switcher on donation forms using the visual form builder
+
 = 3.6.0: March 13th, 2024 =
 * New: Introduced a new beta feature called "Event Tickets" that is open for feedback! If enabled, you can create events and sell tickets on your donation forms.
 * New: Added a new form builder layout called "Two Panel" that offers a side-by-side appearance and a multi-step donation experience.

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -13,7 +13,7 @@ type ModalFormProps = {
 };
 
 /**
- * @unreleased
+ * @since 3.6.1
  * @since 3.4.0
  * @since 3.2.0 include types. update BEM classnames.
  * @since 3.0.0

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/common/FormModal/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/common/FormModal/index.tsx
@@ -10,7 +10,7 @@ type FormModalProps = {
 };
 
 /**
- * @unreleased
+ * @since 3.6.1
  */
 export default function FormModal({openFormButton, children, onChange, isOpen}: FormModalProps) {
     return (

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -102,7 +102,7 @@ import {PayPalSubscriber} from './types';
     /**
      * Get amount with fee (if any).
      *
-     * @unreleased Append 'give-cs-form-currency' to formData
+     * @since 3.6.1 Append 'give-cs-form-currency' to formData
      * @since 3.2.0
      * @return {number} Amount with fee.
      */

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -48,6 +48,8 @@ import {PayPalSubscriber} from './types';
     let updateOrderAmount = false;
     let orderCreated = false;
 
+    let currency;
+
     const buttonsStyle = {
         color: 'gold' as 'gold' | 'blue' | 'silver' | 'white' | 'black',
         label: 'paypal' as 'paypal' | 'checkout' | 'buynow' | 'pay' | 'installment' | 'subscribe' | 'donate',
@@ -100,6 +102,7 @@ import {PayPalSubscriber} from './types';
     /**
      * Get amount with fee (if any).
      *
+     * @unreleased Append 'give-cs-form-currency' to formData
      * @since 3.2.0
      * @return {number} Amount with fee.
      */
@@ -138,6 +141,11 @@ import {PayPalSubscriber} from './types';
             formData.append('card_zip', postalCode);
             formData.append('billing_country', country);
         }
+
+        /**
+         * Ensure the proper currency will be used when using the Currency Switcher add-on.
+         */
+        formData.append('give-cs-form-currency', currency);
 
         return formData;
     };
@@ -266,6 +274,8 @@ import {PayPalSubscriber} from './types';
         postalCode = useWatch({name: 'zip'});
         country = useWatch({name: 'country'});
 
+        currency = useWatch({name: 'currency'});
+
         useEffect(() => {
             if (orderCreated) {
                 updateOrderAmount = true;
@@ -277,7 +287,6 @@ import {PayPalSubscriber} from './types';
 
     const SmartButtonsContainer = () => {
         const {useWatch, useFormState} = window.givewp.form.hooks;
-        const currency = useWatch({name: 'currency'});
         const donationType = useWatch({name: 'donationType'});
         const {isSubmitting, isSubmitSuccessful} = useFormState();
         const {useFormContext} = window.givewp.form.hooks;
@@ -451,7 +460,6 @@ import {PayPalSubscriber} from './types';
 
     function PaymentMethodsWrapper() {
         const {useWatch} = window.givewp.form.hooks;
-        const currency = useWatch({name: 'currency'});
         const donationType = useWatch({name: 'donationType'});
         const [{options}, dispatch] = usePayPalScriptReducer();
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-290]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes the problem by submitting the `'give-cs-form-currency'` value when creating a PayPal order through a v3 form, this is necessary because the Currency Switcher add-on relies on this information to apply the proper currency.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The PayPal Donations gateway.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![give_paypal_commerce_create_order-v2-forms](https://github.com/impress-org/givewp/assets/16308864/f2fb8fb8-4866-459a-847e-59b5a1ade71a)
![give_paypal_commerce_create_order-v3-forms](https://github.com/impress-org/givewp/assets/16308864/3bb0ed13-6f2f-4732-ac97-a429192114cc)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Before testing the fix, I suggest to reproduce the error like in this demo video: https://www.loom.com/share/24c00e60c1c3472d9c8126ff424ef66d?sid=2f0e1fed-38e2-4e80-b07b-83c973a466eb

Then, pull this branch and follow this instructions:

1. Create a V3 form with the Currency Switcher add-on enabled.
2. Select a different currency from the base one.
3. Create a test donation with PayPal Donations.
4. On the PayPal side, make sure that the proper currency (selected in step 2) is applied.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-290]: https://stellarwp.atlassian.net/browse/GIVE-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ