### PR TITLE
Fix fatal error in give-export-donations-exporter.php

### DIFF
--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -646,6 +646,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 	 * @access public
 	 *
 	 * @since  2.1
+	 * @unreleased Use maybe_serialize() for column data (some data are arrays)
 	 *
 	 * @return string|false
 	 */

--- a/includes/admin/tools/export/give-export-donations-exporter.php
+++ b/includes/admin/tools/export/give-export-donations-exporter.php
@@ -663,6 +663,7 @@ class Give_Export_Donations_CSV extends Give_Batch_Export {
 				foreach ( $row as $col_id => $column ) {
 					// Make sure the column is valid
 					if ( array_key_exists( $col_id, $cols ) ) {
+                        $column = maybe_serialize( $column );
 						$row_data .= '"' . $this->escape_csv_cell_data(preg_replace( '/"/', "'", $column )) . '"';
 						$row_data .= $i == count( $cols ) ? '' : ',';
 						$i ++;


### PR DESCRIPTION
The meta 'razorpay_donation_response' is an array. Must be serialized to avoid a fatal error: 

`TypeError: Uncaught TypeError: substr(): Argument #1 ($string) must be of type string, array given in /var/www/html/wordpress/wp-content/plugins/give/includes/admin/tools/export/give-export-donations-exporter.php:684`

To test:
- activate give-razorpay
- export donations
- choose a donation form
- select the custom field column razorpay_donation_response
