### PR TITLE
Fix: Update Currency Switcher integration

### DIFF
--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -127,7 +127,7 @@ export interface DonationAmountProps extends GroupProps {
 }
 
 export interface AmountProps extends FieldProps {
-    levels: number[];
+    levels: {label: string; value: number}[];
     allowLevels: boolean;
     allowCustomAmount: boolean;
     fixedAmountValue: number;

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/getAmountLevelsWithCurrencySettings.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/getAmountLevelsWithCurrencySettings.tsx
@@ -7,7 +7,7 @@ import {isBaseCurrency} from './CurrencySwitcher';
  * @since 3.0.0
  */
 export default function getAmountLevelsWithCurrencySettings(
-    levels: number[],
+    levels: {label: string; value: number}[],
     currency: string,
     currencySettings: CurrencySwitcherSetting[]
 ) {
@@ -17,5 +17,10 @@ export default function getAmountLevelsWithCurrencySettings(
         return levels;
     }
 
-    return levels.map((levelAmount) => levelAmount * currencySetting.exchangeRate);
+    return levels.map((level) => {
+        return {
+            ...level,
+            value: level.value * currencySetting.exchangeRate,
+        };
+    });
 }

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -11,7 +11,6 @@ import DonationAmountLevels from './DonationAmountLevels';
  */
 export default function Amount({
     name,
-    defaultValue,
     Label,
     ErrorMessage,
     inputProps,
@@ -21,8 +20,6 @@ export default function Amount({
     fixedAmountValue,
     allowCustomAmount,
     messages,
-    descriptions,
-    descriptionsEnabled
 }: AmountProps) {
     const isFixedAmount = !allowLevels;
     const [customAmountValue, setCustomAmountValue] = useState<string>(
@@ -78,8 +75,6 @@ export default function Amount({
                         resetCustomAmount();
                         setValue(name, levelAmount);
                     }}
-                    descriptions={descriptions}
-                    descriptionsEnabled={descriptionsEnabled}
                 />
             )}
 

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/withCurrencySettings.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/withCurrencySettings.tsx
@@ -6,7 +6,7 @@ import {isBaseCurrency} from './CurrencySwitcher';
  *
  * @since 3.0.0
  */
-export default function getAmountLevelsWithCurrencySettings(
+export function getAmountLevelsWithCurrencySettings(
     levels: {label: string; value: number}[],
     currency: string,
     currencySettings: CurrencySwitcherSetting[]
@@ -23,4 +23,20 @@ export default function getAmountLevelsWithCurrencySettings(
             value: level.value * currencySetting.exchangeRate,
         };
     });
+}
+
+export function getDefaultAmountWithCurrencySettings(
+    levels: {label: string; value: number}[],
+    amount: number,
+    currency: string,
+    currencySettings: CurrencySwitcherSetting[]
+) {
+    const currencySetting = currencySettings.find(({id}) => id === currency);
+    const defaultLevel = levels.find((level) => level.value === amount);
+
+    if (currencySetting === undefined || isBaseCurrency(currencySetting) || defaultLevel === undefined) {
+        return amount;
+    }
+
+    return defaultLevel.value * currencySetting.exchangeRate;
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -127,7 +127,7 @@ const Inspector = ({attributes, setAttributes}) => {
         levels.map((level) => ({
             ...level,
             id: String(Math.floor(Math.random() * 1000000)),
-            value: level.value.toString(),
+            value: level?.value.toString() ?? '',
         }))
     );
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/types.ts
@@ -4,6 +4,7 @@ import type {subscriptionPeriod} from '@givewp/forms/registrars/templates/groups
 export interface DonationAmountAttributes {
     label: string;
     levels: OptionProps[];
+    descriptionsEnabled: boolean;
     priceOption: string;
     setPrice: number;
     customAmount: boolean;


### PR DESCRIPTION
## Description
This pull request updates the integration for Donation Amount Levels with Currency Switcher. The schema has been changed from an array of numbers to an array of objects. It also updates some remaining prop types.

## Affects
Currency Switcher on Amount Levels

## Visuals
https://github.com/impress-org/givewp/assets/3921017/cebbc381-7990-4cbf-b788-55e6bc2d5a85

## Testing Instructions
1. Configure Currency Switcher and Donation Levels
2. Make sure they still work as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

