### PR TITLE
Fix: Quantity input overflow in Ticket Types with long descriptions

### DIFF
--- a/src/EventTickets/resources/templates/EventTickets/styles.scss
+++ b/src/EventTickets/resources/templates/EventTickets/styles.scss
@@ -94,11 +94,12 @@
             border-radius: var(--givewp-rounded-2);
             border: 1px solid var(--givewp-grey-25);
             display: flex;
+            gap: var(--givewp-spacing-4);
             padding: var(--givewp-spacing-4);
 
             &__description {
                 display: flex;
-                flex: 1 0 auto;
+                flex: 1 0 0;
                 flex-direction: column;
                 gap: var(--givewp-spacing-1);
 


### PR DESCRIPTION
Resolves [GIVE-460]

## Description
This pull request resolves an issue where long descriptions for ticket types caused the quantity input to overflow the box. The problem stemmed from setting the `flex-basis` property to `auto`, which expands to accommodate content. To fix this, the `flex-basis` property was changed to `0`, and a gap was introduced between the description text and the quantity input.

## Visuals
| Before |
| ------ |
| ![CleanShot 2024-03-21 at 20 20 26](https://github.com/impress-org/givewp/assets/3921017/8aa0c2eb-518f-403e-a215-217832118d7d) |

| After |
| ------ |
| ![CleanShot 2024-03-21 at 20 13 20](https://github.com/impress-org/givewp/assets/3921017/86027786-25f9-42bd-a5ba-acc4168c7ac8) |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-460]: https://stellarwp.atlassian.net/browse/GIVE-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ