### PR TITLE
Refactor: Change to use the selected default period in notice

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/Edit.tsx
@@ -99,6 +99,7 @@ const Edit = ({attributes, setAttributes}) => {
     const displayFixedMessage = isFixedAmount && !customAmount;
     const displayFixedRecurringMessage =
         isRecurring &&
+        recurringOptInDefaultBillingPeriod !== 'one-time' &&
         (displayFixedMessage ||
             isRecurringAdmin ||
             Number(recurringLengthOfTime) > 0 ||
@@ -134,7 +135,7 @@ const Edit = ({attributes, setAttributes}) => {
                         <RecurringAmountMessage
                             isFixedAmount={isFixedAmount}
                             fixedAmount={amountFormatted}
-                            period={recurringBillingPeriodOptions[0]}
+                            period={recurringOptInDefaultBillingPeriod}
                             frequency={parseInt(recurringBillingInterval)}
                             installments={parseInt(recurringLengthOfTime)}
                         />


### PR DESCRIPTION
Resolves [GIVE-822]

## Description
Under certain conditions, due to a combination of Give Recurring settings, a notice is shown below the Amount block in the VFB, representing the same message users will see in the Donation Form. This notice informs that the donation will repeat every X periods. Currently, that message always uses the first option label. This pull request changes that behavior to use the selected default period as the source for the period label. With that, was necessary to add an extra conditional to not show the notice when the default option is set to "One-time".

## Affects
Recurring settings in the Amount block

## Visuals
https://github.com/impress-org/givewp/assets/3921017/71a1945d-60e2-40b6-aa28-0a266a7d0144

## Testing Instructions
Make sure the recurring message is still being displayed correctly in both VFB and Donation Form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-822]: https://stellarwp.atlassian.net/browse/GIVE-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ