### PR TITLE
Fix: improve block insertion point indicator's position when inserting from the block menu

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/styles.scss
@@ -15,3 +15,9 @@
         }
     }
 }
+
+.block-editor-block-popover__inbetween-container{
+    position: relative;
+    top: .5rem;
+    height: 100%;
+}


### PR DESCRIPTION
Resolves [GIVE-537]

## Description
This Main purpose of this PR is to address an issue where the block insertion point indicator is inside of a block.
![block-placement-indicator](https://github.com/impress-org/givewp/assets/75056371/c4681e9a-e369-410f-861f-939065de2b5c)

## Affects
Block Preview in VFB forms
## Visuals

https://github.com/impress-org/givewp/assets/75056371/74356445-1c3b-4318-9426-e8fd6ef1db5a

## Testing Instructions.
- On the build preview select some blocks in the visual form builder.
- Open the left sidebar block inserter menu.
- Hover over a block in the menu.
- Verify the insertion indicator does not display inside of any block.
- Should be tested on the last 3 versions of WordPress, be sure to try all the blocks in the preview.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-537]: https://stellarwp.atlassian.net/browse/GIVE-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ