### PR TITLE
Refactor: automatically open sidebar block menu on build preview

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
@@ -2,7 +2,6 @@ import {__} from '@wordpress/i18n';
 import BlockListTree from './panels/BlockListTree';
 import {__experimentalLibrary as Library} from '@wordpress/block-editor';
 import AdditionalFieldsPanel from '@givewp/form-builder/promos/additionalFields';
-import {useSelect} from '@wordpress/data';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 
 const BlockListInserter = () => {

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
@@ -47,7 +47,7 @@ const DesignEditorSkeleton = () => {
 
 const SchemaEditorSkeleton = () => {
     const {state: showSidebar, toggle: toggleShowSidebar} = useToggleState(true);
-    const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState('');
+    const [selectedSecondarySidebar, setSelectedSecondarySidebar] = useState<string>('add');
 
     const toggleSelectedSecondarySidebar = (name) =>
         setSelectedSecondarySidebar(name !== selectedSecondarySidebar ? name : false);


### PR DESCRIPTION
Resolves # [GIVE-536]

## Description
When opening the build section of the visual form builder we want the left sidebar menu set to open automatically as a way to ensure users can easily find new blocks to add. 

The state that manages which sidebar is open can be found as `selectedSecondarySidebar` in the BlockEditorInterfaceSkeletonContainer component. This state manages both the list view and the block menu.

This PR applies the name of the sidebar `add` as a default for the open state that manages the secondary sidebar which will ensure that the block menu is open when selecting the build preview section.

Additionally an unused import was removed.

## Affects
- Visual Form Builder
- Sidebars

## Visuals


https://github.com/impress-org/givewp/assets/75056371/d6c98520-2726-476c-9fb9-ee2081ae15e2


## Testing Instructions
- Create a v3 form
- Select the build section to verify the left sidebar with the block menu opens automatically.
- Test out the other sidebars in both the build & design preview sections.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-536]: https://stellarwp.atlassian.net/browse/GIVE-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ