### PR TITLE
refactor: improve the styling of the anonymous donation checkbox description

### DIFF
--- a/src/DonationForms/resources/styles/elements/_fields.scss
+++ b/src/DonationForms/resources/styles/elements/_fields.scss
@@ -5,7 +5,7 @@
 
     &-anonymous {
         .givewp-fields__description{
-            margin-left: 1.8rem;
+            margin-left: 1.78rem;
         }
     }
 }

--- a/src/DonationForms/resources/styles/elements/_fields.scss
+++ b/src/DonationForms/resources/styles/elements/_fields.scss
@@ -1,6 +1,12 @@
-.givewp-fields-checkbox {
+.givewp-fields-checkbox  {
     &__description {
         margin-left: calc(1.25em + 0.375em);
+    }
+
+    &-anonymous {
+        .givewp-fields__description{
+            margin-left: 1.8rem;
+        }
     }
 }
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -2,7 +2,8 @@
     .components-checkbox-control__label {
         font-size: 1rem;
         font-weight: 500;
-        color: var(--givewp-grey-700);
+        line-height: 24px;
+        color: var(--givewp-gray-100);
     }
 
     .components-base-control__help {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -4,4 +4,9 @@
         font-weight: 500;
         color: var(--givewp-grey-700);
     }
+
+    .components-base-control__help {
+        margin-left: 2rem;
+        color: var(--givewp-grey-700);
+    }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -7,6 +7,7 @@
 
     .components-base-control__help {
         margin-left: 2rem;
+        font-size: 0.875rem;
         color: var(--givewp-grey-700);
     }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -8,6 +8,7 @@
     .components-base-control__help {
         margin-left: 2rem;
         font-size: 0.875rem;
+        line-height: 1rem;
         color: var(--givewp-grey-700);
     }
 }


### PR DESCRIPTION
Resolves: [GIVE-814]

## Description
This PR introduces style changes to align the description of the anonymous donation checkbox with its label. I've also updated the color and size to match between the Build & Design previews.

## Affects
Anonymous Donation Checkbox

## Visuals
### Previous view:
![previous](https://github.com/impress-org/givewp/assets/75056371/9dece387-d93a-48bc-8b04-a4d0c1c45f9b)

### Updated view:
<img width="1999" alt="build" src="https://github.com/impress-org/givewp/assets/75056371/0571a0a4-c71f-4da3-8372-61f27e698e12">

<img width="1999" alt="design" src="https://github.com/impress-org/givewp/assets/75056371/7719f413-916d-4b03-8b2f-807d37da7230">


## Testing Instructions
- add an anonymous donation checkbox to a v3 form.
- check both build & design previews to verify that the bottom description is now aligned with the top label.
  
## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-814]: https://stellarwp.atlassian.net/browse/GIVE-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ