### PR TITLE
Refactor: Update DonationAmountLevels template to support descriptions

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -36,7 +36,11 @@ export default function DonationAmountLevels({
     const allLevels = [...groupedLevels.labeled, ...groupedLevels.unlabeled];
 
     return (
-        <div className={'givewp-fields-amount__levels-container'}>
+        <div
+            className={classNames('givewp-fields-amount__levels-container', {
+                'givewp-fields-amount__levels-container--has-descriptions': groupedLevels.labeled.length > 0,
+            })}
+        >
             {allLevels.map((level, index) => {
                 const label = formatter.format(level.value);
                 const selected = level.value === amount;
@@ -51,7 +55,7 @@ export default function DonationAmountLevels({
                         <button
                             className={classNames('givewp-fields-amount__level', {
                                 'givewp-fields-amount__level--selected': selected,
-                                'givewp-fields-amount__level--description': !hasDescription,
+                                'givewp-fields-amount__level--description': hasDescription,
                             })}
                             type="button"
                             onClick={() => {

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 type DonationAmountLevelsProps = {
     name: string;
     currency: string;
-    levels: number[];
+    levels: {label: string; value: number}[];
     onLevelClick?: (amount: number) => void;
     descriptions: string[];
     descriptionsEnabled: boolean;
@@ -21,19 +21,22 @@ export default function DonationAmountLevels({
     currency,
     levels,
     onLevelClick,
-    descriptions,
-    descriptionsEnabled,
 }: DonationAmountLevelsProps) {
     const {useWatch, useCurrencyFormatter} = window.givewp.form.hooks;
     const amount = useWatch({name});
     const formatter = useCurrencyFormatter(currency);
 
+    const levelsWithDescriptions = levels.filter((level) => level.label);
+    const levelsWithoutDescriptions = levels.filter((level) => !level.label);
+
+    const allLevels = [...levelsWithDescriptions, ...levelsWithoutDescriptions];
+
     return (
         <div className={'givewp-fields-amount__levels-container'}>
-            {levels.map((levelAmount, index) => {
-                const label = formatter.format(levelAmount);
-                const selected = levelAmount === amount;
-                const hasDescription = descriptionsEnabled && descriptions[index] !== '';
+            {allLevels.map((level, index) => {
+                const label = formatter.format(level.value);
+                const selected = level.value === amount;
+                const hasDescription = level.label;
 
                 return (
                     <div
@@ -48,14 +51,14 @@ export default function DonationAmountLevels({
                             })}
                             type="button"
                             onClick={() => {
-                                onLevelClick(levelAmount);
+                                onLevelClick(level.value);
                             }}
                             key={index}
                         >
                             {label}
                         </button>
                         {hasDescription && (
-                            <span className={'givewp-fields-amount__level__description'}>{descriptions[index]}</span>
+                            <span className={'givewp-fields-amount__level__description'}>{level.label}</span>
                         )}
                     </div>
                 );

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -8,8 +8,6 @@ type DonationAmountLevelsProps = {
     currency: string;
     levels: {label: string; value: number}[];
     onLevelClick?: (amount: number) => void;
-    descriptions: string[];
-    descriptionsEnabled: boolean;
 };
 
 /**
@@ -26,10 +24,16 @@ export default function DonationAmountLevels({
     const amount = useWatch({name});
     const formatter = useCurrencyFormatter(currency);
 
-    const levelsWithDescriptions = levels.filter((level) => level.label);
-    const levelsWithoutDescriptions = levels.filter((level) => !level.label);
+    const groupedLevels = levels.reduce(
+        (acc, level) => {
+            const key = level.label ? 'labeled' : 'unlabeled';
+            acc[key].push(level);
+            return acc;
+        },
+        {labeled: [], unlabeled: []}
+    );
 
-    const allLevels = [...levelsWithDescriptions, ...levelsWithoutDescriptions];
+    const allLevels = [...groupedLevels.labeled, ...groupedLevels.unlabeled];
 
     return (
         <div className={'givewp-fields-amount__levels-container'}>

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -8,9 +8,12 @@ type DonationAmountLevelsProps = {
     currency: string;
     levels: number[];
     onLevelClick?: (amount: number) => void;
+    descriptions: string[];
+    descriptionsEnabled: boolean;
 };
 
 /**
+ * @unreleased add level descriptions.
  * @since 3.0.0
  */
 export default function DonationAmountLevels({
@@ -18,29 +21,43 @@ export default function DonationAmountLevels({
     currency,
     levels,
     onLevelClick,
+    descriptions,
+    descriptionsEnabled,
 }: DonationAmountLevelsProps) {
     const {useWatch, useCurrencyFormatter} = window.givewp.form.hooks;
     const amount = useWatch({name});
     const formatter = useCurrencyFormatter(currency);
 
     return (
-        <div className="givewp-fields-amount__levels-container">
+        <div className={'givewp-fields-amount__levels-container'}>
             {levels.map((levelAmount, index) => {
                 const label = formatter.format(levelAmount);
                 const selected = levelAmount === amount;
+                const hasDescription = descriptionsEnabled && descriptions[index] !== '';
+
                 return (
-                    <button
-                        className={classNames('givewp-fields-amount__level', {
-                            'givewp-fields-amount__level--selected': selected,
+                    <div
+                        className={classNames('givewp-fields-amount__level-container', {
+                            'givewp-fields-amount__level-container--col': hasDescription,
                         })}
-                        type="button"
-                        onClick={() => {
-                            onLevelClick(levelAmount);
-                        }}
-                        key={index}
                     >
-                        {label}
-                    </button>
+                        <button
+                            className={classNames('givewp-fields-amount__level', {
+                                'givewp-fields-amount__level--selected': selected,
+                                'givewp-fields-amount__level--description': !hasDescription,
+                            })}
+                            type="button"
+                            onClick={() => {
+                                onLevelClick(levelAmount);
+                            }}
+                            key={index}
+                        >
+                            {label}
+                        </button>
+                        {hasDescription && (
+                            <span className={'givewp-fields-amount__level__description'}>{descriptions[index]}</span>
+                        )}
+                    </div>
                 );
             })}
         </div>

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -21,6 +21,8 @@ export default function Amount({
     fixedAmountValue,
     allowCustomAmount,
     messages,
+    descriptions,
+    descriptionsEnabled
 }: AmountProps) {
     const isFixedAmount = !allowLevels;
     const [customAmountValue, setCustomAmountValue] = useState<string>(
@@ -76,6 +78,8 @@ export default function Amount({
                         resetCustomAmount();
                         setValue(name, levelAmount);
                     }}
+                    descriptions={descriptions}
+                    descriptionsEnabled={descriptionsEnabled}
                 />
             )}
 

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -123,6 +123,31 @@ $borderColor: #9A9A9A;
         @media screen and (min-width: variables.$givewp-breakpoint-sm) {
             grid-template-columns: repeat(3, 1fr);
         }
+        
+        .givewp-fields-amount__level-container {
+            display: flex;
+            align-items: center;
+            gap: var(--givewp-spacing-4);
+
+            &--col {
+                grid-column: 1 / -1;
+            }
+        ;
+
+            .givewp-fields-amount__level {
+                max-width: 144px;
+
+                &--description {
+                    max-width: none;
+                }
+            }
+
+            .givewp-fields-amount__description {
+                margin-bottom: 0;
+                color: var(--givewp-grey-700);
+                font-size: 1rem;
+            }
+        }
     }
 
     &__level {

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -114,7 +114,6 @@ $borderColor: #9A9A9A;
 
     &__levels-container {
         display: grid;
-        grid-auto-rows: 1fr;
         grid-template-columns: repeat(2, 1fr);
         gap: var(--givewp-spacing-2);
         inline-size: 100%;
@@ -123,7 +122,7 @@ $borderColor: #9A9A9A;
         @media screen and (min-width: variables.$givewp-breakpoint-sm) {
             grid-template-columns: repeat(3, 1fr);
         }
-        
+
         .givewp-fields-amount__level-container {
             display: flex;
             align-items: center;
@@ -135,6 +134,7 @@ $borderColor: #9A9A9A;
         ;
 
             .givewp-fields-amount__level {
+                height: 100%;
                 max-width: 144px;
 
                 &--description {

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -113,11 +113,20 @@ $borderColor: #9A9A9A;
     }
 
     &__levels-container {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
         gap: var(--givewp-spacing-2);
+        grid-template-rows: repeat(2, 1fr);
         inline-size: 100%;
         list-style: none;
+
+        @media screen and (min-width: variables.$givewp-breakpoint-sm) {
+            grid-template-columns: repeat(3, 1fr);
+        }
+
+        &--has-descriptions {
+            display: flex;
+            flex-wrap: wrap;
+        }
 
         .givewp-fields-amount__level-container {
             display: flex;
@@ -137,10 +146,9 @@ $borderColor: #9A9A9A;
 
             .givewp-fields-amount__level {
                 height: 100%;
-                max-width: 144px;
 
                 &--description {
-                    max-width: none;
+                    max-width: 144px;
                 }
             }
 

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -113,23 +113,25 @@ $borderColor: #9A9A9A;
     }
 
     &__levels-container {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        display: flex;
+        flex-wrap: wrap;
         gap: var(--givewp-spacing-2);
         inline-size: 100%;
         list-style: none;
 
-        @media screen and (min-width: variables.$givewp-breakpoint-sm) {
-            grid-template-columns: repeat(3, 1fr);
-        }
-
         .givewp-fields-amount__level-container {
             display: flex;
             align-items: center;
+            flex: 1;
             gap: var(--givewp-spacing-4);
+            min-width: calc((100% - var(--givewp-spacing-2)) / 2);
+
+            @media screen and (min-width: variables.$givewp-breakpoint-sm) {
+                min-width: calc((100% - var(--givewp-spacing-2) * 2) / 3);
+            }
 
             &--col {
-                grid-column: 1 / -1;
+                flex-basis: 100%;
             }
         ;
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/types.ts
@@ -4,9 +4,6 @@ import type {subscriptionPeriod} from '@givewp/forms/registrars/templates/groups
 export interface DonationAmountAttributes {
     label: string;
     levels: OptionProps[];
-    descriptions: string[];
-    descriptionsEnabled: boolean;
-    defaultLevel: number;
     priceOption: string;
     setPrice: number;
     customAmount: boolean;


### PR DESCRIPTION
Resolves [GIVE-626]

## Description
Update the `DonationAmountLevels` component to include levels with descriptions. Display a group of levels with descriptions first, followed by the remaining ones.

If no levels have descriptions, show all options in a grid. If at least one level has a description, present the flexible interface below.

It is important to note that these groups respect the order set in the admin, but within each group.

## Affects
Donation Amount Levels template

## Visuals

https://github.com/impress-org/givewp/assets/3921017/0c2ea793-1f4b-4d39-bce7-d70971d92a16

_Variations with 4, 3, 2, 1 and 0 remaining options with no description_

![CleanShot 2024-04-23 at 18 33 37](https://github.com/impress-org/givewp/assets/3921017/1c9e1ba7-6d2d-4b78-85f2-ffc6a471c12f)
_Same options from above but after disabling descriptions_

## Testing Instructions
1. Enable Donation Levels in VFB.
2. Ensure the Donation Form resembles the current design.
3. Return to VFB, activate descriptions, and include some.
4. Check how the Donation Form displays options in a new way.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-626]: https://stellarwp.atlassian.net/browse/GIVE-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ