### PR TITLE
Fix: Set recurring labels width on VFB

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_components.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_components.scss
@@ -292,6 +292,7 @@ This creates a consistent separator between the tabs and the rest of the sidebar
                 font-size: 16px;
                 line-height: 16px;
                 background-color: var(--givewp-gray-20);
+                width: 100%;
             }
 
             &:checked + label {


### PR DESCRIPTION
Resolves [GIVE-645]

## Description
This pull-request fixes a visual issue with the recurring labels in the VFB. After the recent WordPress updates, they were no longer filling all the available space.

## Affects
Recurring labels on VFB

## Visuals
| Before | After |
| --- | --- |
| ![CleanShot 2024-04-22 at 11 03 59](https://github.com/impress-org/givewp/assets/3921017/50ae89c4-0d96-436d-be05-4ba5cc645fc3) | ![CleanShot 2024-04-22 at 11 09 03](https://github.com/impress-org/givewp/assets/3921017/dc2f98d4-5316-4aee-b8fc-33b053afed7a) |

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-645]: https://stellarwp.atlassian.net/browse/GIVE-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ