### PR TITLE
Fix: Set content for missing title in event tickets template

### DIFF
--- a/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
+++ b/src/EventTickets/Actions/EnqueueFormBuilderScripts.php
@@ -31,17 +31,6 @@ class EnqueueFormBuilderScripts
                 'events' => $this->getEvents(),
                 'createEventUrl' => admin_url('edit.php?post_type=give_forms&page=give-event-tickets&new=event'),
                 'listEventsUrl' => admin_url('edit.php?post_type=give_forms&page=give-event-tickets'),
-                'ticketsLabel' => apply_filters(
-                    'givewp_event_tickets_block/tickets_label',
-                    __('Select Tickets', 'give')
-                ),
-                'soldOutMessage' => apply_filters(
-                    'givewp_event_tickets_block/sold_out_message',
-                    __(
-                        'Thank you for supporting our cause. Our fundraising event tickets are officially sold out. You can still contribute by making a donation.',
-                        'give'
-                    )
-                ),
             ]
         );
 

--- a/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
+++ b/src/EventTickets/resources/blocks/EventTicketsBlock/Edit/BlockPlaceholder.tsx
@@ -30,7 +30,6 @@ export default function BlockPlaceholder({attributes}) {
                 {!hasEnded && (
                     <EventTicketsList
                         ticketTypes={event.ticketTypes}
-                        ticketsLabel={ticketsLabel}
                         currency={currency}
                         currencyRate={1}
                     />

--- a/src/EventTickets/resources/components/EventTicketsList.tsx
+++ b/src/EventTickets/resources/components/EventTicketsList.tsx
@@ -1,9 +1,9 @@
+import {__} from '@wordpress/i18n';
 import EventTicketsListItem from './EventTicketsListItem';
 import {EventTicketsListProps} from './types';
 
 export default function EventTicketsList({
     ticketTypes,
-    ticketsLabel,
     currency,
     currencyRate,
     selectedTickets = [],
@@ -15,7 +15,7 @@ export default function EventTicketsList({
 
     return (
         <div className={'givewp-event-tickets__tickets'}>
-            <h4>{ticketsLabel}</h4>
+            <h4>{__('Select tickets', 'give')}</h4>
             {ticketTypes.map((ticketType) => {
                 return (
                     <EventTicketsListItem

--- a/src/EventTickets/resources/components/EventTicketsList.tsx
+++ b/src/EventTickets/resources/components/EventTicketsList.tsx
@@ -1,4 +1,4 @@
-import {__} from '@wordpress/i18n';
+import {_x} from '@wordpress/i18n';
 import EventTicketsListItem from './EventTicketsListItem';
 import {EventTicketsListProps} from './types';
 
@@ -15,7 +15,9 @@ export default function EventTicketsList({
 
     return (
         <div className={'givewp-event-tickets__tickets'}>
-            <h4>{__('Select tickets', 'give')}</h4>
+            <h4>
+                {_x('Select tickets', 'Title above the list of ticket types in the Event Tickets template', 'give')}
+            </h4>
             {ticketTypes.map((ticketType) => {
                 return (
                     <EventTicketsListItem

--- a/src/EventTickets/resources/components/types.ts
+++ b/src/EventTickets/resources/components/types.ts
@@ -9,6 +9,7 @@ export type Event = {
     endDateTime: Date;
     ticketTypes: TicketType[];
     ticketsLabel: string;
+    soldOutMessage: string;
 };
 
 export type TicketType = {
@@ -28,7 +29,6 @@ export type SelectedTicket = {
 
 export type EventTicketsListProps = {
     ticketTypes: TicketType[];
-    ticketsLabel: string;
     currency: string;
     currencyRate: number;
     selectedTickets?: SelectedTicket[];

--- a/src/EventTickets/resources/components/types.ts
+++ b/src/EventTickets/resources/components/types.ts
@@ -8,8 +8,6 @@ export type Event = {
     startDateTime: Date;
     endDateTime: Date;
     ticketTypes: TicketType[];
-    ticketsLabel: string;
-    soldOutMessage: string;
 };
 
 export type TicketType = {

--- a/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
@@ -3,7 +3,7 @@ import {useEffect, useState} from 'react';
 import EventTicketsList from '../../components/EventTicketsList';
 import {EventTicketsListHOCProps, OnSelectTicketProps} from './types';
 
-export default function EventTicketsListHOC({name, ticketTypes, ticketsLabel}: EventTicketsListHOCProps) {
+export default function EventTicketsListHOC({name, ticketTypes}: EventTicketsListHOCProps) {
     const [selectedTickets, setSelectedTickets] = useState([]);
     const {useWatch, useCurrencyFormatter, useDonationFormSettings, useDonationSummary, useFormContext} =
         window.givewp.form.hooks;
@@ -69,7 +69,6 @@ export default function EventTicketsListHOC({name, ticketTypes, ticketsLabel}: E
     return (
         <EventTicketsList
             ticketTypes={ticketTypes}
-            ticketsLabel={ticketsLabel}
             currency={currency}
             currencyRate={currencyRate}
             selectedTickets={selectedTickets}

--- a/src/EventTickets/resources/templates/EventTickets/index.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/index.tsx
@@ -16,7 +16,6 @@ export default function EventTicketsField({
     startDateTime,
     endDateTime,
     ticketTypes,
-    ticketsLabel,
 }: Event) {
     const startDateTimeObj = new Date(startDateTime);
     const endDateTimeObj = new Date(endDateTime);
@@ -28,7 +27,7 @@ export default function EventTicketsField({
 
             {description && <EventTicketsDescription description={description} />}
 
-            {!hasEnded && <EventTicketsListHOC name={name} ticketTypes={ticketTypes} ticketsLabel={ticketsLabel} />}
+            {!hasEnded && <EventTicketsListHOC name={name} ticketTypes={ticketTypes} />}
         </div>
     );
 }

--- a/src/EventTickets/resources/templates/EventTickets/types.ts
+++ b/src/EventTickets/resources/templates/EventTickets/types.ts
@@ -3,7 +3,6 @@ import {TicketType} from '../../components/types';
 export type EventTicketsListHOCProps = {
     name: string;
     ticketTypes: TicketType[];
-    ticketsLabel: string;
 };
 
 export interface OnSelectTicketProps {


### PR DESCRIPTION
Resolves [GIVE-2112]

## Description
Per designs, we have a title above the ticket list in the Event Tickets template, but due to a mistake in its implementation, it was being  rendered as an empty tag. This pull request corrects this issue by directly setting its content in the template. As a consequence of this new implementation, all references to the `ticketLabel` as an attribute are being removed.

## Visuals
![CleanShot 2024-03-21 at 20 53 02](https://github.com/impress-org/givewp/assets/3921017/66b4958c-d32b-41a8-9f16-836f7d3c8191)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2112]: https://stellarwp.atlassian.net/browse/GIVE-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ