### PR TITLE
Refactor: Improve Event Tickets API validations

### DIFF
--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -6,6 +6,7 @@ use Give\API\RestRoute;
 use Give\EventTickets\Models\Event;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * @since 3.6.0
@@ -28,7 +29,7 @@ class CreateEvent implements RestRoute
             $this->endpoint,
             [
                 [
-                    'methods' => 'POST',
+                    'methods' => WP_REST_Server::CREATABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
                         return current_user_can('publish_give_payments');

--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -17,6 +17,9 @@ class CreateEvent implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "publish_give_payments" and description's sanitize callback to "textarea".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -28,7 +28,7 @@ class CreateEvent implements RestRoute
                     'methods' => 'POST',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can( 'manage_options' );
+                        return current_user_can('publish_give_payments');
                     }
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -32,7 +32,7 @@ class CreateEvent implements RestRoute
                     'methods' => WP_REST_Server::CREATABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('publish_give_payments');
+                        return current_user_can('edit_give_forms');
                     }
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/CreateEvent.php
+++ b/src/EventTickets/Routes/CreateEvent.php
@@ -40,7 +40,7 @@ class CreateEvent implements RestRoute
                     'description' => [
                         'type' => 'string',
                         'required' => false,
-                        'sanitize_callback' => 'sanitize_text_field',
+                        'sanitize_callback' => 'sanitize_textarea_field',
                     ],
                     'startDateTime' => [
                         'type' => 'string',

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -9,6 +9,7 @@ use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Support\ValueObjects\Money;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * @since 3.6.0
@@ -31,7 +32,7 @@ class CreateEventTicketType implements RestRoute
             $this->endpoint,
             [
                 [
-                    'methods' => 'POST',
+                    'methods' => WP_REST_Server::CREATABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
                         return current_user_can('publish_give_payments');

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -51,7 +51,7 @@ class CreateEventTicketType implements RestRoute
                     'description' => [
                         'type' => 'string',
                         'required' => false,
-                        'sanitize_callback' => 'sanitize_text_field',
+                        'sanitize_callback' => 'sanitize_textarea_field',
                     ],
                     'price' => [
                         'type' => 'integer',

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -31,7 +31,7 @@ class CreateEventTicketType implements RestRoute
                     'methods' => 'POST',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can( 'manage_options' );
+                        return current_user_can('publish_give_payments');
                     }
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -20,6 +20,9 @@ class CreateEventTicketType implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "publish_give_payments" and description's sanitize callback to "textarea".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/CreateEventTicketType.php
+++ b/src/EventTickets/Routes/CreateEventTicketType.php
@@ -35,7 +35,7 @@ class CreateEventTicketType implements RestRoute
                     'methods' => WP_REST_Server::CREATABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('publish_give_payments');
+                        return current_user_can('edit_give_forms');
                     }
                 ],
                 'args' => [
@@ -43,7 +43,7 @@ class CreateEventTicketType implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return Event::find($eventId);
+                            return Event::find($eventId) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/DeleteEventTicketType.php
+++ b/src/EventTickets/Routes/DeleteEventTicketType.php
@@ -5,7 +5,6 @@ namespace Give\EventTickets\Routes;
 use Give\API\RestRoute;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Exceptions\Primitives\Exception;
-use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -20,6 +19,9 @@ class DeleteEventTicketType implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "delete_give_payments".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/DeleteEventTicketType.php
+++ b/src/EventTickets/Routes/DeleteEventTicketType.php
@@ -30,7 +30,9 @@ class DeleteEventTicketType implements RestRoute
                 [
                     'methods' => WP_REST_Server::DELETABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => [$this, 'permissionsCheck'],
+                    'permission_callback' => function () {
+                        return current_user_can('delete_give_payments');
+                    },
                 ],
                 'args' => [
                     'ticket_type_id' => [
@@ -66,19 +68,5 @@ class DeleteEventTicketType implements RestRoute
         $ticketType->delete();
 
         return new WP_REST_Response();
-    }
-
-    /**
-     * @since 3.6.0
-     *
-     * @return bool|WP_Error
-     */
-    public function permissionsCheck()
-    {
-        return current_user_can('delete_posts') ?: new WP_Error(
-            'rest_forbidden',
-            esc_html__("You don't have permission to delete Event Ticket Types", 'give'),
-            ['status' => is_user_logged_in() ? 403 : 401]
-        );
     }
 }

--- a/src/EventTickets/Routes/DeleteEventsListTable.php
+++ b/src/EventTickets/Routes/DeleteEventsListTable.php
@@ -45,7 +45,7 @@ class DeleteEventsListTable
                     'methods' => WP_REST_Server::DELETABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('delete_give_payments');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/DeleteEventsListTable.php
+++ b/src/EventTickets/Routes/DeleteEventsListTable.php
@@ -78,8 +78,13 @@ class DeleteEventsListTable
         $successes = [];
 
         foreach ($ids as $id) {
-            $soldTicketsCount = give(EventRepository::class)->getById($id)->eventTickets()->count() ?? 0;
+            $event = give(EventRepository::class)->getById($id);
+            if ( ! $event) {
+                $errors[] = $id;
+                continue;
+            }
 
+            $soldTicketsCount = $event->eventTickets()->count() ?? 0;
             if ($soldTicketsCount > 0) {
                 $errors[] = $id;
                 continue;

--- a/src/EventTickets/Routes/DeleteEventsListTable.php
+++ b/src/EventTickets/Routes/DeleteEventsListTable.php
@@ -41,7 +41,9 @@ class DeleteEventsListTable
                 [
                     'methods' => WP_REST_Server::DELETABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => [$this, 'permissionsCheck'],
+                    'permission_callback' => function () {
+                        return current_user_can('delete_give_payments');
+                    },
                 ],
                 'args' => [
                     'ids' => [
@@ -102,19 +104,5 @@ class DeleteEventsListTable
         }
 
         return [trim($ids)];
-    }
-
-        /**
-     * @since 3.6.0
-     *
-     * @return bool|\WP_Error
-     */
-    public function permissionsCheck()
-    {
-        return current_user_can('delete_posts')?: new \WP_Error(
-            'rest_forbidden',
-            esc_html__("You don't have permission to delete Events", 'give'),
-            ['status' => is_user_logged_in() ? 403 : 401]
-        );
     }
 }

--- a/src/EventTickets/Routes/DeleteEventsListTable.php
+++ b/src/EventTickets/Routes/DeleteEventsListTable.php
@@ -31,6 +31,9 @@ class DeleteEventsListTable
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "delete_give_payments".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEventForms.php
+++ b/src/EventTickets/Routes/GetEventForms.php
@@ -32,7 +32,7 @@ class GetEventForms implements RestRoute
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -40,7 +40,7 @@ class GetEventForms implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return Event::find($eventId);
+                            return Event::find($eventId) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/GetEventForms.php
+++ b/src/EventTickets/Routes/GetEventForms.php
@@ -18,6 +18,9 @@ class GetEventForms implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "read".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEventForms.php
+++ b/src/EventTickets/Routes/GetEventForms.php
@@ -28,7 +28,9 @@ class GetEventForms implements RestRoute
                 [
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'event_id' => [

--- a/src/EventTickets/Routes/GetEventTicketTypeTickets.php
+++ b/src/EventTickets/Routes/GetEventTicketTypeTickets.php
@@ -30,7 +30,9 @@ class GetEventTicketTypeTickets implements RestRoute
                 [
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'ticket_type_id' => [

--- a/src/EventTickets/Routes/GetEventTicketTypeTickets.php
+++ b/src/EventTickets/Routes/GetEventTicketTypeTickets.php
@@ -33,7 +33,7 @@ class GetEventTicketTypeTickets implements RestRoute
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -41,7 +41,9 @@ class GetEventTicketTypeTickets implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($ticketTypeId) {
-                            return EventTicketType::find($ticketTypeId);
+                            return EventTicketType::find(
+                                    $ticketTypeId
+                                ) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/GetEventTicketTypeTickets.php
+++ b/src/EventTickets/Routes/GetEventTicketTypeTickets.php
@@ -3,7 +3,6 @@
 namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
-use Give\EventTickets\Models\Event;
 use Give\EventTickets\Models\EventTicket;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Models\Model;
@@ -20,6 +19,9 @@ class GetEventTicketTypeTickets implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "read".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEventTicketTypes.php
+++ b/src/EventTickets/Routes/GetEventTicketTypes.php
@@ -33,7 +33,7 @@ class GetEventTicketTypes implements RestRoute
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -41,7 +41,7 @@ class GetEventTicketTypes implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return Event::find($eventId);
+                            return Event::find($eventId) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/GetEventTicketTypes.php
+++ b/src/EventTickets/Routes/GetEventTicketTypes.php
@@ -4,7 +4,6 @@ namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
 use Give\EventTickets\Models\Event;
-use Give\EventTickets\Models\EventTicket;
 use Give\EventTickets\Models\EventTicketType;
 use Give\Framework\Models\Model;
 use WP_REST_Request;
@@ -20,6 +19,9 @@ class GetEventTicketTypes implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "read".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEventTicketTypes.php
+++ b/src/EventTickets/Routes/GetEventTicketTypes.php
@@ -30,7 +30,9 @@ class GetEventTicketTypes implements RestRoute
                 [
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'event_id' => [

--- a/src/EventTickets/Routes/GetEventTickets.php
+++ b/src/EventTickets/Routes/GetEventTickets.php
@@ -29,7 +29,9 @@ class GetEventTickets implements RestRoute
                 [
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'event_id' => [

--- a/src/EventTickets/Routes/GetEventTickets.php
+++ b/src/EventTickets/Routes/GetEventTickets.php
@@ -19,6 +19,9 @@ class GetEventTickets implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "read".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEventTickets.php
+++ b/src/EventTickets/Routes/GetEventTickets.php
@@ -33,7 +33,7 @@ class GetEventTickets implements RestRoute
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -41,7 +41,7 @@ class GetEventTickets implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return Event::find($eventId);
+                            return Event::find($eventId) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/GetEvents.php
+++ b/src/EventTickets/Routes/GetEvents.php
@@ -27,7 +27,9 @@ class GetEvents implements RestRoute
                 [
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'page' => [

--- a/src/EventTickets/Routes/GetEvents.php
+++ b/src/EventTickets/Routes/GetEvents.php
@@ -17,6 +17,9 @@ class GetEvents implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "read".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/GetEvents.php
+++ b/src/EventTickets/Routes/GetEvents.php
@@ -31,7 +31,7 @@ class GetEvents implements RestRoute
                     'methods' => 'GET',
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/GetEventsListTable.php
+++ b/src/EventTickets/Routes/GetEventsListTable.php
@@ -45,7 +45,7 @@ class GetEventsListTable
                     'methods' => WP_REST_Server::READABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('read');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [

--- a/src/EventTickets/Routes/GetEventsListTable.php
+++ b/src/EventTickets/Routes/GetEventsListTable.php
@@ -43,7 +43,9 @@ class GetEventsListTable
                 [
                     'methods' => WP_REST_Server::READABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => [$this, 'permissionsCheck'],
+                    'permission_callback' => function () {
+                        return current_user_can('read');
+                    },
                 ],
                 'args' => [
                     'page' => [
@@ -166,19 +168,5 @@ class GetEventsListTable
         }
 
         return $query;
-    }
-
-        /**
-     * @since 3.6.0
-     *
-     * @return bool|\WP_Error
-     */
-    public function permissionsCheck()
-    {
-        return current_user_can('edit_posts')?: new \WP_Error(
-            'rest_forbidden',
-            esc_html__("You don't have permission to view Events", 'give'),
-            ['status' => is_user_logged_in() ? 403 : 401]
-        );
     }
 }

--- a/src/EventTickets/Routes/GetEventsListTable.php
+++ b/src/EventTickets/Routes/GetEventsListTable.php
@@ -32,6 +32,7 @@ class GetEventsListTable
     /**
      * @inheritDoc
      *
+     * @unreleased Set the permission callback to "read".
      * @since 3.6.0
      */
     public function registerRoute(): void

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -28,7 +28,9 @@ class UpdateEvent implements RestRoute
                 [
                     'methods' => WP_REST_Server::EDITABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('edit_give_payments');
+                    },
                 ],
                 'args' => [
                     'event_id' => [

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -4,6 +4,7 @@ namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
 use Give\EventTickets\Models\Event;
+use Give\EventTickets\Repositories\EventRepository;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -40,7 +41,7 @@ class UpdateEvent implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return Event::find($eventId);
+                            return give(EventRepository::class)->queryById($eventId)->count() > 0;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -18,6 +18,9 @@ class UpdateEvent implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "edit_give_payments" and description's sanitize callback to "textarea".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -49,7 +49,7 @@ class UpdateEvent implements RestRoute
                     'description' => [
                         'type' => 'string',
                         'required' => false,
-                        'sanitize_callback' => 'sanitize_text_field',
+                        'sanitize_callback' => 'sanitize_textare_field',
                     ],
                     'startDateTime' => [
                         'type' => 'string',

--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -4,7 +4,6 @@ namespace Give\EventTickets\Routes;
 
 use Give\API\RestRoute;
 use Give\EventTickets\Models\Event;
-use Give\EventTickets\Repositories\EventRepository;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -33,7 +32,7 @@ class UpdateEvent implements RestRoute
                     'methods' => WP_REST_Server::EDITABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('edit_give_payments');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -41,7 +40,7 @@ class UpdateEvent implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($eventId) {
-                            return give(EventRepository::class)->queryById($eventId)->count() > 0;
+                            return Event::find($eventId) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -5,6 +5,7 @@ namespace Give\EventTickets\Routes;
 use Give\API\RestRoute;
 use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
 use Give\EventTickets\Models\EventTicketType;
+use Give\EventTickets\Repositories\EventTicketTypeRepository;
 use Give\Framework\Support\ValueObjects\Money;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -41,8 +42,8 @@ class UpdateEventTicketType implements RestRoute
                     'ticket_type_id' => [
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
-                        'validate_callback' => function ($eventId) {
-                            return EventTicketType::find($eventId);
+                        'validate_callback' => function ($ticketTypeId) {
+                            return give(EventTicketTypeRepository::class)->queryById($ticketTypeId)->count() > 0;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -5,7 +5,6 @@ namespace Give\EventTickets\Routes;
 use Give\API\RestRoute;
 use Give\EventTickets\DataTransferObjects\EventTicketTypeData;
 use Give\EventTickets\Models\EventTicketType;
-use Give\EventTickets\Repositories\EventTicketTypeRepository;
 use Give\Framework\Support\ValueObjects\Money;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -35,7 +34,7 @@ class UpdateEventTicketType implements RestRoute
                     'methods' => WP_REST_Server::EDITABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
-                        return current_user_can('edit_give_payments');
+                        return current_user_can('edit_give_forms');
                     },
                 ],
                 'args' => [
@@ -43,7 +42,9 @@ class UpdateEventTicketType implements RestRoute
                         'type' => 'integer',
                         'sanitize_callback' => 'absint',
                         'validate_callback' => function ($ticketTypeId) {
-                            return give(EventTicketTypeRepository::class)->queryById($ticketTypeId)->count() > 0;
+                            return EventTicketType::find(
+                                    $ticketTypeId
+                                ) !== null;
                         },
                         'required' => true,
                     ],

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -30,7 +30,9 @@ class UpdateEventTicketType implements RestRoute
                 [
                     'methods' => WP_REST_Server::EDITABLE,
                     'callback' => [$this, 'handleRequest'],
-                    'permission_callback' => '__return_true',
+                    'permission_callback' => function () {
+                        return current_user_can('edit_give_payments');
+                    },
                 ],
                 'args' => [
                     'ticket_type_id' => [

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -51,7 +51,7 @@ class UpdateEventTicketType implements RestRoute
                     'description' => [
                         'type' => 'string',
                         'required' => false,
-                        'sanitize_callback' => 'sanitize_text_field',
+                        'sanitize_callback' => 'sanitize_textarea_field',
                     ],
                     'price' => [
                         'type' => 'integer',

--- a/src/EventTickets/Routes/UpdateEventTicketType.php
+++ b/src/EventTickets/Routes/UpdateEventTicketType.php
@@ -20,6 +20,9 @@ class UpdateEventTicketType implements RestRoute
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Set the permission callback to "edit_give_payments" and description's sanitize callback to "textarea".
+     * @since 3.6.0
      */
     public function registerRoute()
     {

--- a/tests/Unit/EventTickets/Routes/CreateEventTest.php
+++ b/tests/Unit/EventTickets/Routes/CreateEventTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Unit\EventTickets\Routes;
+
+use Exception;
+use Give\EventTickets\Models\Event;
+use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Response;
+
+class CreateEventTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * Test that a valid request successfully creates a new Event.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventCreationSuccess()
+    {
+        $data = [
+            'title' => 'New Title',
+            'description' => 'New Description',
+            'startDateTime' => '2024-01-01 00:00:00',
+            'endDateTime' => '2024-01-01 23:59:59',
+        ];
+
+        $response = $this->handleRequest($data);
+        $event = Event::find($response->get_data()['id']);
+
+        $this->assertEquals(201, $response->get_status());
+        $this->assertEquals($data['title'], $event->title);
+        $this->assertEquals($data['description'], $event->description);
+        $this->assertEquals(Temporal::toDateTime($data['startDateTime']), $event->startDateTime);
+        $this->assertEquals(Temporal::toDateTime($data['endDateTime']), $event->endDateTime);
+    }
+
+    /**
+     * Test that creating an event with missing required fields returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventCreationWithMissingRequiredFields()
+    {
+        $response = $this->handleRequest([]);
+
+        $this->assertErrorResponse('rest_missing_callback_param', $response);
+
+        $errorData = $response->as_error()->get_error_data();
+        if (isset($errorData['params'])) {
+            $this->assertContains('title', $errorData['params']);
+            $this->assertContains('startDateTime', $errorData['params']);
+        }
+    }
+
+    /**
+     * Test that creating an event with an invalid date format returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventCreationWithInvalidDateFormat()
+    {
+        $data = [
+            'title' => 'New Title',
+            'startDateTime' => '2024/01/01',
+        ];
+
+        $response = $this->handleRequest($data);
+
+        $this->assertErrorResponse('rest_invalid_param', $response);
+
+        $errorData = $response->as_error()->get_error_data();
+        if (isset($errorData['params'])) {
+            $this->assertArrayHasKey('startDateTime', $errorData['params']);
+        }
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventCreationRequiresAuthorization()
+    {
+        $data = [
+            'title' => 'New Title',
+            'startDateTime' => '2024-01-01 00:00:00',
+        ];
+
+        $response = $this->handleRequest($data, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param array $data
+     * @param bool  $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'POST',
+            "/give-api/v2/events-tickets/events",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
+    }
+}

--- a/tests/Unit/EventTickets/Routes/CreateEventTicketTypeTest.php
+++ b/tests/Unit/EventTickets/Routes/CreateEventTicketTypeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Unit\EventTickets\Routes;
+
+use Exception;
+use Give\EventTickets\Models\EventTicketType;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Response;
+
+class CreateEventTicketTypeTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * Test that a valid request successfully creates a new Event Ticket Type.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeCreationSuccess()
+    {
+        $data = [
+            'title' => 'New Title',
+            'description' => 'New Description',
+            'price' => 1000,
+            'capacity' => 100,
+        ];
+
+        $response = $this->handleRequest(1, $data);
+        $ticketType = EventTicketType::find($response->get_data()->id);
+
+        $this->assertEquals(201, $response->get_status());
+        $this->assertEquals(1, $ticketType->eventId);
+        $this->assertEquals($data['title'], $ticketType->title);
+        $this->assertEquals($data['description'], $ticketType->description);
+        $this->assertEquals(new Money($data['price'], give_get_currency()), $ticketType->price);
+        $this->assertEquals($data['capacity'], $ticketType->capacity);
+    }
+
+    /**
+     * Test that creating an Event Ticket Type with missing required fields returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeCreationWithMissingRequiredFields()
+    {
+        $response = $this->handleRequest(1, []);
+
+        $this->assertErrorResponse('rest_missing_callback_param', $response);
+
+        $errorData = $response->as_error()->get_error_data();
+        if (isset($errorData['params'])) {
+            $this->assertContains('title', $errorData['params']);
+            $this->assertContains('price', $errorData['params']);
+            $this->assertContains('capacity', $errorData['params']);
+        }
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeCreationRequiresAuthorization()
+    {
+        $data = [
+            'title' => 'New Title',
+            'price' => '1000',
+            'capacity' => 100,
+        ];
+
+        $response = $this->handleRequest(1, $data, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param int $eventId
+     * @param array $data
+     * @param bool $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        int $eventId,
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'POST',
+            "/give-api/v2/events-tickets/event/{$eventId}/ticket-types",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
+    }
+}

--- a/tests/Unit/EventTickets/Routes/DeleteEventTicketTypeTest.php
+++ b/tests/Unit/EventTickets/Routes/DeleteEventTicketTypeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Unit\EventTickets\Routes;
+
+use Exception;
+use Give\EventTickets\Models\EventTicket;
+use Give\EventTickets\Models\EventTicketType;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Response;
+
+class DeleteEventTicketTypeTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * Test that a valid request successfully deletes an Event Ticket Type.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeDeletionSuccess()
+    {
+        $ticketTypeId = EventTicketType::factory()->create()->id;
+
+        $response = $this->handleRequest($ticketTypeId);
+
+        $this->assertEquals(200, $response->get_status());
+        $this->assertNull(EventTicketType::find($ticketTypeId));
+    }
+
+    /**
+     * Test that an invalid ticket type ID returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeDeletionWithInvalidId()
+    {
+        $response = $this->handleRequest(PHP_INT_MAX);
+
+        $this->assertErrorResponse('rest_invalid_param', $response);
+    }
+
+    /**
+     * Test that a ticket type with associated tickets cannot be deleted.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeDeletionPreventedByTickets()
+    {
+        $eventTicket = EventTicket::factory()->create();
+        $ticketTypeId = $eventTicket->ticketTypeId;
+
+        $response = $this->handleRequest($ticketTypeId);
+
+        $this->assertErrorResponse('event_ticket_type_delete_failed', $response);
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeDeletionRequiresAuthorization()
+    {
+        $ticketTypeId = EventTicketType::factory()->create()->id;
+
+        $response = $this->handleRequest($ticketTypeId, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param int   $ticketTypeId
+     * @param bool  $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        int $ticketTypeId,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'DELETE',
+            "/give-api/v2/events-tickets/ticket-type/{$ticketTypeId}",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        return $this->dispatchRequest($request);
+    }
+}

--- a/tests/Unit/EventTickets/Routes/DeleteEventTicketTypeTest.php
+++ b/tests/Unit/EventTickets/Routes/DeleteEventTicketTypeTest.php
@@ -57,7 +57,23 @@ class DeleteEventTicketTypeTest extends RestApiTestCase
 
         $response = $this->handleRequest($ticketTypeId);
 
-        $this->assertErrorResponse('event_ticket_type_delete_failed', $response);
+        $this->assertErrorResponse('rest_invalid_param', $response);
+
+        $errorData = $response->as_error()->get_error_data();
+        if (isset($errorData['params'])) {
+            $this->assertContains(
+                'ticket_type_id',
+                array_keys($errorData['params'])
+            );
+            $this->assertEquals(
+                'event_ticket_type_sold_delete_failed',
+                $errorData['details']['ticket_type_id']['code']
+            );
+            $this->assertEquals(
+                403,
+                $errorData['details']['ticket_type_id']['data']['status']
+            );
+        }
     }
 
     /**
@@ -80,8 +96,8 @@ class DeleteEventTicketTypeTest extends RestApiTestCase
      *
      * @unreleased
      *
-     * @param int   $ticketTypeId
-     * @param bool  $authenticatedAsAdmin
+     * @param int  $ticketTypeId
+     * @param bool $authenticatedAsAdmin
      *
      * @return WP_REST_Response
      */

--- a/tests/Unit/EventTickets/Routes/DeleteEventsListTableTest.php
+++ b/tests/Unit/EventTickets/Routes/DeleteEventsListTableTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Unit\EventTickets\Routes;
+
+use Exception;
+use Give\EventTickets\Models\Event;
+use Give\EventTickets\Models\EventTicket;
+use Give\EventTickets\Repositories\EventRepository;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Response;
+
+class DeleteEventsListTableTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * Test that a valid request successfully deletes multiple events.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testMultipleEventsDeletionSuccess()
+    {
+        $events = Event::factory()->count(3)->create();
+        $eventIds = array_map(function ($event) {
+            return $event->id;
+        }, $events);
+
+        $response = $this->handleRequest($eventIds);
+
+        $this->assertEquals(200, $response->get_status());
+        $this->assertEquals(0, give(EventRepository::class)->prepareQuery()->whereIn('id', $eventIds)->count());
+    }
+
+    /**
+     * Test that an invalid Event ID returns it in the errors array.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventDeletionWithInvalidId()
+    {
+        $response = $this->handleRequest([PHP_INT_MAX]);
+
+        $this->assertCount(1, $response->get_data()['errors']);
+    }
+
+    /**
+     * Test that an event with associated tickets cannot be deleted.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventDeletionPreventedByTickets()
+    {
+        $eventTicket = EventTicket::factory()->create();
+        $eventId = $eventTicket->eventId;
+
+        $response = $this->handleRequest([$eventId]);
+
+        $this->assertCount(1, $response->get_data()['errors']);
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventDeletionRequiresAuthorization()
+    {
+        $eventId = Event::factory()->create()->id;
+
+        $response = $this->handleRequest([$eventId], false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param int[] $eventIds
+     * @param bool  $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        array $eventIds,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'DELETE',
+            "/give-api/v2/events-tickets/events/list-table",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_param('ids', implode(',', $eventIds));
+
+        return $this->dispatchRequest($request);
+    }
+}

--- a/tests/Unit/EventTickets/Routes/UpdateEventTest.php
+++ b/tests/Unit/EventTickets/Routes/UpdateEventTest.php
@@ -1,54 +1,90 @@
 <?php
 
-namespace Give\Tests\Unit\EventTickets\Routes;
+namespace Unit\EventTickets\Routes;
 
 use Exception;
-use Give\Donations\Endpoints\ListDonations;
-use Give\Donations\ListTable\DonationsListTable;
-use Give\Donations\Models\Donation;
 use Give\EventTickets\Models\Event;
-use Give\EventTickets\Routes\GetEventsListTable;
-use Give\EventTickets\Routes\UpdateEvent;
-use Give\Tests\TestCase;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
 use Give\Tests\TestTraits\RefreshDatabase;
-use WP_REST_Request;
-use WP_REST_Server;
+use WP_REST_Response;
 
-class UpdateEventTest extends TestCase
+class UpdateEventTest extends RestApiTestCase
 {
     use RefreshDatabase;
+    use HasDefaultWordPressUsers;
 
     /**
-     * @since 3.6.0
-     */
-    protected function getMockRequest($eventId): WP_REST_Request
-    {
-        $request = new WP_REST_Request(
-            WP_REST_Server::EDITABLE,
-            "/give-api/v2/event-tickets/event/$eventId"
-        );
-
-        $request->set_param('event_id', $eventId);
-
-        return $request;
-    }
-
-    /**
-     * @since 3.6.0
+     * Test that a valid request successfully updates an Event.
      *
-     * @return void
+     * @unreleased
      * @throws Exception
      */
-    public function testShouldUpdateEventTitle()
+    public function testEventUpdateSuccess()
     {
         $event = Event::factory()->create([
             'title' => 'Old Title',
         ]);
 
-        $mockRequest = $this->getMockRequest($event->id);
-        $mockRequest->set_param('title', 'New Title');
-        $response = (new UpdateEvent())->handleRequest($mockRequest);
+        $response = $this->handleRequest($event->id, ['title' => 'New Title']);
 
+        $this->assertEquals(200, $response->get_status());
         $this->assertEquals('New Title', Event::find($event->id)->title);
+    }
+
+    /**
+     * Test that an invalid Event ID returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventUpdateWithInvalidId()
+    {
+        $response = $this->handleRequest(PHP_INT_MAX, ['title' => 'New Title']);
+
+        $this->assertErrorResponse('rest_invalid_param', $response);
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventUpdateRequiresAuthorization()
+    {
+        $eventId = Event::factory()->create()->id;
+
+        $response = $this->handleRequest($eventId, ['title' => 'New Title'], false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param int   $eventId
+     * @param array $data
+     * @param bool  $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        int $eventId,
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'POST',
+            "/give-api/v2/events-tickets/event/{$eventId}",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
     }
 }

--- a/tests/Unit/EventTickets/Routes/UpdateEventTicketTypeTest.php
+++ b/tests/Unit/EventTickets/Routes/UpdateEventTicketTypeTest.php
@@ -1,76 +1,109 @@
 <?php
 
-namespace Give\Tests\Unit\EventTickets\Routes;
+namespace Unit\EventTickets\Routes;
 
 use Exception;
-use Give\Donations\Endpoints\ListDonations;
-use Give\Donations\ListTable\DonationsListTable;
-use Give\Donations\Models\Donation;
-use Give\EventTickets\Models\Event;
 use Give\EventTickets\Models\EventTicketType;
-use Give\EventTickets\Routes\GetEventsListTable;
-use Give\EventTickets\Routes\UpdateEvent;
-use Give\EventTickets\Routes\UpdateEventTicketType;
 use Give\Framework\Support\ValueObjects\Money;
-use Give\Tests\TestCase;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
 use Give\Tests\TestTraits\RefreshDatabase;
-use WP_REST_Request;
-use WP_REST_Server;
+use WP_REST_Response;
 
-class UpdateEventTicketTypeTest extends TestCase
+class UpdateEventTicketTypeTest extends RestApiTestCase
 {
     use RefreshDatabase;
+    use HasDefaultWordPressUsers;
 
     /**
-     * @since 3.6.0
-     */
-    protected function getMockRequest($id): WP_REST_Request
-    {
-        $request = new WP_REST_Request(
-            WP_REST_Server::EDITABLE,
-            "/give-api/v2/event-tickets/ticket-type/$id"
-        );
-
-        $request->set_param('ticket_type_id', $id);
-
-        return $request;
-    }
-
-    /**
-     * @since 3.6.0
+     * Test that a valid request successfully updates an Event Ticket Type's title.
      *
-     * @return void
+     * @unreleased
      * @throws Exception
      */
-    public function testShouldUpdateTicketTypeTitle()
+    public function testEventTicketTypeTitleUpdateSuccess()
     {
         $ticketType = EventTicketType::factory()->create([
             'title' => 'Old Title',
         ]);
 
-        $mockRequest = $this->getMockRequest($ticketType->id);
-        $mockRequest->set_param('title', 'New Title');
-        $response = (new UpdateEventTicketType())->handleRequest($mockRequest);
+        $response = $this->handleRequest($ticketType->id, ['title' => 'New Title']);
 
+        $this->assertEquals(200, $response->get_status());
         $this->assertEquals('New Title', EventTicketType::find($ticketType->id)->title);
     }
 
     /**
-     * @since 3.6.0
+     * Test that a valid request successfully updates an Event Ticket Type's price.
      *
-     * @return void
+     * @unreleased
      * @throws Exception
      */
-    public function testShouldUpdateTicketTypePrice()
+    public function testEventTicketTypePriceUpdateSuccess()
     {
         $ticketType = EventTicketType::factory()->create([
             'price' => new Money(1000, 'USD'),
         ]);
 
-        $mockRequest = $this->getMockRequest($ticketType->id);
-        $mockRequest->set_param('price', 2000);
-        $response = (new UpdateEventTicketType())->handleRequest($mockRequest);
+        $response = $this->handleRequest($ticketType->id, ['price' => 2000]);
 
+        $this->assertEquals(200, $response->get_status());
         $this->assertEquals(2000, EventTicketType::find($ticketType->id)->price->formatToMinorAmount());
+    }
+
+    /**
+     * Test that an invalid Event Ticket Type ID returns an error.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventTicketTypeUpdateWithInvalidId()
+    {
+        $response = $this->handleRequest(PHP_INT_MAX, ['title' => 'New Title']);
+
+        $this->assertErrorResponse('rest_invalid_param', $response);
+    }
+
+    /**
+     * Test that unauthorized requests are denied.
+     *
+     * @unreleased
+     * @throws Exception
+     */
+    public function testEventUpdateRequiresAuthorization()
+    {
+        $ticketTypeId = EventTicketType::factory()->create()->id;
+
+        $response = $this->handleRequest($ticketTypeId, ['title' => 'New Title'], false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * Handle the request common to all tests.
+     *
+     * @unreleased
+     *
+     * @param int   $ticketTypeId
+     * @param array $data
+     * @param bool  $authenticatedAsAdmin
+     *
+     * @return WP_REST_Response
+     */
+    private function handleRequest(
+        int $ticketTypeId,
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'POST',
+            "/give-api/v2/events-tickets/ticket-type/{$ticketTypeId}",
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
     }
 }


### PR DESCRIPTION
Resolves [GIVE-371]

## Description

This pull request improves Event Tickets API routes by enhancing permission checks and validations to prevent invalid requests from reaching the handler. Additionally, it includes unit tests that cover various edge cases, that ran through the actual API system with the `RestApiTestCase`.

## Affects

Event Tickets API routes

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-371]: https://stellarwp.atlassian.net/browse/GIVE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ