### PR TITLE
Fix: throw error message instead of the error object when submitting an donation made with Stripe Element gateway

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -8,6 +8,8 @@ import {
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js';
 import {applyFilters} from '@wordpress/hooks';
 import type {Gateway, GatewaySettings} from '@givewp/forms/types';
+import {Simulate} from 'react-dom/test-utils';
+import {__, sprintf} from '@wordpress/i18n';
 
 let stripePromise = null;
 let stripePaymentMethod = null;
@@ -119,7 +121,13 @@ const stripePaymentElementGateway: StripeGateway = {
         const {error: submitError} = await this.elements.submit();
 
         if (submitError) {
-            throw new Error(submitError);
+            throw new Error(
+                sprintf(
+                    __('Invalid Payment Data. Error Details: %s (code: %s)', 'give'),
+                    submitError.message,
+                    submitError.code
+                )
+            );
         }
 
         return {

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -8,7 +8,6 @@ import {
 import {Elements, PaymentElement, useElements, useStripe} from '@stripe/react-stripe-js';
 import {applyFilters} from '@wordpress/hooks';
 import type {Gateway, GatewaySettings} from '@givewp/forms/types';
-import {Simulate} from 'react-dom/test-utils';
 import {__, sprintf} from '@wordpress/i18n';
 
 let stripePromise = null;
@@ -121,13 +120,21 @@ const stripePaymentElementGateway: StripeGateway = {
         const {error: submitError} = await this.elements.submit();
 
         if (submitError) {
-            throw new Error(
-                sprintf(
+            let errorMessage = __('Invalid Payment Data.', 'give');
+
+            if (typeof submitError === 'string') {
+                errorMessage = sprintf(__('Invalid Payment Data. Error Details: %s', 'give'), submitError);
+            }
+
+            if (submitError.hasOwnProperty('code') && submitError.hasOwnProperty('message')) {
+                errorMessage = sprintf(
                     __('Invalid Payment Data. Error Details: %s (code: %s)', 'give'),
                     submitError.message,
                     submitError.code
-                )
-            );
+                );
+            }
+
+            throw new Error(errorMessage);
         }
 
         return {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-345]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes the error message that was being displayed in certain cases as `[object Object]` when a donation made with Stripe Element gateway was submitted. Now we are displaying a proper string to indicate the error instead of an object.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Stripe Element gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/16308864/38a9b06a-3169-49ed-8635-9ade5ffb1d58)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**Credit Card:**

1. Create a donation and miss any of CC #, expiry, or CVV and press Donate;
2. The new friendly error message will show above the Donate button.

**Google Pay:**

1. Enable Google Pay in your Stripe Dashboard;
2. Create a donation and press Donate, a modal should be opened;
3. Close the Google modal;
4. The new friendly error message will show above the Donate button.

To set up Google Pay in your Chrome for Desktop, check out this link: https://givewp.com/documentation/add-ons/stripe-gateway/stripe-apple-pay-google-pay/

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-345]: https://stellarwp.atlassian.net/browse/GIVE-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ