### PR TITLE
Refactor: Prevent File Upload description from triggering file selection modal

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,23 +1,19 @@
 import {FileProps} from '@givewp/forms/propTypes';
 
-export default function File({
-    Label,
-    allowedMimeTypes,
-    ErrorMessage,
-    fieldError,
-    description,
-    inputProps,
-}: FileProps) {
+export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError, description, inputProps}: FileProps) {
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
     const {setValue} = window.givewp.form.hooks.useFormContext();
     const {name} = inputProps;
 
     return (
-        <label>
-            <Label />
+        <>
+            <label htmlFor={`${name}-field`}>
+                <Label />
+            </label>
             {description && <FieldDescription description={description} />}
 
             <input
+                id={`${name}-field`}
                 type="file"
                 aria-invalid={fieldError ? 'true' : 'false'}
                 accept={allowedMimeTypes.join(',')}
@@ -29,6 +25,6 @@ export default function File({
             <input type="hidden" {...inputProps} />
 
             <ErrorMessage />
-        </label>
+        </>
     );
 }


### PR DESCRIPTION
Resolves [GIVE-820]

## Description
The File Upload template is entirely clickable, triggering the file selection modal. This issue is caused by a label element wrapping the entire component. This pull request changes it by unwrapping the label element, keeping it only around the label text while still allowing it to trigger the file selection modal. The difference is that now, clicking the description text will not activate the modal, making this template consistent with how other fields behave.

## Affects
File input template

## Visuals
https://github.com/impress-org/givewp/assets/3921017/2e66c450-23a0-448c-99b1-df4b175dd8b0
_Clicking the input, then the label, the description_

## Testing Instructions
Make sure the input field works just like before, except it will not trigger the file selection modal when clicking on the description text.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-820]: https://stellarwp.atlassian.net/browse/GIVE-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ