### PR TITLE
Fix: The Reports Dashboard Widget was not displayed translated

### DIFF
--- a/src/Views/Admin/DashboardWidgets/Reports.php
+++ b/src/Views/Admin/DashboardWidgets/Reports.php
@@ -71,6 +71,7 @@ class Reports
                 'assetsUrl' => GIVE_PLUGIN_URL . 'assets/dist',
             ]
         );
+        wp_set_script_translations( 'give-admin-reports-widget-js', 'give' );
     }
 
     public function get_all_time_start()


### PR DESCRIPTION
Fix: The **Reports Dashboard Widget** was not displayed translated

Before (Language set to Italian)
![report-before](https://github.com/impress-org/givewp/assets/1197819/8f0e415b-7379-47a7-892f-f4f662bee111)

After (Language set to Italian)
![report-after](https://github.com/impress-org/givewp/assets/1197819/adae4afa-36d9-45d1-a024-7b1bc1002ba2)
