### PR TITLE
Fix: add user capability check for Onboarding

### DIFF
--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -62,6 +62,7 @@ class Page
      * Register Onboarding Wizard as an admin page route
      *
      * @since 2.8.0
+     * @unreleased change capability to manage_give_settings
      **/
     public function add_page()
     {
@@ -74,6 +75,7 @@ class Page
      * If the current page query matches the onboarding wizard's slug, method renders the onboarding wizard.
      *
      * @since 2.8.0
+     * @unreleased add user capability check
      **/
     public function setup_wizard()
     {

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -65,7 +65,7 @@ class Page
      **/
     public function add_page()
     {
-        add_submenu_page('', '', '', 'manage_options', $this->slug);
+        add_submenu_page('', '', '', 'manage_give_settings', $this->slug);
     }
 
     /**
@@ -77,7 +77,7 @@ class Page
      **/
     public function setup_wizard()
     {
-        if (empty($_GET['page']) || $this->slug !== $_GET['page']) { // WPCS: CSRF ok, input var ok.
+        if (empty($_GET['page']) || $this->slug !== $_GET['page'] || ! current_user_can('manage_give_settings')) { // WPCS: CSRF ok, input var ok.
             return;
         } else {
             $this->render_page();


### PR DESCRIPTION
Resolves [GIVE-981]

## Description
This PR adds a user capability check for the Onboarding page.
## Affects

Onboarding page

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-981]: https://stellarwp.atlassian.net/browse/GIVE-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ