### PR TITLE
refactor: ensure global setting links open in a new tab

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -139,7 +139,11 @@ export default function Edit({
                                                 }}
                                             >
                                                 {__(' Go to the settings to change the ')}
-                                                <a href="/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=display-settings">
+                                                <a
+                                                    href="/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=display-settings"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                >
                                                     {__('global Title Prefixes options.')}
                                                 </a>
                                             </p>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -144,7 +144,7 @@ export default function Edit({
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                 >
-                                                    {__('global Title Prefixes options.')}
+                                                    {__('Global Title Prefixes options.')}
                                                 </a>
                                             </p>
                                         )}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/GlobalSettingsLink.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/GlobalSettingsLink.tsx
@@ -17,7 +17,7 @@ export default function GlobalSettingsLink({href}: GlobalSettingsLinkProps) {
         >
             {__(' Go to the settings to change the ')}
             <a href={href} target="_blank" rel="noopener noreferrer">
-                {__('global Label and Text options.')}
+                {__('Global Label and Text options.')}
             </a>
         </p>
     );

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/GlobalSettingsLink.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/terms-and-conditions/GlobalSettingsLink.tsx
@@ -16,7 +16,9 @@ export default function GlobalSettingsLink({href}: GlobalSettingsLinkProps) {
             }}
         >
             {__(' Go to the settings to change the ')}
-            <a href={href}>{__('global Label and Text options.')}</a>
+            <a href={href} target="_blank" rel="noopener noreferrer">
+                {__('global Label and Text options.')}
+            </a>
         </p>
     );
 }


### PR DESCRIPTION
Resolves: [GIVE-813]

## Description
Some v3 block settings have the option to use global settings for the block. When global settings have been chosen, a link that navigates the user to the blocks settings page is shown. clicking this link can be frustrating if you are editing a form as it will navigate you from the builder to the settings page & you will lose any changes in progress.

The terms & conditions block + the donor name block both have this global setting link. This PR updates the anchor tags target and rel attributes to ensure they open the settings in a new tab. We also update the text within the link to capitalize the g in Global. 

## Affects
Donor Name Block
Terms & Conditions Block

## Visuals
https://www.loom.com/share/197392b48ef341ae81b0f0535b18461c?sid=9af685c8-f528-43ee-a32c-a6f5f9653e12

## Testing Instructions
- Create a v3 form
- Add the Terms & Conditions Block
- Select the Terms & Conditions Block from the Build settings
- Toggle the first setting
- Click the link under the global settings selector from within the right sidebar
- Verify it opens the global settings page in a new tab
- Repeat steps with the Donor Name Block

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-813]: https://stellarwp.atlassian.net/browse/GIVE-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ