### PR TITLE
Fix: form builder sidebar tabs for WP 6.5 compatibility

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -250,16 +250,47 @@
 
 .givewp-block-editor-sidebar {
     &__tabs {
+        display: flex; // WP 6.5 backwards compatibility
         flex: 1 1 0;
         justify-content: center;
 
         li {
             flex: 1;
+            margin: 0; // WP 6.5 backwards compatibility
 
             > .components-button {
                 display: block;
                 width: 100%;
                 text-align: center;
+
+                // WP 6.5 backwards compatibility
+                position: relative;
+                height: 48px;
+                padding: 3px 16px;
+
+                &:focus {
+                    outline: none;
+                    box-shadow: none;
+                }
+
+                &.is-active:after {
+                    height: calc(var(--wp-admin-border-width-focus) * 1);
+                    outline: 1px solid transparent;
+                    outline-offset: -1px;
+                }
+
+                &:after {
+                    content: "";
+                    background: var(--wp-admin-theme-color);
+                    border-radius: 0;
+                    bottom: 0;
+                    height: calc(var(--wp-admin-border-width-focus) * 0);
+                    pointer-events: none;
+                    position: absolute;
+                    left: 0;
+                    right: 0;
+                    transition: all .1s linear;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-600]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The form builder sidebar tabs have been visually compromised after updated to WP 6.5. This PR preserves the backwards compatible styles.  

For context, it appears the new version of Gutenberg updated some styles which affected this.  To preserve those styles I went back a version to grab what we were relying on and updated our own stylesheet.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form builder sidebar tab styles

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**WP 6.5**

<img width="1504" alt="Screenshot 2024-04-05 at 12 19 02 PM" src="https://github.com/impress-org/givewp/assets/10138447/392f9db8-7051-476c-94ae-4d1297962d1f">


**WP 6.4**

<img width="1508" alt="Screenshot 2024-04-05 at 12 19 31 PM" src="https://github.com/impress-org/givewp/assets/10138447/ae6f40ef-1f2a-4eef-bb95-300dc4e6fbfe">



**WP 6.3**

<img width="1512" alt="Screenshot 2024-04-05 at 12 19 51 PM" src="https://github.com/impress-org/givewp/assets/10138447/54b975f0-652f-4511-a355-1419ee99c3ab">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Install WP 6.5
- Use this branch / [zip](https://github.com/impress-org/givewp/actions/runs/8572917571) to check the form builder sidebar tabs
- Check on a couple previous WP versions as well.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-600]: https://stellarwp.atlassian.net/browse/GIVE-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ