### PR TITLE
Fix: The "Donor Dashboard" block was not displayed translated

### DIFF
--- a/src/DonorDashboards/Block.php
+++ b/src/DonorDashboards/Block.php
@@ -90,5 +90,6 @@ class Block
             GIVE_VERSION,
             true
         );
+        wp_set_script_translations( 'give-donor-dashboards-block', 'give' );
     }
 }


### PR DESCRIPTION
Fix: The "**Donor Dashboard**" block was not displayed translated

Before (Language set to Italian)

![donor-dashboard-before](https://github.com/impress-org/givewp/assets/1197819/2d4d772d-c83d-4308-92bc-7084fae728cd)

After (Language set to Italian)

![donor-dashboard-after](https://github.com/impress-org/givewp/assets/1197819/fc515cba-d274-4380-a434-246170bd6de0)
