### PR TITLE
Fix: sanitize shortcode atts

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -838,6 +838,11 @@ class Give_Donate_Form {
 		// Remove empty class names.
 		$form_classes_array = array_filter( $form_classes_array );
 
+        /**
+         * @unreleased sanitize attributes
+         */
+        $form_classes_array = array_map('esc_attr', $form_classes_array);
+
 		return implode( ' ', $form_classes_array );
 
 	}
@@ -884,6 +889,11 @@ class Give_Donate_Form {
 		 * @since 1.0
 		 */
 		$form_wrap_classes_array = (array) apply_filters( 'give_form_wrap_classes', $custom_class, $this->ID, $args );
+
+        /**
+         * @unreleased sanitize attributes
+         */
+        $form_wrap_classes_array = array_map('esc_attr', $form_wrap_classes_array);
 
 		return implode( ' ', $form_wrap_classes_array );
 


### PR DESCRIPTION
## Description
This PR is an addition to https://github.com/impress-org/givewp/pull/7375
In the previous PR, sanitization is added to input args only, but that won't be enough if the malicious code is already saved in the database. To fix this, sanitization of the data before output is also added.

## Affects

`give_form` shortcode


## Testing Instructions

Install and activate Give
Create a form using  "Legacy Form" template
Create a new Post and add a shortcode
`[give_form id="13721" display_style='abcdef"onmouseover=alert(123) b=']`
Replace id with form id
Open the post and move the mouse on the button

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

