### PR TITLE
Fix: make blocks and shortcodes display the right collected amount and make queries considering the proper donation statuses and mode

### DIFF
--- a/includes/admin/forms/dashboard-columns.php
+++ b/includes/admin/forms/dashboard-columns.php
@@ -168,6 +168,7 @@ add_filter( 'manage_edit-give_forms_sortable_columns', 'give_sortable_form_colum
 /**
  * Sorts Columns in the Forms List Table
  *
+ * @unreleased Use the 'give_donate_form_get_sales" filter to ensure the correct donation count will be used
  * @since 1.0
  *
  * @param array $vars Array of all the sort variables.
@@ -179,6 +180,10 @@ function give_sort_forms( $vars ) {
 	if ( ! isset( $vars['post_type'] ) || ! isset( $vars['orderby'] ) || 'give_forms' !== $vars['post_type'] ) {
 		return $vars;
 	}
+
+    add_filter('give_donate_form_get_sales', function ($sales, $donationFormId) {
+        return (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$donationFormId]]))->getDonationCount();
+    }, 10, 2);
 
 	switch ( $vars['orderby'] ) {
 		// Check if 'orderby' is set to "sales".

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -952,8 +952,10 @@ class Give_Donate_Form {
 			}
 		}
 
-		return $this->sales;
-
+        /**
+        * @unreleased
+        */
+		return apply_filters('give_donate_form_get_sales', $this->sales, $this->ID);
 	}
 
 	/**

--- a/includes/forms/functions.php
+++ b/includes/forms/functions.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Give\DonationForms\DonationQuery;
 use Give\Helpers\Form\Utils as FormUtils;
 
 /**
@@ -1248,15 +1249,19 @@ function give_set_form_closed_status( $form_id ) {
 /**
  * Show Form Goal Stats in Admin ( Listing and Detail page )
  *
+ * @unreleased Use the 'give_get_form_earnings_stats" filter to ensure the correct value will be displayed in the form  progress bar
  * @since 2.19.0 Prevent divide by zero issue in goal percentage calculation logic.
  *
- * @param int $form_id Form ID.
- *
  * @since 2.1.0
+ *
+ * @param int $form_id Form ID.
  *
  * @return string
  */
 function give_admin_form_goal_stats( $form_id ) {
+    add_filter('give_get_form_earnings_stats', function ($earnings, $donationFormId) {
+        return (new DonationQuery())->form($donationFormId)->sumAmount();
+    }, 10, 2);
 
 	$html             = '';
 	$goal_stats       = give_goal_progress_stats( $form_id );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1943,7 +1943,7 @@ function give_goal_progress_stats( $form ) {
 
 	/**
 	 * Filter the form.
-	 * @unreleased Replace "$form->earnings" with $query->form($post)->sumIntendedAmount()
+	 * @unreleased Replace "$form->earnings" with (new DonationQuery())->form($form->ID)->sumIntendedAmount()
 	 * @since 1.8.8
 	 */
 	$total_goal = apply_filters( 'give_goal_amount_target_output', round( give_maybe_sanitize_amount( $form->goal ), 2 ), $form->ID, $form );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -10,7 +10,7 @@
  */
 
 // Exit if accessed directly.
-use Give\License\PremiumAddonsListManager;
+use Give\DonationForms\DonationQuery;use Give\License\PremiumAddonsListManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -1942,7 +1942,7 @@ function give_goal_progress_stats( $form ) {
 
 	/**
 	 * Filter the form.
-	 *
+	 * @unreleased Replace "$form->earnings" with $query->form($post)->sumIntendedAmount()
 	 * @since 1.8.8
 	 */
 	$total_goal = apply_filters( 'give_goal_amount_target_output', round( give_maybe_sanitize_amount( $form->goal ), 2 ), $form->ID, $form );
@@ -1975,7 +1975,7 @@ function give_goal_progress_stats( $form ) {
 			 *
 			 * @since 1.8.8
 			 */
-			$actual = apply_filters( 'give_goal_amount_raised_output', $form->earnings, $form->ID, $form );
+			$actual = apply_filters( 'give_goal_amount_raised_output', (new DonationQuery())->form($form->ID)->sumIntendedAmount(), $form->ID, $form );
 			break;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -10,7 +10,8 @@
  */
 
 // Exit if accessed directly.
-use Give\DonationForms\DonationQuery;use Give\License\PremiumAddonsListManager;
+use Give\DonationForms\DonationQuery;
+use Give\License\PremiumAddonsListManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -10,7 +10,7 @@
  */
 
 // Exit if accessed directly.
-use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\DonationForms\DonationQuery;use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Frontend\ConfirmDonation;
 use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;
@@ -629,6 +629,7 @@ add_action( 'give_edit_user_profile', 'give_process_profile_editor_updates' );
  *
  * Shows a donation total.
  *
+ * @unreleased Replace "_give_form_earnings" form meta with $query->form($post)->sumAmount()
  * @since 3.7.0 Sanitize attributes
  * @since  2.1
  *
@@ -737,8 +738,9 @@ function give_totals_shortcode( $atts ) {
 
 		if ( isset( $forms->posts ) ) {
 			$total = 0;
+            $query = new DonationQuery();
 			foreach ( $forms->posts as $post ) {
-				$form_earning = give_get_meta( $post, '_give_form_earnings', true );
+				$form_earning = $query->form($post)->sumAmount();
 				$form_earning = ! empty( $form_earning ) ? $form_earning : 0;
 
 				/**

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -10,7 +10,8 @@
  */
 
 // Exit if accessed directly.
-use Give\DonationForms\DonationQuery;use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
+use Give\DonationForms\DonationQuery;
+use Give\Helpers\Form\Template\Utils\Frontend as FrontendFormTemplateUtils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Helpers\Frontend\ConfirmDonation;
 use Give\Helpers\Frontend\Shortcode as ShortcodeUtils;

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -124,7 +124,7 @@ class DonationQuery extends QueryBuilder
         $this->joinMeta('_give_payment_total', 'amount');
         $this->joinMeta('_give_fee_donation_amount', 'intendedAmount');
         return $this->sum(
-            'COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0))'
+            'COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)'
         );
     }
 
@@ -143,7 +143,7 @@ class DonationQuery extends QueryBuilder
         if ($includeOnlyCurrentMode) {
             $this->includeOnlyCurrentMode();
         }
-        
+
         $this->joinMeta('_give_payment_total', 'amount');
 
         return $this->sum(

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -85,6 +85,8 @@ class DonationQuery extends QueryBuilder
 
     /**
      * Returns a calculated sum of the intended amounts (without recovered fees) for the donations.
+     *
+     * @unreleased Use the NULLIF function to prevent zero values and consider the donation mode (test or live) instead of summing both modes together
      * @since 3.12.0
      * @return int|float
      */
@@ -92,8 +94,10 @@ class DonationQuery extends QueryBuilder
     {
         $this->joinMeta('_give_payment_total', 'amount');
         $this->joinMeta('_give_fee_donation_amount', 'intendedAmount');
+        $this->joinMeta('_give_payment_mode', 'paymentMode');
+        $this->where('paymentMode.meta_value', give_is_test_mode() ? 'test' : 'live');
         return $this->sum(
-            'COALESCE(intendedAmount.meta_value, amount.meta_value)'
+            'COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0))'
         );
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -31,7 +31,7 @@ class DonationQuery extends QueryBuilder
      * An opinionated join method for the donation meta table.
      * @since 3.12.0
      */
-    public function joinMeta($key, $alias)
+    public function joinMeta($key, $alias): DonationQuery
     {
         $this->join(function (JoinQueryBuilder $builder) use ($key, $alias) {
             $builder
@@ -58,7 +58,7 @@ class DonationQuery extends QueryBuilder
      * An opinionated where method for the multiple donation form IDs meta field.
      * @since 3.12.0
      */
-    public function forms(array $formIds)
+    public function forms(array $formIds): DonationQuery
     {
         $this->joinMeta('_give_payment_form_id', 'formId');
         $this->whereIn('formId.meta_value', $formIds);
@@ -69,7 +69,7 @@ class DonationQuery extends QueryBuilder
      * An opinionated whereBetween method for the completed date meta field.
      * @since 3.12.0
      */
-    public function between($startDate, $endDate)
+    public function between($startDate, $endDate): DonationQuery
     {
         // If the dates are empty or invalid, they will fallback to January 1st, 1970.
         // For the start date, this is exactly what we need, but for the end date, we should set it as the current date so that we have a correct date range.
@@ -86,7 +86,7 @@ class DonationQuery extends QueryBuilder
     /**
      * @unreleased
      */
-    public function includeOnlyValidStatuses()
+    public function includeOnlyValidStatuses(): DonationQuery
     {
         $this->whereIn('donation.post_status', ['publish', 'give_subscription']);
 
@@ -96,7 +96,7 @@ class DonationQuery extends QueryBuilder
     /**
      * @unreleased
      */
-    public function includeOnlyCurrentMode()
+    public function includeOnlyCurrentMode(): DonationQuery
     {
         $this->joinMeta('_give_payment_mode', 'paymentMode');
         $this->where('paymentMode.meta_value', give_is_test_mode() ? 'test' : 'live');
@@ -111,10 +111,16 @@ class DonationQuery extends QueryBuilder
      * @since 3.12.0
      * @return int|float
      */
-    public function sumIntendedAmount()
+    public function sumIntendedAmount($includeOnlyValidStatuses = true, $includeOnlyCurrentMode = true)
     {
-        $this->includeOnlyValidStatuses();
-        $this->includeOnlyCurrentMode();
+        if ($includeOnlyValidStatuses) {
+            $this->includeOnlyValidStatuses();
+        }
+
+        if ($includeOnlyCurrentMode) {
+            $this->includeOnlyCurrentMode();
+        }
+
         $this->joinMeta('_give_payment_total', 'amount');
         $this->joinMeta('_give_fee_donation_amount', 'intendedAmount');
         return $this->sum(
@@ -128,10 +134,16 @@ class DonationQuery extends QueryBuilder
      * @unreleased
      * @return int|float
      */
-    public function sumAmount()
+    public function sumAmount($includeOnlyValidStatuses = true, $includeOnlyCurrentMode = true)
     {
-        $this->includeOnlyValidStatuses();
-        $this->includeOnlyCurrentMode();
+        if ($includeOnlyValidStatuses) {
+            $this->includeOnlyValidStatuses();
+        }
+
+        if ($includeOnlyCurrentMode) {
+            $this->includeOnlyCurrentMode();
+        }
+        
         $this->joinMeta('_give_payment_total', 'amount');
 
         return $this->sum(

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -20,12 +20,13 @@ use Give\Framework\QueryBuilder\QueryBuilder;
 class DonationQuery extends QueryBuilder
 {
     /**
-     * @unreleased Consider the donation mode (test or live) instead of querying both modes together
+     * @unreleased Consider the donation status ('publish' or 'give_subscription') and the donation mode (test or live) instead of querying both modes together
      * @since 3.12.0
      */
     public function __construct()
     {
         $this->from('posts', 'donation');
+        $this->whereIn('donation.post_status', ['publish', 'give_subscription']);
         $this->joinMeta('_give_payment_mode', 'paymentMode');
         $this->where('paymentMode.meta_value', give_is_test_mode() ? 'test' : 'live');
     }

--- a/src/DonationForms/V2/ListTable/Columns/DonationCountColumn.php
+++ b/src/DonationForms/V2/ListTable/Columns/DonationCountColumn.php
@@ -6,6 +6,7 @@ namespace Give\DonationForms\V2\ListTable\Columns;
 
 use Give\DonationForms\V2\Models\DonationForm;
 use Give\Framework\ListTable\ModelColumn;
+use Give\MultiFormGoals\ProgressBar\Model as ProgressBarModel;
 
 /**
  * @since 2.24.0
@@ -38,6 +39,7 @@ class DonationCountColumn extends ModelColumn
     }
 
     /**
+     * @unreleased Use the 'getDonationCount()" method from progress bar model to ensure the correct donation count will be used
      * @since 2.24.0
      *
      * @inheritDoc
@@ -46,7 +48,7 @@ class DonationCountColumn extends ModelColumn
      */
     public function getCellValue($model): string
     {
-        $totalDonations = $model->totalNumberOfDonations;
+        $totalDonations = (new ProgressBarModel(['ids' => [$model->id]]))->getDonationCount();
 
         $label = $totalDonations > 0
             ? sprintf(

--- a/src/DonationForms/V2/ListTable/Columns/GoalColumn.php
+++ b/src/DonationForms/V2/ListTable/Columns/GoalColumn.php
@@ -36,6 +36,7 @@ class GoalColumn extends ModelColumn
     }
 
     /**
+     * @unreleased Use the 'give_get_form_earnings_stats" filter to ensure the correct value will be displayed in the form  progress bar
      * @since 2.24.0
      *
      * @inheritDoc
@@ -48,9 +49,6 @@ class GoalColumn extends ModelColumn
             return __('No Goal Set', 'give');
         }
 
-        /**
-         * @unreleased
-         */
         add_filter('give_get_form_earnings_stats', function ($earnings, $donationFormId) {
             return (new DonationQuery())->form($donationFormId)->sumAmount();
         }, 10, 2);

--- a/src/DonationForms/V2/ListTable/Columns/GoalColumn.php
+++ b/src/DonationForms/V2/ListTable/Columns/GoalColumn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Give\DonationForms\V2\ListTable\Columns;
 
+use Give\DonationForms\DonationQuery;
 use Give\DonationForms\V2\Models\DonationForm;
 use Give\Framework\ListTable\ModelColumn;
 
@@ -46,6 +47,13 @@ class GoalColumn extends ModelColumn
         if ( ! $model->goalOption) {
             return __('No Goal Set', 'give');
         }
+
+        /**
+         * @unreleased
+         */
+        add_filter('give_get_form_earnings_stats', function ($earnings, $donationFormId) {
+            return (new DonationQuery())->form($donationFormId)->sumAmount();
+        }, 10, 2);
 
         $goal = give_goal_progress_stats($model->id);
         $goalPercentage = ('percentage' === $goal['format']) ? str_replace('%', '',

--- a/src/MultiFormGoals/ProgressBar/Query.php
+++ b/src/MultiFormGoals/ProgressBar/Query.php
@@ -29,12 +29,13 @@ class Query
     }
 
     /**
+     * @unreleased Consider the donation mode (test or live) instead of querying both modes together
      * @return string
      */
     public function getSQL()
     {
         global $wpdb;
-
+        $mode = give_is_test_mode() ? 'test' : 'live';
         $sql = "
             SELECT
                 sum( revenue.amount ) as total,
@@ -42,10 +43,14 @@ class Query
             FROM {$wpdb->posts} as payment
                 JOIN {$wpdb->give_revenue} as revenue
                     ON revenue.donation_id = payment.ID
+                JOIN {$wpdb->paymentmeta} paymentMode
+                    ON payment.ID = paymentMode.donation_id AND paymentMode.meta_key = '_give_payment_mode'
             WHERE
                 payment.post_type = 'give_payment'
                 AND
                 payment.post_status IN ( 'publish', 'give_subscription' )
+                AND
+                paymentMode.meta_value = '{$mode}'
         ";
 
         if ( ! empty($this->formIDs)) {

--- a/src/Views/Form/Templates/Sequoia/sections/income-stats.php
+++ b/src/Views/Form/Templates/Sequoia/sections/income-stats.php
@@ -3,6 +3,13 @@
 /**
  * @var int $formId
  */
+
+use Give\DonationForms\DonationQuery;
+use Give\MultiFormGoals\ProgressBar\Model as ProgressBarModal;
+
+/**
+ * @unreleased Use sumIntendedAmount() and getDonationCount() methods to retrieve the proper values for the raised amount and donations count
+ */
 if ($form->has_goal()) : ?>
     <?php
     $goalStats = give_goal_progress_stats($formId);
@@ -10,7 +17,7 @@ if ($form->has_goal()) : ?>
     // Setup default raised value
     $raised = give_currency_filter(
         give_format_amount(
-            $form->get_earnings(),
+            (new DonationQuery())->form($formId)->sumIntendedAmount(),
             [
                 'sanitize' => false,
                 'decimal' => false,
@@ -19,7 +26,7 @@ if ($form->has_goal()) : ?>
     );
 
     // Setup default count value
-    $count = $form->get_sales();
+    $count = (new ProgressBarModal(['ids' => [$formId]]))->getDonationCount();;
 
     // Setup default count label
     $countLabel = _n('donation', 'donations', $count, 'give');

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -261,7 +261,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 $goal = $shortcode_stats['goal'];
 
                 /**
-                 * @unreleased
+                 * @unreleased Use the 'give_donate_form_get_sales" filter to ensure the correct donation count will be used
                  */
                 add_filter('give_donate_form_get_sales', function ($sales, $donationFormId) {
                     return (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$donationFormId]]))->getDonationCount();

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -244,7 +244,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 $color = $atts['progress_bar_color'];
                 $show_goal = isset($atts['show_goal']) ? filter_var($atts['show_goal'], FILTER_VALIDATE_BOOLEAN) : true;
                 /**
-                 * @unreleased Replace "$form->get_earnings()" with $query->form($post)->sumIntendedAmount()
+                 * @unreleased Replace "$form->get_earnings()" with (new DonationQuery())->form($form->ID)->sumIntendedAmount()
                  */
                 $shortcode_stats = apply_filters(
                     'give_goal_shortcode_stats',

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -263,8 +263,8 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 /**
                  * @unreleased
                  */
-                add_filter('give_donate_form_get_sales', function ($sales, $donationForm) {
-                    return (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$donationForm]]))->getDonationCount();
+                add_filter('give_donate_form_get_sales', function ($sales, $donationFormId) {
+                    return (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$donationFormId]]))->getDonationCount();
                 }, 10, 2);
 
                 switch ($goal_format) {

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -260,6 +260,13 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 $income = $shortcode_stats['income'];
                 $goal = $shortcode_stats['goal'];
 
+                /**
+                 * @unreleased
+                 */
+                add_filter('give_donate_form_get_sales', function ($sales, $donationForm) {
+                    return (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$donationForm]]))->getDonationCount();
+                }, 10, 2);
+
                 switch ($goal_format) {
                     case 'donation':
                         $progress = $goal ? round(($form->get_sales() / $goal) * 100, 2) : 0;
@@ -456,10 +463,7 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                         <div class="form-grid-raised__details">
                             <span class="amount form-grid-raised__details_donations">
                                 <?php
-                                /**
-                                 * @unreleased Replace $form->get_sales with (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$form->ID]]))->getDonationCount()
-                                 */
-                                echo (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$form->ID]]))->getDonationCount() ?>
+                                echo $form->get_sales() ?>
                             </span>
                             <span class="goal">
                                 <?php

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -456,7 +456,10 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                         <div class="form-grid-raised__details">
                             <span class="amount form-grid-raised__details_donations">
                                 <?php
-                                echo give_format_amount($form->get_sales(), ['decimal' => false]) ?>
+                                /**
+                                 * @unreleased Replace $form->get_sales with (new Give\MultiFormGoals\ProgressBar\Model(['id' => $form_id]))->getDonationCount()
+                                 */
+                                echo (new Give\MultiFormGoals\ProgressBar\Model(['id' => $form_id]))->getDonationCount() ?>
                             </span>
                             <span class="goal">
                                 <?php

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -457,9 +457,9 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                             <span class="amount form-grid-raised__details_donations">
                                 <?php
                                 /**
-                                 * @unreleased Replace $form->get_sales with (new Give\MultiFormGoals\ProgressBar\Model(['id' => $form_id]))->getDonationCount()
+                                 * @unreleased Replace $form->get_sales with (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$form->ID]]))->getDonationCount()
                                  */
-                                echo (new Give\MultiFormGoals\ProgressBar\Model(['id' => $form_id]))->getDonationCount() ?>
+                                echo (new Give\MultiFormGoals\ProgressBar\Model(['ids' => [$form->ID]]))->getDonationCount() ?>
                             </span>
                             <span class="goal">
                                 <?php

--- a/templates/shortcode-form-grid.php
+++ b/templates/shortcode-form-grid.php
@@ -4,6 +4,7 @@
  */
 
 // Exit if accessed directly.
+use Give\DonationForms\DonationQuery;
 use Give\Helpers\Form\Template;
 use Give\Helpers\Form\Utils as FormUtils;
 
@@ -242,10 +243,13 @@ $renderTags = static function ($wrapper_class, $apply_styles = true) use ($form_
                 $goal_format = $goal_progress_stats['format'];
                 $color = $atts['progress_bar_color'];
                 $show_goal = isset($atts['show_goal']) ? filter_var($atts['show_goal'], FILTER_VALIDATE_BOOLEAN) : true;
+                /**
+                 * @unreleased Replace "$form->get_earnings()" with $query->form($post)->sumIntendedAmount()
+                 */
                 $shortcode_stats = apply_filters(
                     'give_goal_shortcode_stats',
                     [
-                        'income' => $form->get_earnings(),
+                        'income' => (new DonationQuery())->form($form->ID)->sumIntendedAmount(),
                         'goal' => $goal_progress_stats['raw_goal'],
                     ],
                     $form_id,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-876]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes two bugs related to the `[give_totals]` and `[give_goal]` Shortcodes, and the **Multi-Form Goal** and **Donation Form Grid** blocks. 

The first bug was making these shortcodes and blocks display the wrong total amount collected and/or the donations count because the query had a problem related to how we are retrieving the information from DB - more details in the video linked in the _"Visuals"_ section. Now we are querying the the data properly.

The second bug also was related to how we were querying the donations, we were querying donations without checking the status (that should be 'publish' or 'give_subscription') and using both modes (test and live) together instead of considering only the current site mode. Now we are considering the allowed status and the current site mode when querying the form goal progress and counting the donations associated with that form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `[give_totals]` and `[give_goal]` Shortcodes, and the **Multi-Form Goal** and **Donation Form Grid** blocks. 

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Demo video:** https://www.loom.com/share/700debe450084bfa9d9d1d059df4492d?sid=6ad08b5e-e4af-4c58-985f-fb4e317e8f51

Sample of the total amount being reflected in all shortcodes and blocks:

![image](https://github.com/impress-org/givewp/assets/16308864/2ed99128-6228-46c3-9549-dbe757e6de79)

![image](https://github.com/impress-org/givewp/assets/16308864/09da6ef0-f9c0-4c1a-a4b4-1b3c2314ab0d)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a new form with the goals feature enabled;
2. Create a new page and add the `[give_totals ids="your-form-ID" message="Thanks to you, we’ve raised {total} across all our congregations combined! Let's keep it up!" progress_bar="true"]` and `[give_goal id="your-form-ID"]` shortcodes, and the **Multi-Form Goal** and **Donation Form Grid** blocks;
3. Create a few donations using the **test** mode and make sure the values displayed in the shortcodes and blocks reflect the donation total donation amount;
4. Change the status of some of the donations created in the previous step to Pending or Failed;
5. Refresh the page with the shortcodes and blocks and make sure the values are properly updated;
6. Ensure the form list table with a goal bar progress also displays the expected values.
7. Create a new donation, but now using the **live** mode;
8. Switch back to the **test** mode, refresh the pages with shortcodes and blocks again, and make sure the donation created in the previous step wasn't included there. 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-876]: https://stellarwp.atlassian.net/browse/GIVE-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ