### PR TITLE
Fix: sanitize give_form shortcode args

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -814,6 +814,10 @@ class Give_Donate_Form {
 	 * @return string
 	 */
 	public function get_form_classes( $args ) {
+        /**
+         * @unreleased sanitize $args
+         */
+        $args = give_clean($args);
 
 		$float_labels_option = give_is_float_labels_enabled( $args )
 			? 'float-labels-enabled'
@@ -850,6 +854,11 @@ class Give_Donate_Form {
 	 * @return string
 	 */
 	public function get_form_wrap_classes( $args ) {
+        /**
+         * @unreleased sanitize $args
+         */
+        $args = give_clean($args);
+
 		$custom_class = [
 			'give-form-wrap',
 		];

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -27,6 +27,11 @@ function give_get_donation_form( $args = [] ) {
 	global $post;
 	static $count = 1;
 
+    /**
+     * @unreleased sanitize $args
+     */
+    $args = give_clean($args);
+
 	$args = wp_parse_args( $args, give_get_default_form_shortcode_args() );
 
 	// Backward compatibility for `form_id` function param.


### PR DESCRIPTION
## Description

This PR adds sanitization to give_form shortcode args.

## Affects

Legacy form template

## Testing Instructions

Install and activate plugin Give
Admin create at least 1 Form with the type "Legacy Form"
Create new Post and add shortcode 
`[give_form id="13721" display_style='abcdef"onmouseover=alert(123) b=']`
Replace id by your form id
Open post and move mouse on button

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

