### PR TITLE
Feature: Update all form goal blocks/shortcodes to respect the new v3 fields/queries

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -213,6 +213,7 @@ add_shortcode( 'give_form', 'give_form_shortcode' );
  *
  * Show the Give donation form goals.
  *
+ * @unreleased add start_date and end_date attributes
  * @since 3.7.0 Sanitize attributes
  * @since 3.4.0 Add additional validations to check if the form is valid and has the 'published' status.
  * @since  1.0
@@ -228,7 +229,9 @@ function give_goal_shortcode( $atts ) {
 			'id'        => '',
 			'show_text' => true,
 			'show_bar'  => true,
-			'color'		=> '',
+			'color'		=> '#66BB6A',
+            'start_date' => '',
+            'end_date' => '',
 		],
 		$atts,
 		'give_goal'

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -59,7 +59,11 @@ class DonationQuery extends QueryBuilder
     public function between($startDate, $endDate)
     {
         $this->joinMeta('_give_completed_date', 'completed');
-        $this->whereBetween('completed.meta_value', $startDate, $endDate);
+        $this->whereBetween(
+            'completed.meta_value',
+            date('Y-m-d H:i:s', strtotime($startDate)),
+            date('Y-m-d H:i:s', strtotime($endDate))
+        );
         return $this;
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -52,6 +52,18 @@ class DonationQuery extends QueryBuilder
         return $this;
     }
 
+
+    /**
+     * An opinionated where method for the multiple donation form IDs meta field.
+     * @unreleased
+     */
+    public function forms(array $formIds)
+    {
+        $this->joinMeta('_give_payment_form_id', 'formId');
+        $this->whereIn('formId.meta_value', $formIds);
+        return $this;
+    }
+
     /**
      * An opinionated whereBetween method for the completed date meta field.
      * @unreleased

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -2,6 +2,7 @@
 
 namespace Give\MultiFormGoals\ProgressBar;
 
+use Give\DonationForms\DonationQuery;
 use Give\ValueObjects\Money;
 
 class Model
@@ -132,14 +133,18 @@ class Model
     /**
      * Get raw earnings value for Progress Bar
      *
+     * @unreleased use DonationQuery
      * @since 2.9.0
      */
     public function getTotal(): string
     {
-        $query = new Query($this->getForms());
-        $results = $query->getResults();
+        $amount = 0;
 
-        return Money::ofMinor($results->total, give_get_option('currency'))->getAmount();
+        foreach($this->getForms() as $formId) {
+            $amount += (new DonationQuery())->form($formId)->sumIntendedAmount();
+        }
+
+        return $amount;
     }
 
     /**

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -138,13 +138,7 @@ class Model
      */
     public function getTotal(): string
     {
-        $amount = 0;
-
-        foreach($this->getForms() as $formId) {
-            $amount += (new DonationQuery())->form($formId)->sumIntendedAmount();
-        }
-
-        return $amount;
+        return (new DonationQuery())->forms($this->getForms())->sumIntendedAmount();
     }
 
     /**

--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -42,19 +42,17 @@ $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'
  * @unreleased use DonationQuery to get donation amounts
  */
 $form_income = 0;
+$donationQuery = (new DonationQuery())->form($form->ID);
 
 if ($args['start_date'] === $args['end_date']) {
-    $form_income = (new DonationQuery())->form($form->ID)->sumIntendedAmount();
+    $form_income = $donationQuery->sumIntendedAmount();
 } else {
     // If end date is not set, we have to use the current datetime.
     if ( ! $args['end_date']) {
         $args['end_date'] = date('Y-m-d H:i:s');
     }
 
-    $form_income = (new DonationQuery())
-        ->form($form->ID)
-        ->between($args['start_date'], $args['end_date'])
-        ->sumIntendedAmount();
+    $form_income = $donationQuery->between($args['start_date'], $args['end_date'])->sumIntendedAmount();
 }
 
 /**


### PR DESCRIPTION
## Description

This PR updates all form goal blocks/shortcodes to respect the new v3 fields/queries. 
`[give_goal]` shortcode is updated and now it supports two new arguments `start_date` and `end_date` where the user can set a date range for the goal. 

## Affects

- Multi-Form Goal block
- [give_goal]
- [give_multi_form_goal]
- [give_totals]

## Testing Instructions



<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

