### PR TITLE
Refactor: Set line-height to Section block in the VFB

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/section/Edit.tsx
@@ -4,7 +4,7 @@ import {InnerBlocks, InspectorControls, RichText, store as blockEditorStore} fro
 import {PanelBody, PanelRow, TextareaControl, TextControl} from '@wordpress/components';
 import {useSelect} from '@wordpress/data';
 import {BlockEditProps} from '@wordpress/blocks';
-import {getBlockRegistrar} from "@givewp/form-builder/common/getWindowData";
+import {getBlockRegistrar} from '@givewp/form-builder/common/getWindowData';
 
 import BaseEmptyBlockInserter from './EmptyBlockInserter';
 import './styles.scss';
@@ -44,7 +44,7 @@ export default function Edit(props: BlockEditProps<any>) {
                             tagName="h2"
                             value={title}
                             onChange={(val) => setAttributes({title: val})}
-                            style={{margin: '0', fontSize: '22px', fontWeight: 700}}
+                            style={{margin: '0', fontSize: '22px', fontWeight: 700, lineHeight: '1.6'}}
                             allowedFormats={[]}
                         />
                     )}
@@ -53,7 +53,7 @@ export default function Edit(props: BlockEditProps<any>) {
                             tagName="p"
                             value={description}
                             onChange={(val) => setAttributes({description: val})}
-                            style={{fontSize: '16px', fontWeight: 500}}
+                            style={{fontSize: '16px', fontWeight: 500, marginTop: '0.25rem'}}
                             allowedFormats={[]}
                         />
                     )}


### PR DESCRIPTION
Resolves [GIVE-816]

## Description
When adding a long title in a section block, it does not look good. This pull request increases its line-height to match the style in the donation form and sets a top margin for the following paragraph element, reducing the spacing between these elements.

## Affects
Section block title

## Visuals
![CleanShot 2024-07-03 at 17 26 46](https://github.com/impress-org/givewp/assets/3921017/7f8b2160-5579-4b2f-b0d4-acb2bbecf592)
_Before_

![CleanShot 2024-07-03 at 17 26 03](https://github.com/impress-org/givewp/assets/3921017/1f8d50dc-ca62-4fa7-92a1-e97025694853)
_After_

![CleanShot 2024-07-03 at 17 28 12](https://github.com/impress-org/givewp/assets/3921017/939320f7-f854-479d-bea6-6a39a1ce6447)
_Donation Form_

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-816]: https://stellarwp.atlassian.net/browse/GIVE-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ