### PR TITLE
FIx: use capabilities check

### DIFF
--- a/src/DonationForms/V2/Endpoints/Endpoint.php
+++ b/src/DonationForms/V2/Endpoints/Endpoint.php
@@ -27,6 +27,16 @@ abstract class Endpoint implements RestRoute
     }
 
     /**
+     * @unreleased
+     * @param  string  $id
+     * @return bool
+     */
+    public function validatePostType(string $id)
+    {
+        return get_post_type($id) === 'give_forms';
+    }
+
+    /**
      * Check user permissions
      * @return bool|WP_Error
      */

--- a/src/DonationForms/V2/Endpoints/FormActions.php
+++ b/src/DonationForms/V2/Endpoints/FormActions.php
@@ -47,7 +47,7 @@ class FormActions extends Endpoint
                         'required'          => true,
                         'validate_callback' => function ($ids) {
                             foreach ($this->splitString($ids) as $id) {
-                                if ( ! $this->validateInt($id)) {
+                                if ( ! $this->validateInt($id) || !$this->validatePostType($id)) {
                                     return false;
                                 }
                             }
@@ -75,7 +75,7 @@ class FormActions extends Endpoint
      */
     public function permissionsCheck()
     {
-        if ( ! current_user_can('edit_posts')) {
+        if ( ! current_user_can('edit_give_forms')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You don\'t have permission to edit Donation Forms', 'give'),

--- a/src/DonationForms/V2/Endpoints/FormActions.php
+++ b/src/DonationForms/V2/Endpoints/FormActions.php
@@ -75,7 +75,7 @@ class FormActions extends Endpoint
      */
     public function permissionsCheck()
     {
-        if ( ! current_user_can('edit_give_forms')) {
+        if ( ! current_user_can('edit_posts')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You don\'t have permission to edit Donation Forms', 'give'),

--- a/src/DonationForms/V2/Endpoints/FormActions.php
+++ b/src/DonationForms/V2/Endpoints/FormActions.php
@@ -7,6 +7,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 
 /**
+ * @unreleased updated to validate form id is a donation form post type
  * @since 2.19.0
  */
 class FormActions extends Endpoint


### PR DESCRIPTION
Resolves [GIVE-979]

## Description

This PR resolves the issue where users with `edit_give_forms` capabilities like the `give_worker` role could delete any post or page. The problem is resolved by checking if the user has the right capability for handling posts. 


<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-979]: https://stellarwp.atlassian.net/browse/GIVE-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ