### PR TITLE
refactor: update default colors in PanelColorSettings

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
@@ -1,7 +1,7 @@
 import {__} from '@wordpress/i18n';
 import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-state';
 import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPubSub';
-import {PanelColorSettings, SETTINGS_DEFAULTS} from '@wordpress/block-editor';
+import {PanelColorSettings} from '@wordpress/block-editor';
 import {PanelBody} from '@wordpress/components';
 
 export default function Color({dispatch}) {
@@ -10,6 +10,20 @@ export default function Color({dispatch}) {
     } = useFormState();
 
     const {publishColors} = useDonationFormPubSub();
+
+    const defaultColors = [
+        {name: 'Black', slug: 'black', color: '#000000'},
+        {name: 'Dark Blue', slug: 'dark-blue', color: '#1E1AE2'},
+        {name: 'Give Primary Default', slug: 'give-primary-default', color: '#69b86b'},
+        {name: 'Red', slug: 'red', color: '#BD3D36'},
+        {name: 'Orange', slug: 'orange', color: '#EB712E'},
+        {name: 'Gray', slug: 'gray', color: '#5F7385'},
+        {name: 'Light Blue', slug: 'light-blue', color: '#4492DD'},
+        {name: 'Light Green', slug: 'light-green', color: '#63CC8A'},
+        {name: 'Purple', slug: 'purple', color: '#9058D8'},
+        {name: 'Teal', slug: 'teal', color: '#2BBAB1'},
+        {name: 'Yellow', slug: 'yellow', color: '#F1BB40'},
+    ];
 
     return (
         <PanelBody title={__('Color', 'give')}>
@@ -23,7 +37,7 @@ export default function Color({dispatch}) {
                         },
                         label: __('Primary Color', 'give'),
                         disableCustomColors: false,
-                        colors: SETTINGS_DEFAULTS.colors,
+                        colors: defaultColors,
                     },
                     {
                         value: secondaryColor,
@@ -33,7 +47,7 @@ export default function Color({dispatch}) {
                         },
                         label: __('Secondary Color', 'give'),
                         disableCustomColors: false,
-                        colors: SETTINGS_DEFAULTS.colors,
+                        colors: defaultColors,
                     },
                 ]}
             />


### PR DESCRIPTION
Resolves: https://stellarwp.atlassian.net/browse/GIVE-807

## Description
This PR includes a temporary fix for the PanelColorSettings default color list. The original default colors included "White" which could not be seen on the form. It along with the rest of the default colors to choose from have been updated. In the future we will look into integrating theme.json for the Visual Form Builder to handle presets.

## Affects

Visual Form Builder

## Visuals
<img width="1996" alt="Screen Shot 2024-07-08 at 8 02 51 AM" src="https://github.com/impress-org/givewp/assets/75056371/cd080dd6-edeb-4433-b463-073efaac0bfc">


## Testing Instructions
- In the Visual Form Builder, open the Styles sidebar in Design mode
- 	Select both color controls and verify the new default color list.
- 
## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed