### PR TITLE
Feature: add Stellar2024 banners

### DIFF
--- a/assets/src/css/admin/sale-banners.scss
+++ b/assets/src/css/admin/sale-banners.scss
@@ -2,8 +2,6 @@
     display: block;
     width: 100%;
     position: relative;
-    padding: 1.75rem 0 1.5rem 2.75rem;
-    box-shadow: 0 0.0625em 0.25em rgba(0, 0, 0, 0.25);
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center center;
@@ -49,18 +47,13 @@
     }
 }
 
-/* Reports page */
-.give_forms_page_give-reports {
-    .givewp-sale-banners-container {
-        margin: .5rem 0 0 0;
-    }
-}
-
 .givewp-sale-banner {
     &__content {
         width: 70%;
         line-height: normal;
         font-style: normal;
+        padding: 1.75rem 0 1.5rem 2.75rem;
+        box-shadow: 0 0.0625em 0.25em rgba(0, 0, 0, 0.25);
 
         & h2 {
             font-size: 2rem;

--- a/assets/src/js/admin/reports/widget/index.js
+++ b/assets/src/js/admin/reports/widget/index.js
@@ -15,12 +15,16 @@ import RESTChart from '../components/rest-chart';
 import RESTMiniChart from '../components/rest-mini-chart';
 import LoadingNotice from '../components/loading-notice';
 import MiniPeriodSelector from '../components/mini-period-selector';
+import useBannerVisibility from '../../../../../../src/promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts';
+import WidgetBanner from '../../../../../../src/promotions/ReportsWidgetBanner/components/WidgetBanner';
 
 const Widget = () => {
-    const [{giveStatus, pageLoaded}] = useStoreValue();
+    const [{giveStatus, pageLoaded, widgetBanner}] = useStoreValue();
+    const {hideWidgetBanner, isVisible} = useBannerVisibility();
 
     return (
         <div className="givewp-reports-widget-container">
+            {isVisible &&  <WidgetBanner hideWidgetBanner={hideWidgetBanner} />}
             {giveStatus === 'no_donations_found' && <RecurringAddonOverlay />}
             {pageLoaded === false && <LoadingNotice />}
             <Grid gap="12px" visible={pageLoaded}>

--- a/assets/src/js/admin/reports/widget/index.js
+++ b/assets/src/js/admin/reports/widget/index.js
@@ -15,8 +15,8 @@ import RESTChart from '../components/rest-chart';
 import RESTMiniChart from '../components/rest-mini-chart';
 import LoadingNotice from '../components/loading-notice';
 import MiniPeriodSelector from '../components/mini-period-selector';
-import useBannerVisibility from '../../../../../../src/promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts';
-import WidgetBanner from '../../../../../../src/promotions/ReportsWidgetBanner/components/WidgetBanner';
+import useBannerVisibility from '../../../../../../src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts';
+import WidgetBanner from '../../../../../../src/Promotions/ReportsWidgetBanner/components/WidgetBanner';
 
 const Widget = () => {
     const [{giveStatus, pageLoaded, widgetBanner}] = useStoreValue();

--- a/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
+++ b/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
@@ -52,7 +52,9 @@ class HideSaleBannerRoute implements RestRoute
             $request->get_param('id') . get_current_user_id()
         );
 
-        return new WP_REST_Response();
-    }
+        return new WP_REST_Response([
+            'status' => 'success',
+            'message' => 'Banner hidden successfully'
+        ], 200);    }
 
 }

--- a/src/Promotions/InPluginUpsells/SaleBanners.php
+++ b/src/Promotions/InPluginUpsells/SaleBanners.php
@@ -5,7 +5,6 @@ namespace Give\Promotions\InPluginUpsells;
 use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
-use Give\Framework\Shims\Shim;
 
 /**
  * @since 2.17.0
@@ -78,7 +77,7 @@ class SaleBanners
                         'Free' => 'https://go.givewp.com/bf23',
                         'Basic' => 'https://go.givewp.com/bfup23',
                         'Plus' => 'https://go.givewp.com/bfup23',
-                        'Default' => 'https://go.givewp.com/bfup23',
+                        'default' => 'https://go.givewp.com/bfup23',
                     ]
                 ),
                 'startDate' => '2023-11-20 00:00',
@@ -95,10 +94,6 @@ class SaleBanners
      */
     public function getVisibleBanners(): array
     {
-        if (self::getUserPricingPlan() === 'Pro') {
-            return [];
-        }
-
         $currentDateTime = current_datetime();
         $currentUserId = get_current_user_id();
         $giveWPWebsiteTimezone = new DateTimeZone('America/Los_Angeles');
@@ -189,6 +184,7 @@ class SaleBanners
     }
 
     /**
+     * @unreleased remove all_access_pass.
      * @since 3.1.0 retrieve licensed plugin slugs.
      */
     public static function getLicensedPluginSlugs(): array
@@ -197,10 +193,8 @@ class SaleBanners
         $licenses = get_option("give_licenses", []);
 
         foreach ($licenses as $license) {
-            if (isset($license['is_all_access_pass']) && $license['is_all_access_pass'] && !empty($license['download'])) {
-                $pluginSlugs = ['is_all_access_pass'];
-            } else {
-                $pluginSlugs[] = $license['plugin_slug'];
+            foreach ($license['download'] as $plugin) {
+                $pluginSlugs[] = $plugin['plugin_slug'];
             }
         }
 
@@ -215,17 +209,9 @@ class SaleBanners
         $plan = 'Free';
 
         $pricingPlans = [
-            'Basic' => ['pdf' => 'give-pdf-receipts'],
-            'Plus' => [
-                'pdf_receipts' => 'give-pdf-receipts',
-                'recurring_donations' => 'give-recurring',
-                'fee_recovery' => 'give-fee-recovery',
-                'form_field_manager' => 'give-form-field-manager',
-                'tributes' => 'give-tributes',
-                'annual_receipts' => 'give-annual-receipts',
-                'peer_to_peer' => 'give-peer-to-peer',
-            ],
-            'Pro' => ['is_all_access_pass'],
+            'Basic' => self::getBasicLicenseSlugs(),
+            'Plus'  => self::getPlusLicenseSlugs(),
+            'Pro'   => self::getProLicenseSlugs(),
         ];
 
         $licensedPluginSlugs = self::getLicensedPluginSlugs();
@@ -241,17 +227,149 @@ class SaleBanners
     }
 
     /**
+     * @unreleased add type for $data.
      * @since 3.1.0 return data by user pricing plan.
      */
-    public static function getDataByPricingPlan($data): string
+    public static function getDataByPricingPlan(array $data): string
     {
         $userPricingPlan = self::getUserPricingPlan();
 
         if (array_key_exists($userPricingPlan, $data)) {
+
             return $data[$userPricingPlan];
         }
 
         return $data['default'];
     }
+
+    /**
+     * @unreleased
+     *
+     *  This method cycles through the visible banners, selecting the next banner in the list
+     *  on each call. If no banners are visible, or if the session index is not set, it returns
+     *  all visible banners.
+     */
+    public function alternateVisibleBanners(): array
+    {
+        $visibleBanners = $this->getVisibleBanners();
+        $bannerCount = count($visibleBanners);
+
+        if ($bannerCount > 0) {
+            $currentIndex = $_SESSION['banner_index'] ?? 0;
+
+            $selectedBanner = $visibleBanners[$currentIndex];
+
+            $currentIndex = ($currentIndex + 1) % $bannerCount;
+
+            $_SESSION['banner_index'] = $currentIndex;
+
+            if( !$selectedBanner){
+                $this->destroySession();
+                return $visibleBanners;
+            }
+
+            return [$selectedBanner];
+        }
+
+        return $visibleBanners;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function startSession(): void
+    {
+        if (!session_id()) {
+            session_start();
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function destroySession(): void
+    {
+        if (session_id()) {
+            session_destroy();
+        }
+    }
+
+
+    /**
+     * @unreleased
+     */
+    public static function getBasicLicenseSlugs(): array
+    {
+        return [
+            'give-bitpay',
+            'give-text-to-give',
+            'give-activecampaign',
+            'give-moneris',
+            'give-square',
+            'give-mollie',
+            'give-payfast',
+            'give-sofort',
+            'give-americloud-payments',
+            'give-paytm',
+            'give-gocardless',
+            'give-razorpay',
+            'give-payumoney',
+            'give-convertkit',
+            'give-aweber',
+            'give-per-form-gateways',
+            'give-email-reports',
+            'give-manual-donations',
+            'give-zapier',
+            'give-google-analytics',
+            'ccavenue'            => 'give-ccavenue',
+            'give-constant-contact',
+            'give-braintree',
+            'give-iats',
+            'give-2checkout',
+            'give-pdf-receipts',
+            'give-paymill',
+            'give-stripe',
+            'give-authorize-net',
+            'give-mailchimp',
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function getPlusLicenseSlugs(): array
+    {
+        $basicLicenseSlugs = self::getBasicLicenseSlugs();
+
+        $plusLicenseSlugs = [
+            'give-webhooks',
+            'give-salesforce',
+            'give-funds',
+            'give-annual-receipts',
+            'give-currency-switcher',
+            'give-donation-upsells-woocommerce',
+            'give-tributes',
+            'give-fee-recovery',
+            'give-email-reports',
+            'give-gift-aid',
+            'give-recurring',
+            'give-form-field-manager',
+        ];
+
+        return array_merge($basicLicenseSlugs, $plusLicenseSlugs);
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function getProLicenseSlugs(): array
+    {
+        $plusLicenseSlugs = self::getPlusLicenseSlugs();
+
+        $proLicenseSlugs = ['give-peer-to-peer'];
+
+        return array_merge($plusLicenseSlugs, $proLicenseSlugs);
+    }
+
 }
 

--- a/src/Promotions/InPluginUpsells/StellarSaleBanners.php
+++ b/src/Promotions/InPluginUpsells/StellarSaleBanners.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Give\Promotions\InPluginUpsells;
+
+/**
+ * @unreleased
+ */
+class StellarSaleBanners extends SaleBanners
+{
+    /**
+     * @unreleased
+     */
+    public function getBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2024-give',
+                'mainHeader' => __('Make it yours.', 'give'),
+                'subHeader' => __('Save 40% on the GiveWP Plus Plan'),
+                'actionText' => __('Shop Now', 'give'),
+                'actionURL' => 'https://www.actionURL.com',
+                'secondaryActionText' => __('View all StellarWP Deals', 'give'),
+                'secondaryActionURL' => 'https://www.secondaryActionURL.com',
+                'content' => __('Take 40% off all StellarWP brands during the annual Stellar Sale. Now through July 30.', 'give'),
+                'startDate' => '2024-06-23 00:00',
+                'endDate' => '2024-06-30 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function loadScripts(): void
+    {
+        wp_enqueue_style(
+            'give-in-plugin-upsells-stellar-sales-banner',
+            GIVE_PLUGIN_URL . 'assets/dist/css/admin-stellarwp-sales-banner.css',
+            [],
+            GIVE_VERSION
+        );
+
+        wp_enqueue_style('givewp-admin-fonts');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function render(): void
+    {
+        $banners = $this->getVisibleBanners();
+
+        if (!empty($banners)) {
+            include __DIR__ . '/resources/views/stellarwp-sale-banner.php';
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function isShowing(): bool
+    {
+        $saleBanners = new self();
+        $page = $_GET['page'] ?? [];
+        $validPages = ['give-donors', 'give-payment-history', 'give-reports'];
+
+        return isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms' &&
+               in_array($page, $validPages, true) &&
+               !empty($saleBanners->getBanners());
+    }
+}

--- a/src/Promotions/InPluginUpsells/StellarSaleBanners.php
+++ b/src/Promotions/InPluginUpsells/StellarSaleBanners.php
@@ -12,20 +12,92 @@ class StellarSaleBanners extends SaleBanners
      */
     public function getBanners(): array
     {
-        return [
+        $banners = [
             [
                 'id' => 'bfgt2024-give',
-                'mainHeader' => __('Make it yours.', 'give'),
-                'subHeader' => __('Save 40% on the GiveWP Plus Plan'),
+                'mainHeader' => self::getDataByPricingPlan([
+                    'Pro' => __('Make it stellar.', 'give'),
+                    'default' => __('Make it yours.', 'give'),
+                ]),
+                'subHeader' => self::getDataByPricingPlan([
+                    'Basic' => __('Save 40% on the GiveWP Plus Plan.', 'give'),
+                    'Plus' => __('Save 40% on the GiveWP Pro Plan.', 'give'),
+                    'Pro' => __('Save 40% on all StellarWP products.', 'give'),
+                    'default' => __('Save 40% on the GiveWP Plus Plan.', 'give'),
+                ]),
                 'actionText' => __('Shop Now', 'give'),
-                'actionURL' => 'https://www.actionURL.com',
+                'actionURL' => self::getDataByPricingPlan([
+                    'Basic' => 'https://go.givewp.com/plusplan',
+                    'Plus' => 'https://go.givewp.com/pro',
+                    'Pro' => 'https://go.givewp.com/stellarsale',
+                    'default' => 'https://go.givewp.com/plusplan',
+                ]),
                 'secondaryActionText' => __('View all StellarWP Deals', 'give'),
-                'secondaryActionURL' => 'https://www.secondaryActionURL.com',
-                'content' => __('Take 40% off all StellarWP brands during the annual Stellar Sale. Now through July 30.', 'give'),
-                'startDate' => '2024-06-23 00:00',
-                'endDate' => '2024-06-30 23:59',
+                'secondaryActionURL' => 'https://go.givewp.com/stellarsale',
+                'content' => self::getDataByPricingPlan([
+                    'Pro' => sprintf(__('Take %s off all brands during the annual Stellar Sale. Now through July 30.', 'give'),
+                        '<strong>40%</strong>'),
+                    'default' => sprintf(__('Take %s off all StellarWP brands during the annual Stellar Sale. Now through July 30.', 'give'),
+                        '<strong>40%</strong>'),
+                ]),
+                'startDate' => '2024-07-23 00:00',
+                'endDate' => '2024-07-30 23:59',
             ],
         ];
+
+        foreach($this->getAddonBanners() as $addonBanner){
+            $banners[] = $addonBanner;
+        }
+
+        return $banners;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getP2PBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2024-p2p',
+                'mainHeader' => __('Make it yours.', 'give'),
+                'subHeader' => __('Save 40% on Peer-to-Peer Fundraising.', 'give'),
+                'actionText' => __('Shop Now', 'give'),
+                'actionURL' => self::getDataByPricingPlan([
+                    'Basic' => 'https://go.givewp.com/p2p',
+                    'Plus' => 'https://go.givewp.com/p2ppro',
+                    'default' => 'https://go.givewp.com/p2p',
+                ]),
+                'secondaryActionText' => __('View all StellarWP Deals', 'give'),
+                'secondaryActionURL' => 'https://go.givewp.com/stellarsale',
+                'content' => self::getDataByPricingPlan([
+                    'Basic' => __('Open up your donation forms to your supporters during the annual Stellar Sale. Now through July 30.', 'give'),
+                    'Plus' => __('Upgrade to the Pro Plan and get Peer-to-Peer Fundraising during the annual Stellar Sale. Now through July 30.', 'give'),
+                    'Pro' => __('Upgrade to the Pro Plan and get Peer-to-Peer Fundraising during the annual Stellar Sale. Now through July 30.', 'give'),
+                    'default' => __('Open up your donation forms to your supporters during the annual Stellar Sale. Now through July 30.', 'give'),
+                ]),
+                'startDate' => '2024-07-23 00:00',
+                'endDate' => '2024-07-30 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getAddonBanners(): array
+    {
+        if(self::getUserPricingPlan() === 'Pro') {
+            return [];
+        }
+
+        $addonBanners = [];
+
+        if(!defined('GIVE_P2P_VERSION')) {
+            $addonBanners = $this->getP2PBanners();
+        }
+
+        return $addonBanners;
     }
 
     /**
@@ -48,7 +120,7 @@ class StellarSaleBanners extends SaleBanners
      */
     public function render(): void
     {
-        $banners = $this->getVisibleBanners();
+        $banners = $this->alternateVisibleBanners();
 
         if (!empty($banners)) {
             include __DIR__ . '/resources/views/stellarwp-sale-banner.php';

--- a/src/Promotions/InPluginUpsells/resources/css/stellarwp-sales-banner.scss
+++ b/src/Promotions/InPluginUpsells/resources/css/stellarwp-sales-banner.scss
@@ -1,4 +1,4 @@
-.give-sale-banners-container {
+.give_forms_page_give-reports .give-sale-banners-container, .givewp-sale-banners-container {
     /* Box-sizing reset */
     &,
     & *,
@@ -7,31 +7,28 @@
         box-sizing: border-box;
     }
 
-    overflow: hidden;
+    margin: 0 auto;
 }
 
-.give-sale-banner {
+.give_forms_page_give-reports .give-sale-banner, .give-sale-banner {
     position: relative;
     display: flex;
     justify-content: space-between;
     background: #1D202F;
-    min-height: 180px;
-    --banner-y-pad: 0.6875em;
-    padding-top: var(--banner-y-pad);
-    padding-bottom: var(--banner-y-pad);
-    padding-left: 3.25em;
-    padding-right: 1.3125em;
+    padding: 2rem 1.25rem 1.5rem 3.25rem;
     box-shadow: 0 0.0625em 0.25em rgba(0, 0, 0, 0.25);
     font-size: clamp(max(0.875rem, 14px), 2vw, max(1rem, 16px));
     color: #F9FAF9;
+    overflow: hidden;
 }
 
-.give-sale-banner-content {
+.give_forms_page_give-reports .give-sale-banner-content, .give-sale-banner-content {
+    flex: .7;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 3rem;
-    width: 70%;
+
 
     & * {
         font-size: inherit;
@@ -40,10 +37,8 @@
 
     a {
         color: inherit;
-        font-weight: 700;
         text-decoration-thickness: 0.05em;
         transform-style: preserve-3d;
-        font-size: 0.875rem;
 
         &::after {
             content: "";
@@ -67,27 +62,30 @@
     }
 
     &__primary-cta {
-        width: fit-content;
+        white-space: nowrap;
 
-        > h1 {
-            font-size: 1.5rem;
-            font-style: normal;
-            font-weight: 700;
-            line-height: normal;
+        &__header, &__sub-header {
+            flex: 1 1 auto;
+            margin: 0;
+            padding: 0;
+            line-height: 29px;
             color: #F9FAF9;
         }
 
-        > p {
-            font-size: 1.375rem;
-            font-style: normal;
-            font-weight: 400;
-            line-height: normal;
+        &__header {
+            font-size: 1.5rem;
+            font-weight: 700;
         }
 
+        &__sub-header {
+            font-size: 1.25rem;
+            font-weight: 300;
+            line-height: normal
+        }
 
-        &-link {
-            font-family: 'Inconsolata', Montserrat, sans-serif;;
-            margin-top: 1.125rem;
+        &__link {
+            font-family: 'Inconsolata', Montserrat, sans-serif;
+            font-size: .875rem;
             display: inline-flex;
             padding: 0.73125rem 1.6714375rem;
             justify-content: center;
@@ -95,45 +93,29 @@
             background: #62B265;
             border-radius: 9999px;
             text-decoration: none;
-            margin-right: auto;
-        }
-
-        &-mobile-link {
-            display: none;
-            margin: 1rem 0 0 1rem;
-            color: #fff;
-            background: none;
+            margin: 1rem auto 0 0;
         }
     }
 
     &__secondary-cta {
-        flex: 1;
         display: flex;
         flex-direction: column;
-        gap: 1.125rem;
-    }
+        gap: 1rem;
 
-    & p {
-        display: flex;
-        flex-wrap: wrap;
-        row-gap: 0.25rem;
-        column-gap: 0.9375em;
-        margin: 0;
-        line-height: 1.37;
+        &__content {
+            font-size: 1rem;
+            font-style: normal;
+            font-weight: 400;
+            line-height: normal;
+        }
     }
 }
 
-.give-sale-banner__abstract-icon {
+.give-sale-banner-dismiss.givewp-sale-banner__dismiss[aria-label="Dismiss"][aria-controls][data-id] {
     position: absolute;
-    bottom: 0;
-    right: 0;
-}
-
-
-.give-sale-banner-dismiss {
+    top: 1rem;
+    right: 1rem;
     --size: 1.25rem;
-    /* Artificially align this with the sale icon, since we shouldn’t use align-items: center on the banner */
-    //margin-top: calc((var(--sale-icon-size) - var(--size)) / 2);
     appearance: none;
     background: none;
     display: grid;
@@ -168,10 +150,43 @@
     }
 }
 
-@media screen and (max-width: 1100px) {
+.give-sale-banner__abstract-icon {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}
+
+
+@media screen and (min-width: 1800px) {
+    .give-sale-banner__abstract-icon {
+        bottom: -4rem;
+
+        svg {
+            width: 330px;
+            height: 224px;
+        }
+    }
+}
+
+@media screen and (max-width: 1200px) {
     .give-sale-banner-content {
-        flex-direction: column;
-        align-items: flex-start;
+        gap: 1.5rem;
+
+        & a {
+            font-size: 0.875rem;
+        }
+
+        &__primary-cta {
+            white-space: normal;
+        }
+
+        &__secondary-cta {
+            gap: 1rem;
+        }
+    }
+
+    .give_forms_page_give-reports .give-sale-banner-content__primary-cta {
+        white-space: normal;
     }
 }
 
@@ -180,22 +195,13 @@
         padding-left: 1rem;
     }
 
-    .give-sale-banner-content__secondary-cta {
+    .give_forms_page_give-reports .give-sale-banner-content__secondary-cta, .give-sale-banner-content__secondary-cta {
         display: none;
-    }
-
-    .give-sale-banner-content__primary-cta-mobile-link {
-        display: inline-block;
     }
 
     .give-sale-banner__abstract-icon {
         max-width: 8.25rem;
         max-height: 9.5rem;
-    }
-}
-
-@media screen and (max-width: 480px) {
-    .give-sale-banner-content__primary-cta-mobile-link {
-        margin-left: 0;
+        right: 6rem;
     }
 }

--- a/src/Promotions/InPluginUpsells/resources/js/sale-banner.js
+++ b/src/Promotions/InPluginUpsells/resources/js/sale-banner.js
@@ -32,7 +32,7 @@ if ((pageTitle || listTable) && bannersContainer) {
     bannersContainer.style.display = null;
 
     if (settings) {
-        settings.insertAdjacentElement('afterend', bannersContainer);
+       settings.insertAdjacentElement('afterend', bannersContainer);
     } else if (listTable) {
         listTable.querySelector('header').insertAdjacentElement('afterend', bannersContainer);
     }

--- a/src/Promotions/InPluginUpsells/resources/js/sale-banner.js
+++ b/src/Promotions/InPluginUpsells/resources/js/sale-banner.js
@@ -2,8 +2,10 @@ const bannersContainer = document.querySelector('.givewp-sale-banners-container'
 const dismissActions = document.querySelectorAll('.givewp-sale-banner__dismiss');
 const pageTitle = document.querySelector('.page-title-action, .wp-heading-inline, #give-in-plugin-upsells h1');
 const listTable = document.querySelector('#give-admin-donations-root, #give-admin-donation-forms-root, #give-admin-donors-root');
+const settings = document.querySelector('.give-settings-header');
 
 /**
+ * @unreleased move placement of banner on Reports page.
  * @since 3.1.0 show banner on ListTable pages.
  */
 const hideBanner = ({target: dismissAction}) => {
@@ -25,12 +27,13 @@ const hideBanner = ({target: dismissAction}) => {
     }
 };
 
-if((pageTitle || listTable) && bannersContainer ){
+
+if ((pageTitle || listTable) && bannersContainer) {
     bannersContainer.style.display = null;
 
-    if (pageTitle) {
-        pageTitle.parentNode.insertBefore(bannersContainer, pageTitle.nextSibling);
-    } else if (listTable){
+    if (settings) {
+        settings.insertAdjacentElement('afterend', bannersContainer);
+    } else if (listTable) {
         listTable.querySelector('header').insertAdjacentElement('afterend', bannersContainer);
     }
 }

--- a/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @unreleased
+ */
+
+/** @var array[] $banners */
+ foreach ($banners as $banner):
+    [$id, $mainHeader, $subHeader, $actionText, $actionURL, $content, $secondaryActionText, $secondaryActionURL, $startDate, $endDate] = $banner;
+    ?>
+    <div class="givewp-sale-banners-container">
+        <aside aria-label="" id="<?= $dismissableElementId = "give-sale-banner-{$id}" ?>" class="give-sale-banner">
+            <div class="give-sale-banner-content">
+                <div class="give-sale-banner-content__primary-cta">
+                    <h1 class="give-sale-banner-content__primary-cta__header"><?= $mainHeader ?></h1>
+                    <h3 class="give-sale-banner-content__primary-cta__sub-header"><?= $subHeader ?></h3>
+                    <a class="give-sale-banner-content__primary-cta__link" href="<?= $actionURL ?>" rel="noopener"
+                       target="_blank"><?= $actionText ?></a>
+                </div>
+
+                <div class="give-sale-banner-content__secondary-cta">
+                    <p class="give-sale-banner-content__secondary-cta__content"><?= $content ?></p>
+                    <a class="give-sale-banner-content__secondary-cta__link"
+                       href="<?= $secondaryActionURL ?>" rel="noopener"
+                       target="_blank"><?= $secondaryActionText ?></a>
+                </div>
+            </div>
+
+            <div class="give-sale-banner__abstract-icon">
+                <svg width="230" height="124" viewBox="0 0 280 154" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_1482_402)">
+                        <circle cx="10.2895" cy="9.58348" r="9.58348" fill="#F9FAF9" />
+                        <circle cx="245.085" cy="46.9587" r="4.79174" fill="#F9FAF9" />
+                        <path
+                            d="M245.085 46.0009L103.249 220.42L9.33105 7.66699L245.085 46.0009ZM245.085 46.0009L306.419 124.586"
+                            stroke="#F9FAF9" stroke-width="1.43752" />
+                    </g>
+                    <defs>
+                        <clipPath id="clip0_1482_402">
+                            <rect width="280" height="154" fill="white" />
+                        </clipPath>
+                    </defs>
+                </svg>
+            </div>
+            <button type="button" aria-label="<?= __('Dismiss', 'give') ?>"
+                    aria-controls="<?= $dismissableElementId ?>"
+                    class="give-sale-banner-dismiss givewp-sale-banner__dismiss"
+                    data-id="<?= $id ?>">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
+                    <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                    <line y1="-0.5" x2="25.4558" y2="-0.5"
+                          transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                          stroke="#F9FAF9" />
+                </svg>
+            </button>
+        </aside>
+        <br>
+    </div>
+<?php endforeach; ?>

--- a/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
@@ -5,8 +5,18 @@
 
 /** @var array[] $banners */
  foreach ($banners as $banner):
-    [$id, $mainHeader, $subHeader, $actionText, $actionURL, $content, $secondaryActionText, $secondaryActionURL, $startDate, $endDate] = $banner;
+    $id = $banner['id'];
+    $mainHeader = $banner['mainHeader'];
+    $subHeader = $banner['subHeader'];
+    $actionText = $banner['actionText'];
+    $actionURL = $banner['actionURL'];
+    $content = $banner['content'];
+    $secondaryActionText = $banner['secondaryActionText'];
+    $secondaryActionURL = $banner['secondaryActionURL'];
+    $startDate = $banner['startDate'];
+    $endDate = $banner['endDate'];
     ?>
+
     <div class="givewp-sale-banners-container">
         <aside aria-label="" id="<?php echo $dismissableElementId = "give-sale-banner-{$id}" ?>"
                class="give-sale-banner">

--- a/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
+++ b/src/Promotions/InPluginUpsells/resources/views/stellarwp-sale-banner.php
@@ -8,20 +8,20 @@
     [$id, $mainHeader, $subHeader, $actionText, $actionURL, $content, $secondaryActionText, $secondaryActionURL, $startDate, $endDate] = $banner;
     ?>
     <div class="givewp-sale-banners-container">
-        <aside aria-label="" id="<?= $dismissableElementId = "give-sale-banner-{$id}" ?>" class="give-sale-banner">
+        <aside aria-label="" id="<?php echo $dismissableElementId = "give-sale-banner-{$id}" ?>"
+               class="give-sale-banner">
             <div class="give-sale-banner-content">
                 <div class="give-sale-banner-content__primary-cta">
-                    <h1 class="give-sale-banner-content__primary-cta__header"><?= $mainHeader ?></h1>
-                    <h3 class="give-sale-banner-content__primary-cta__sub-header"><?= $subHeader ?></h3>
-                    <a class="give-sale-banner-content__primary-cta__link" href="<?= $actionURL ?>" rel="noopener"
-                       target="_blank"><?= $actionText ?></a>
+                    <h1 class="give-sale-banner-content__primary-cta__header"><?php echo $mainHeader ?></h1>
+                    <h3 class="give-sale-banner-content__primary-cta__sub-header"><?php echo $subHeader ?></h3>
+                    <a class="give-sale-banner-content__primary-cta__link" href="<?php echo $actionURL ?>"
+                       rel="noopener" target="_blank"><?php echo $actionText ?></a>
                 </div>
 
                 <div class="give-sale-banner-content__secondary-cta">
-                    <p class="give-sale-banner-content__secondary-cta__content"><?= $content ?></p>
-                    <a class="give-sale-banner-content__secondary-cta__link"
-                       href="<?= $secondaryActionURL ?>" rel="noopener"
-                       target="_blank"><?= $secondaryActionText ?></a>
+                    <p class="give-sale-banner-content__secondary-cta__content"><?php echo wp_kses($content, ['strong' =>[]]) ?></p>
+                    <a class="give-sale-banner-content__secondary-cta__link" href="<?php echo $secondaryActionURL ?>"
+                       rel="noopener" target="_blank"><?php echo $secondaryActionText ?></a>
                 </div>
             </div>
 
@@ -41,14 +41,12 @@
                     </defs>
                 </svg>
             </div>
-            <button type="button" aria-label="<?= __('Dismiss', 'give') ?>"
-                    aria-controls="<?= $dismissableElementId ?>"
-                    class="give-sale-banner-dismiss givewp-sale-banner__dismiss"
-                    data-id="<?= $id ?>">
+            <button type="button" aria-label="<?php echo __('Dismiss', 'give') ?>"
+                    aria-controls="<?php echo $dismissableElementId ?>"
+                    class="give-sale-banner-dismiss givewp-sale-banner__dismiss" data-id="<?php echo $id ?>">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="19" viewBox="0 0 20 19" fill="none">
                     <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
-                    <line y1="-0.5" x2="25.4558" y2="-0.5"
-                          transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                    <line y1="-0.5" x2="25.4558" y2="-0.5" transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
                           stroke="#F9FAF9" />
                 </svg>
             </button>

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Give\Promotions\ReportsWidgetBanner;
+
+use Give\Promotions\InPluginUpsells\SaleBanners;
+
+/**
+* @unreleased
+ */
+class ReportsWidgetBanner extends SaleBanners
+{
+
+    /**
+     @unreleased
+     */
+    public function getBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2024-reports-widget',
+                'header' => __('Make it yours. Save 40% on all GiveWP products.', 'give'),
+                'actionText' => __('Shop Now', 'give'),
+                'actionUrl' => 'https://go.givewp.com/40sale24',
+                'startDate' => '2024-07-23 00:00',
+                'endDate' => '2024-07-30 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function loadScripts(): void
+    {
+        wp_enqueue_script(
+            'give-in-plugin-upsells-sale-banners',
+            GIVE_PLUGIN_URL . 'assets/dist/js/admin-upsell-sale-banner.js',
+            [],
+            GIVE_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'give-in-plugin-upsells-sale-banners',
+            'giveReportsWidget',
+            [
+                'apiRoot' => esc_url_raw(rest_url('give-api/v2/sale-banner')),
+                'apiNonce' => wp_create_nonce('wp_rest'),
+                'banner' => $this->getVisibleBanners()[0],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function isShowing(): bool
+    {
+        $hasBanners = !empty((new ReportsWidgetBanner)->getVisibleBanners());
+        $isDashboardWidgetPage = admin_url() . 'index.php' === get_site_url() . $_SERVER['REQUEST_URI'];
+
+        return $hasBanners && $isDashboardWidgetPage;
+    }
+}

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/index.tsx
@@ -1,0 +1,51 @@
+import {__} from '@wordpress/i18n';
+
+import './styles.scss';
+import {getWidgetWindowData} from "../../window/widgetWindow";
+
+
+type widgetBannerProps = {
+    hideWidgetBanner: (id) => void;
+};
+
+export default function WidgetBanner({hideWidgetBanner}: widgetBannerProps) {
+    const banner = getWidgetWindowData().banner;
+
+    const dismissBanner = () => {
+        hideWidgetBanner(banner.id);
+    }
+
+    return (
+        <div id={`givewp-sale-banner-${banner.id}`} className={'givewp-reports-widget-banner'}>
+            <div className={'givewp-reports-widget-banner__header'}>
+                <h1 className={'givewp-reports-widget-banner__header__main'}>{__('Make it yours.', 'give')}</h1>
+                <h2 className={'givewp-reports-widget-banner__header__secondary'}>{__('Save 40% on all GiveWP products', 'give')}</h2>
+            </div>
+            <a className={'givewp-reports-widget-banner__cta'}
+               href={banner.actionUrl}
+               target={"_blank"}
+               rel={"noopener noreferrer"}
+            >
+                {banner.actionText}
+            </a>
+            <button
+                onClick={dismissBanner}
+                type="button"
+                aria-label={__('Dismiss', 'give')}
+                aria-controls={`givewp-sale-banner-${banner.id}`}
+                className={'givewp-reports-widget-banner__dismiss'}
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" width="15px" height="14px" viewBox="0 0 20 19" fill="none">
+                    <line x1="1.35355" y1="0.646447" x2="19.3535" y2="18.6464" stroke="#F9FAF9" />
+                    <line
+                        y1="-0.5"
+                        x2="25.4558"
+                        y2="-0.5"
+                        transform="matrix(0.707107 -0.707106 0.707107 0.707106 1 19)"
+                        stroke="#F9FAF9"
+                    />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
+++ b/src/Promotions/ReportsWidgetBanner/components/WidgetBanner/styles.scss
@@ -1,0 +1,60 @@
+#givewp-reports-widget .givewp-reports-widget-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 1rem 2rem 1.5rem;
+    min-height: 8rem;
+    background: #1D202F;
+    color: #ffffff;
+
+    &__header {
+        &__main {
+            font-size: 1.5rem;
+            color: #fff4f2;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        &__secondary {
+            font-size: 1.25rem;
+            color: #fff4f2;
+            font-weight: 500;
+            line-height: normal;
+            padding: 0;
+        }
+    }
+
+    &__cta {
+        font-family: 'Inconsolata', Montserrat, sans-serif;;
+        margin-top: 1.125rem;
+        display: inline-flex;
+        padding: .5rem 1.5rem;
+        justify-content: center;
+        align-items: center;
+        background: #62B265;
+        color: #fff4f2;
+        font-weight: 600;
+        border-radius: 9999px;
+        border: none;
+        text-decoration: none;
+    }
+
+    &__dismiss {
+        position: absolute;
+        top: .75rem;
+        right: .5rem;
+        background: none;
+        border: none;
+        cursor: pointer;
+
+        &:hover {
+            transform: scale(1.15);
+        }
+
+        &:active {
+            transform: scale(0.95);
+        }
+    }
+}
+

--- a/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
+++ b/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import {getWidgetWindowData} from "../window/widgetWindow";
+
+
+export const useBannerVisibility = () => {
+    const windowData = getWidgetWindowData();
+    const [isVisible, setIsVisible] = useState<boolean>(false);
+
+    useEffect(() => {
+            setIsVisible(!!windowData?.banner);
+    }, [windowData?.banner]);
+
+    const hideWidgetBanner = async (id) => {
+        const formData = new FormData();
+        formData.append('id', id);
+
+        try {
+             await fetch(`${windowData.apiRoot}/hide`, {
+                method: 'POST',
+                headers: {
+                    'X-WP-Nonce': windowData.apiNonce,
+                },
+                body: formData,
+            });
+
+            setIsVisible(false);
+        } catch (error) {
+            console.error('Error hiding banner:', error);
+        }
+    };
+
+    return {
+        isVisible,
+        hideWidgetBanner,
+    };
+};
+
+export default useBannerVisibility;

--- a/src/Promotions/ReportsWidgetBanner/window/widgetWindow.ts
+++ b/src/Promotions/ReportsWidgetBanner/window/widgetWindow.ts
@@ -1,0 +1,22 @@
+/**
+ * @unreleased
+ */
+
+type windowData = {
+    apiRoot: string;
+    apiNonce: string;
+    banner: {
+       id: string;
+       header: string;
+       actionText: string;
+       actionUrl: string;
+    };
+};
+
+declare const window: {
+    giveReportsWidget: windowData;
+} & Window;
+
+export function getWidgetWindowData(): windowData {
+    return window.giveReportsWidget;
+}

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -10,6 +10,7 @@ use Give\Promotions\InPluginUpsells\Endpoints\ProductRecommendationsRoute;
 use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
 use Give\Promotions\InPluginUpsells\SaleBanners;
+use Give\Promotions\InPluginUpsells\StellarSaleBanners;
 use Give\Promotions\WelcomeBanner\Endpoints\DismissWelcomeBannerRoute;
 use Give\Promotions\WelcomeBanner\WelcomeBanner;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
@@ -37,11 +38,12 @@ class ServiceProvider implements ServiceProviderContract
     }
 
     /**
+     * @unreleased add Stellar banner.
      * @since      2.27.1 Removed Recurring donations tab app.
+     * @since      2.19.0
      *
      * Boots the Plugin Upsell promotional page
      *
-     * @since      2.19.0
      */
     private function bootPluginUpsells()
     {
@@ -57,6 +59,11 @@ class ServiceProvider implements ServiceProviderContract
         if (SaleBanners::isShowing()) {
             Hooks::addAction('admin_notices', SaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', SaleBanners::class, 'loadScripts');
+        }
+
+        if (StellarSaleBanners::isShowing()) {
+            Hooks::addAction('admin_notices', StellarSaleBanners::class, 'render');
+            Hooks::addAction('admin_enqueue_scripts', StellarSaleBanners::class, 'loadScripts');
         }
 
         if (PaymentGateways::isShowing()) {

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -11,6 +11,7 @@ use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
 use Give\Promotions\InPluginUpsells\SaleBanners;
 use Give\Promotions\InPluginUpsells\StellarSaleBanners;
+use Give\Promotions\ReportsWidgetBanner\ReportsWidgetBanner;
 use Give\Promotions\WelcomeBanner\Endpoints\DismissWelcomeBannerRoute;
 use Give\Promotions\WelcomeBanner\WelcomeBanner;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
@@ -65,6 +66,10 @@ class ServiceProvider implements ServiceProviderContract
             Hooks::addAction('admin_init', SaleBanners::class, 'startSession');
             Hooks::addAction('admin_notices', StellarSaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', StellarSaleBanners::class, 'loadScripts');
+        }
+
+        if (ReportsWidgetBanner::isShowing()) {
+            Hooks::addAction('admin_enqueue_scripts', ReportsWidgetBanner::class, 'loadScripts');
         }
 
         if (PaymentGateways::isShowing()) {

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -62,6 +62,7 @@ class ServiceProvider implements ServiceProviderContract
         }
 
         if (StellarSaleBanners::isShowing()) {
+            Hooks::addAction('admin_init', SaleBanners::class, 'startSession');
             Hooks::addAction('admin_notices', StellarSaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', StellarSaleBanners::class, 'loadScripts');
         }

--- a/src/Views/Components/ListTable/ProductRecommendations/style.module.scss
+++ b/src/Views/Components/ListTable/ProductRecommendations/style.module.scss
@@ -84,5 +84,5 @@
 }
 
 .wp-die-message, p {
-    font-size: .875rem !important;
+    font-size: .875rem;
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -18,7 +18,7 @@ mix.setPublicPath('assets/dist')
     .sass('src/Views/Form/Templates/Classic/resources/css/form.scss', 'css/give-classic-template.css')
     .sass('src/MultiFormGoals/resources/css/common.scss', 'css/multi-form-goal-block.css')
     .sass('src/DonationSummary/resources/css/summary.scss', 'css/give-donation-summary.css')
-    .sass('assets/src/css/admin/summer-sales-banner.scss', 'css/admin-summer-sales-banner.css')
+    .sass('src/Promotions/InPluginUpsells/resources/css/stellarwp-sales-banner.scss', 'css/admin-stellarwp-sales-banner.css')
 
     .js('assets/src/js/frontend/give.js', 'js/')
     .js('assets/src/js/frontend/give-stripe.js', 'js/')


### PR DESCRIPTION
Resolves: [GIVE-867]

This includes the Stellar2024 admin banners.

## Description
[Feature: add initial banner #7408
](https://github.com/impress-org/givewp/pull/7408)
[Feature: add alternating banners by pricing tier #7412
](https://github.com/impress-org/givewp/pull/7412)
[Feature: add Reports widget banner #7418
](https://github.com/impress-org/givewp/pull/7418)

## Affects
- Donations, Donors, Reports page.
- Reports widget

## Testing Instructions
### Admin Banners
- Clear cookies/history in the browser you intend to use. (IMPORTANT)
- Create a new test site & install/activate GiveWP or use a local server.
- Add New Plugin > Upload Plugin > upload the attached file or activate the give plugin.
- Click through the Donations, Donors, and Reports pages.
- Verify the banners alternate between: GiveWP Plus plan & Peer-to-Peer.
- Add a Basic license.
- Click back through the same pages.
- Verify you see the same banners that were shown before you added a license.
- Now, add a Plus license instead.
- Click back through the same pages.
- Verify the banners alternate between: GiveWP Pro plan & Peer-to-Peer.
- Now, add a Pro and Agency license instead.
- Click back through the same pages.
- Verify only a stellar banner is shown.
- Test that the P2P banner never displays if P2P is active.
- Test that once a banner is closed it remains closed.
- Verify the links for each banner match the pricing plan.

### Reports Widget Banners
- Visit the WordPress dashboard.
- Locate the GiveWP widget on the page.
- Verify the banner is displayed and the link takes you to the appropriate page.
- Verify after closing the banner, it is removed and remains closed.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-867]: https://stellarwp.atlassian.net/browse/GIVE-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ