### PR TITLE
Fix: The "Welcome Banner" was not displayed translated

### DIFF
--- a/src/Promotions/WelcomeBanner/WelcomeBanner.php
+++ b/src/Promotions/WelcomeBanner/WelcomeBanner.php
@@ -48,6 +48,8 @@ class WelcomeBanner
             ]
         );
 
+        wp_set_script_translations( 'givewp-welcome-banner', 'give' );
+        
         wp_enqueue_style('givewp-design-system-foundation');
         wp_enqueue_style('givewp-admin-fonts');
     }


### PR DESCRIPTION
Fix: The "**Welcome Banner**" was not displayed translated

Before (Language set to Italian)
![welcome-before](https://github.com/impress-org/givewp/assets/1197819/c759c2d8-653b-4afc-94be-98552f6fd49c)

After (Language set to Italian)
![welcome-after](https://github.com/impress-org/givewp/assets/1197819/2944cfed-b6fe-4717-a38c-b8668c915a00)
