### PR TITLE
Feature: add Reports widget banner

### DIFF
--- a/assets/src/js/admin/reports/widget/index.js
+++ b/assets/src/js/admin/reports/widget/index.js
@@ -15,12 +15,16 @@ import RESTChart from '../components/rest-chart';
 import RESTMiniChart from '../components/rest-mini-chart';
 import LoadingNotice from '../components/loading-notice';
 import MiniPeriodSelector from '../components/mini-period-selector';
+import useBannerVisibility from '../../../../../../src/promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts';
+import WidgetBanner from '../../../../../../src/promotions/ReportsWidgetBanner/components/WidgetBanner';
 
 const Widget = () => {
-    const [{giveStatus, pageLoaded}] = useStoreValue();
+    const [{giveStatus, pageLoaded, widgetBanner}] = useStoreValue();
+    const {hideWidgetBanner, isVisible} = useBannerVisibility();
 
     return (
         <div className="givewp-reports-widget-container">
+            {isVisible &&  <WidgetBanner hideWidgetBanner={hideWidgetBanner} />}
             {giveStatus === 'no_donations_found' && <RecurringAddonOverlay />}
             {pageLoaded === false && <LoadingNotice />}
             <Grid gap="12px" visible={pageLoaded}>

--- a/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
+++ b/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
@@ -52,7 +52,9 @@ class HideSaleBannerRoute implements RestRoute
             $request->get_param('id') . get_current_user_id()
         );
 
-        return new WP_REST_Response();
-    }
+        return new WP_REST_Response([
+            'status' => 'success',
+            'message' => 'Banner hidden successfully'
+        ], 200);    }
 
 }

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -21,8 +21,8 @@ class ReportsWidgetBanner extends SaleBanners
                 'header' => __('Make it yours. Save 40% on all GiveWP products.', 'give'),
                 'actionText' => __('Shop Now', 'give'),
                 'actionUrl' => 'https://go.givewp.com/40sale24',
-                'startDate' => '2024-06-12 00:00',
-                'endDate' => '2024-06-30 23:59',
+                'startDate' => '2024-07-23 00:00',
+                'endDate' => '2024-07-30 23:59',
             ],
         ];
     }

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -2,7 +2,63 @@
 
 namespace Give\Promotions\ReportsWidgetBanner;
 
-class ReportsWidgetBanner
+use Give\Promotions\InPluginUpsells\SaleBanners;
+
+/**
+* @unreleased
+ */
+class ReportsWidgetBanner extends SaleBanners
 {
 
+    /**
+     @unreleased
+     */
+    public function getBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2024-reports-widget',
+                'header' => __('Make it yours. Save 40% on all GiveWP products.', 'give'),
+                'actionText' => __('Shop Now', 'give'),
+                'actionUrl' => 'www.test.com',
+                'startDate' => '2024-06-12 00:00',
+                'endDate' => '2024-06-30 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function loadScripts(): void
+    {
+        wp_enqueue_script(
+            'give-in-plugin-upsells-sale-banners',
+            GIVE_PLUGIN_URL . 'assets/dist/js/admin-upsell-sale-banner.js',
+            [],
+            GIVE_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'give-in-plugin-upsells-sale-banners',
+            'giveReportsWidget',
+            [
+                'apiRoot' => esc_url_raw(rest_url('give-api/v2/sale-banner')),
+                'apiNonce' => wp_create_nonce('wp_rest'),
+                'banner' => $this->getVisibleBanners()[0],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function isShowing(): bool
+    {
+        $hasBanners = !empty((new ReportsWidgetBanner)->getVisibleBanners());
+        $isDashboardWidgetPage = admin_url() . 'index.php' === get_site_url() . $_SERVER['REQUEST_URI'];
+
+        return $hasBanners && $isDashboardWidgetPage;
+    }
 }

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -20,7 +20,7 @@ class ReportsWidgetBanner extends SaleBanners
                 'id' => 'bfgt2024-reports-widget',
                 'header' => __('Make it yours. Save 40% on all GiveWP products.', 'give'),
                 'actionText' => __('Shop Now', 'give'),
-                'actionUrl' => 'www.test.com',
+                'actionUrl' => 'https://go.givewp.com/40sale24',
                 'startDate' => '2024-06-12 00:00',
                 'endDate' => '2024-06-30 23:59',
             ],

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Give\Promotions\ReportsWidgetBanner;
+
+class ReportsWidgetBanner
+{
+
+}

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
@@ -1,0 +1,45 @@
+import {__} from '@wordpress/i18n';
+
+import './styles.scss';
+import {getWidgetWindowData} from "../../window/widgetWindow";
+
+
+type widgetBannerProps = {
+    hideWidgetBanner: (id) => void;
+};
+
+export default function WidgetBanner({hideWidgetBanner}: widgetBannerProps) {
+    const banner = getWidgetWindowData().banner;
+
+    const dismissBanner = () => {
+        hideWidgetBanner(banner.id);
+    }
+
+    return (
+        <div id={`givewp-sale-banner-${banner.id}`} className={'givewp-reports-widget-banner'}>
+            <div className={'givewp-reports-widget-banner__header'}>
+                <h1 className={'givewp-reports-widget-banner__header__main'}>{__('Make it yours.', 'give')}</h1>
+                <h2 className={'givewp-reports-widget-banner__header__secondary'}>{__('Save 40% on all GiveWP products', 'give')}</h2>
+            </div>
+            <a className={'givewp-reports-widget-banner__cta'} href={banner.actionUrl}>{banner.actionText}</a>
+            <button
+                onClick={dismissBanner}
+                type="button"
+                aria-label={__('Dismiss', 'give')}
+                aria-controls={`givewp-sale-banner-${banner.id}`}
+                className={'givewp-reports-widget-banner__dismiss'}
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" width="15px" height="14px" viewBox="0 0 20 19" fill="none">
+                    <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                    <line
+                        y1="-0.5"
+                        x2="25.4558"
+                        y2="-0.5"
+                        transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                        stroke="#F9FAF9"
+                    />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
@@ -21,7 +21,13 @@ export default function WidgetBanner({hideWidgetBanner}: widgetBannerProps) {
                 <h1 className={'givewp-reports-widget-banner__header__main'}>{__('Make it yours.', 'give')}</h1>
                 <h2 className={'givewp-reports-widget-banner__header__secondary'}>{__('Save 40% on all GiveWP products', 'give')}</h2>
             </div>
-            <a className={'givewp-reports-widget-banner__cta'} href={banner.actionUrl}>{banner.actionText}</a>
+            <a className={'givewp-reports-widget-banner__cta'}
+               href={banner.actionUrl}
+               target={"_blank"}
+               rel={"noopener noreferrer"}
+            >
+                {banner.actionText}
+            </a>
             <button
                 onClick={dismissBanner}
                 type="button"

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
@@ -1,0 +1,58 @@
+#givewp-reports-widget .givewp-reports-widget-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 1rem 2rem 1.5rem;
+    min-height: 8rem;
+    background: #1D202F;
+    color: #ffffff;
+
+    &__header {
+        &__main {
+            font-size: 1.5rem;
+            color: #fff4f2;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        &__secondary {
+            font-size: 1.25rem;
+            color: #fff4f2;
+            font-weight: 500;
+            line-height: 0;
+        }
+    }
+
+    &__cta {
+        font-family: 'Inconsolata', Montserrat, sans-serif;;
+        margin-top: 1.125rem;
+        display: inline-flex;
+        padding: .5rem 1.5rem;
+        justify-content: center;
+        align-items: center;
+        background: #62B265;
+        color: #fff4f2;
+        font-weight: 600;
+        border-radius: 9999px;
+        border: none;
+        text-decoration: none;
+    }
+
+    &__dismiss {
+        position: absolute;
+        top: .75rem;
+        right: .5rem;
+        background: none;
+        border: none;
+        cursor: pointer;
+
+        &:hover {
+            transform: scale(1.15);
+        }
+
+        &:active {
+            transform: scale(0.95);
+        }
+    }
+}

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
@@ -13,14 +13,15 @@
             font-size: 1.5rem;
             color: #fff4f2;
             font-weight: 700;
-            margin: 0;
+            line-height: 1;
         }
 
         &__secondary {
             font-size: 1.25rem;
             color: #fff4f2;
             font-weight: 500;
-            line-height: 0;
+            line-height: normal;
+            padding: 0;
         }
     }
 
@@ -56,3 +57,4 @@
         }
     }
 }
+

--- a/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
+++ b/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import {getWidgetWindowData} from "../window/widgetWindow";
+
+
+export const useBannerVisibility = () => {
+    const windowData = getWidgetWindowData();
+    const [isVisible, setIsVisible] = useState<boolean>(false);
+
+    useEffect(() => {
+            setIsVisible(!!windowData?.banner);
+    }, [windowData]);
+
+    const hideWidgetBanner = async (id) => {
+        const formData = new FormData();
+        formData.append('id', id);
+
+        try {
+            const response = await fetch(`${windowData.apiRoot}/hide`, {
+                method: 'POST',
+                headers: {
+                    'X-WP-Nonce': windowData.apiNonce,
+                },
+                body: formData,
+            });
+
+            const data = await response.json();
+            console.log('Banner hidden successfully:', data);
+            setIsVisible(false);
+        } catch (error) {
+            console.error('Error hiding banner:', error);
+        }
+    };
+
+    return {
+        isVisible,
+        hideWidgetBanner,
+    };
+};
+
+export default useBannerVisibility;

--- a/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
+++ b/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
@@ -8,14 +8,14 @@ export const useBannerVisibility = () => {
 
     useEffect(() => {
             setIsVisible(!!windowData?.banner);
-    }, [windowData]);
+    }, [windowData?.banner]);
 
     const hideWidgetBanner = async (id) => {
         const formData = new FormData();
         formData.append('id', id);
 
         try {
-            const response = await fetch(`${windowData.apiRoot}/hide`, {
+             await fetch(`${windowData.apiRoot}/hide`, {
                 method: 'POST',
                 headers: {
                     'X-WP-Nonce': windowData.apiNonce,
@@ -23,8 +23,6 @@ export const useBannerVisibility = () => {
                 body: formData,
             });
 
-            const data = await response.json();
-            console.log('Banner hidden successfully:', data);
             setIsVisible(false);
         } catch (error) {
             console.error('Error hiding banner:', error);

--- a/src/Promotions/ReportsWidgetBanner/window/widgetWindow.ts
+++ b/src/Promotions/ReportsWidgetBanner/window/widgetWindow.ts
@@ -1,0 +1,22 @@
+/**
+ * @unreleased
+ */
+
+type windowData = {
+    apiRoot: string;
+    apiNonce: string;
+    banner: {
+       id: string;
+       header: string;
+       actionText: string;
+       actionUrl: string;
+    };
+};
+
+declare const window: {
+    giveReportsWidget: windowData;
+} & Window;
+
+export function getWidgetWindowData(): windowData {
+    return window.giveReportsWidget;
+}

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Give\Promotions;
 
 use Give\Helpers\Hooks;
+use Give\Log\Log;
 use Give\Promotions\FreeAddonModal\Controllers\CompleteRestApiEndpoint;
 use Give\Promotions\InPluginUpsells\AddonsAdminPage;
 use Give\Promotions\InPluginUpsells\Endpoints\HideSaleBannerRoute;
@@ -10,6 +11,7 @@ use Give\Promotions\InPluginUpsells\Endpoints\ProductRecommendationsRoute;
 use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
 use Give\Promotions\InPluginUpsells\SaleBanners;
+use Give\Promotions\ReportsWidgetBanner\ReportsWidgetBanner;
 use Give\Promotions\WelcomeBanner\Endpoints\DismissWelcomeBannerRoute;
 use Give\Promotions\WelcomeBanner\WelcomeBanner;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
@@ -57,6 +59,10 @@ class ServiceProvider implements ServiceProviderContract
         if (SaleBanners::isShowing()) {
             Hooks::addAction('admin_notices', SaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', SaleBanners::class, 'loadScripts');
+        }
+
+        if (ReportsWidgetBanner::isShowing()) {
+            Hooks::addAction('admin_enqueue_scripts', ReportsWidgetBanner::class, 'loadScripts');
         }
 
         if (PaymentGateways::isShowing()) {

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Give\Promotions;
 
 use Give\Helpers\Hooks;
-use Give\Log\Log;
 use Give\Promotions\FreeAddonModal\Controllers\CompleteRestApiEndpoint;
 use Give\Promotions\InPluginUpsells\AddonsAdminPage;
 use Give\Promotions\InPluginUpsells\Endpoints\HideSaleBannerRoute;
@@ -11,6 +10,7 @@ use Give\Promotions\InPluginUpsells\Endpoints\ProductRecommendationsRoute;
 use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
 use Give\Promotions\InPluginUpsells\SaleBanners;
+use Give\Promotions\InPluginUpsells\StellarSaleBanners;
 use Give\Promotions\ReportsWidgetBanner\ReportsWidgetBanner;
 use Give\Promotions\WelcomeBanner\Endpoints\DismissWelcomeBannerRoute;
 use Give\Promotions\WelcomeBanner\WelcomeBanner;
@@ -66,6 +66,10 @@ class ServiceProvider implements ServiceProviderContract
             Hooks::addAction('admin_init', SaleBanners::class, 'startSession');
             Hooks::addAction('admin_notices', StellarSaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', StellarSaleBanners::class, 'loadScripts');
+        }
+
+        if (ReportsWidgetBanner::isShowing()) {
+            Hooks::addAction('admin_enqueue_scripts', ReportsWidgetBanner::class, 'loadScripts');
         }
 
         if (PaymentGateways::isShowing()) {


### PR DESCRIPTION
Resolves: [GIVE-866]

## Description
This update includes the necessary changes to extend our admin banners to the Reports widget. Similar to the admin banner, it should adhere to similar requirements. The main difference will be that it should only show a single banner to be displayed at a time and does not alternate between options.

URL for report widget: https://go.givewp.com/40sale24
Date range the banner is displayed: July 23rd through July 30th.

## Affects
Reports Widget

## Visuals
https://github.com/impress-org/givewp/assets/75056371/2cae3700-f04b-44bc-9c9c-aa4358ccddb9

## Testing Instructions
- Visit the WP dashboard.
- Locate the GiveWP widget on the page.
- Verify the banner is displayed and the link takes you to the appropriate page.
- Try closing the banner, it should remain closed.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-866]: https://stellarwp.atlassian.net/browse/GIVE-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ