### PR TITLE
Refactor: Improve form footer style

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -86,18 +86,15 @@ button[type="submit"] {
     font-size: 1.375rem;
     font-weight: 600;
     line-height: 1.2;
-    transition-property: filter, box-shadow, transform;
-    transition-duration: 0.3s;
-    transition-timing-function: ease-in-out;
     cursor: pointer;
     inline-size: 100%;
     width: 100%;
     margin: 1rem 0;
 
-    &:hover {
-        filter: brightness(1.2);
-        transform: scale(1.01);
-        box-shadow: 0 0.0625rem 0.25rem rgb(0 0 0 / 25%);
+    @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
+        &:hover {
+            background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
+        }
     }
 }
 

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -37,9 +37,9 @@ export default function StepsWrapper({steps, children}: {steps: StepObject[]; ch
             <div className="givewp-donation-form__steps-footer">
                 <div className="givewp-donation-form__steps-footer-secure">
                     <i className="fas fa-lock givewp-donation-form__steps-footer-secure-icon"></i>
-                    <small className="givewp-donation-form__steps-footer-secure-icon">
-                        {__('Secure Donation', 'give')}
-                    </small>
+                    <span className="givewp-donation-form__steps-footer-secure-text">
+                        {__('100% Secure Donation', 'give')}
+                    </span>
                 </div>
             </div>
         </div>

--- a/src/DonationForms/resources/styles/elements/_multi-step-form.scss
+++ b/src/DonationForms/resources/styles/elements/_multi-step-form.scss
@@ -98,6 +98,7 @@
         }
     }
 
+    button[type="submit"],
     &__steps-button-next {
         display: flex;
         justify-content: center;
@@ -107,6 +108,14 @@
         line-height: 1.5;
         font-weight: 600;
 
+        @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
+            &:hover {
+                background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
+            }
+        }
+    }
+
+    &__steps-button-next {
         &:after {
             content: "";
             display: inline-block;
@@ -116,12 +125,6 @@
             background-image: var(--givewp-icon-arrow-right);
             background-position: center;
             background-repeat: no-repeat;
-        }
-
-        @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
-            &:hover {
-                background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
-            }
         }
     }
 

--- a/src/DonationForms/resources/styles/elements/_multi-step-form.scss
+++ b/src/DonationForms/resources/styles/elements/_multi-step-form.scss
@@ -83,8 +83,9 @@
 
         &-footer-secure {
             display: flex;
-            column-gap: 0.5rem;
+            column-gap: 1rem;
             width: 100%;
+            margin-top: var(--givewp-spacing-4);
             padding: var(--givewp-spacing-4);
             font-size: var(--givewp-font-size-paragraph-md);
             color: var(--givewp-grey-900);
@@ -92,9 +93,13 @@
             justify-content: center;
         }
 
-        &-footer-secure-icon,
-        &-footer-secure-text {
+        &-footer-secure-icon {
             color: var(--givewp-secondary-color);
+            translate: 0 -1px;
+        }
+
+        &-footer-secure-text {
+            font-weight: 500;
         }
     }
 
@@ -107,6 +112,7 @@
         color: var(--givewp-grey-5);
         line-height: 1.5;
         font-weight: 600;
+        margin: 0;
 
         @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
             &:hover {


### PR DESCRIPTION
Resolves [GIVE-811]

## Description
Currently, the form footer does not match the intended design. In the Classic design, the hover state of the Donate button is unique, differentiating it from other buttons. However, in the Multi-Step design, there is no hover state for the Donate button.

This pull request fixes these issues by adding the same hover state to the Donate button in both designs. Additionally, it also corrects the content and design of the secure notice badge present in the Multi-Step footer.

## Affects
Classic and multi-step form footer

## Visuals
![CleanShot 2024-07-03 at 14 34 09](https://github.com/impress-org/givewp/assets/3921017/24baa983-6959-41c3-8a7e-1ef4f81b238d)
_Hover state on Classic design_

![CleanShot 2024-07-03 at 14 34 43](https://github.com/impress-org/givewp/assets/3921017/c033c7dc-9f30-4266-8fee-dbab52cce16b)
_Hover state on Multi-Step design_

![CleanShot 2024-07-03 at 14 32 27](https://github.com/impress-org/givewp/assets/3921017/a8d98101-37d0-4361-abd6-f0e6e358be15)
_Secure notice badge on Multi-Step design_

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-811]: https://stellarwp.atlassian.net/browse/GIVE-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ