### PR TITLE
Refactor: Simplify goal data to use query builder directly

### DIFF
--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -2,6 +2,7 @@
 
 namespace Give\DonationForms;
 
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Framework\QueryBuilder\JoinQueryBuilder;
 use Give\Framework\QueryBuilder\QueryBuilder;
 
@@ -91,5 +92,11 @@ class DonationQuery extends QueryBuilder
         return $this->sum(
             'COALESCE(intendedAmount.meta_value, amount.meta_value)'
         );
+    }
+
+    public function countDonors()
+    {
+        $this->joinMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+        return $this->count('DISTINCT donorId.meta_value');
     }
 }

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -367,15 +367,9 @@ class DonationFormRepository
      */
     public function getTotalNumberOfDonors(int $formId): int
     {
-        return DB::table('give_donationmeta')
-            ->where('meta_key', DonationMetaKeys::DONOR_ID)
-            ->whereIn('donation_id', function ($builder) use ($formId) {
-                $builder
-                    ->select('donation_id')
-                    ->from('give_donationmeta')
-                    ->where('meta_key', DonationMetaKeys::FORM_ID)
-                    ->where('meta_value', $formId);
-            })->count('DISTINCT meta_value');
+        return (new DonationQuery)
+            ->form($formId)
+            ->countDonors();
     }
 
     /**
@@ -399,14 +393,6 @@ class DonationFormRepository
             ->count();
     }
 
-    public function getTotalNumberOfDonationsForDateRange(int $formId, string $startDate, string $endDate): int
-    {
-        return (new DonationQuery)
-            ->form($formId)
-            ->between($startDate, $endDate)
-            ->count();
-    }
-
     /**
      * @since 3.0.0
      */
@@ -425,17 +411,6 @@ class DonationFormRepository
     {
         return (int) (new DonationQuery)
             ->form($formId)
-            ->sumIntendedAmount();
-    }
-
-    /**
-     * @unreleased
-     */
-    public function getTotalRevenueForDateRange(int $formId, string $startDate, string $endDate): int
-    {
-        return (int) (new DonationQuery)
-            ->form($formId)
-            ->between($startDate, $endDate)
             ->sumIntendedAmount();
     }
 

--- a/src/DonationForms/Repositories/DonationFormRepository.php
+++ b/src/DonationForms/Repositories/DonationFormRepository.php
@@ -367,9 +367,15 @@ class DonationFormRepository
      */
     public function getTotalNumberOfDonors(int $formId): int
     {
-        return (new DonationQuery)
-            ->form($formId)
-            ->countDonors();
+        return DB::table('give_donationmeta')
+            ->where('meta_key', DonationMetaKeys::DONOR_ID)
+            ->whereIn('donation_id', function ($builder) use ($formId) {
+                $builder
+                    ->select('donation_id')
+                    ->from('give_donationmeta')
+                    ->where('meta_key', DonationMetaKeys::FORM_ID)
+                    ->where('meta_value', $formId);
+            })->count('DISTINCT meta_value');
     }
 
     /**

--- a/src/DonationForms/SubscriptionQuery.php
+++ b/src/DonationForms/SubscriptionQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Give\DonationForms;
+
+use Give\Framework\QueryBuilder\QueryBuilder;
+
+/**
+ * @unreleased
+ */
+class SubscriptionQuery extends QueryBuilder
+{
+    /**
+     * @unreleased
+     */
+    public function __construct()
+    {
+        $this->from('give_subscriptions');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function form($formId)
+    {
+        $this->where('product_id', $formId);
+        return $this;
+    }
+
+
+    /**
+     * @unreleased
+     */
+    public function forms(array $formIds)
+    {
+        $this->whereIn('product_id', $formIds);
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function between($startDate, $endDate)
+    {
+        $this->whereBetween(
+            'created',
+            date('Y-m-d H:i:s', strtotime($startDate)),
+            date('Y-m-d H:i:s', strtotime($endDate))
+        );
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function sumInitialAmount()
+    {
+        return $this->sum('initial_amount');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function countDonors()
+    {
+        return $this->count('DISTINCT customer_id');
+    }
+}


### PR DESCRIPTION
Instead of supporting new repository methods, this PR simplifies the goal data to use the new `DonationQuery` directly.

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I noticed that each update required a check for all-time vs custom and then an additional `*ForDateRange()` method. This instantiates the query and conditionally sets the start/end values.

Each type of value then completes the query.

`GoalType::DONATIONS()` calls `$query->count()`.
`GoalType::DONORS()` calls `$query->countDonors()`.
`GoalType::AMOUNT()` calls `$query->sumIntendedAmount()`.
