### PR TITLE
Refactor: standardize primary color on VFB input borders

### DIFF
--- a/src/DonationForms/resources/styles/_base-overrides.scss
+++ b/src/DonationForms/resources/styles/_base-overrides.scss
@@ -81,7 +81,10 @@ input[type="file"] {
 input[type="text"]:not([name="amount"], [name="amount-custom"]),
 input[type="password"],
 input[type="email"],
+input[type="checkbox"],
 textarea {
+    border-color: var(--givewp-primary-color);
+
     &:focus {
         border-color: transparent;
         --box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color);


### PR DESCRIPTION
Resolves: [GIVE-818]

## Description
This change ensures all inputs in the visual form builder are standardized with the primary color applied to the border. This is necessary for some of the blocks in our addons which display a grey border with high specificity.

## Affects
VFB inputs

## Visuals

https://github.com/impress-org/givewp/assets/75056371/50586ae2-cefe-4922-ace8-e4709868b040

## Testing Instructions
- Install FFM, add a checkbox block.
- View design mode and click on the checkbox.
- Click away from the checkbox on the form verify the border color is not grey.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-818]: https://stellarwp.atlassian.net/browse/GIVE-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ