### PR TITLE
Feature: add Razorpay per-form settings migration step

### DIFF
--- a/src/FormMigration/FormMetaDecorator.php
+++ b/src/FormMigration/FormMetaDecorator.php
@@ -1022,4 +1022,12 @@ class FormMetaDecorator extends FormModelDecorator
     {
         return (array)$this->getMeta('cs_supported_currency', []);
     }
+
+    /**
+     * @unreleased
+     */
+    public function isRazorpayPerFormSettingsEnabled(): bool
+    {
+        return give_is_setting_enabled($this->getMeta('razorpay_per_form_account_options'));
+    }
 }

--- a/src/FormMigration/ServiceProvider.php
+++ b/src/FormMigration/ServiceProvider.php
@@ -56,6 +56,7 @@ class ServiceProvider implements ServiceProviderInterface
                 Steps\ActiveCampaign::class,
                 Steps\DoubleTheDonation::class,
                 Steps\CurrencySwitcher::class,
+                Steps\RazorpayPerFormSettings::class,
             ]);
         });
     }

--- a/src/FormMigration/Steps/RazorpayPerFormSettings.php
+++ b/src/FormMigration/Steps/RazorpayPerFormSettings.php
@@ -18,17 +18,17 @@ class RazorpayPerFormSettings extends FormMigrationStep
 
         $paymentGatewaysBlock = $this->fieldBlocks->findByName('givewp/payment-gateways');
 
-        $paymentGatewaysBlock->setAttribute('useGlobalSettings',
+        $paymentGatewaysBlock->setAttribute('razorpayUseGlobalSettings',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_account_options', 'global') === 'global');
 
-        $paymentGatewaysBlock->setAttribute('liveKeyId',
+        $paymentGatewaysBlock->setAttribute('razorpayLiveKeyId',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_live_merchant_key_id', ''));
-        $paymentGatewaysBlock->setAttribute('liveSecretKey',
+        $paymentGatewaysBlock->setAttribute('razorpayLiveSecretKey',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_live_merchant_secret_key', ''));
 
-        $paymentGatewaysBlock->setAttribute('testKeyId',
+        $paymentGatewaysBlock->setAttribute('razorpayTestKeyId',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_test_merchant_key_id', ''));
-        $paymentGatewaysBlock->setAttribute('testSecretKey',
+        $paymentGatewaysBlock->setAttribute('razorpayTestSecretKey',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_test_merchant_secret_key', ''));
     }
 

--- a/src/FormMigration/Steps/RazorpayPerFormSettings.php
+++ b/src/FormMigration/Steps/RazorpayPerFormSettings.php
@@ -19,7 +19,7 @@ class RazorpayPerFormSettings extends FormMigrationStep
         $paymentGatewaysBlock = $this->fieldBlocks->findByName('givewp/payment-gateways');
 
         $paymentGatewaysBlock->setAttribute('useGlobalSettings',
-            $this->getMetaValue($oldFormId, 'razorpay_per_form_account_options', 'global'));
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_account_options', 'global') === 'global');
 
         $paymentGatewaysBlock->setAttribute('liveKeyId',
             $this->getMetaValue($oldFormId, 'razorpay_per_form_live_merchant_key_id', ''));

--- a/src/FormMigration/Steps/RazorpayPerFormSettings.php
+++ b/src/FormMigration/Steps/RazorpayPerFormSettings.php
@@ -12,6 +12,14 @@ class RazorpayPerFormSettings extends FormMigrationStep
     /**
      * @unreleased
      */
+    public function canHandle(): bool
+    {
+        return $this->formV2->isRazorpayPerFormSettingsEnabled();
+    }
+
+    /**
+     * @unreleased
+     */
     public function process()
     {
         $oldFormId = $this->formV2->id;

--- a/src/FormMigration/Steps/RazorpayPerFormSettings.php
+++ b/src/FormMigration/Steps/RazorpayPerFormSettings.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Give\FormMigration\Steps;
+
+use Give\FormMigration\Contracts\FormMigrationStep;
+
+/**
+ * @unreleased
+ */
+class RazorpayPerFormSettings extends FormMigrationStep
+{
+    /**
+     * @unreleased
+     */
+    public function process()
+    {
+        $oldFormId = $this->formV2->id;
+
+        $paymentGatewaysBlock = $this->fieldBlocks->findByName('givewp/payment-gateways');
+
+        $paymentGatewaysBlock->setAttribute('useGlobalSettings',
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_account_options', 'global'));
+
+        $paymentGatewaysBlock->setAttribute('liveKeyId',
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_live_merchant_key_id', ''));
+        $paymentGatewaysBlock->setAttribute('liveSecretKey',
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_live_merchant_secret_key', ''));
+
+        $paymentGatewaysBlock->setAttribute('testKeyId',
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_test_merchant_key_id', ''));
+        $paymentGatewaysBlock->setAttribute('testSecretKey',
+            $this->getMetaValue($oldFormId, 'razorpay_per_form_test_merchant_secret_key', ''));
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getMetaValue(int $formId, string $metaKey, $defaultValue)
+    {
+        $metaValue = give()->form_meta->get_meta($formId, $metaKey, true);
+
+        if ( ! $metaValue) {
+            return $defaultValue;
+        }
+
+        return $metaValue;
+    }
+}

--- a/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
+++ b/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
@@ -21,14 +21,13 @@ class TestRazorpayPerFormSettings extends TestCase
      */
     public function testProcessShouldUpdatePaymentGatewaysBlockAttributes(): void
     {
-        $useGlobalSettings = 'enabled';
         $liveKeyId = 'live_12304567890';
         $liveSecretKey = 'live_0123456789';
         $testKeyId = 'test_12304567890';
         $testSecretKey = 'test_0123456789';
 
         $meta = [
-            'razorpay_per_form_account_options' => $useGlobalSettings,
+            'razorpay_per_form_account_options' => 'global',
             'razorpay_per_form_live_merchant_key_id' => $liveKeyId,
             'razorpay_per_form_live_merchant_secret_key' => $liveSecretKey,
             'razorpay_per_form_test_merchant_key_id' => $testKeyId,
@@ -44,7 +43,7 @@ class TestRazorpayPerFormSettings extends TestCase
 
         $paymentGatewaysBlock = $payload->formV3->blocks->findByName('givewp/payment-gateways');
 
-        $this->assertSame($useGlobalSettings, $paymentGatewaysBlock->getAttribute('useGlobalSettings'));
+        $this->assertSame(true, $paymentGatewaysBlock->getAttribute('useGlobalSettings'));
         $this->assertSame($liveKeyId, $paymentGatewaysBlock->getAttribute('liveKeyId'));
         $this->assertSame($liveSecretKey, $paymentGatewaysBlock->getAttribute('liveSecretKey'));
         $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('testKeyId'));

--- a/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
+++ b/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
@@ -43,11 +43,11 @@ class TestRazorpayPerFormSettings extends TestCase
 
         $paymentGatewaysBlock = $payload->formV3->blocks->findByName('givewp/payment-gateways');
 
-        $this->assertSame(true, $paymentGatewaysBlock->getAttribute('useGlobalSettings'));
-        $this->assertSame($liveKeyId, $paymentGatewaysBlock->getAttribute('liveKeyId'));
-        $this->assertSame($liveSecretKey, $paymentGatewaysBlock->getAttribute('liveSecretKey'));
-        $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('testKeyId'));
-        $this->assertSame($testSecretKey, $paymentGatewaysBlock->getAttribute('testSecretKey'));
+        $this->assertSame(true, $paymentGatewaysBlock->getAttribute('razorpayUseGlobalSettings'));
+        $this->assertSame($liveKeyId, $paymentGatewaysBlock->getAttribute('razorpayLiveKeyId'));
+        $this->assertSame($liveSecretKey, $paymentGatewaysBlock->getAttribute('razorpayLiveSecretKey'));
+        $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('razorpayTestKeyId'));
+        $this->assertSame($testSecretKey, $paymentGatewaysBlock->getAttribute('razorpayTestSecretKey'));
     }
 
 }

--- a/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
+++ b/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Feature\FormMigration\Steps;
+
+use Give\FormMigration\DataTransferObjects\FormMigrationPayload;
+use Give\FormMigration\Steps\RazorpayPerFormSettings;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
+
+/**
+ * @unreleased
+ */
+class TestRazorpayPerFormSettings extends TestCase
+{
+
+    use RefreshDatabase, LegacyDonationFormAdapter;
+
+    /**
+     * @unreleased
+     */
+    public function testProcessShouldUpdatePaymentGatewaysBlockAttributes(): void
+    {
+        $useGlobalSettings = 'enabled';
+        $liveKeyId = 'live_12304567890';
+        $liveSecretKey = 'live_0123456789';
+        $testKeyId = 'test_12304567890';
+        $testSecretKey = 'test_0123456789';
+
+        $meta = [
+            'razorpay_per_form_account_options' => $useGlobalSettings,
+            'razorpay_per_form_live_merchant_key_id' => $liveKeyId,
+            'razorpay_per_form_live_merchant_secret_key' => $liveSecretKey,
+            'razorpay_per_form_test_merchant_key_id' => $testKeyId,
+            'razorpay_per_form_test_merchant_secret_key' => $testSecretKey,
+        ];
+
+        $formV2 = $this->createSimpleDonationForm(['meta' => $meta]);
+
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+
+        $razorpayPerFormSettings = new RazorpayPerFormSettings($payload);
+        $razorpayPerFormSettings->process();
+
+        $paymentGatewaysBlock = $payload->formV3->blocks->findByName('givewp/payment-gateways');
+
+        $this->assertSame($useGlobalSettings, $paymentGatewaysBlock->getAttribute('useGlobalSettings'));
+        $this->assertSame($liveKeyId, $paymentGatewaysBlock->getAttribute('liveKeyId'));
+        $this->assertSame($liveSecretKey, $paymentGatewaysBlock->getAttribute('liveSecretKey'));
+        $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('testKeyId'));
+        $this->assertSame($testSecretKey, $paymentGatewaysBlock->getAttribute('testSecretKey'));
+    }
+
+}
+

--- a/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
+++ b/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
@@ -13,8 +13,37 @@ use Give\Tests\Unit\DonationForms\TestTraits\LegacyDonationFormAdapter;
  */
 class TestRazorpayPerFormSettings extends TestCase
 {
-
     use RefreshDatabase, LegacyDonationFormAdapter;
+
+    /**
+     * @unreleased
+     */
+    public function testCanHandleShouldReturnFalse()
+    {
+        $meta = [
+            'razorpay_per_form_account_options' => 'global',
+        ];
+        $formV2 = $this->createSimpleDonationForm(['meta' => $meta]);
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+        $razorpayPerFormSettings = new RazorpayPerFormSettings($payload);
+
+        $this->assertNotTrue($razorpayPerFormSettings->canHandle());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCanHandleShouldReturnTrue()
+    {
+        $meta = [
+            'razorpay_per_form_account_options' => 'enabled',
+        ];
+        $formV2 = $this->createSimpleDonationForm(['meta' => $meta]);
+        $payload = FormMigrationPayload::fromFormV2($formV2);
+        $razorpayPerFormSettings = new RazorpayPerFormSettings($payload);
+
+        $this->assertTrue($razorpayPerFormSettings->canHandle());
+    }
 
     /**
      * @unreleased
@@ -49,6 +78,5 @@ class TestRazorpayPerFormSettings extends TestCase
         $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('razorpayTestKeyId'));
         $this->assertSame($testSecretKey, $paymentGatewaysBlock->getAttribute('razorpayTestSecretKey'));
     }
-
 }
 

--- a/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
+++ b/tests/Feature/FormMigration/Steps/TestRazorpayPerFormSettings.php
@@ -56,7 +56,7 @@ class TestRazorpayPerFormSettings extends TestCase
         $testSecretKey = 'test_0123456789';
 
         $meta = [
-            'razorpay_per_form_account_options' => 'global',
+            'razorpay_per_form_account_options' => 'enabled',
             'razorpay_per_form_live_merchant_key_id' => $liveKeyId,
             'razorpay_per_form_live_merchant_secret_key' => $liveSecretKey,
             'razorpay_per_form_test_merchant_key_id' => $testKeyId,
@@ -72,7 +72,7 @@ class TestRazorpayPerFormSettings extends TestCase
 
         $paymentGatewaysBlock = $payload->formV3->blocks->findByName('givewp/payment-gateways');
 
-        $this->assertSame(true, $paymentGatewaysBlock->getAttribute('razorpayUseGlobalSettings'));
+        $this->assertSame(false, $paymentGatewaysBlock->getAttribute('razorpayUseGlobalSettings'));
         $this->assertSame($liveKeyId, $paymentGatewaysBlock->getAttribute('razorpayLiveKeyId'));
         $this->assertSame($liveSecretKey, $paymentGatewaysBlock->getAttribute('razorpayLiveSecretKey'));
         $this->assertSame($testKeyId, $paymentGatewaysBlock->getAttribute('razorpayTestKeyId'));


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-934]

Related PR: https://github.com/impress-org/give-razorpay/pull/84

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a new form migration step to ensure that the Razorpay per-form settings will be migrated to new V3 forms.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The form migration process.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/impress-org/givewp/assets/16308864/031ba6a7-56cd-49c1-9bd0-a6142f8bcb36)

![image](https://github.com/impress-org/givewp/assets/16308864/d3df7996-8a60-41b3-bd1f-b7e3fcb56ad5)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Set up a v2 form and setup Razorpay per-form settings;
2. Migrate the form created in the previous step to a v3 form;
3. Make sure the settings from step 1 were migrated and available in the Payment Gateways block settings.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-934]: https://stellarwp.atlassian.net/browse/GIVE-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ