### PR TITLE
Feature: add custom alt tags to "HeaderImage"

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -189,6 +189,12 @@ class FormSettings implements Arrayable, Jsonable
     public $designSettingsImageUrl;
 
     /**
+     * @unreleased
+     * @var string
+     */
+    public $designSettingsImageAlt;
+
+    /**
      * @since 3.4.0
      * @var string
      */
@@ -314,6 +320,7 @@ class FormSettings implements Arrayable, Jsonable
         ) ? $array['pdfSettings'] : [];
 
         $self->designSettingsImageUrl = $array['designSettingsImageUrl'] ?? '';
+        $self->designSettingsImageAlt = ! empty($array['designSettingsImageAlt']) ? $array['designSettingsImageAlt'] : $self->formTitle;
         $self->designSettingsImageStyle = ! empty($array['designSettingsImageStyle']) ? new DesignSettingsImageStyle(
             $array['designSettingsImageStyle']
         ) : DesignSettingsImageStyle::BACKGROUND();

--- a/src/DonationForms/resources/app/form/Header.tsx
+++ b/src/DonationForms/resources/app/form/Header.tsx
@@ -32,7 +32,7 @@ export default function Header({form}: {form: DonationForm}) {
                     form.settings?.designSettingsImageUrl && (
                         <HeaderImageTemplate
                             url={form.settings?.designSettingsImageUrl}
-                            alt={form.settings?.formTitle}
+                            alt={form.settings?.designSettingsImageAlt || form.settings?.formTitle}
                             color={form.settings?.designSettingsImageColor}
                             opacity={form.settings?.designSettingsImageOpacity}
                         />

--- a/src/FormBuilder/resources/js/form-builder/src/components/settings/MediaLibrary/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/settings/MediaLibrary/index.tsx
@@ -12,7 +12,7 @@ import './styles.scss';
 type MediaLibrary = {
     id: string;
     value: string;
-    onChange: (url: string) => void;
+    onChange: (url: string, alt: string) => void;
     reset: () => void;
     label: string;
     help?: string;
@@ -44,7 +44,7 @@ export default function MediaLibrary({id, value, onChange, label, help, actionLa
             // Get media attachment details from the frame state
             var attachment = frame.state().get('selection').first().toJSON();
 
-            onChange(attachment.url);
+            onChange(attachment.url, attachment.alt);
         });
 
         // Finally, open the modal on click

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
@@ -123,16 +123,18 @@ export default function Header({dispatch, publishSettings}) {
                             label={__('Image', 'give')}
                             actionLabel={__('Upload Image', 'give')}
                             value={designSettingsImageUrl}
-                            onChange={(designSettingsImageUrl) => {
+                            onChange={(designSettingsImageUrl, designSettingsImageAlt) => {
                                 dispatch(
                                     setFormSettings({
                                         designSettingsImageUrl,
+                                        designSettingsImageAlt,
                                         designSettingsImageStyle,
                                     })
                                 );
 
                                 publishSettings({
                                     designSettingsImageUrl,
+                                    designSettingsImageAlt,
                                     designSettingsImageStyle,
                                 });
                             }}

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -45,6 +45,7 @@ export type FormSettings = {
     pdfSettings: object;
     designSettingsImageUrl: string;
     designSettingsImageStyle: string;
+    designSettingsImageAlt: string;
     designSettingsLogoUrl: string;
     designSettingsLogoPosition: string;
     designSettingsSectionStyle: string;


### PR DESCRIPTION
Resolves # [GIVE-568]

## Description

This introduces a new setting that allows users to include custom alt tag information for the HeaderImage setting. This is done by passing attachment.alt to the onChange handler inside the media-library component. If no alt tag information is available the alt tag will use the form title as a fallback.

The media-library component will assign an empty string if the information is not filled out, so an "empty" check was added to the formSettings for the frontend and the Logical OR (||) was used for design preview to ensure the form title properly renders as a fallback.

## Affects
HeaderImage
FormSettings

## Visuals


## Testing Instructions
- Create a v3 form
- Add a an image for the Header, while selecting an image on the right of the media uploader you should see an input to add alt tag information. Assign custom alt tag text.
- Right click HeaderImage in design preview to open up the console and view the img tag, you should see the alt property is assigned your custom text. Also verify on the frontend page.
- Go back to the builder and remove the alt tag information. 
- View the element in the console for both design preview & on the frontend. Verify that the alt tag has been replaced by the form title.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

