### PR TITLE
Feature: Add Double The Donation migration step

### DIFF
--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -342,7 +342,7 @@ class DonationFormsAdminPage
             //            'MailChimp' => class_exists('Give_MailChimp'),
             //            'Text-to-Give' => defined('GIVE_TEXT_TO_GIVE_ADDON_NAME'),
             //            'Donation Block for Stripe' => defined('DONATION_BLOCK_FILE'),
-            //            'Double the Donation' => defined('GIVE_DTD_NAME'),
+            'Double the Donation' => defined('GIVE_DTD_NAME'),
             //            'Simple Social Shout' => class_exists('SIMPLE_SOCIAL_SHARE_4_GIVEWP'),
             //            'Receipt Attachments' => defined('GIVERA_VERSION'),
             'Per Form Gateways' => class_exists('Give_Per_Form_Gateways'),

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -765,6 +765,22 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased
+     */
+    public function getDoubleTheDonationStatus(): string
+    {
+        return $this->getMeta('dtd_enable_disable');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getDoubleTheDonationLabel(): string
+    {
+        return $this->getMeta('give_dtd_label');
+    }
+
+    /**
      * @since 3.5.0
      */
     public function getFormFeaturedImage()

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -51,6 +51,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Steps\GiftAid::class,
                 Steps\FormFeaturedImage::class,
                 Steps\FormExcerpt::class,
+                Steps\DoubleTheDonation::class,
             ]);
         });
     }

--- a/src/FormMigration/Steps/DoubleTheDonation.php
+++ b/src/FormMigration/Steps/DoubleTheDonation.php
@@ -14,12 +14,16 @@ class DoubleTheDonation extends FormMigrationStep
     /**
      * @unreleased
      */
+    public function canHandle(): bool
+    {
+        return $this->formV2->getDoubleTheDonationStatus() === 'enabled';
+    }
+
+    /**
+     * @unreleased
+     */
     public function process()
     {
-        if ($this->formV2->getDoubleTheDonationStatus() !== 'enabled') {
-            return;
-        }
-
         $block = BlockModel::make([
             'name'       => 'givewp/dtd',
             'attributes' => [

--- a/src/FormMigration/Steps/DoubleTheDonation.php
+++ b/src/FormMigration/Steps/DoubleTheDonation.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Give\FormMigration\Steps;
+
+use Give\FormMigration\Contracts\FormMigrationStep;
+use Give\Framework\Blocks\BlockModel;
+
+/**
+ * @unreleased
+ */
+class DoubleTheDonation extends FormMigrationStep
+{
+
+    /**
+     * @unreleased
+     */
+    public function process()
+    {
+        if ($this->formV2->getDoubleTheDonationStatus() !== 'enabled') {
+            return;
+        }
+
+        $block = BlockModel::make([
+            'name'       => 'givewp/dtd',
+            'attributes' => [
+                'label'   => $this->formV2->getDoubleTheDonationLabel(),
+                'company' => [
+                    'company_id'   => '',
+                    'company_name' => '',
+                    'entered_text' => '',
+                ],
+            ],
+        ]);
+
+        $this->fieldBlocks->insertAfter('givewp/donation-amount', $block);
+    }
+}

--- a/tests/Feature/FormMigration/Steps/TestDoubleTheDonation.php
+++ b/tests/Feature/FormMigration/Steps/TestDoubleTheDonation.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Give\Tests\Feature\FormMigration\Steps;
+
+use Give\FormMigration\DataTransferObjects\FormMigrationPayload;
+use Give\FormMigration\Steps\DoubleTheDonation;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
+
+/**
+ * @unreleased
+ *
+ * @covers \Give\FormMigration\Steps\DoubleTheDonation
+ */
+class TestDoubleTheDonation extends TestCase
+{
+    use RefreshDatabase, LegacyDonationFormAdapter;
+
+    public function testProcessShouldUpdateDoubleTheDonationBlockAttributes(): void
+    {
+        $meta = [
+            'give_dtd_label' => 'DTD Label',
+        ];
+
+        $company = [
+            'company_id'   => '',
+            'company_name' => '',
+            'entered_text' => '',
+        ];
+
+        $formV2  = $this->createSimpleDonationForm(['meta' => $meta]);
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+
+        $dtd = new DoubleTheDonation($payload);
+        $dtd->process();
+
+        $block = $payload->formV3->blocks->findByName('givewp/dtd');
+
+        $this->assertSame($meta['give_dtd_label'], $block->getAttribute('label'));
+        $this->assertEqualsIgnoringCase($company, $block->getAttribute('company'));
+    }
+}

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -265,4 +265,53 @@ class TestFormMetaDecorator extends TestCase {
 
         return $this->_make_attachment($upload);
     }
+
+
+    /**
+     * @unreleased
+     */
+    public function testIsDoubleTheDonationEnabledShouldReturnTrue(): void
+    {
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'dtd_enable_disable' => 'enabled',
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        $this->assertTrue($formMetaDecorator->getDoubleTheDonationStatus() === 'enabled');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testIsDoubleTheDonationDisabledShouldReturnTrue(): void
+    {
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'dtd_enable_disable' => 'disabled',
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        $this->assertTrue($formMetaDecorator->getDoubleTheDonationStatus() === 'disabled');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testIsDoubleTheDonationLabelSetShouldReturnTrue(): void
+    {
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'give_dtd_label' => 'DTD Label',
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        $this->assertTrue($formMetaDecorator->getDoubleTheDonationLabel() === 'DTD Label');
+    }
 }


### PR DESCRIPTION
Resolves: [GIVE-497]

## Description

This PR adds the Double The Donation migration step.

## Affects

Form migration


## Testing Instructions

Create a V2 form with Company Matching enabled
Upgrade form to V3
DTD block should be added to V3 from

Now repeat the process with the Company Matching disabled
DTD block should not be added to V3 from


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-497]: https://stellarwp.atlassian.net/browse/GIVE-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ