### PR TITLE
Refactor: Change v2 to v3 migration to include level descriptions

### DIFF
--- a/src/FormMigration/Steps/DonationOptions.php
+++ b/src/FormMigration/Steps/DonationOptions.php
@@ -31,7 +31,7 @@ class DonationOptions extends FormMigrationStep
                     return [
                         'value' => $this->roundAmount($donationLevel['_give_amount']),
                         'label' => $donationLevel['_give_text'],
-                        'checked' => $donationLevel['_give_default'] === 'default' ?? false,
+                        'checked' => isset($donationLevel['_give_default']) && $donationLevel['_give_default'] === 'default',
                     ];
                 }, $donationLevels)
             );

--- a/tests/Feature/FormMigration/Steps/TestDonationOptions.php
+++ b/tests/Feature/FormMigration/Steps/TestDonationOptions.php
@@ -47,6 +47,7 @@ class TestDonationOptions extends TestCase {
     }
 
     /**
+     * @unreleased Updated test to include donation levels with descriptions
      * @since 3.4.0
      */
     public function testProcessShouldUpdateDonationAmountBlockAttributesWithDonationLevels(): void
@@ -67,7 +68,29 @@ class TestDonationOptions extends TestCase {
 
         $block = $payload->formV3->blocks->findByName('givewp/donation-amount');
 
-        $this->assertSame([10.00, 25.00, 50.00, 100.00], $block->getAttribute('levels'));
+        $expectedLevels = [
+            [
+                'value' => 10.00,
+                'label' => 'Small Gift',
+                'checked' => false,
+            ],
+            [
+                'value' => 25.00,
+                'label' => 'Mid-size Gift',
+                'checked' => true,
+            ],
+            [
+                'value' => 50.00,
+                'label' => 'Large Gift',
+                'checked' => false,
+            ],
+            [
+                'value' => 100.00,
+                'label' => 'Big Gift',
+                'checked' => false,
+            ],
+        ];
+        $this->assertSame($expectedLevels, $block->getAttribute('levels'));
         $this->assertTrue($block->getAttribute('customAmount'));
         $this->assertSame((float)$meta['_give_custom_amount_range_minimum'], $block->getAttribute('customAmountMin'));
         $this->assertSame((float)$meta['_give_custom_amount_range_maximum'], $block->getAttribute('customAmountMax'));


### PR DESCRIPTION
Resolves [GIVE-668]

## Description
Update the DonationOptions step in Form Migrations to align with the new donation levels schema, and migrate the level description accordingly.

## Affects
DonationOptions migration from v2 to v3 forms

## Visuals
https://github.com/impress-org/givewp/assets/3921017/20380bde-83c7-4311-afe0-05bb79a3c043

## Testing Instructions
1. Create a v2 form using donation levels.
2. Migrate that form to v3.
3. Confirm that levels have been migrated properly.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-668]: https://stellarwp.atlassian.net/browse/GIVE-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ