### PR TITLE
Hotfix: Resolve incompatibility issue with WP 6.5

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.6.1
+ * Version: 3.6.2
  * Requires at least: 6.0
  * Requires PHP: 7.2
  * Text Domain: give
@@ -404,7 +404,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.6.1');
+            define('GIVE_VERSION', '3.6.2');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: givewp, dlocc, webdevmattcrom, ravinderk, mehul0810, kevinwhoffman
 Donate link: https://go.givewp.com/home
 Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 7.2
-Stable tag: 3.6.1
+Stable tag: 3.6.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.6.2: April 4th, 2024 =
+* Fix: Resolved an issue with WordPress 6.5 and the visual form builder that was making it difficult to interact with blocks
+
 = 3.6.1: March 21st, 2024 =
 * Fix: Resolved an issue with PayPal donations and currency switcher on donation forms using the visual form builder
 

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -10,12 +10,19 @@ import {__} from "@wordpress/i18n";
 
 
 /**
+ * @unreleased Early return dispatchFormBlocks if there are no unwrapped blocks.
  * @since 3.0.0
  */
 export default function BlockEditorContainer() {
     const {blocks} = useFormState();
     const dispatch = useFormStateDispatch();
     const dispatchFormBlocks = (blocks) => {
+        const hasUnwrappedBlocks = blocks.some((block) => block.name !== 'givewp/section');
+
+        if (!hasUnwrappedBlocks) {
+            return;
+        }
+
         dispatch(setFormBlocks(blocks.map((block) => {
             return block.name == 'givewp/section'
                 ? block

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -10,7 +10,7 @@ import {__} from "@wordpress/i18n";
 
 
 /**
- * @unreleased Early return dispatchFormBlocks if there are no unwrapped blocks.
+ * @since 3.6.2 Early return dispatchFormBlocks if there are no unwrapped blocks.
  * @since 3.0.0
  */
 export default function BlockEditorContainer() {

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -20,7 +20,7 @@ export default function BlockEditorContainer() {
         const hasUnwrappedBlocks = blocks.some((block) => block.name !== 'givewp/section');
 
         if (!hasUnwrappedBlocks) {
-            return;
+            return dispatch(setFormBlocks(blocks));
         }
 
         dispatch(setFormBlocks(blocks.map((block) => {
@@ -41,7 +41,7 @@ export default function BlockEditorContainer() {
     parseMissingBlocks(blocks);
 
     return (
-        <BlockEditorProvider value={blocks} onChange={dispatchFormBlocks}>
+        <BlockEditorProvider value={blocks} onInput={dispatchFormBlocks} onChange={dispatchFormBlocks}>
             <Onboarding />
             <SlotFillProvider>
                 <Sidebar.InspectorFill>

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorContainer.tsx
@@ -41,7 +41,7 @@ export default function BlockEditorContainer() {
     parseMissingBlocks(blocks);
 
     return (
-        <BlockEditorProvider value={blocks} onInput={dispatchFormBlocks} onChange={dispatchFormBlocks}>
+        <BlockEditorProvider value={blocks} onChange={dispatchFormBlocks}>
             <Onboarding />
             <SlotFillProvider>
                 <Sidebar.InspectorFill>

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -70,6 +70,7 @@
         font-size: 16px !important;
         font-weight: normal;
         line-height: 20px;
+        height: auto;
     }
 
     .components-select-control__input {


### PR DESCRIPTION
Resolves [GIVE-583]

## Description
This pull request introduces a hotfix for an incompatibility issue between Visual Form Builder and WordPress 6.5. Previously, any modification to a block resulted in a re-render. Upon investigation, I discovered this was caused by a function designed to ensure all blocks reside within a section block. However, this function was triggering a change to the form state on every modification. This pull request now verifies whether a change causes a block to be placed outside of a section block; if not, it simply ignores the remainder of the function.

## Affects
Visual Form Builder

## Visuals
![CleanShot 2024-04-04 at 15 14 45](https://github.com/impress-org/givewp/assets/3921017/e2c23fb2-841a-48a6-a80a-f9b3b8c3d527)

## Testing Instructions
1. Create/Open a form in the VFB
2. Edit any block attribute
3. Confirm the block remains selected
4. Move a block to be placed outside of a section block
5. Confirm a section block is automatically created and the moved block is placed within that new section

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-583]: https://stellarwp.atlassian.net/browse/GIVE-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ