### PR TITLE
Refactor: Remove radio button for single active gateway

### DIFF
--- a/src/DonationForms/resources/styles/components/_gateways.scss
+++ b/src/DonationForms/resources/styles/components/_gateways.scss
@@ -18,6 +18,12 @@
         list-style: none;
         margin: 0;
 
+        &:first-child:last-child {
+            label > input {
+                display: none;
+            }
+        }
+
         label {
             display: flex;
             flex-direction: row;


### PR DESCRIPTION
Resolves [GIVE-545]

## Description
Currently, even when there is only one payment gateway option in the donation form, the radio button is shown. This does not make much sense in that situation since you cannot switch to any other method.

This pull request adds CSS styles to hide the radio button when the payment gateway is the only one in the list.

## Affects
Gateways list

## Visuals
![CleanShot 2024-07-03 at 13 48 29](https://github.com/impress-org/givewp/assets/3921017/1cc43e8a-00ea-4add-8b8d-bf8c2e51984d)
_Before_

![CleanShot 2024-07-03 at 13 50 46](https://github.com/impress-org/givewp/assets/3921017/6c2ac72d-2846-47a2-996f-5833c79ff3b2)
_After_

![CleanShot 2024-07-03 at 13 51 30](https://github.com/impress-org/givewp/assets/3921017/1d2522ea-80db-4f49-af55-e63a4f6bf993)
_After but having more than 1 option_

## Testing Instructions
1.	Configure more than one payment method in Settings.
2.	Open a form and confirm that all options have radio buttons.
3.	Re-configure the payment methods to have only one active.
4.	Open the form and confirm that when there is only one option, no radio button is shown.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-545]: https://stellarwp.atlassian.net/browse/GIVE-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ