### PR TITLE
Fix: Enhance Donation Form block to display up to 100 forms

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
@@ -12,6 +12,7 @@ export interface FormOption extends Form {
 }
 
 /**
+ * @unreleased Increase the per_page attribute to 100 to accommodate for more forms.
  * @since 3.2.0 include isLegacyForm, isLegacyFormTemplate & link.
  * @since 3.0.0
  */

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/hooks/useFormOptions.ts
@@ -22,11 +22,16 @@ export default function useFormOptions(): {
     const formOptions = [];
 
     const {forms, isResolving} = useSelect((select) => {
+        const query = {per_page: 100};
         return {
             // @ts-ignore
-            forms: select('core').getEntityRecords<Post[]>('postType', 'give_forms'),
+            forms: select('core').getEntityRecords<Post[]>('postType', 'give_forms', query),
             // @ts-ignore
-            isResolving: select('core/data').getIsResolving('core', 'getEntityRecords', ['postType', 'give_forms']),
+            isResolving: select('core/data').getIsResolving('core', 'getEntityRecords', [
+                'postType',
+                'give_forms',
+                query,
+            ]),
         };
     }, []);
 


### PR DESCRIPTION
Resolves [GIVE-487]

## Description
The Donation Form block currently displays only the last 10 donation forms. This pull request increases the limit to 100, aiming to cover most cases effectively.

[Read more](https://lw.slack.com/archives/C04SLRDD9CK/p1712000947705309)

## Affects
Donation Form block

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-487]: https://stellarwp.atlassian.net/browse/GIVE-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ