### PR TITLE
Fix: enable custom donor columns in csv export

### DIFF
--- a/src/Exports/DonorsExport.php
+++ b/src/Exports/DonorsExport.php
@@ -157,31 +157,49 @@ class DonorsExport extends Give_Batch_Export
     }
 
     /**
+     * @unreleased
+     */
+    protected function filterColumnData(array $defaultColumns): array
+    {
+        /**
+         * @unreleased
+         *
+         * @param array $defaultColumns
+         */
+        return apply_filters('give_export_donors_get_default_columns', $defaultColumns );
+    }
+
+    /**
+     * @unreleased allow cols to be filtered.
      * @since 3.12.1 Include donor_phone_number col.
      * @since      2.29.0 Include donor created col
      * @since      2.21.2
      */
     public function csv_cols(): array
     {
-        return $this->flattenAddressColumn(
-            array_intersect_key([
-                'full_name' => __('Name', 'give'),
-                'email' => __('Email', 'give'),
-                'address' => [
-                    'address_line1' => __('Address', 'give'),
-                    'address_line2' => __('Address 2', 'give'),
-                    'address_city' => __('City', 'give'),
-                    'address_state' => __('State', 'give'),
-                    'address_zip' => __('Zip', 'give'),
-                    'address_country' => __('Country', 'give'),
-                ],
-                'userid' => __('User ID', 'give'),
-                'donor_created_date' => __('Donor Created', 'give'),
-                'donor_phone_number' => __('Donor Phone Number', 'give'),
-                'donations' => __('Number of donations', 'give'),
-                'donation_sum' => __('Total Donated', 'give'),
-            ], $this->postedData['give_export_columns'])
+        $defaultColumns = [
+            'full_name' => __('Name', 'give'),
+            'email' => __('Email', 'give'),
+            'userid' => __('User ID', 'give'),
+            'donor_created_date' => __('Donor Created', 'give'),
+            'donor_phone_number' => __('Donor Phone Number', 'give'),
+            'donations' => __('Number of donations', 'give'),
+            'donation_sum' => __('Total Donated', 'give'),
+            'address' => [
+                'address_line1' => __('Address', 'give'),
+                'address_line2' => __('Address 2', 'give'),
+                'address_city' => __('City', 'give'),
+                'address_state' => __('State', 'give'),
+                'address_zip' => __('Zip', 'give'),
+                'address_country' => __('Country', 'give'),
+            ],
+        ];
+
+        $defaultColumns = $this->flattenAddressColumn(
+            array_intersect_key($defaultColumns, $this->postedData['give_export_columns'])
         );
+
+        return $this->filterColumnData($defaultColumns);
     }
 
     /**


### PR DESCRIPTION
Resolves: [GIVE-923](https://stellarwp.atlassian.net/browse/GIVE-923)
 https://github.com/impress-org/givewp/discussions/7398

## Description
This pull request enables the filtering of the donor export csv columns. In the past, users could introduce custom columns via the `give_export_donors_get_default_columns` filter in the previous Donor export class. This filter was utilized in two methods:

- Displaying Custom Columns on the Tools Page: One method would display the custom columns on the donor export section of the tools page to be checked. 

- Merging Custom Columns with Export Data: A second method, which incorporated custom columns into the export data.

By reintroducing this functionality in the new Donor export class, users can once again add custom donor information to the csv exports.

## Affects
Donor Column Export

## Visuals
<img width="2001" alt="donor-column-tools" src="https://github.com/impress-org/givewp/assets/75056371/644c37d5-e326-4a82-acb9-84b18b576b7a">

<img width="2052" alt="donor-csv" src="https://github.com/impress-org/givewp/assets/75056371/987f99df-83a9-4895-a568-387a51229ae3">

## Testing Instructions
- add the relevant filters to insert custom columns & data.
- export csv and verify that the custom information is printed.

Example:

        add_filter( 'give_export_donors_get_default_columns', static function($columnData) {
            $columnData['test'] = 'test-column';
            return $columnData;
        }); 


       add_filter( 'give_export_get_data_donors', static function($exportData) {
            $exportData[0]['test'] = 'test-data';
            return $exportData;
        });

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-923]: https://stellarwp.atlassian.net/browse/GIVE-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ