### PR TITLE
Feature: Time Based Form Goals

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -213,6 +213,7 @@ add_shortcode( 'give_form', 'give_form_shortcode' );
  *
  * Show the Give donation form goals.
  *
+ * @unreleased add start_date and end_date attributes
  * @since 3.7.0 Sanitize attributes
  * @since 3.4.0 Add additional validations to check if the form is valid and has the 'published' status.
  * @since  1.0
@@ -228,7 +229,9 @@ function give_goal_shortcode( $atts ) {
 			'id'        => '',
 			'show_text' => true,
 			'show_bar'  => true,
-			'color'		=> '',
+			'color'		=> '#66BB6A',
+            'start_date' => '',
+            'end_date' => '',
 		],
 		$atts,
 		'give_goal'

--- a/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
@@ -4,6 +4,7 @@ namespace Give\DonationForms\DataTransferObjects;
 
 use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\Repositories\DonationFormRepository;
+use Give\DonationForms\ValueObjects\GoalProgressType;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\Framework\Support\Contracts\Arrayable;
 
@@ -32,6 +33,18 @@ class DonationFormGoalData implements Arrayable
      * @var int
      */
     public $targetAmount;
+    /**
+     * @var GoalProgressType
+     */
+    public $goalProgressType;
+    /**
+     * @var string|null
+     */
+    public $goalStartDate;
+    /**
+     * @var string|null
+     */
+    public $goalEndDate;
 
     /**
      * @since 3.0.0
@@ -43,6 +56,9 @@ class DonationFormGoalData implements Arrayable
         $this->isEnabled = $formSettings->enableDonationGoal ?? false;
         $this->goalType = $formSettings->goalType ?? GoalType::AMOUNT();
         $this->targetAmount = $this->formSettings->goalAmount ?? 0;
+        $this->goalProgressType = $this->formSettings->goalProgressType ?? GoalProgressType::ALL_TIME();
+        $this->goalStartDate = $this->formSettings->goalStartDate ?? null;
+        $this->goalEndDate = $this->formSettings->goalEndDate ?? null;
     }
 
     /**
@@ -68,7 +84,9 @@ class DonationFormGoalData implements Arrayable
                 return $donationFormRepository->getTotalNumberOfDonorsFromSubscriptions($this->formId);
             case GoalType::AMOUNT():
             default:
-                return $donationFormRepository->getTotalRevenue($this->formId);
+                return $this->goalProgressType->isAllTime()
+                    ? $donationFormRepository->getTotalRevenue($this->formId)
+                    : $donationFormRepository->getTotalRevenueForDateRange($this->formId,$this->goalStartDate, $this->goalEndDate);
         endswitch;
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -2,6 +2,7 @@
 
 namespace Give\DonationForms;
 
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Framework\QueryBuilder\JoinQueryBuilder;
 use Give\Framework\QueryBuilder\QueryBuilder;
 
@@ -91,5 +92,11 @@ class DonationQuery extends QueryBuilder
         return $this->sum(
             'COALESCE(intendedAmount.meta_value, amount.meta_value)'
         );
+    }
+
+    public function countDonors()
+    {
+        $this->joinMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+        return $this->count('DISTINCT donorId.meta_value');
     }
 }

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -71,12 +71,15 @@ class DonationQuery extends QueryBuilder
      */
     public function between($startDate, $endDate)
     {
+        // If the dates are empty or invalid, they will fallback to January 1st, 1970.
+        // For the start date, this is exactly what we need, but for the end date, we should set it as the current date so that we have a correct date range.
+        $startDate = date('Y-m-d H:i:s', strtotime($startDate));
+        $endDate = empty($endDate)
+            ? date('Y-m-d H:i:s')
+            : date('Y-m-d H:i:s', strtotime($endDate));
+
         $this->joinMeta('_give_completed_date', 'completed');
-        $this->whereBetween(
-            'completed.meta_value',
-            date('Y-m-d H:i:s', strtotime($startDate)),
-            date('Y-m-d H:i:s', strtotime($endDate))
-        );
+        $this->whereBetween('completed.meta_value', $startDate, $endDate);
         return $this;
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -52,6 +52,18 @@ class DonationQuery extends QueryBuilder
         return $this;
     }
 
+
+    /**
+     * An opinionated where method for the multiple donation form IDs meta field.
+     * @unreleased
+     */
+    public function forms(array $formIds)
+    {
+        $this->joinMeta('_give_payment_form_id', 'formId');
+        $this->whereIn('formId.meta_value', $formIds);
+        return $this;
+    }
+
     /**
      * An opinionated whereBetween method for the completed date meta field.
      * @unreleased
@@ -59,7 +71,11 @@ class DonationQuery extends QueryBuilder
     public function between($startDate, $endDate)
     {
         $this->joinMeta('_give_completed_date', 'completed');
-        $this->whereBetween('completed.meta_value', $startDate, $endDate);
+        $this->whereBetween(
+            'completed.meta_value',
+            date('Y-m-d H:i:s', strtotime($startDate)),
+            date('Y-m-d H:i:s', strtotime($endDate))
+        );
         return $this;
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Give\DonationForms;
+
+use Give\Framework\QueryBuilder\JoinQueryBuilder;
+use Give\Framework\QueryBuilder\QueryBuilder;
+
+/**
+ * An opinionated Query Builder for GiveWP donations and meta fields.
+ *
+ * @unreleased
+ *
+ * Example usage:
+ * (new DonationQuery)
+ *     ->form(1816)
+ *     ->between('2024-02-00', '2024-02-23')
+ *     ->sumIntendedAmount();
+ */
+class DonationQuery extends QueryBuilder
+{
+    /**
+     * @unreleased
+     */
+    public function __construct()
+    {
+        $this->from('posts', 'donation');
+    }
+
+    /**
+     * An opinionated join method for the donation meta table.
+     * @unreleased
+     */
+    public function joinMeta($key, $alias)
+    {
+        $this->join(function (JoinQueryBuilder $builder) use ($key, $alias) {
+            $builder
+                ->leftJoin('give_donationmeta', $alias)
+                ->on('donation.ID', $alias . '.donation_id')
+                ->andOn($alias . '.meta_key', $key, true);
+        });
+        return $this;
+    }
+
+    /**
+     * An opinionated where method for the donation form ID meta field.
+     * @unreleased
+     */
+    public function form($formId)
+    {
+        $this->joinMeta('_give_payment_form_id', 'formId');
+        $this->where('formId.meta_value', $formId);
+        return $this;
+    }
+
+    /**
+     * An opinionated whereBetween method for the completed date meta field.
+     * @unreleased
+     */
+    public function between($startDate, $endDate)
+    {
+        $this->joinMeta('_give_completed_date', 'completed');
+        $this->whereBetween('completed.meta_value', $startDate, $endDate);
+        return $this;
+    }
+
+    /**
+     * Returns a calculated sum of the intended amounts (without recovered fees) for the donations.
+     * @unreleased
+     * @return int|float
+     */
+    public function sumIntendedAmount()
+    {
+        $this->joinMeta('_give_payment_total', 'amount');
+        $this->joinMeta('_give_fee_donation_amount', 'intendedAmount');
+        return $this->sum(
+            'COALESCE(intendedAmount.meta_value, amount.meta_value)'
+        );
+    }
+}

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -7,11 +7,13 @@ use Give\DonationForms\ValueObjects\DesignSettingsLogoPosition;
 use Give\DonationForms\ValueObjects\DesignSettingsSectionStyle;
 use Give\DonationForms\ValueObjects\DesignSettingsTextFieldStyle;
 use Give\DonationForms\ValueObjects\DonationFormStatus;
+use Give\DonationForms\ValueObjects\GoalProgressType;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\Framework\Support\Contracts\Arrayable;
 use Give\Framework\Support\Contracts\Jsonable;
 
 /**
+ * @unreleased Add goalProgressType
  * @since      3.2.0 Remove addSlashesRecursive method
  * @since      3.0.0
  */
@@ -45,6 +47,18 @@ class FormSettings implements Arrayable, Jsonable
      * @var GoalType
      */
     public $goalType;
+    /**
+     * @var GoalProgressType
+     */
+    public $goalProgressType;
+    /**
+     * @var string
+     */
+    public $goalStartDate;
+    /**
+     * @var string
+     */
+    public $goalEndDate;
     /**
      * @var string
      */
@@ -268,6 +282,11 @@ class FormSettings implements Arrayable, Jsonable
         $self->goalType = ! empty($array['goalType']) && GoalType::isValid($array['goalType']) ? new GoalType(
             $array['goalType']
         ) : GoalType::AMOUNT();
+        $self->goalProgressType = ! empty($array['goalProgressType']) && GoalProgressType::isValid($array['goalProgressType'])
+            ? new GoalProgressType($array['goalProgressType'])
+            : GoalProgressType::ALL_TIME();
+        $self->goalStartDate = $array['goalStartDate'] ?? '';
+        $self->goalEndDate = $array['goalEndDate'] ?? '';
         $self->designId = $array['designId'] ?? null;
         $self->primaryColor = $array['primaryColor'] ?? '#69b86b';
         $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -399,14 +399,6 @@ class DonationFormRepository
             ->count();
     }
 
-    public function getTotalNumberOfDonationsForDateRange(int $formId, string $startDate, string $endDate): int
-    {
-        return (new DonationQuery)
-            ->form($formId)
-            ->between($startDate, $endDate)
-            ->count();
-    }
-
     /**
      * @since 3.0.0
      */
@@ -425,17 +417,6 @@ class DonationFormRepository
     {
         return (int) (new DonationQuery)
             ->form($formId)
-            ->sumIntendedAmount();
-    }
-
-    /**
-     * @unreleased
-     */
-    public function getTotalRevenueForDateRange(int $formId, string $startDate, string $endDate): int
-    {
-        return (int) (new DonationQuery)
-            ->form($formId)
-            ->between($startDate, $endDate)
             ->sumIntendedAmount();
     }
 

--- a/src/DonationForms/SubscriptionQuery.php
+++ b/src/DonationForms/SubscriptionQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Give\DonationForms;
+
+use Give\Framework\QueryBuilder\QueryBuilder;
+
+/**
+ * @unreleased
+ */
+class SubscriptionQuery extends QueryBuilder
+{
+    /**
+     * @unreleased
+     */
+    public function __construct()
+    {
+        $this->from('give_subscriptions');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function form($formId)
+    {
+        $this->where('product_id', $formId);
+        return $this;
+    }
+
+
+    /**
+     * @unreleased
+     */
+    public function forms(array $formIds)
+    {
+        $this->whereIn('product_id', $formIds);
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function between($startDate, $endDate)
+    {
+        $this->whereBetween(
+            'created',
+            date('Y-m-d H:i:s', strtotime($startDate)),
+            date('Y-m-d H:i:s', strtotime($endDate))
+        );
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function sumInitialAmount()
+    {
+        return $this->sum('initial_amount');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function countDonors()
+    {
+        return $this->count('DISTINCT customer_id');
+    }
+}

--- a/src/DonationForms/ValueObjects/GoalProgressType.php
+++ b/src/DonationForms/ValueObjects/GoalProgressType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Give\DonationForms\ValueObjects;
+
+use Give\Framework\Support\ValueObjects\Enum;
+
+/**
+ * @unreleased
+ *
+ * @method static GoalProgressType ALL_TIME()
+ * @method static GoalProgressType CUSTOM()
+ * @method bool isAllTime()
+ * @method bool isCustom()
+ */
+class GoalProgressType extends Enum
+{
+    const ALL_TIME = 'all_time';
+    const CUSTOM = 'custom';
+}

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -6,6 +6,7 @@ use Give\DonationForms\Actions\GenerateAuthUrl;
 use Give\DonationForms\Actions\GenerateDonateRouteUrl;
 use Give\DonationForms\Actions\GenerateDonationFormValidationRouteUrl;
 use Give\DonationForms\DataTransferObjects\DonationFormGoalData;
+use Give\DonationForms\DonationQuery;
 use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\Repositories\DonationFormRepository;
 use Give\DonationForms\ValueObjects\GoalType;
@@ -181,14 +182,18 @@ class DonationFormViewModel
     {
         $goalType = $this->goalType();
 
-        $totalRevenue = $this->getTotalRevenue($goalType);
-        $totalCountValue = $this->getTotalCountValue($goalType);
-        $totalCountLabel = $this->getCountLabel($goalType);
+        $donationQuery = (new DonationQuery)->form($this->donationFormId);
+
+        if($this->formSettings->goalProgressType->isCustom()) {
+            $donationQuery->between($this->formSettings->goalStartDate, $this->formSettings->goalEndDate);
+        }
 
         return [
-            'totalRevenue' => $totalRevenue,
-            'totalCountValue' => $totalCountValue,
-            'totalCountLabel' => $totalCountLabel,
+            'totalRevenue' => $donationQuery->sumIntendedAmount(),
+            'totalCountValue' => $goalType->isDonations() || $goalType->isAmount()
+                ? $donationQuery->count()
+                : $this->getTotalCountValue($goalType),
+            'totalCountLabel' => $this->getCountLabel($goalType),
         ];
     }
 

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -152,6 +152,11 @@ class RegisterFormBuilderPageRoute
                 ),
         ]);
 
+        wp_localize_script('@givewp/form-builder/script', 'goalNotificationData', [
+            'actionUrl' => admin_url('admin-ajax.php?action=givewp_goal_hide_notice'),
+            'isDismissed' => get_user_meta(get_current_user_id(), 'givewp-goal-notice-dismissed', true),
+        ]);
+
         View::render('FormBuilder.admin-form-builder');
     }
 
@@ -165,7 +170,7 @@ class RegisterFormBuilderPageRoute
     public function loadGutenbergScripts()
     {
         wp_enqueue_editor();
-        
+
         // Gutenberg scripts
         wp_enqueue_script('wp-block-library');
         wp_enqueue_script('wp-format-library');

--- a/src/FormBuilder/ServiceProvider.php
+++ b/src/FormBuilder/ServiceProvider.php
@@ -84,5 +84,9 @@ class ServiceProvider implements ServiceProviderInterface
         add_action('wp_ajax_givewp_transfer_hide_notice', static function () {
             give_update_meta((int)$_GET['formId'], 'givewp-form-builder-transfer-hide-notice', time(), true);
         });
+
+        add_action('wp_ajax_givewp_goal_hide_notice', static function () {
+            add_user_meta(get_current_user_id(), 'givewp-goal-notice-dismissed', time(), true);
+        });
     }
 }

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -4,6 +4,7 @@ namespace Give\FormBuilder\ViewModels;
 
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\DonationForms\Models\DonationForm;
+use Give\DonationForms\ValueObjects\GoalProgressType;
 use Give\DonationForms\ValueObjects\GoalType;
 use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationMetaKeys;
@@ -21,6 +22,7 @@ use Give\Subscriptions\Models\Subscription;
 class FormBuilderViewModel
 {
     /**
+     * @unreleased  Add goalProgressOptions key to the returned array
      * @since 3.9.0 Add support to intlTelInputSettings key in the returned array
      * @since      3.7.0 Add support to isExcerptEnabled key in the returned array
      * @since 3.2.0 Add nameTitlePrefixes key to the returned array
@@ -78,6 +80,7 @@ class FormBuilderViewModel
                 'agreementText' => give_get_option('agreement_text'),
             ],
             'goalTypeOptions' => $this->getGoalTypeOptions(),
+            'goalProgressOptions' => $this->getGoalProgressOptions(),
             'nameTitlePrefixes' => give_get_option('title_prefixes'),
             'isExcerptEnabled' => give_is_setting_enabled(give_get_option('forms_excerpt')),
             'intlTelInputSettings' => IntlTelInput::getSettings(),
@@ -109,6 +112,23 @@ class FormBuilderViewModel
             'isCurrency' => $isCurrency,
         ];
     }
+
+    /**
+     * @unreleased
+     */
+    public function getGoalProgressOption(
+        string $value,
+        string $label,
+        string $description
+    ): array
+    {
+        return [
+            'value' => $value,
+            'label' => $label,
+            'description' => $description
+        ];
+    }
+
 
     /**
      * @since 3.0.0
@@ -156,6 +176,25 @@ class FormBuilderViewModel
         }
 
         return $options;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getGoalProgressOptions(): array
+    {
+        return [
+            $this->getGoalProgressOption(
+                GoalProgressType::ALL_TIME,
+                __('All time', 'give'),
+                __('Displays the goal progress for a lifetime, starting from when this form was published.', 'give')
+            ),
+            $this->getGoalProgressOption(
+                GoalProgressType::CUSTOM,
+                __('Custom', 'give'),
+                __('Displays the goal progress from the start date to the end date.', 'give')
+            )
+        ];
     }
 
     /**

--- a/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
@@ -19,6 +19,17 @@ type GoalTypeOption = {
 };
 
 /**
+ * @unreleased
+ */
+type GoalProgressOption = {
+    value: string;
+    label: string;
+    description: string;
+    isCustom: boolean;
+};
+
+/**
+ * @unreleased Added goalProgressOptions
  * @since 3.9.0 Added intlTelInputSettings
  * @since 3.7.0 Added isExcerptEnabled
  * @since 3.0.0
@@ -50,6 +61,7 @@ interface FormBuilderWindowData {
     donationConfirmationTemplateTags: TemplateTag[];
     termsAndConditions: TermsAndConditions;
     goalTypeOptions: GoalTypeOption[];
+    goalProgressOptions: GoalProgressOption[];
     nameTitlePrefixes: string[];
     isExcerptEnabled: boolean;
     intlTelInputSettings: IntlTelInputSettings;

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -59,7 +59,7 @@ export default ({
             return !(date > new Date(invalidDateBefore) && date < new Date(invalidDateAfter));
         }
 
-        if (invalidDateBefore && date < new Date(invalidDateAfter)) {
+        if (invalidDateBefore && date < new Date(invalidDateBefore)) {
             return true;
         }
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -84,6 +84,7 @@ export default ({
                         anchor={popoverRef.current}
                         position="middle left bottom"
                         className="givewp-date-picker_popover"
+                        offset={window?.chrome ? 30 : 0}
                     >
                         <Button
                             className="givewp-date-picker_popover__close-button"

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -1,0 +1,141 @@
+import {__} from '@wordpress/i18n';
+import {useRef, useState} from 'react';
+import {close} from '@wordpress/icons';
+import {Button, DatePicker, DateTimePicker, PanelRow, Popover, TextControl} from '@wordpress/components';
+
+import './styles.scss';
+
+interface DatePickerProps {
+    label: string;
+    placeholder: string;
+    date: string;
+    onSelect: (date: string) => void;
+    invalidDateBefore?: string;
+    invalidDateAfter?: string;
+    is12Hour?: boolean;
+    showTimeSelector?: boolean;
+}
+
+/**
+ * @unreleased
+ */
+export default ({
+    label,
+    placeholder,
+    date: value,
+    onSelect,
+    invalidDateBefore = null,
+    invalidDateAfter = null,
+    is12Hour = true,
+    showTimeSelector = false,
+}: DatePickerProps) => {
+
+    const popoverRef = useRef();
+
+    const [date, setDate] = useState<string>(value);
+    const [isVisible, setIsVisible] = useState<boolean>(false);
+    const currentDate = date ? new Date(date) : new Date();
+
+
+    const convertJsDateToMySQLDate = (dateTime: string) => {
+        // split the ISO string into date and time
+        const [date, time] = new Date(dateTime).toISOString().split('T');
+
+        return `${date} ${time.slice(0, 8)}`;
+    };
+
+    const toggleVisible = () => {
+        setIsVisible((state) => !state);
+    };
+
+    const onSelectDate = () => {
+        onSelect(convertJsDateToMySQLDate(date));
+        setIsVisible(false);
+    };
+
+    const checkDate = (date: Date) => {
+        // Check if the date is in range
+        if (invalidDateBefore && invalidDateAfter) {
+            return !(date > new Date(invalidDateBefore) && date < new Date(invalidDateAfter));
+        }
+
+        if (invalidDateBefore && date < new Date(invalidDateAfter)) {
+            return true;
+        }
+
+        if (invalidDateAfter && date > new Date(invalidDateAfter)) {
+            return true;
+        }
+
+        return false;
+    };
+
+    return (
+        <PanelRow ref={popoverRef}>
+            <TextControl
+                type="text"
+                value={value}
+                label={label}
+                placeholder={placeholder}
+                className="givewp-date-picker_input"
+                onChange={() => {}}
+                onClick={toggleVisible}
+            />
+            {isVisible && (
+                <>
+                    <Popover
+                        shift
+                        anchor={popoverRef.current}
+                        position="middle left bottom"
+                        className="givewp-date-picker_popover"
+                    >
+                        <Button
+                            className="givewp-date-picker_popover__close-button"
+                            icon={close}
+                            label={__('Close', 'give')}
+                            onClick={toggleVisible}
+                        />
+
+                        <label>{label}</label>
+
+                        {showTimeSelector ? (
+                            <DateTimePicker
+                                is12Hour={is12Hour}
+                                currentDate={currentDate}
+                                isInvalidDate={(date) => checkDate(date)}
+                                onChange={(date) => {
+                                    setDate(date);
+                                }}
+                            />
+                        ) : (
+                            <DatePicker
+                                currentDate={currentDate}
+                                isInvalidDate={(date) => checkDate(date)}
+                                onChange={(date) => {
+                                    setDate(date);
+                                }}
+                            />
+                        )}
+
+                        <div className="givewp-date-picker_popover__buttons">
+                            <Button variant="primary" onClick={onSelectDate}>
+                                {__('Set Date', 'give')}
+                            </Button>
+
+                            <Button variant="secondary" onClick={() => {
+                                onSelect('');
+                                setIsVisible(false);
+                            }}>
+                                {__('Reset', 'give')}
+                            </Button>
+
+                            <Button onClick={toggleVisible}>
+                                {__('Cancel', 'give')}
+                            </Button>
+                        </div>
+                    </Popover>
+                </>
+            )}
+        </PanelRow>
+    );
+}

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -34,14 +34,10 @@ export default ({
 
     const [date, setDate] = useState<string>(value);
     const [isVisible, setIsVisible] = useState<boolean>(false);
-    const currentDate = date ? new Date(date) : new Date();
-
 
     const convertJsDateToMySQLDate = (dateTime: string) => {
-        // split the ISO string into date and time
-        const [date, time] = new Date(dateTime).toISOString().split('T');
-
-        return `${date} ${time.slice(0, 8)}`;
+        const [date, time] = dateTime.split('T');
+        return `${date} ${time}`;
     };
 
     const toggleVisible = () => {
@@ -101,7 +97,7 @@ export default ({
                         {showTimeSelector ? (
                             <DateTimePicker
                                 is12Hour={is12Hour}
-                                currentDate={currentDate}
+                                currentDate={value}
                                 isInvalidDate={(date) => checkDate(date)}
                                 onChange={(date) => {
                                     setDate(date);
@@ -109,7 +105,7 @@ export default ({
                             />
                         ) : (
                             <DatePicker
-                                currentDate={currentDate}
+                                currentDate={value}
                                 isInvalidDate={(date) => checkDate(date)}
                                 onChange={(date) => {
                                     setDate(date);

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -84,6 +84,7 @@ export default ({
                         anchor={popoverRef.current}
                         position="middle left bottom"
                         className="givewp-date-picker_popover"
+                        //@ts-ignore
                         offset={window?.chrome ? 30 : 0}
                     >
                         <Button

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/styles.scss
@@ -1,0 +1,50 @@
+.givewp-date-picker {
+    &_input {
+        .components-text-control__input {
+            background-image: url('data:image/svg+xml,<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.5 8.333h-15m10.833-6.666V5M6.667 1.667V5M6.5 18.333h7c1.4 0 2.1 0 2.635-.272a2.5 2.5 0 0 0 1.092-1.093c.273-.535.273-1.235.273-2.635v-7c0-1.4 0-2.1-.273-2.635a2.5 2.5 0 0 0-1.092-1.092c-.535-.273-1.235-.273-2.635-.273h-7c-1.4 0-2.1 0-2.635.273a2.5 2.5 0 0 0-1.093 1.092C2.5 5.233 2.5 5.933 2.5 7.333v7c0 1.4 0 2.1.272 2.635a2.5 2.5 0 0 0 1.093 1.093c.535.272 1.235.272 2.635.272z" stroke="%238C8C8C" stroke-width="1.667" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+            background-repeat: no-repeat;
+            background-position: right 10px center;
+        }
+    }
+
+    &_popover {
+        .components-popover__content {
+            min-width: 320px;
+            padding: 16px;
+
+            .components-number-control {
+                width: unset;
+            }
+        }
+
+        .components-input-control__input {
+            max-width: 50px;
+        }
+
+        &__close-button {
+            all: unset;
+            position: absolute;
+            cursor: pointer;
+            top: 10px;
+            right: 20px;
+        }
+
+        &__close-button:focus {
+            border: none !important;
+            box-shadow: none !important;
+        }
+
+        &__buttons {
+            padding-top: 20px;
+            display: flex;
+            gap: 10px;
+        }
+
+        label {
+            font-size: 13px;
+            font-weight: 600;
+            color: #0e0e0e;
+            padding-bottom: 20px;
+        }
+    }
+}

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/styles.scss
@@ -9,6 +9,7 @@
 
     &_popover {
         .components-popover__content {
+            position: relative;
             min-width: 320px;
             padding: 16px;
 
@@ -22,11 +23,10 @@
         }
 
         &__close-button {
-            all: unset;
             position: absolute;
             cursor: pointer;
-            top: 10px;
-            right: 20px;
+            top: 8px;
+            right: 10px;
         }
 
         &__close-button:focus {
@@ -41,6 +41,7 @@
         }
 
         label {
+            display: block;
             font-size: 13px;
             font-weight: 600;
             color: #0e0e0e;

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -24,6 +24,8 @@ const DesignPreview = () => {
     }, [
         formSettings.designId,
         formSettings.goalType,
+        formSettings.goalStartDate,
+        formSettings.goalEndDate,
         JSON.stringify(blocks), // stringify to prevent re-renders caused by object as dep
     ]);
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -26,6 +26,7 @@ const DesignPreview = () => {
         formSettings.goalType,
         formSettings.goalStartDate,
         formSettings.goalEndDate,
+        formSettings.goalProgressType,
         JSON.stringify(blocks), // stringify to prevent re-renders caused by object as dep
     ]);
 

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
@@ -209,8 +209,7 @@ const DonationGoal = ({dispatch}) => {
                                             {__('You can now set a time frame to show progress toward your goal.', 'give')}
                                         </span>
                                         <span>
-                                            {/*todo: add link to docs*/}
-                                            <a href="#" target="_blank">
+                                            <a href="https://docs.givewp.com/goal-timeframe" target="_blank">
                                                 <Icon
                                                     style={noticeStyles.externalIcon as CSSProperties}
                                                     icon={external}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
@@ -11,18 +11,30 @@ import {
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPubSub';
 import {CurrencyControl} from '@givewp/form-builder/components/CurrencyControl';
+import DatePicker from '@givewp/form-builder/components/DatePicker';
 
-const {goalTypeOptions} = getFormBuilderWindowData();
+const {goalTypeOptions, goalProgressOptions} = getFormBuilderWindowData();
 
 const DonationGoal = ({dispatch}) => {
     const {
-        settings: {enableDonationGoal, enableAutoClose, goalAchievedMessage, goalType, goalAmount},
+        settings: {
+            enableDonationGoal,
+            enableAutoClose,
+            goalAchievedMessage,
+            goalType,
+            goalProgressType,
+            goalAmount,
+            goalStartDate,
+            goalEndDate
+        },
     } = useFormState();
 
     const {publishGoal, publishGoalType} = useDonationFormPubSub();
 
     const selectedGoalType = goalTypeOptions.find((option) => option.value === goalType);
     const selectedGoalDescription = selectedGoalType ? selectedGoalType.description : '';
+    const selectedGoalProgressType = goalProgressOptions.find((option) => option.value === goalProgressType);
+    const selectedGoalProgressDescription = selectedGoalProgressType ? selectedGoalProgressType.description : '';
 
     return (
         <PanelBody title={__('Donation Goal', 'give')} initialOpen={false}>
@@ -40,28 +52,6 @@ const DonationGoal = ({dispatch}) => {
 
             {enableDonationGoal && (
                 <>
-                    <PanelRow>
-                        <ToggleControl
-                            label={__('Auto-Close Form', 'give')}
-                            help={__(
-                                'Do you want to close the donation forms and stop accepting donations once this goal has been met?',
-                                'give'
-                            )}
-                            checked={enableAutoClose}
-                            onChange={() => dispatch(setFormSettings({enableAutoClose: !enableAutoClose}))}
-                        />
-                    </PanelRow>
-                    {enableAutoClose && (
-                        <PanelRow>
-                            <TextareaControl
-                                label={__('Goal Achieved Message', 'give')}
-                                value={goalAchievedMessage}
-                                onChange={(goalAchievedMessage) =>
-                                    dispatch(setFormSettings({goalAchievedMessage: goalAchievedMessage}))
-                                }
-                            />
-                        </PanelRow>
-                    )}
                     <PanelRow>
                         <SelectControl
                             label={__('Goal Type', 'give')}
@@ -97,6 +87,65 @@ const DonationGoal = ({dispatch}) => {
                             />
                         )}
                     </PanelRow>
+                    <PanelRow>
+                        <ToggleControl
+                            label={__('Auto-Close Form', 'give')}
+                            help={__(
+                                'Do you want to close the donation forms and stop accepting donations once this goal has been met?',
+                                'give',
+                            )}
+                            checked={enableAutoClose}
+                            onChange={() => dispatch(setFormSettings({enableAutoClose: !enableAutoClose}))}
+                        />
+                    </PanelRow>
+                    {enableAutoClose && (
+                        <PanelRow>
+                            <TextareaControl
+                                label={__('Goal Achieved Message', 'give')}
+                                value={goalAchievedMessage}
+                                onChange={(goalAchievedMessage) =>
+                                    dispatch(setFormSettings({goalAchievedMessage: goalAchievedMessage}))
+                                }
+                            />
+                        </PanelRow>
+                    )}
+                    <PanelRow>
+                        <SelectControl
+                            label={__('Goal Progress', 'give')}
+                            value={goalProgressType}
+                            options={goalProgressOptions}
+                            onChange={(goalProgressType: string) => {
+                                dispatch(setFormSettings({goalProgressType}));
+                            }}
+                            help={selectedGoalProgressDescription}
+                        />
+                    </PanelRow>
+
+                    {goalProgressType === 'custom' && (
+                        <>
+                            <DatePicker
+                                showTimeSelector
+                                label={__('Start Date', 'give')}
+                                placeholder={__('Select Date', 'give')}
+                                date={goalStartDate}
+                                invalidDateAfter={goalEndDate}
+                                onSelect={(goalStartDate) => {
+                                    dispatch(setFormSettings({goalStartDate}));
+                                }}
+                            />
+
+                            <DatePicker
+                                showTimeSelector
+                                label={__('End Date', 'give')}
+                                placeholder={__('Select Date', 'give')}
+                                date={goalEndDate}
+                                invalidDateBefore={goalStartDate}
+                                onSelect={(goalEndDate) => {
+                                    dispatch(setFormSettings({goalEndDate}));
+                                }}
+                            />
+                        </>
+                    )}
                 </>
             )}
         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -15,6 +15,9 @@ export type FormSettings = {
     goalAchievedMessage: string;
     registrationNotification: boolean;
     goalType: string;
+    goalProgressType: string;
+    goalStartDate: string;
+    goalEndDate: string;
     goalAmount: number;
     designId: string;
     heading: string;

--- a/src/MultiFormGoals/ProgressBar/Model.php
+++ b/src/MultiFormGoals/ProgressBar/Model.php
@@ -2,6 +2,7 @@
 
 namespace Give\MultiFormGoals\ProgressBar;
 
+use Give\DonationForms\DonationQuery;
 use Give\ValueObjects\Money;
 
 class Model
@@ -132,14 +133,12 @@ class Model
     /**
      * Get raw earnings value for Progress Bar
      *
+     * @unreleased use DonationQuery
      * @since 2.9.0
      */
     public function getTotal(): string
     {
-        $query = new Query($this->getForms());
-        $results = $query->getResults();
-
-        return Money::ofMinor($results->total, give_get_option('currency'))->getAmount();
+        return (new DonationQuery())->forms($this->getForms())->sumIntendedAmount();
     }
 
     /**

--- a/templates/shortcode-goal.php
+++ b/templates/shortcode-goal.php
@@ -1,6 +1,7 @@
 <?php
 
 use Give\Log\Log;
+use Give\DonationForms\DonationQuery;
 
 /**
  * This template is used to display the goal with [give_goal]
@@ -8,6 +9,7 @@ use Give\Log\Log;
 
 /**
  * @var int $form_id form id passed from the give_show_goal_progress() context
+ * @var $args array shortcode args
  */
 
 if ( empty($form_id) ) {
@@ -37,6 +39,23 @@ $show_text           = isset( $args['show_text'] ) ? filter_var( $args['show_tex
 $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'], FILTER_VALIDATE_BOOLEAN ) : true;
 
 /**
+ * @unreleased use DonationQuery to get donation amounts
+ */
+$form_income = 0;
+$donationQuery = (new DonationQuery())->form($form->ID);
+
+if ($args['start_date'] === $args['end_date']) {
+    $form_income = $donationQuery->sumIntendedAmount();
+} else {
+    // If end date is not set, we have to use the current datetime.
+    if ( ! $args['end_date']) {
+        $args['end_date'] = date('Y-m-d H:i:s');
+    }
+
+    $form_income = $donationQuery->between($args['start_date'], $args['end_date'])->sumIntendedAmount();
+}
+
+/**
  * Allow filtering the goal stats used for this shortcode context.
  *
  * @since 2.23.1
@@ -49,7 +68,7 @@ $show_bar            = isset( $args['show_bar'] ) ? filter_var( $args['show_bar'
 $shortcode_stats = apply_filters(
     'give_goal_shortcode_stats',
     array(
-        'income' => $form->get_earnings(),
+        'income' => $form_income,
         'goal'   => $goal_progress_stats['raw_goal'],
     ),
     $form_id,

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -87,6 +87,7 @@ class FormBuilderViewModelTest extends TestCase
                     'agreementText' => give_get_option('agreement_text'),
                 ],
                 'goalTypeOptions' => $viewModel->getGoalTypeOptions(),
+                'goalProgressOptions' => $viewModel->getGoalProgressOptions(),
                 'nameTitlePrefixes' => give_get_option('title_prefixes'),
                 'isExcerptEnabled' => give_is_setting_enabled(give_get_option('forms_excerpt')),
                 'intlTelInputSettings' => IntlTelInput::getSettings(),


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR introduces time based form goals for the Visual Donation Form Builder, which includes a new "custom" settings (as opposed to "all time") with support for amount goals, donor goals, and donation goals with support for recurring donations.

## Affects

Query results for all goal types have been updated, including Amount Raised, Donation Count, Donor Count, Subscription Initial Amount, Subscription Count, and Subscriber Count.

## Additional Details

The new time-based settings are implemented using a new `DonationQuery` (and related `SubscriptionQuery`. These new query classes are opinionated extensions of the `QueryBuilder` with a fluid syntax designed for goal settings.

Notably, the `DonationQuery` supports calculating a sum of the _intended amount_, which takes into account support for fee recovery and calculates goal progress excluding those fees.

## Visuals

| All-Time | Custom |
| --- | --- |
| ![Screen Shot 2024-05-07 at 09 10 21](https://github.com/impress-org/givewp/assets/10858303/01c4011a-7e33-4bf6-9ebf-4cc573839dff) | ![Screen Shot 2024-05-07 at 09 11 01](https://github.com/impress-org/givewp/assets/10858303/fd037887-30e4-424b-95f4-8a6e7d3d0724) |
