### PR TITLE
Refactor: Re-style Login block

### DIFF
--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -77,6 +77,11 @@ export default function Authentication({
     const [isAuth, setIsAuth] = useState<boolean>(isAuthenticated);
     const [showLogin, setShowLogin] = useState<boolean>(required);
     const toggleShowLogin = () => setShowLogin(!showLogin);
+    const redirectToLoginPage = (e) => {
+        e.preventDefault();
+        const loginUrl = getRedirectUrl(new URL(loginRedirectUrl));
+        window.top.location.assign(loginUrl);
+    };
 
     return (
         <>
@@ -94,16 +99,7 @@ export default function Authentication({
             {!isAuth && !showLogin && (
                 <div style={{display: 'flex'}}>
                     {loginRedirect ? (
-                        <button
-                            type="button"
-                            onClick={() => {
-                                const loginUrl = getRedirectUrl(new URL(loginRedirectUrl));
-
-                                window.top.location.assign(loginUrl);
-                            }}
-                        >
-                            {loginNotice}
-                        </button>
+                        <LoginNotice onClick={redirectToLoginPage}>{loginNotice}</LoginNotice>
                     ) : (
                         <LoginNotice onClick={toggleShowLogin}>{loginNotice}</LoginNotice>
                     )}

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -144,39 +144,25 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
     };
 
     return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '15px'}}>
-            <div style={{display: 'flex', flexDirection: 'row', gap: '15px'}}>{children}</div>
+        <div className={styles['authentication__login-form']}>
+            <div className={styles['authentication__login-form__fields-wrapper']}>{children}</div>
 
             {!!errorMessage && <FieldError error={errorMessage} name={nodeName} />}
 
-            <div
-                style={{
-                    display: 'flex',
-                    flexDirection: 'row-reverse',
-                    gap: '15px',
-                    justifyContent: 'space-between',
-                    alignItems: 'baseline',
-                }}
-            >
-                <button className={styles.loginButton} onClick={tryLogin}>
+            <div className={styles['authentication__login-form__buttons-wrapper']}>
+                <button className={styles['authentication__login-form__login-button']} onClick={tryLogin}>
                     {__('Log In', 'give')}
                 </button>
                 <a
+                    className={styles['authentication__login-form__reset-button']}
                     onClick={(event) => {
                         event.preventDefault();
                         const passwordResetUrl = getRedirectUrl(new URL(lostPasswordUrl));
 
                         window.top.location.assign(passwordResetUrl);
                     }}
-                    style={{
-                        color: 'var(--givewp-grey-500)',
-                        cursor: 'pointer',
-                        fontSize: '14px',
-                        lineHeight: '1.43',
-                    }}
                 >
-                    {__('Forgot your password?', 'give')}{' '}
-                    <span style={{color: 'var(--primary)', fontWeight: '500'}}>{__('Reset', 'give')}</span>
+                    {__('Forgot your password?', 'give')} <span>{__('Reset', 'give')}</span>
                 </a>
             </div>
         </div>
@@ -185,19 +171,7 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
 
 const LoginNotice = ({children, onClick}) => {
     return (
-        <button
-            onClick={onClick}
-            style={{
-                backgroundColor: 'transparent',
-                border: 0,
-                color: 'var(--primary)',
-                fontSize: '14px',
-                fontWeight: '500',
-                margin: '0',
-                padding: '0',
-                width: 'auto',
-            }}
-        >
+        <button className={styles['authentication__login-notice']} onClick={onClick}>
             {children}
         </button>
     );

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -6,6 +6,7 @@ import getWindowData from '@givewp/forms/app/utilities/getWindowData';
 import postData from '@givewp/forms/app/utilities/postData';
 import getCurrentFormUrlData from '@givewp/forms/app/utilities/getCurrentFormUrlData';
 import FieldError from '../layouts/FieldError';
+import styles from '../styles.module.scss';
 
 const {originUrl, isEmbed, embedId} = getCurrentFormUrlData();
 
@@ -91,7 +92,7 @@ export default function Authentication({
                 </LoginForm>
             )}
             {!isAuth && !showLogin && (
-                <div style={{display: 'flex', flexDirection: 'row-reverse'}}>
+                <div style={{display: 'flex'}}>
                     {loginRedirect ? (
                         <button
                             type="button"
@@ -161,7 +162,7 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
                     alignItems: 'baseline',
                 }}
             >
-                <button style={{width: 'auto'}} onClick={tryLogin}>
+                <button className={styles.loginButton} onClick={tryLogin}>
                     {__('Log In', 'give')}
                 </button>
                 <a
@@ -171,8 +172,15 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
 
                         window.top.location.assign(passwordResetUrl);
                     }}
+                    style={{
+                        color: 'var(--givewp-grey-500)',
+                        cursor: 'pointer',
+                        fontSize: '14px',
+                        lineHeight: '1.43',
+                    }}
                 >
-                    {__('Reset Password', 'give')}
+                    {__('Forgot your password?', 'give')}{' '}
+                    <span style={{color: 'var(--primary)', fontWeight: '500'}}>{__('Reset', 'give')}</span>
                 </a>
             </div>
         </div>
@@ -183,9 +191,18 @@ const LoginNotice = ({children, onClick}) => {
     return (
         <button
             onClick={onClick}
-            style={{width: 'auto', backgroundColor: 'transparent', border: 0, color: 'var(--wp-admin-theme-color)'}}
+            style={{
+                backgroundColor: 'transparent',
+                border: 0,
+                color: 'var(--primary)',
+                fontSize: '14px',
+                fontWeight: '500',
+                margin: '0',
+                padding: '0',
+                width: 'auto',
+            }}
         >
             {children}
         </button>
-    )
-}
+    );
+};

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -92,20 +92,65 @@
     }
 }
 
-.loginButton {
-    border-radius: 5px;
-    color: var(--givewp-grey-5);
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1.5;
-    margin: 0;
-    min-width: 154px;
-    padding: var(--givewp-spacing-2) var(--givewp-spacing-6);
-    width: auto;
+.authentication {
+    &__login-notice {
+        background-color: transparent;
+        border: 0;
+        color: var(--primary);
+        font-size: 14px;
+        font-weight: 500;
+        margin: 0;
+        padding: 0;
+        width: auto;
+    }
 
-    @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
-        &:hover {
-            background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
+    &__login-form {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+
+        &__fields-wrapper {
+            display: flex;
+            flex-direction: row;
+            gap: 15px;
+        }
+
+        &__buttons-wrapper {
+            display: flex;
+            flex-direction: row-reverse;
+            gap: 15px;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        &__login-button {
+            border-radius: 5px;
+            color: var(--givewp-grey-5);
+            font-size: 1rem;
+            font-weight: 600;
+            line-height: 1.5;
+            margin: 0;
+            min-width: 154px;
+            padding: var(--givewp-spacing-2) var(--givewp-spacing-6);
+            width: auto;
+
+            @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
+                &:hover {
+                    background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
+                }
+            }
+        }
+
+        &__reset-button {
+            color: var(--givewp-grey-500);
+            cursor: pointer;
+            font-size: 14px;
+            line-height: 1.43;
+
+            span {
+                color: var(--primary);
+                font-weight: 500;
+            }
         }
     }
 }

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -91,3 +91,21 @@
         }
     }
 }
+
+.loginButton {
+    border-radius: 5px;
+    color: var(--givewp-grey-5);
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.5;
+    margin: 0;
+    min-width: 154px;
+    padding: var(--givewp-spacing-2) var(--givewp-spacing-6);
+    width: auto;
+
+    @supports (background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black)) {
+        &:hover {
+            background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
+        }
+    }
+}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
@@ -132,8 +132,25 @@ const login: FieldBlock = {
                                     label={__('Require donor login', 'give')}
                                     checked={required}
                                     onChange={() => setAttributes({required: !required})}
+                                    help={__(
+                                        'Enable this option if you want to require the donor login by default.',
+                                        'give'
+                                    )}
                                 />
                             </PanelRow>
+                            {!required && (
+                                <PanelRow>
+                                    <TextControl
+                                        label={__('Login Notice', 'give')}
+                                        value={loginNotice}
+                                        onChange={(loginNotice) => setAttributes({loginNotice})}
+                                        help={__(
+                                            'Add your own to customize or leave blank to use the default text placeholder.',
+                                            'give'
+                                        )}
+                                    />
+                                </PanelRow>
+                            )}
                             <PanelRow>
                                 <ToggleControl
                                     label={__('Redirect to login page', 'give')}
@@ -143,16 +160,13 @@ const login: FieldBlock = {
                             </PanelRow>
                             <PanelRow>
                                 <TextControl
-                                    label={__('Login Notice', 'give')}
-                                    value={loginNotice}
-                                    onChange={(loginNotice) => setAttributes({loginNotice})}
-                                />
-                            </PanelRow>
-                            <PanelRow>
-                                <TextControl
                                     label={__('Login Confirmation', 'give')}
                                     value={loginConfirmation}
                                     onChange={(loginConfirmation) => setAttributes({loginConfirmation})}
+                                    help={__(
+                                        'Add your own to customize or leave blank to use the default text placeholder.',
+                                        'give'
+                                    )}
                                 />
                             </PanelRow>
                         </PanelBody>

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/login/index.tsx
@@ -13,7 +13,7 @@ const login: FieldBlock = {
         ...defaultSettings,
         icon: BlockIcon,
         title: __('User Login', 'give'),
-        description: __('...', 'give'),
+        description: __('Provides the donor the option to log in to complete donation', 'give'),
         supports: {
             multiple: false,
         },
@@ -44,39 +44,81 @@ const login: FieldBlock = {
                         <div style={{display: 'flex', flexDirection: 'column', gap: '15px'}}>
                             <div style={{display: 'flex', flexDirection: 'row', gap: '15px'}}>
                                 <TextControl
-                                    label={__('Login', 'give')}
+                                    label={__('Username', 'give')}
                                     onChange={() => null}
                                     value={''}
-                                    placeholder={__('Username or Email Address', 'give')}
+                                    placeholder={__('Enter your username or email', 'give')}
                                 />
                                 <TextControl
                                     type="password"
                                     label={__('Password', 'give')}
                                     onChange={() => null}
-                                    value={'password123'}
+                                    value={''}
+                                    placeholder={__('Enter your password', 'give')}
                                 />
                             </div>
                             <div
                                 style={{
+                                    alignItems: 'center',
                                     display: 'flex',
                                     flexDirection: 'row-reverse',
                                     gap: '15px',
                                     justifyContent: 'space-between',
                                 }}
                             >
-                                <Button variant={'primary'}>{__('Log In', 'give')}</Button>
-                                <Button variant={'link'}>{__('Reset Password', 'give')}</Button>
+                                <Button
+                                    variant={'primary'}
+                                    style={{
+                                        backgroundColor: 'var(--givewp-neutral-70)',
+                                        color: 'var(--givewp-grey-900)',
+                                        borderRadius: '4px',
+                                        fontSize: '1rem',
+                                        fontWeight: '600',
+                                        height: 'auto',
+                                        lineHeight: '1.38',
+                                        padding: '12px 16px',
+                                    }}
+                                >
+                                    {__('Log In', 'give')}
+                                </Button>
+                                <Button
+                                    style={{
+                                        color: 'var(--givewp-grey-700)',
+                                        display: 'inline',
+                                        fontSize: '14px',
+                                        fontWeight: '500',
+                                        padding: '0',
+                                    }}
+                                >
+                                    {__('Forgot your password?', 'give')} <strong>{__('Reset', 'give')}</strong>
+                                </Button>
                             </div>
                         </div>
                     )}
 
                     {!required && (
-                        <div style={{display: 'flex', flexDirection: 'row-reverse'}}>
+                        <div
+                            style={{
+                                backgroundColor: 'var(--givewp-grey-50)',
+                                borderRadius: '5px',
+                                display: 'flex',
+                                padding: '12px 24px',
+                            }}
+                        >
                             <Button
-                                variant={'link'}
-                                icon={!!loginRedirect ? <Icon icon={external} /> : undefined}
+                                icon={
+                                    !!loginRedirect ? (
+                                        <Icon icon={external} style={{height: '20px', width: '20px'}} />
+                                    ) : undefined
+                                }
                                 // iconPosition={'right' as 'left' | 'right'} // The icon position does not seem to be working.
-                                style={{flexDirection: 'row-reverse'}}
+                                style={{
+                                    flexDirection: 'row-reverse',
+                                    fontSize: '14px',
+                                    height: 'auto',
+                                    lineHeight: '1.5',
+                                    padding: '0',
+                                }}
                             >
                                 {loginNotice}
                             </Button>

--- a/src/Framework/FieldsAPI/Authentication.php
+++ b/src/Framework/FieldsAPI/Authentication.php
@@ -21,11 +21,13 @@ class Authentication extends Group
         return parent::make($name)
             ->append(
                 Text::make('login')
-                    ->label(__('Username or Email Address', 'give'))
+                    ->label(__('Username', 'give'))
+                    ->placeholder(__('Enter your username or email', 'give'))
             )
             ->append(
                 Password::make('password')
                     ->label(__('Password', 'give'))
+                    ->placeholder(__('Enter your password', 'give'))
             );
     }
 


### PR DESCRIPTION
Resolves [GIVE-809]

## Description
This pull request re-style the Login block to match the new designs. This includes reorder of the settings in the sidebar, with the addition of helper texts.

## Affects
Login block

## Visuals
![CleanShot 2024-07-03 at 21 46 20](https://github.com/impress-org/givewp/assets/3921017/fd94f5ac-be6c-4079-9504-be187a21d8d3)
_Already have an account button on Form Builder_

![CleanShot 2024-07-03 at 21 56 34](https://github.com/impress-org/givewp/assets/3921017/9a7e3123-702d-4e97-b4cb-c7fb216843e4)
_Login form on the Form Builder_

![CleanShot 2024-07-03 at 22 07 51](https://github.com/impress-org/givewp/assets/3921017/b3a26e34-d881-420d-94de-52e74acbc970)
_Already have an account button on Donation Form_

![CleanShot 2024-07-03 at 22 27 40](https://github.com/impress-org/givewp/assets/3921017/115f939c-ecb2-4c79-b2fb-e24b17cfa513)
_Login form on the Donation Form_

## Testing Instructions
Make sure the login form keep working just like before.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-809]: https://stellarwp.atlassian.net/browse/GIVE-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ