### PR TITLE
Refactor: update amount node conversion with descriptions & descriptionsEnabled

### DIFF
--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -176,7 +176,7 @@ class ConvertDonationAmountBlockToFieldsApi
      *
      * @unreleased
      *
-     * @return array ['options' => [], 'checked' => string]
+     * @return array ['options' => ['label' => string, 'value' => string][], 'checked' => string]
      */
     private function prepareLevelsArray(DonationAmountBlockModel $block): array
     {
@@ -185,7 +185,7 @@ class ConvertDonationAmountBlockToFieldsApi
             array_filter(
                 array_map(
                     function ($item) use (&$checked, $block) {
-                        if ($item['checked']) {
+                        if (isset($item['checked']) && $item['checked']) {
                             $checked = $item['value'];
                         }
 
@@ -197,7 +197,7 @@ class ConvertDonationAmountBlockToFieldsApi
                     $block->getLevels()
                 ),
                 function ($item) {
-                    return $item[0] !== '';
+                    return $item['value'] !== '';
                 }
             )
         );

--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -56,18 +56,24 @@ class ConvertDonationAmountBlockToFieldsApi
 
             /** @var Amount $amountNode */
             $amountNode = $group->getNodeByName('amount');
-            $defaultLevel = $block->getDefaultLevel() > 0 ? $block->getDefaultLevel() : 10;
             $amountNode
                 ->label($block->getLabel())
-                ->levels(...$block->getLevels())
-                ->allowLevels($block->getPriceOption() === 'multi')
                 ->allowCustomAmount($block->isCustomAmountEnabled())
-                ->fixedAmountValue($block->getSetPrice())
-                ->defaultValue(
-                    $block->getPriceOption() === 'set' ?
-                        $block->getSetPrice() : $defaultLevel
-                )
                 ->rules(...$amountRules);
+
+            $priceOptions = $block->getPriceOption();
+            if ($priceOptions === 'multi') {
+                ['levels' => $levels, 'checked' => $checked] = $this->prepareLevelsArray($block);
+
+                $amountNode
+                    ->allowLevels()
+                    ->levels(...$levels)
+                    ->defaultValue($checked);
+            } else {
+                $amountNode
+                    ->fixedAmountValue($block->getSetPrice())
+                    ->defaultValue($block->getSetPrice());
+            }
 
             /** @var Hidden $currencyNode */
             $currencyNode = $group->getNodeByName('currency');
@@ -163,5 +169,42 @@ class ConvertDonationAmountBlockToFieldsApi
             ->label(__('Choose your donation frequency', 'give'))
             ->options(...$options)
             ->rules(new SubscriptionPeriodRule());
+    }
+
+    /**
+     * Prepares the options array to be used in the field.
+     *
+     * @unreleased
+     *
+     * @return array ['options' => [], 'checked' => string]
+     */
+    private function prepareLevelsArray(DonationAmountBlockModel $block): array
+    {
+        $checked = null;
+        $levels = array_values(
+            array_filter(
+                array_map(
+                    function ($item) use (&$checked, $block) {
+                        if ($item['checked']) {
+                            $checked = $item['value'];
+                        }
+
+                        return [
+                            'value' => $item['value'] ?? '',
+                            'label' => $block->isDescriptionEnabled() ? $item['label'] : '',
+                        ];
+                    },
+                    $block->getLevels()
+                ),
+                function ($item) {
+                    return $item[0] !== '';
+                }
+            )
+        );
+
+        return [
+            'levels' => $levels,
+            'checked' => $checked,
+        ];
     }
 }

--- a/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
+++ b/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
@@ -67,14 +67,13 @@ class GenerateDefaultDonationFormBlockCollection
             'attributes' => [
                 "label" => __("Donation Amount", 'give'),
                 "levels" => [
-                    ['value' => 10],
+                    ['value' => 10, 'checked' => true],
                     ['value' => 25],
                     ['value' => 50],
                     ['value' => 100],
                     ['value' => 250],
                     ['value' => 500],
                 ],
-                "defaultLevel" => 10,
                 "priceOption" => "multi",
                 "setPrice" => 25,
                 "customAmount" => true,

--- a/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
+++ b/src/FormBuilder/Actions/GenerateDefaultDonationFormBlockCollection.php
@@ -67,12 +67,12 @@ class GenerateDefaultDonationFormBlockCollection
             'attributes' => [
                 "label" => __("Donation Amount", 'give'),
                 "levels" => [
-                    10,
-                    25,
-                    50,
-                    100,
-                    250,
-                    500
+                    ['value' => 10],
+                    ['value' => 25],
+                    ['value' => 50],
+                    ['value' => 100],
+                    ['value' => 250],
+                    ['value' => 500],
                 ],
                 "defaultLevel" => 10,
                 "priceOption" => "multi",

--- a/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
+++ b/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
@@ -60,23 +60,22 @@ class DonationAmountBlockModel
     }
 
     /**
+     * @unreleased Changed the return type to an array of OptionsProps
      * @since 3.0.0
      *
-     * @return float[]
+     * @return array ['label' => string, 'value' => string, 'checked' => bool][]
      */
     public function getLevels(): array
     {
-        return array_map(static function($level) {
-            return (float)filter_var($level, FILTER_SANITIZE_NUMBER_FLOAT,FILTER_FLAG_ALLOW_FRACTION);
-        }, $this->block->getAttribute('levels'));
+        return $this->block->getAttribute('levels');
     }
 
     /**
-     * @since 3.0.0
+     * @unreleased
      */
-    public function getDefaultLevel(): ?float
+    public function isDescriptionEnabled(): bool
     {
-        return (float)filter_var($this->block->getAttribute('defaultLevel'), FILTER_SANITIZE_NUMBER_FLOAT,FILTER_FLAG_ALLOW_FRACTION);
+        return $this->block->getAttribute('descriptionsEnabled') === true;
     }
 
     /**

--- a/src/Framework/FieldsAPI/Amount.php
+++ b/src/Framework/FieldsAPI/Amount.php
@@ -13,7 +13,7 @@ class Amount extends Field
     const TYPE = 'amount';
 
     /**
-     * @var int[]
+     * @var array ['label' => string, 'value' => int, 'checked' => bool]
      */
     protected $levels = [];
     /**
@@ -36,11 +36,12 @@ class Amount extends Field
     protected $fixedAmountValue;
 
     /**
-     * Set the preset donation levels. Provide levels in minor units.
+     * Set the preset donation levels. Provide level amounts in minor units.
      *
+     * @unreleased Changed to receive an array as a parameter.
      * @since 3.0.0
      */
-    public function levels(float ...$levels): self
+    public function levels(array ...$levels): self
     {
         $this->levels = $levels;
 

--- a/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
+++ b/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
@@ -37,7 +37,7 @@ class GenerateDefaultDonationFormBlockCollectionTest extends TestCase
             [
                 "label" => __("Donation Amount", 'give'),
                 "levels" => [
-                    ['value' => 10],
+                    ['value' => 10, 'checked' => true],
                     ['value' => 25],
                     ['value' => 50],
                     ['value' => 100],

--- a/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
+++ b/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
@@ -44,7 +44,6 @@ class GenerateDefaultDonationFormBlockCollectionTest extends TestCase
                     ['value' => 250],
                     ['value' => 500],
                 ],
-                "defaultLevel" => 10,
                 "priceOption" => "multi",
                 "setPrice" => 25,
                 "customAmount" => true,

--- a/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
+++ b/tests/Unit/Actions/GenerateDefaultDonationFormBlockCollectionTest.php
@@ -37,12 +37,12 @@ class GenerateDefaultDonationFormBlockCollectionTest extends TestCase
             [
                 "label" => __("Donation Amount", 'give'),
                 "levels" => [
-                    10,
-                    25,
-                    50,
-                    100,
-                    250,
-                    500
+                    ['value' => 10],
+                    ['value' => 25],
+                    ['value' => 50],
+                    ['value' => 100],
+                    ['value' => 250],
+                    ['value' => 500],
                 ],
                 "defaultLevel" => 10,
                 "priceOption" => "multi",


### PR DESCRIPTION
Resolves: [GIVE-644]

## Description
This PR updates the DonationAmount block model & node conversion so that both the descriptions & descriptionsEnabled attributes can be used in the UI

## Affects
Block Model
Node Conversion

## Testing Instructions

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-644]: https://stellarwp.atlassian.net/browse/GIVE-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ