### PR TITLE
Refactor: limit description length to 120 chars and re-style them

### DIFF
--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -130,7 +130,7 @@ $borderColor: #9A9A9A;
 
         .givewp-fields-amount__level-container {
             display: flex;
-            align-items: center;
+            align-items: start;
             flex: 1;
             gap: var(--givewp-spacing-4);
             min-width: calc((100% - var(--givewp-spacing-2)) / 2);
@@ -145,17 +145,16 @@ $borderColor: #9A9A9A;
         ;
 
             .givewp-fields-amount__level {
-                height: 100%;
-
                 &--description {
                     max-width: 144px;
                 }
             }
 
-            .givewp-fields-amount__description {
-                margin-bottom: 0;
+            .givewp-fields-amount__level__description {
+                align-items: center;
                 color: var(--givewp-grey-700);
-                font-size: 1rem;
+                display: flex;
+                min-height: 100%;
             }
         }
     }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -226,6 +226,7 @@ const Inspector = ({attributes, setAttributes}) => {
                         toggleLabel={__('Enable amount description', 'give')}
                         toggleEnabled={descriptionsEnabled}
                         onHandleToggle={(value) => setAttributes({descriptionsEnabled: value})}
+                        maxLabelLength={120}
                     />
                 )}
             </PanelBody>


### PR DESCRIPTION
Resolves [GIVE-700]

## Description
This pull request sets a limit for level descriptions to 120 characters. Additionally, levels are now styled in a way that for long descriptions, their buttons are top-aligned.

FYI: In this PR, we are only setting the max length. All related code has been added to the `OptionsPanel` component as that's the responsible for controlling that.

## Affects
Amount level descriptions

## Visuals
![CleanShot 2024-04-29 at 17 16 00](https://github.com/impress-org/givewp/assets/3921017/17b5f29d-d21f-4c78-b7db-6a26ca56648f)
![CleanShot 2024-04-29 at 17 14 27](https://github.com/impress-org/givewp/assets/3921017/208f9fb4-ec81-4687-a11b-f42017a86f55)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-700]: https://stellarwp.atlassian.net/browse/GIVE-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ