### PR TITLE
Hot Fix: don't prevent PayPal donations from getting finished when there is no Billing Address block in the form

### DIFF
--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 3.12.2
+ * Version: 3.12.3
  * Requires at least: 6.3
  * Requires PHP: 7.2
  * Text Domain: give
@@ -404,7 +404,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '3.12.2');
+            define('GIVE_VERSION', '3.12.3');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.3
 Tested up to: 6.5
 Requires PHP: 7.2
-Stable tag: 3.12.2
+Stable tag: 3.12.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -262,6 +262,9 @@ The 2% fee on Stripe donations only applies to donations taken via our free Stri
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 3.12.3: June 19th, 2024 =
+* Fix: Resolved an issue where PayPal was not processing donations due to missing billing address fields
+
 = 3.12.2: June 11th, 2024 =
 * Fix: Resolved an issue where only the donation amount was sent to PayPal, ignoring event ticket values for one-time donations.
 * Fix: Resolved an issue where donations were processed on PayPal but not recorded in GiveWP due to missing city, state, and zip fields.

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -402,21 +402,37 @@ import {PayPalSubscriber} from './types';
                  * when the donation is already created on the PayPal side. This way, we need the conditions below to check it earlier
                  * and prevent the donation creation on the PayPal side if the required billing address fields are missing.
                  */
-                if (city.length === 0 && isCityRequired()) {
-                    setError('city', {type: 'custom', message: getRequiredValidationMessage()}, {shouldFocus: true});
-                    return actions.reject();
-                }
+                if (country) {
+                    if (city.length === 0 && isCityRequired()) {
+                        setError(
+                            'city',
+                            {
+                                type: 'custom',
+                                message: getRequiredValidationMessage(),
+                            },
+                            {shouldFocus: true}
+                        );
+                        return actions.reject();
+                    }
 
-                if (state.length === 0 && isStateRequired()) {
-                    setError('state', {type: 'custom', message: getRequiredValidationMessage()}, {shouldFocus: true});
-                    // As the state is a hidden field we need to use this workaround because the "shouldFocus" option does not work in hidden fields.
-                    document.querySelector('.givewp-fields-select-state').scrollIntoView({behavior: 'smooth'});
-                    return actions.reject();
-                }
+                    if (state.length === 0 && isStateRequired()) {
+                        setError(
+                            'state',
+                            {
+                                type: 'custom',
+                                message: getRequiredValidationMessage(),
+                            },
+                            {shouldFocus: true}
+                        );
+                        // As the state is a hidden field we need to use this workaround because the "shouldFocus" option does not work in hidden fields.
+                        document.querySelector('.givewp-fields-select-state').scrollIntoView({behavior: 'smooth'});
+                        return actions.reject();
+                    }
 
-                if (postalCode.length === 0 && isZipRequired()) {
-                    setError('zip', {type: 'custom', message: getRequiredValidationMessage()}, {shouldFocus: true});
-                    return actions.reject();
+                    if (postalCode.length === 0 && isZipRequired()) {
+                        setError('zip', {type: 'custom', message: getRequiredValidationMessage()}, {shouldFocus: true});
+                        return actions.reject();
+                    }
                 }
 
                 orderCreated = true;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-895]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug introduced in #7405 which prevents PayPal donations from getting finished when there is no Billing Address block added in the form.

To accomplish that, all we need to do is check if the country field is set, otherwise, we ignore the validations for city, state, and zip fields.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The PayPal Donations

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Enable PayPal donations
2. Create a V3 form without an address block
3. Create a test donation using the PP smart buttons and make sure it works.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-895]: https://stellarwp.atlassian.net/browse/GIVE-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ