### PR TITLE
Feature: Add migration step for Currency Switcher

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -988,7 +988,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getCurrencySwitcherStatus(): string
     {
-        return $this->getMeta('cs_status');
+        return $this->getMeta('cs_status', 'global');
     }
 
     /**
@@ -996,7 +996,15 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getCurrencySwitcherMessage(): string
     {
-        return $this->getMeta('cs_message');
+        return $this->getMeta(
+            'cs_message',
+            sprintf(
+                __('The current exchange rate is 1.00 %1$s equals %2$s %3$s.', 'give-currency-switcher'),
+                '{base_currency}',
+                '{new_currency_rate}',
+                '{new_currency}'
+            )
+        );
     }
 
     /**
@@ -1004,7 +1012,7 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getCurrencySwitcherDefaultCurrency(): string
     {
-        return $this->getMeta('give_cs_default_currency');
+        return $this->getMeta('give_cs_default_currency', '');
     }
 
     /**
@@ -1012,6 +1020,6 @@ class FormMetaDecorator extends FormModelDecorator
      */
     public function getCurrencySwitcherSupportedCurrencies(): array
     {
-        return (array)$this->getMeta('cs_supported_currency');
+        return (array)$this->getMeta('cs_supported_currency', []);
     }
 }

--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -982,4 +982,36 @@ class FormMetaDecorator extends FormModelDecorator
         return ! empty($this->getMeta('give_activecampaign_tags')) ?
             $this->getMeta('give_activecampaign_tags') : $defaultMeta;
     }
+
+    /**
+     * @unreleased
+     */
+    public function getCurrencySwitcherStatus(): string
+    {
+        return $this->getMeta('cs_status');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getCurrencySwitcherMessage(): string
+    {
+        return $this->getMeta('cs_message');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getCurrencySwitcherDefaultCurrency(): string
+    {
+        return $this->getMeta('give_cs_default_currency');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getCurrencySwitcherSupportedCurrencies(): array
+    {
+        return (array)$this->getMeta('cs_supported_currency');
+    }
 }

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -55,6 +55,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Steps\ConvertKit::class,
                 Steps\ActiveCampaign::class,
                 Steps\DoubleTheDonation::class,
+                Steps\CurrencySwitcher::class,
             ]);
         });
     }

--- a/src/FormMigration/Steps/CurrencySwitcher.php
+++ b/src/FormMigration/Steps/CurrencySwitcher.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Give\FormMigration\Steps;
+
+use Give\FormMigration\Contracts\FormMigrationStep;
+
+/**
+ * @unreleased
+ */
+class CurrencySwitcher extends FormMigrationStep
+{
+    /**
+     * @unreleased
+     */
+    public function process()
+    {
+        $status = $this->formV2->getCurrencySwitcherStatus();
+        if (!$status) {
+            return;
+        }
+
+        $currencySwitcherSettings = [];
+        $currencySwitcherSettings['enable'] = $status;
+
+        $message = $this->formV2->getCurrencySwitcherMessage();
+        if ($message) {
+            $currencySwitcherSettings['message'] = $message;
+        }
+
+        $defaultCurrency = $this->formV2->getCurrencySwitcherDefaultCurrency();
+        if ($defaultCurrency) {
+            $currencySwitcherSettings['defaultCurrency'] = $defaultCurrency;
+        }
+
+        $supportedCurrencies = $this->formV2->getCurrencySwitcherSupportedCurrencies();
+        if ($supportedCurrencies) {
+            $currencySwitcherSettings['supportedCurrencies'] = $supportedCurrencies;
+        }
+
+        $this->formV3->settings->currencySwitcherSettings = $currencySwitcherSettings;
+    }
+}

--- a/tests/Feature/FormMigration/Steps/TestCurrencySwitcher.php
+++ b/tests/Feature/FormMigration/Steps/TestCurrencySwitcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Give\Tests\Unit\FormMigration\Steps;
+namespace Feature\FormMigration\Steps;
 
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\V2\Models\DonationForm as V2DonationForm;
@@ -11,7 +11,7 @@ use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
 
-class CurrencySwitcherTest extends TestCase
+class TestCurrencySwitcher extends TestCase
 {
     use RefreshDatabase;
     use LegacyDonationFormAdapter;
@@ -19,7 +19,7 @@ class CurrencySwitcherTest extends TestCase
     /**
      * @unreleased
      */
-    public function testFormWithoutCurrencySwitcherSettingsIsNotMigrated(): void
+    public function testFormWithoutCurrencySwitcherSettingsMigratesUsingGlobalSettings(): void
     {
         // Arrange
         $v2Form = $this->setUpDonationForm();
@@ -29,7 +29,9 @@ class CurrencySwitcherTest extends TestCase
 
         // Assert
         $form = DonationForm::find($v3Form->id);
-        $this->assertEmpty($form->settings->currencySwitcherSettings);
+        $this->assertIsArray($form->settings->currencySwitcherSettings);
+        $this->assertArrayHasKey('enable', $form->settings->currencySwitcherSettings);
+        $this->assertEquals('global', $form->settings->currencySwitcherSettings['enable']);
     }
 
     /**

--- a/tests/Feature/FormMigration/TestFormMetaDecorator.php
+++ b/tests/Feature/FormMigration/TestFormMetaDecorator.php
@@ -12,7 +12,8 @@ use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
  *
  * @covers \Give\FormMigration\FormMetaDecorator
  */
-class TestFormMetaDecorator extends TestCase {
+class TestFormMetaDecorator extends TestCase
+{
     use RefreshDatabase, LegacyDonationFormAdapter;
 
     /**
@@ -20,19 +21,23 @@ class TestFormMetaDecorator extends TestCase {
      */
     public function testIsLastNameRequiredShouldReturnTrue(): void
     {
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_last_name_field_required' => 'required',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_last_name_field_required' => 'required',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
         $this->assertTrue($formMetaDecorator->isLastNameRequired());
 
-        give_update_option( 'last_name_field_required', 'required' );
+        give_update_option('last_name_field_required', 'required');
 
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_last_name_field_required' => 'global',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_last_name_field_required' => 'global',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
@@ -44,19 +49,23 @@ class TestFormMetaDecorator extends TestCase {
      */
     public function testIsLastNameRequiredShouldReturnFalse(): void
     {
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_last_name_field_required' => '',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_last_name_field_required' => '',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
         $this->assertFalse($formMetaDecorator->isLastNameRequired());
 
-        give_update_option( 'last_name_field_required', 'optional' );
+        give_update_option('last_name_field_required', 'optional');
 
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_last_name_field_required' => 'global',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_last_name_field_required' => 'global',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
@@ -68,19 +77,23 @@ class TestFormMetaDecorator extends TestCase {
      */
     public function testIsNameTitlePrefixEnabledShouldReturnTrue(): void
     {
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_name_title_prefix' => 'required',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_name_title_prefix' => 'required',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
         $this->assertTrue($formMetaDecorator->isNameTitlePrefixEnabled());
 
-        give_update_option( 'name_title_prefix', 'required' );
+        give_update_option('name_title_prefix', 'required');
 
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_name_title_prefix' => 'optional',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_name_title_prefix' => 'optional',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
@@ -92,19 +105,23 @@ class TestFormMetaDecorator extends TestCase {
      */
     public function testIsNameTitlePrefixEnabledShouldReturnFalse(): void
     {
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_name_title_prefix' => 'disabled',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_name_title_prefix' => 'disabled',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
         $this->assertFalse($formMetaDecorator->isNameTitlePrefixEnabled());
 
-        give_update_option( 'name_title_prefix', 'optional' );
+        give_update_option('name_title_prefix', 'optional');
 
-        $formV2 = $this->createSimpleDonationForm(['meta' => [
-            '_give_name_title_prefix' => 'disabled',
-        ]]);
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                '_give_name_title_prefix' => 'disabled',
+            ]
+        ]);
 
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
@@ -252,7 +269,7 @@ class TestFormMetaDecorator extends TestCase {
     }
 
     /**
-     * @see https://core.trac.wordpress.org/browser/branches/4.5/tests/phpunit/tests/post/attachments.php#L24
+     * @see   https://core.trac.wordpress.org/browser/branches/4.5/tests/phpunit/tests/post/attachments.php#L24
      *
      * @since 3.5.0
      */
@@ -313,5 +330,103 @@ class TestFormMetaDecorator extends TestCase {
         $formMetaDecorator = new FormMetaDecorator($formV2);
 
         $this->assertTrue($formMetaDecorator->getDoubleTheDonationLabel() === 'DTD Label');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetCurrencySwitcherStatus(): void
+    {
+        $status = 'enabled';
+
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'cs_status' => $status,
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        // Test - Status is present in the form meta
+        $this->assertEquals($status, $formMetaDecorator->getCurrencySwitcherStatus());
+
+        // Test - Status is NOT present in the form meta
+        give_update_meta($formV2->id, 'cs_status', '');
+        $this->assertEquals('global', $formMetaDecorator->getCurrencySwitcherStatus());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetCurrencySwitcherMessage(): void
+    {
+        $message = 'The current exchange rate is 1.00 {base_currency} equals {new_currency_rate} {new_currency}.';
+
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'cs_message' => $message,
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        // Test - Message is present in the form meta
+        $this->assertEquals($message, $formMetaDecorator->getCurrencySwitcherMessage());
+
+        // Test - Message is NOT present in the form meta
+        give_update_meta($formV2->id, 'cs_message', '');
+        $expectedMessage = sprintf(
+            __('The current exchange rate is 1.00 %1$s equals %2$s %3$s.', 'give-currency-switcher'),
+            '{base_currency}',
+            '{new_currency_rate}',
+            '{new_currency}'
+        );
+        $this->assertEquals($expectedMessage, $formMetaDecorator->getCurrencySwitcherMessage());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetCurrencySwitcherDefaultCurrency(): void
+    {
+        $defaultCurrency = 'USD';
+
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'give_cs_default_currency' => $defaultCurrency,
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        // Test - Default currency is present in the form meta
+        $this->assertEquals($defaultCurrency, $formMetaDecorator->getCurrencySwitcherDefaultCurrency());
+
+        // Test - Default currency is NOT present in the form meta
+        give_update_meta($formV2->id, 'give_cs_default_currency', '');
+        $this->assertEquals('', $formMetaDecorator->getCurrencySwitcherDefaultCurrency());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetCurrencySwitcherSupportedCurrencies(): void
+    {
+        $supportedCurrencies = ['USD', 'EUR', 'GBP'];
+
+        $formV2 = $this->createSimpleDonationForm([
+            'meta' => [
+                'cs_supported_currency' => $supportedCurrencies,
+            ],
+        ]);
+
+        $formMetaDecorator = new FormMetaDecorator($formV2);
+
+        // Test - Supported currencies are present in the form meta
+        $this->assertEquals($supportedCurrencies, $formMetaDecorator->getCurrencySwitcherSupportedCurrencies());
+
+        // Test - Supported currencies are NOT present in the form meta
+        give_update_meta($formV2->id, 'cs_supported_currency', []);
+        $this->assertEquals([], $formMetaDecorator->getCurrencySwitcherSupportedCurrencies());
     }
 }

--- a/tests/Unit/FormMigration/Steps/CurrencySwitcherTest.php
+++ b/tests/Unit/FormMigration/Steps/CurrencySwitcherTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Give\Tests\Unit\FormMigration\Steps;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\DonationForms\V2\Models\DonationForm as V2DonationForm;
+use Give\FormMigration\DataTransferObjects\FormMigrationPayload;
+use Give\FormMigration\StepProcessor;
+use Give\FormMigration\Steps\CurrencySwitcher;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
+
+class CurrencySwitcherTest extends TestCase
+{
+    use RefreshDatabase;
+    use LegacyDonationFormAdapter;
+
+    /**
+     * @unreleased
+     */
+    public function testFormWithoutCurrencySwitcherSettingsIsNotMigrated(): void
+    {
+        // Arrange
+        $v2Form = $this->setUpDonationForm();
+
+        // Act
+        $v3Form = $this->migrateForm($v2Form);
+
+        // Assert
+        $form = DonationForm::find($v3Form->id);
+        $this->assertEmpty($form->settings->currencySwitcherSettings);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testFormConfiguredToUseGlobalCurrencySwitcherSettingsIsMigrated(): void
+    {
+        // Arrange
+        $attributes = [
+            'cs_status' => 'global',
+        ];
+        $v2Form = $this->setUpDonationForm($attributes);
+
+        // Act
+        $v3Form = $this->migrateForm($v2Form);
+
+        // Assert
+        $form = DonationForm::find($v3Form->id);
+        $this->assertIsArray($form->settings->currencySwitcherSettings);
+        $this->assertArrayHasKey('enable', $form->settings->currencySwitcherSettings);
+        $this->assertEquals('global', $form->settings->currencySwitcherSettings['enable']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testFormConfiguredToDisableCurrencySwitcherIsMigrated(): void
+    {
+        // Arrange
+        $attributes = [
+            'cs_status' => 'disabled',
+        ];
+        $v2Form = $this->setUpDonationForm($attributes);
+
+        // Act
+        $v3Form = $this->migrateForm($v2Form);
+
+        // Assert
+        $form = DonationForm::find($v3Form->id);
+        $this->assertIsArray($form->settings->currencySwitcherSettings);
+        $this->assertArrayHasKey('enable', $form->settings->currencySwitcherSettings);
+        $this->assertEquals('disabled', $form->settings->currencySwitcherSettings['enable']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testFormConfiguredToUseLocalCurrencySwitcherIsMigrated(): void
+    {
+        // Arrange
+        $attributes = [
+            'cs_status' => 'enabled',
+            'cs_message' => 'Testing message',
+            'give_cs_default_currency' => 'USD',
+            'cs_supported_currency' => ['USD', 'EUR'],
+        ];
+        $v2Form = $this->setUpDonationForm($attributes);
+
+        // Act
+        $v3Form = $this->migrateForm($v2Form);
+
+        // Assert
+        $form = DonationForm::find($v3Form->id);
+        $settings = $form->settings->currencySwitcherSettings;
+
+        $this->assertArrayHasKey('enable', $settings);
+        $this->assertEquals('enabled', $settings['enable']);
+        $this->assertArrayHasKey('message', $settings);
+        $this->assertEquals('Testing message', $settings['message']);
+        $this->assertArrayHasKey('defaultCurrency', $settings);
+        $this->assertEquals('USD', $settings['defaultCurrency']);
+        $this->assertArrayHasKey('supportedCurrencies', $settings);
+        $this->assertEquals(['USD', 'EUR'], $settings['supportedCurrencies']);
+    }
+
+    /**
+     * Sets up and returns a v2 donation form configured with the
+     * given attributes being set to the Currency Switcher settings.
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    private function setUpDonationForm(array $attributes = []): V2DonationForm
+    {
+        $form = $this->createSimpleDonationForm();
+
+        foreach ($attributes as $key => $value) {
+            give_update_meta($form->id, $key, $value);
+        }
+
+        return $form;
+    }
+
+    /**
+     * @unreleased
+     */
+    private function migrateForm(V2DonationForm $form): DonationForm
+    {
+        $payload = FormMigrationPayload::fromFormV2($form);
+        $processor = new StepProcessor($payload);
+        $processor(new CurrencySwitcher($payload));
+        $payload->formV3->save();
+
+        return $payload->formV3;
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-679]

## Description
This pull request adds a new FormMigration step that migrates Currency Switcher settings from v2 forms to v3.

## Affects
Form Migration

## Testing Instructions
1. Create a v2 form
2. Customize Currency Switcher settings
3. Migrate that form to v3
4. Ensure the settings have been migrated properly

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-679]: https://stellarwp.atlassian.net/browse/GIVE-679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ