### PR TITLE
Refactor: Replace ticket price input with a currency input

### DIFF
--- a/src/EventTickets/Routes/UpdateEvent.php
+++ b/src/EventTickets/Routes/UpdateEvent.php
@@ -52,7 +52,7 @@ class UpdateEvent implements RestRoute
                     'description' => [
                         'type' => 'string',
                         'required' => false,
-                        'sanitize_callback' => 'sanitize_textare_field',
+                        'sanitize_callback' => 'sanitize_textarea_field',
                     ],
                     'startDateTime' => [
                         'type' => 'string',

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
@@ -15,7 +15,7 @@ export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
                 id,
                 title,
                 description,
-                price: (price / 100).toFixed(2),
+                price: price / 100,
                 capacity,
             });
         };

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/TicketTypesRowActions.tsx
@@ -15,7 +15,7 @@ export function TicketTypesRowActions({tickets, setTickets, openEditModal}) {
                 id,
                 title,
                 description,
-                price: price / 100,
+                price: (price / 100).toFixed(2),
                 capacity,
             });
         };

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -40,6 +40,7 @@ export default function TicketTypesSection() {
     const {
         apiRoot,
         apiNonce,
+        currencyCode,
         event,
         event: {ticketTypes},
     }: GiveEventTicketsDetails = window.GiveEventTicketsDetails;
@@ -101,7 +102,7 @@ export default function TicketTypesSection() {
                         })}
                     />
                     <TicketTypeFormModal
-                        apiSettings={{apiRoot, apiNonce}}
+                        apiSettings={{apiRoot, apiNonce, currencyCode}}
                         isOpen={isOpen}
                         handleClose={closeModal}
                         eventId={event?.id}

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
@@ -1,4 +1,4 @@
-import {SubmitHandler, useForm} from 'react-hook-form';
+import {Controller, SubmitHandler, useForm} from 'react-hook-form';
 import {__} from '@wordpress/i18n';
 import styles from './TicketTypeFormModal.module.scss';
 import FormModal from '../FormModal';
@@ -6,6 +6,8 @@ import {useTicketTypeForm} from './ticketTypeFormContext';
 import {Inputs, TicketModalProps} from './types';
 import {useEffect} from 'react';
 import EventTicketsApi from '../api';
+import CurrencyInput from 'react-currency-input-field';
+import parseValueFromLocale from './parseValueFromLocale';
 
 /**
  * Ticket Form Modal component
@@ -18,6 +20,7 @@ export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, e
 
     const {
         register,
+        control,
         handleSubmit,
         reset,
         formState: {errors, isDirty},
@@ -74,9 +77,27 @@ export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, e
             <div className="givewp-event-tickets__form-row givewp-event-tickets__form-row--half">
                 <div className="givewp-event-tickets__form-column">
                     <label htmlFor="price">{__('Price', 'give')}</label>
-                    <input type="number" {...register('price')} />
+                    <Controller
+                        name="price"
+                        control={control}
+                        render={({field: {onChange, value: fieldValue, ref}}) => (
+                            <CurrencyInput
+                                intlConfig={{
+                                    locale: navigator.language,
+                                    currency: apiSettings.currencyCode,
+                                }}
+                                ref={ref}
+                                id="price"
+                                name="price"
+                                decimalsLimit={2}
+                                value={fieldValue}
+                                onValueChange={(value) => onChange(parseValueFromLocale(value))}
+                            />
+                        )}
+                    />
                     <span>
-                        {__('Leave empty for', 'give')} <strong>{__('free', 'give')}</strong>
+                        {__('Leave empty for', 'give')}&nbsp;
+                        <strong>{__('free', 'give')}</strong>
                     </span>
                 </div>
                 <div className="givewp-event-tickets__form-column">

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
@@ -91,7 +91,9 @@ export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, e
                                 name="price"
                                 decimalsLimit={2}
                                 value={fieldValue}
-                                onValueChange={(value) => onChange(parseValueFromLocale(value))}
+                                onValueChange={(value) =>
+                                    onChange(parseInt(value) >= 0 ? parseValueFromLocale(value) : '')
+                                }
                             />
                         )}
                     />

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
@@ -12,6 +12,7 @@ import parseValueFromLocale from './parseValueFromLocale';
 /**
  * Ticket Form Modal component
  *
+ * @unreleased Replace number input with CurrencyInput component
  * @since 3.6.0
  */
 export default function TicketTypeFormModal({isOpen, handleClose, apiSettings, eventId}: TicketModalProps) {

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/parseValueFromLocale.ts
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/parseValueFromLocale.ts
@@ -1,0 +1,21 @@
+export default function parseValueFromLocale(amount: string): string {
+    if (!amount) {
+        return amount;
+    }
+
+    const numberFormat = new Intl.NumberFormat(window.navigator.language);
+    const parts = numberFormat.formatToParts(1234.56);
+
+    let groupSeparator: string;
+    let decimalSeparator: string;
+
+    for (const part of parts) {
+        if (part.type === 'group') {
+            groupSeparator = part.value;
+        } else if (part.type === 'decimal') {
+            decimalSeparator = part.value;
+        }
+    }
+
+    return amount.replaceAll(groupSeparator, '').replace(decimalSeparator, '.');
+}

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/parseValueFromLocale.ts
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/parseValueFromLocale.ts
@@ -1,3 +1,6 @@
+/*
+ * @unreleased
+ */
 export default function parseValueFromLocale(amount: string): string {
     if (!amount) {
         return amount;

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/types.ts
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/types.ts
@@ -21,6 +21,7 @@ export interface TicketModalProps {
     apiSettings: {
         apiRoot: string;
         apiNonce: string;
+        currencyCode: string;
     };
     eventId: number;
 }


### PR DESCRIPTION
Resolves [GIVE-463]

## Description
This pull request enhances Event Tickets creation/edition by replacing the default number input with a custom component designed for handling currency values.

## Affects
Event Ticket create/edit modal

## Visuals
![CleanShot 2024-04-08 at 17 24 26](https://github.com/impress-org/givewp/assets/3921017/7d4c2e5a-8f4d-4ebd-a706-7c42fd9df8b3)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-463]: https://stellarwp.atlassian.net/browse/GIVE-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ