### PR TITLE
Refactor: Improve Donor Title Prefix field styles

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -7,7 +7,7 @@
 }
 
 .givewp-fields-select-honorific {
-    flex-basis: 25%;
+    flex-basis: 35%;
 }
 
 .givewp-fields-hidden {
@@ -23,13 +23,13 @@ select:not(.givewp-fields-amount__currency-select) {
     font-family: inherit;
     font-weight: 500;
     line-height: 1.2;
-    padding: 0.9rem;
+    padding: 0.9rem var(--givewp-spacing-8) 0.9rem 1.1875rem;
     margin-bottom: 0.5rem;
     appearance: none;
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='13' height='8' viewBox='0 0 13 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.66016 7.19531C5.90625 7.44141 6.31641 7.44141 6.5625 7.19531L11.8945 1.89062C12.1406 1.61719 12.1406 1.20703 11.8945 0.960938L11.2656 0.332031C11.0195 0.0859375 10.6094 0.0859375 10.3359 0.332031L6.125 4.54297L1.88672 0.332031C1.61328 0.0859375 1.20312 0.0859375 0.957031 0.332031L0.328125 0.960938C0.0820312 1.20703 0.0820312 1.61719 0.328125 1.89062L5.66016 7.19531Z' fill='%23A2A3A2'/%3E%3C/svg%3E"),
     linear-gradient(to bottom, #fff 0%, #fff 100%);
     background-repeat: no-repeat, repeat;
-    background-position: right 0.5em top 50%, 0 0;
+    background-position: right var(--givewp-spacing-4) top 50%, 0 0;
     background-size: 0.65em auto, 100%;
 
     &[aria-invalid="true"],

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -79,6 +79,7 @@ export default function Edit({
                         options={honorificOptions}
                         value={selectedTitle}
                         onChange={setSelectedTitle}
+                        style={{padding: '16px 38px 16px 16px'}}
                     />
                 )}
                 <TextControl

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -105,65 +105,66 @@ export default function Edit({
             <InspectorControls>
                 <PanelBody title={__('Name Title Prefix', 'give')} initialOpen={true}>
                     <PanelRow>
-                        <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-                            <div>
-                                {/* Wrapper added to control spacing between control and help text. */}
-                                <ToggleControl
-                                    label={__('Show Name Title Prefix', 'give')}
-                                    checked={showHonorific}
-                                    onChange={() => setAttributes({showHonorific: !showHonorific})}
-                                    help={__(
-                                        "Do you want to add a name title prefix dropdown field before the donor's first name field? This will display a dropdown with options such as Mrs, Miss, Ms, Sir, and Dr for the donor to choose from.",
-                                        'give'
-                                    )}
-                                />
-                                {!!showHonorific && (
-                                    <>
-                                        <SelectControl
-                                            label={__('Options', 'give')}
-                                            onChange={() => setAttributes({useGlobalSettings: !useGlobalSettings})}
-                                            value={useGlobalSettings}
-                                            options={[
-                                                {label: __('Global', 'give'), value: 'true'},
-                                                {label: __('Customize', 'give'), value: 'false'},
-                                            ]}
-                                        />
-                                        {useGlobalSettings && (
-                                            <p
-                                                style={{
-                                                    color: '#595959',
-                                                    fontStyle: 'SF Pro Text',
-                                                    fontSize: '0.75rem',
-                                                    lineHeight: '120%',
-                                                    fontWeight: 400,
-                                                    marginTop: '-0.5rem',
-                                                }}
-                                            >
-                                                {__(' Go to the settings to change the ')}
-                                                <a
-                                                    href="/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=display-settings"
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                >
-                                                    {__('Global Title Prefixes options.')}
-                                                </a>
-                                            </p>
-                                        )}
-                                    </>
+                        <ToggleControl
+                            label={__('Show Name Title Prefix', 'give')}
+                            checked={showHonorific}
+                            onChange={() => setAttributes({showHonorific: !showHonorific})}
+                            help={__(
+                                "Do you want to add a name title prefix dropdown field before the donor's first name field? This will display a dropdown with options such as Mrs, Miss, Ms, Sir, and Dr for the donor to choose from.",
+                                'give'
+                            )}
+                        />
+                    </PanelRow>
+                    {!!showHonorific && (
+                        <PanelRow>
+                            <div style={{width: '100%'}}>
+                                <div>
+                                    <SelectControl
+                                        label={__('Options', 'give')}
+                                        onChange={() => setAttributes({useGlobalSettings: !useGlobalSettings})}
+                                        value={useGlobalSettings}
+                                        options={[
+                                            {label: __('Global', 'give'), value: 'true'},
+                                            {label: __('Customize', 'give'), value: 'false'},
+                                        ]}
+                                    />
+                                </div>
+                                {useGlobalSettings && (
+                                    <p
+                                        style={{
+                                            color: '#595959',
+                                            fontStyle: 'SF Pro Text',
+                                            fontSize: '0.75rem',
+                                            lineHeight: '120%',
+                                            fontWeight: 400,
+                                            marginTop: '0.5rem',
+                                        }}
+                                    >
+                                        {__(' Go to the settings to change the ')}
+                                        <a
+                                            href="/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=display&section=display-settings"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {__('Global Title Prefixes options.')}
+                                        </a>
+                                    </p>
                                 )}
                             </div>
+                        </PanelRow>
+                    )}
 
-                            {!!showHonorific && !useGlobalSettings && (
-                                <OptionsPanel
-                                    multiple={false}
-                                    selectable={false}
-                                    options={honorificOptions}
-                                    setOptions={setOptions}
-                                    defaultControlsTooltip={__('Title Prefixes', 'give')}
-                                />
-                            )}
+                    {!!showHonorific && !useGlobalSettings && (
+                        <div style={{marginTop: '1rem'}}>
+                            <OptionsPanel
+                                multiple={false}
+                                selectable={false}
+                                options={honorificOptions}
+                                setOptions={setOptions}
+                                defaultControlsTooltip={__('Title Prefixes', 'give')}
+                            />
                         </div>
-                    </PanelRow>
+                    )}
                 </PanelBody>
                 <PanelBody title={__('First Name', 'give')} initialOpen={true}>
                     <PanelRow>

--- a/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_block-editor.scss
@@ -74,7 +74,7 @@
     }
 
     .components-select-control__input {
-        height: 52px !important;
+        height: auto !important;
 
         & ~ .components-input-control__suffix {
             & > div {


### PR DESCRIPTION
Resolves [GIVE-812]

## Description
Some issues were identified related to the Donor Title Prefix field and its settings. The field’s padding did not match with other inputs. Additionally, in its settings, there was some odd extra spacing when toggling certain options.

This pull request fixes these issues by standardizing the padding for the select field to match other inputs and adjusting the wrappers in the settings so that the correct margins are applied.

## Affects
Donor Title Prefix

## Visuals
![CleanShot 2024-07-03 at 14 48 48](https://github.com/impress-org/givewp/assets/3921017/542ddde6-b9fb-4b6c-979a-462d177bc4c9)
_Donor Title Prefix field in the Donation Form_

![CleanShot 2024-07-03 at 14 53 32](https://github.com/impress-org/givewp/assets/3921017/76f646cd-ed4b-4c80-a5d8-c93445e50e02)
_Donor Title Prefix field in the Form Builder_

![CleanShot 2024-07-03 at 15 55 38](https://github.com/impress-org/givewp/assets/3921017/76bfbb29-3c03-4f0c-8b8a-9b7d8a3ecba1)
_Switching settings in the Form Builder_

## Testing Instructions
1. Open a form
2. Enable Donor Title Prefix
3. Switch between the variety of options available
4. Confirm them all look and work well

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-812]: https://stellarwp.atlassian.net/browse/GIVE-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ