### PR TITLE
Feature: add mailchimp form migration unit tests

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -529,8 +529,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpLabel()
     {
-        $value = $this->getMeta('_give_mailchimp_custom_label');
-        return $value === '' ? null : $value;
+        return $this->getMeta('_give_mailchimp_custom_label',  give_get_option('give_mailchimp_label', __('Subscribe to newsletter?')));
     }
 
     /**
@@ -538,7 +537,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpDefaultChecked(): bool
     {
-        return $this->getMeta('_give_mailchimp_checked_default');
+        return $this->getMeta('_give_mailchimp_checked_default', give_get_option('give_mailchimp_checked_default', true));
     }
 
     /**
@@ -546,7 +545,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpDoubleOptIn(): bool
     {
-        return $this->getMeta('_give_mailchimp_double_opt_in');
+        return $this->getMeta('_give_mailchimp_double_opt_in',  give_get_option('give_mailchimp_double_opt_in'));
     }
 
     /**
@@ -554,7 +553,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSendDonationData(): bool
     {
-        return $this->getMeta('_give_mailchimp_send_donation');
+        return $this->getMeta('_give_mailchimp_send_donation',  give_get_option('give_mailchimp_donation_data', true));
     }
 
     /**
@@ -562,7 +561,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSendFFMData(): bool
     {
-        return $this->getMeta('_give_mailchimp_send_ffm');
+        return $this->getMeta('_give_mailchimp_send_ffm',  give_get_option('give_mailchimp_ffm_pass_field'));
     }
 
     /**
@@ -570,7 +569,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpDefaultAudiences(): array
     {
-        return (array)$this->getMeta('_give_mailchimp');
+        return (array)$this->getMeta('_give_mailchimp', give_get_option('give_mailchimp_list', ['']));
     }
 
     /**
@@ -578,7 +577,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSubscriberTags(): array
     {
-        return (array)$this->getMeta('_give_mailchimp_tags');
+        return (array)$this->getMeta('_give_mailchimp_tags', ['']);
     }
 
 

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -547,7 +547,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSendDonationData(): bool
     {
-        return give_is_setting_enabled($this->getMeta('_give_mailchimp_send_donation',
+        return give_is_setting_enabled($this->getMeta('_give_mailchimp_send_donation_data',
             give_get_option('give_mailchimp_donation_data', true)));
     }
 
@@ -556,7 +556,8 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSendFFMData(): bool
     {
-        return $this->getMeta('_give_mailchimp_send_ffm',  give_get_option('give_mailchimp_ffm_pass_field'));
+        return  give_is_setting_enabled($this->getMeta('_give_mailchimp_send_ffm',
+            give_get_option('give_mailchimp_ffm_pass_field')));
     }
 
     /**

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -533,6 +533,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased add global setting as default.
      * @since 3.3.0
      */
     public function getMailchimpDefaultChecked(): bool
@@ -543,6 +544,7 @@ class FormMetaDecorator extends FormModelDecorator
 
 
     /**
+     * @unreleased add global setting as default.
      * @since 3.3.0
      */
     public function getMailchimpSendDonationData(): bool
@@ -552,6 +554,7 @@ class FormMetaDecorator extends FormModelDecorator
     }
 
     /**
+     * @unreleased add global setting as default.
      * @since 3.3.0
      */
     public function getMailchimpSendFFMData(): bool

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -575,9 +575,9 @@ class FormMetaDecorator extends FormModelDecorator
     /**
      * @since 3.3.0
      */
-    public function getMailchimpSubscriberTags(): array
+    public function getMailchimpSubscriberTags():? array
     {
-        return (array)$this->getMeta('_give_mailchimp_tags', ['']);
+        return (array)$this->getMeta('_give_mailchimp_tags', null);
     }
 
 

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -527,7 +527,7 @@ class FormMetaDecorator extends FormModelDecorator
     /**
      * @since 3.3.0
      */
-    public function getMailchimpLabel()
+    public function getMailchimpLabel(): string
     {
         return $this->getMeta('_give_mailchimp_custom_label',  give_get_option('give_mailchimp_label', __('Subscribe to newsletter?')));
     }

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -541,13 +541,6 @@ class FormMetaDecorator extends FormModelDecorator
             give_get_option('give_mailchimp_checked_default', true)));
     }
 
-    /**
-     * @since 3.3.0
-     */
-    public function getMailchimpDoubleOptIn(): bool
-    {
-        return $this->getMeta('_give_mailchimp_double_opt_in',  give_get_option('give_mailchimp_double_opt_in'));
-    }
 
     /**
      * @since 3.3.0

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -570,7 +570,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpDefaultAudiences(): array
     {
-        return $this->getMeta('_give_mailchimp');
+        return (array)$this->getMeta('_give_mailchimp');
     }
 
     /**
@@ -578,7 +578,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSubscriberTags(): array
     {
-        return $this->getMeta('_give_mailchimp_tags');
+        return (array)$this->getMeta('_give_mailchimp_tags');
     }
 
 

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -537,7 +537,8 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpDefaultChecked(): bool
     {
-        return $this->getMeta('_give_mailchimp_checked_default', give_get_option('give_mailchimp_checked_default', true));
+        return give_is_setting_enabled($this->getMeta('_give_mailchimp_checked_default',
+            give_get_option('give_mailchimp_checked_default', true)));
     }
 
     /**
@@ -553,7 +554,8 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getMailchimpSendDonationData(): bool
     {
-        return $this->getMeta('_give_mailchimp_send_donation',  give_get_option('give_mailchimp_donation_data', true));
+        return give_is_setting_enabled($this->getMeta('_give_mailchimp_send_donation',
+            give_get_option('give_mailchimp_donation_data', true)));
     }
 
     /**

--- a/src/FormMigration/Steps/Mailchimp.php
+++ b/src/FormMigration/Steps/Mailchimp.php
@@ -25,7 +25,7 @@ class Mailchimp extends FormMigrationStep
     {
         $block = BlockModel::make([
             'name'       => 'givewp/mailchimp',
-            'attributes' => $this->getAttributes()
+            'attributes' => $this->getAttributes(),
         ]);
 
         $this->fieldBlocks->insertAfter('givewp/email', $block);
@@ -36,7 +36,7 @@ class Mailchimp extends FormMigrationStep
      */
     private function getAttributes(): array
     {
-        return   [
+        return [
             'label'            => $this->formV2->getMailchimpLabel() ??
                                   give_get_option('give_mailchimp_label', __('Subscribe to newsletter?')),
             'checked'          => $this->formV2->getMailchimpDefaultChecked() ??
@@ -44,13 +44,13 @@ class Mailchimp extends FormMigrationStep
             'doubleOptIn'      => $this->formV2->getMailchimpDoubleOptIn() ??
                                   give_get_option('give_mailchimp_double_opt_in'),
             'subscriberTags'   => $this->formV2->getMailchimpSubscriberTags() ??
-                                  [],
+                                  [''],
             'sendDonationData' => $this->formV2->getMailchimpSendDonationData() ??
                                   give_get_option('give_mailchimp_donation_data', true),
             'sendFFMData'      => $this->formV2->getMailchimpSendFFMData() ??
                                   give_get_option('give_mailchimp_ffm_pass_field'),
             'defaultAudiences' => $this->formV2->getMailchimpDefaultAudiences() ??
-                                  give_get_option('give_mailchimp_list', []),
+                                  give_get_option('give_mailchimp_list', ['']),
         ];
     }
 }

--- a/src/FormMigration/Steps/Mailchimp.php
+++ b/src/FormMigration/Steps/Mailchimp.php
@@ -39,7 +39,7 @@ class Mailchimp extends FormMigrationStep
         return [
             'label'            => $this->formV2->getMailchimpLabel(),
             'checked'          => $this->formV2->getMailchimpDefaultChecked(),
-            'doubleOptIn'      => $this->formV2->getMailchimpDoubleOptIn(),
+            'doubleOptIn'      => give_get_option('give_mailchimp_double_opt_in', true),
             'subscriberTags'   => $this->formV2->getMailchimpSubscriberTags(),
             'sendDonationData' => $this->formV2->getMailchimpSendDonationData(),
             'sendFFMData'      => $this->formV2->getMailchimpSendFFMData(),

--- a/src/FormMigration/Steps/Mailchimp.php
+++ b/src/FormMigration/Steps/Mailchimp.php
@@ -37,20 +37,13 @@ class Mailchimp extends FormMigrationStep
     private function getAttributes(): array
     {
         return [
-            'label'            => $this->formV2->getMailchimpLabel() ??
-                                  give_get_option('give_mailchimp_label', __('Subscribe to newsletter?')),
-            'checked'          => $this->formV2->getMailchimpDefaultChecked() ??
-                                  give_get_option('give_mailchimp_checked_default', true),
-            'doubleOptIn'      => $this->formV2->getMailchimpDoubleOptIn() ??
-                                  give_get_option('give_mailchimp_double_opt_in'),
-            'subscriberTags'   => $this->formV2->getMailchimpSubscriberTags() ??
-                                  [''],
-            'sendDonationData' => $this->formV2->getMailchimpSendDonationData() ??
-                                  give_get_option('give_mailchimp_donation_data', true),
-            'sendFFMData'      => $this->formV2->getMailchimpSendFFMData() ??
-                                  give_get_option('give_mailchimp_ffm_pass_field'),
-            'defaultAudiences' => $this->formV2->getMailchimpDefaultAudiences() ??
-                                  give_get_option('give_mailchimp_list', ['']),
+            'label'            => $this->formV2->getMailchimpLabel(),
+            'checked'          => $this->formV2->getMailchimpDefaultChecked(),
+            'doubleOptIn'      => $this->formV2->getMailchimpDoubleOptIn(),
+            'subscriberTags'   => $this->formV2->getMailchimpSubscriberTags(),
+            'sendDonationData' => $this->formV2->getMailchimpSendDonationData(),
+            'sendFFMData'      => $this->formV2->getMailchimpSendFFMData(),
+            'defaultAudiences' => $this->formV2->getMailchimpDefaultAudiences(),
         ];
     }
 }

--- a/tests/Feature/FormMigration/Steps/TestMailchimp.php
+++ b/tests/Feature/FormMigration/Steps/TestMailchimp.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Feature\FormMigration\Steps;
+
+namespace Give\Tests\Feature\FormMigration\Steps;
+
+use Give\FormMigration\DataTransferObjects\FormMigrationPayload;
+use Give\FormMigration\Steps\Mailchimp;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
+
+class TestMailchimp extends TestCase
+{
+    use RefreshDatabase, LegacyDonationFormAdapter;
+
+    /**
+     * @unreleased
+     */
+    public function testProcessShouldUpdateMailchimpBlockAttributesFromV2FormMeta(): void
+    {
+        $meta = [
+            '_give_mailchimp_custom_label'    => __('Subscribe to newsletter?'),
+            '_give_mailchimp_tags'            => ['Animal-Rescue-Campaign', 'Housing-And-Shelter-Campaign'],
+            '_give_mailchimp'                 => ['de73f3f82f'],
+            '_give_mailchimp_checked_default' => true,
+            '_give_mailchimp_double_opt_in'   => true,
+            '_give_mailchimp_send_donation'   => true,
+            '_give_mailchimp_send_ffm'        => true,
+        ];
+
+        $formV2 = $this->createSimpleDonationForm(['meta' => $meta]);
+
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+
+        $mailchimp = new Mailchimp($payload);
+
+        $mailchimp->process();
+
+        $block = $payload->formV3->blocks->findByName('givewp/mailchimp');
+
+        $this->assertSame($meta['_give_mailchimp_custom_label'], $block->getAttribute('label'));
+        $this->assertSame($meta['_give_mailchimp_tags'], $block->getAttribute('subscriberTags'));
+        $this->assertSame($meta['_give_mailchimp'], $block->getAttribute('defaultAudiences'));
+        $this->assertTrue(true, $block->getAttribute('checked'));
+        $this->assertTrue(true, $block->getAttribute('doubleOptIn'));
+        $this->assertTrue(true, $block->getAttribute('sendDonationData'));
+        $this->assertTrue(true, $block->getAttribute('sendFFMData'));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testProcessShouldUpdateMailchimpBlockAttributesFromGlobalSettings(): void
+    {
+        $meta = [
+            'give_mailchimp_label'           => __('Subscribe to newsletter?'),
+            'give_mailchimp_list'            => ['de73f3f82f'],
+            'give_mailchimp_checked_default' => true,
+            'give_mailchimp_double_opt_in'   => true,
+            'give_mailchimp_donation_data'   => true,
+            'give_mailchimp_ffm_pass_field'  => true,
+        ];
+
+        foreach ($meta as $key => $value) {
+            give_update_option($key, $value);
+        }
+
+        $formV2 = $this->createSimpleDonationForm(['meta' => $meta]);
+
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+
+        $mailchimp = new Mailchimp($payload);
+
+        $mailchimp->process();
+
+        $block = $payload->formV3->blocks->findByName('givewp/mailchimp');
+
+        $this->assertSame($meta['give_mailchimp_label'], $block->getAttribute('label'));
+        $this->assertSame($meta['give_mailchimp_list'], $block->getAttribute('defaultAudiences'));
+        $this->assertSame([''], $block->getAttribute('subscriberTags'));
+        $this->assertTrue(true, $block->getAttribute('checked'));
+        $this->assertTrue(true, $block->getAttribute('doubleOptIn'));
+        $this->assertTrue(true, $block->getAttribute('sendDonationData'));
+        $this->assertTrue(true, $block->getAttribute('sendFFMData'));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testProcessShouldUpdateMailchimpBlockAttributesWhenNoMeta(): void
+    {
+        $formV2 = $this->createSimpleDonationForm();
+
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+
+        $mailchimp = new Mailchimp($payload);
+
+        $mailchimp->process();
+
+        $block = $payload->formV3->blocks->findByName('givewp/mailchimp');
+
+        $this->assertSame(__('Subscribe to newsletter?'), $block->getAttribute('label'));
+        $this->assertSame([''], $block->getAttribute('subscriberTags'));
+        $this->assertSame([''], $block->getAttribute('defaultAudiences'));
+        $this->assertTrue(true, $block->getAttribute('checked'));
+        $this->assertTrue(true, $block->getAttribute('doubleOptIn'));
+        $this->assertTrue(true, $block->getAttribute('sendDonationData'));
+        $this->assertTrue(true, $block->getAttribute('sendFFMData'));
+    }
+}

--- a/tests/Feature/FormMigration/Steps/TestMailchimp.php
+++ b/tests/Feature/FormMigration/Steps/TestMailchimp.php
@@ -24,7 +24,6 @@ class TestMailchimp extends TestCase
             '_give_mailchimp_tags'            => ['Animal-Rescue-Campaign', 'Housing-And-Shelter-Campaign'],
             '_give_mailchimp'                 => ['de73f3f82f'],
             '_give_mailchimp_checked_default' => true,
-            '_give_mailchimp_double_opt_in'   => true,
             '_give_mailchimp_send_donation'   => true,
             '_give_mailchimp_send_ffm'        => true,
         ];
@@ -43,7 +42,6 @@ class TestMailchimp extends TestCase
         $this->assertSame($meta['_give_mailchimp_tags'], $block->getAttribute('subscriberTags'));
         $this->assertSame($meta['_give_mailchimp'], $block->getAttribute('defaultAudiences'));
         $this->assertTrue(true, $block->getAttribute('checked'));
-        $this->assertTrue(true, $block->getAttribute('doubleOptIn'));
         $this->assertTrue(true, $block->getAttribute('sendDonationData'));
         $this->assertTrue(true, $block->getAttribute('sendFFMData'));
     }

--- a/tests/Feature/FormMigration/Steps/TestMailchimp.php
+++ b/tests/Feature/FormMigration/Steps/TestMailchimp.php
@@ -24,7 +24,7 @@ class TestMailchimp extends TestCase
             '_give_mailchimp_tags'            => ['Animal-Rescue-Campaign', 'Housing-And-Shelter-Campaign'],
             '_give_mailchimp'                 => ['de73f3f82f'],
             '_give_mailchimp_checked_default' => true,
-            '_give_mailchimp_send_donation'   => true,
+            '_give_mailchimp_send_donation_data'   => true,
             '_give_mailchimp_send_ffm'        => true,
         ];
 
@@ -76,7 +76,7 @@ class TestMailchimp extends TestCase
 
         $this->assertSame($meta['give_mailchimp_label'], $block->getAttribute('label'));
         $this->assertSame($meta['give_mailchimp_list'], $block->getAttribute('defaultAudiences'));
-        $this->assertSame([''], $block->getAttribute('subscriberTags'));
+        $this->assertNull(null, $block->getAttribute('subscriberTags'));
         $this->assertTrue(true, $block->getAttribute('checked'));
         $this->assertTrue(true, $block->getAttribute('doubleOptIn'));
         $this->assertTrue(true, $block->getAttribute('sendDonationData'));
@@ -99,7 +99,7 @@ class TestMailchimp extends TestCase
         $block = $payload->formV3->blocks->findByName('givewp/mailchimp');
 
         $this->assertSame(__('Subscribe to newsletter?'), $block->getAttribute('label'));
-        $this->assertSame([''], $block->getAttribute('subscriberTags'));
+        $this->assertNull(null, $block->getAttribute('subscriberTags'));
         $this->assertSame([''], $block->getAttribute('defaultAudiences'));
         $this->assertTrue(true, $block->getAttribute('checked'));
         $this->assertTrue(true, $block->getAttribute('doubleOptIn'));


### PR DESCRIPTION
Resolves # [GIVE-447]

## Description
This PR includes unit tests on the form migration process for the Mailchimp add-on. Three tests were added that check when migrating a form that uses the global settings, migrating a form that has per-form settings & migrating a form without meta.

The tests revealed some areas of improvement within the Mailchimp migration process & adjustments were made to accommodate them.
- The double optin setting is limited to global settings through`give_mailchimp_double_opt_in`. The method checking the form meta for this option in the decorator has been removed.
- In the decorator the meta key for `_give_mailchimp_send_donation` has been updated to `_give_mailchimp_send_donation_data`
- Previously an array was used as the default for subscriber tags. The subscriber tag setting is limited to form meta through `_give_mailchimp_tags`. A null value should explicitly be used as the default for this. While Migrating a form from the global settings the previous array value would add a blank tag in the subscriber tag list.

Additionally the Nullish coalescing operator (??) was used to determine which value should be used inside the getAttributes method of the migration. This was keeping some values from properly accessing the global option as a fallback. I've added the global options inside the decorator as the default for the getMeta method and have included `give_is_setting_enabled` to help determine the boolean values.

## Affects
Mailchimp Migration Process

## Visuals

https://github.com/impress-org/givewp/assets/75056371/7fda7d88-d99a-4b24-94f6-ea7555efddca


https://github.com/impress-org/givewp/assets/75056371/f0b8016a-c830-450e-b11c-13f96c8fcdeb



## Testing Instructions
- Set your global settings
- add a v2 form -> then migrate the form without editing the form settings.
- Verify the v3 form has the correct settings set from the global options.
- Create another v2 form -> update the per-form settings on the right -> then migrate the form
- Verify the v3 form has the correct settings set from the form options.
- Enable globally than disable per form settings the block should not be added.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-447]: https://stellarwp.atlassian.net/browse/GIVE-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ