### PR TITLE
Fix: Sanitize Donation Form CSS

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -273,7 +273,7 @@ class FormSettings implements Arrayable, Jsonable
         $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';
         $self->goalAmount = $array['goalAmount'] ?? 0;
         $self->registrationNotification = $array['registrationNotification'] ?? false;
-        $self->customCss = $array['customCss'] ?? '';
+        $self->customCss = wp_strip_all_tags($array['customCss']) ?? '';
         $self->pageSlug = $array['pageSlug'] ?? '';
         $self->goalAchievedMessage = $array['goalAchievedMessage'] ?? __(
             'Thank you to all our donors, we have met our fundraising goal.',

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -246,6 +246,7 @@ class FormSettings implements Arrayable, Jsonable
      * @since 3.7.0 Added formExcerpt
 
     /**
+     * @unreleased Sanitize customCSS property
      * @since 3.2.0 Added registrationNotification
      * @since 3.0.0
      */

--- a/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -84,6 +84,7 @@ class DonationConfirmationReceiptViewModel
     }
 
     /**
+     * @unreleased Sanitize customCSS property
      * @since 3.0.0
      */
     public function render(): string

--- a/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -111,7 +111,7 @@ class DonationConfirmationReceiptViewModel
 
         <?php
         if ($customCss): ?>
-            <style><?= $customCss ?></style>
+            <style><?php echo wp_strip_all_tags($customCss); ?></style>
         <?php
         endif; ?>
 

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -266,7 +266,7 @@ class DonationFormViewModel
         <?php
         if ($this->previewMode || $this->formSettings->customCss): ?>
             <style id="root-givewp-donation-form-style"><?php
-                echo $this->formSettings->customCss; ?></style>
+                echo wp_strip_all_tags($this->formSettings->customCss); ?></style>
         <?php
         endif; ?>
 

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -247,6 +247,7 @@ class DonationFormViewModel
      * 5. Finally, call the specific WP function wp_print_footer_scripts()
      *  - This will only print the footer scripts that are enqueued within our route.
      *
+     * @unreleased Sanitize customCSS property
      * @since 3.0.0
      */
     public function render(): string

--- a/tests/Unit/DonationForms/Properties/FormSettingsTest.php
+++ b/tests/Unit/DonationForms/Properties/FormSettingsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Unit\DonationForms\Properties;
+
+use Give\DonationForms\Properties\FormSettings;
+use Give\Tests\TestCase;
+
+/**
+ * @unreleased
+ */
+class FormSettingsTest extends TestCase
+{
+    public function testSanitizationRemovesHtmlTagsFromCustomCss()
+    {
+        $formSettings = FormSettings::fromArray([
+            'customCss' => '<script>alert("hi!")</script>',
+        ]);
+
+        $this->assertEmpty($formSettings->customCss);
+    }
+
+    public function testSanitizationPreservesCssWhileRemovingHtmlTags()
+    {
+        $formSettings = FormSettings::fromArray([
+            'customCss' => '.test { color: green; }</style><script>alert("hi!")</script><style>',
+        ]);
+
+        $this->assertSame('.test { color: green; }', $formSettings->customCss);
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-696]

## Description
This pull request sanitizes the content saved in the `customCss` property of `FormSettings` by removing any HTML tags added to it. It then ensures that any tag will not be rendered by sanitizing the value of that property when it is displayed.

## Affects
Donation Forms custom CSS

## Visuals
![CleanShot 2024-04-30 at 23 22 10](https://github.com/impress-org/givewp/assets/3921017/524f6819-4263-4bd0-81e8-89584f2c235b)
![CleanShot 2024-04-30 at 23 23 15](https://github.com/impress-org/givewp/assets/3921017/a6cbc38b-e763-4cf3-a9e2-21d547c7005b)

## Testing Instructions
1. Add HTML tags to the Custom Styles field on VFB
2. Ensure no HTML tags are rendered in the page

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

