### PR TITLE
refactor: include element focus color in base-overrides

### DIFF
--- a/src/DonationForms/resources/styles/_base-overrides.scss
+++ b/src/DonationForms/resources/styles/_base-overrides.scss
@@ -84,5 +84,6 @@ input[type="email"],
 textarea {
     &:focus {
         border-color: transparent;
+        --box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color);
     }
 }


### PR DESCRIPTION
Resolves: [GIVE-815]

## Description
The Donor Comment Block had a slightly different `::focus` color around its border when selected. When it should reflect the primary color of the form. The reason for the incorrect color was from a style implemented in the Pico base styles which was overriding its box shadow. To address this I've included the --box-shadow variable required in our base-overrides to ensure the proper color is being used across all forms with high priority.

## Affects
Donor Comment Block
Text fields
Base styles

## Visuals
<img width="1996" alt="twopanel" src="https://github.com/impress-org/givewp/assets/75056371/d9f43c80-731d-4cc4-b96c-15f60da1a669">
<img width="1996" alt="multistep" src="https://github.com/impress-org/givewp/assets/75056371/6c814773-79a9-425b-a085-3b01e0825357">
<img width="1996" alt="classic" src="https://github.com/impress-org/givewp/assets/75056371/d78a5b54-6059-409a-ad6e-b8cd55d94488">


## Testing Instructions
- Add the donor comment block and click to focus the element.
- The ::focus border should reflect the primary color, just as the other text fields.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-815]: https://stellarwp.atlassian.net/browse/GIVE-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ