### PR TITLE
Fix: add user capability and user role check for Donor dashboard endpoint

### DIFF
--- a/src/DonorDashboards/Helpers.php
+++ b/src/DonorDashboards/Helpers.php
@@ -39,6 +39,7 @@ class Helpers
      * Retrieve donor logged in status
      *
      * @since 2.20.2
+     * @unreleased Add user capability and user role check
      */
     public static function isDonorLoggedIn(): bool
     {

--- a/src/DonorDashboards/Helpers.php
+++ b/src/DonorDashboards/Helpers.php
@@ -42,7 +42,9 @@ class Helpers
      */
     public static function isDonorLoggedIn(): bool
     {
-        return is_user_logged_in() || (
+        $user = wp_get_current_user();
+
+        return is_user_logged_in() && (current_user_can('administrator') || in_array('give_donor', $user->roles)) || (
                 give_is_setting_enabled( give_get_option( 'email_access' ) ) &&
                 Give()->email_access->is_valid_token(Give()->email_access->get_token())
         );


### PR DESCRIPTION
Resolves [GIVE-983]

## Description
This PR resolves the issue where any registered user like a subscriber was able to upload attachments using donor dashboard endpoints. The issue is resolved by adding a user capability and user role check. 

## Affects
Donor dashboard endpoints


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-983]: https://stellarwp.atlassian.net/browse/GIVE-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ