### PR TITLE
Refactor: Replace carets with bullets in the onboarding wizard

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/index.js
@@ -1,51 +1,49 @@
 // Import vendor dependencies
-import { __ } from '@wordpress/i18n'
+import {__} from '@wordpress/i18n';
 
 // Import components
 import ContinueButton from '../../../components/continue-button';
 import DonationFormComponent from '../../../components/donation-form';
-import GradientChevronIcon from '../../../components/icons/gradient-chevron';
+import Bullet from '../../../components/icons/bullet';
 
 // Import styles
 import './style.scss';
 
 const DonationForm = () => {
-	return (
-		<div className="give-obw-donation-form">
-			<div className="give-obw-donation-form__preview">
-				<DonationFormComponent />
-			</div>
-			<div className="give-obw-donation-form__content">
-				<div className="give-obw-donation-form__fixed">
-					<h1>{ __( '🎉 Congrats! Check out your first donation form.', 'give' ) }</h1>
-					<p>
-						{ __( 'This form is customized based on your responses.', 'give' ) }
-					</p>
+    return (
+        <div className="give-obw-donation-form">
+            <div className="give-obw-donation-form__preview">
+                <DonationFormComponent />
+            </div>
+            <div className="give-obw-donation-form__content">
+                <div className="give-obw-donation-form__fixed">
+                    <h1>{__('🎉 Congrats! Check out your first donation form.', 'give')}</h1>
+                    <p>{__('This form is customized based on your responses.', 'give')}</p>
 
-					<h2>{ __( 'After setup you can:', 'give' ) }</h2>
-					<ul>
-						<li>
-							<GradientChevronIcon index={ 1 } />
-							{ __( 'Customize the text, color and image', 'give' ) }
-						</li>
-						<li>
-							<GradientChevronIcon index={ 2 } />
-							{ __( 'Modify donation amounts and add a fundraising goal', 'give' ) }
-						</li>
-						<li>
-							<GradientChevronIcon index={ 3 } />
-							{ __( 'Add or remove payment options', 'give' ) }
-						</li>
-						<li>
-							<GradientChevronIcon index={ 4 } />
-							{ __( 'Extend functionality with add-ons and more', 'give' ) }
-						</li>
-					</ul>
-					<ContinueButton testId="preview-continue-button" />
-				</div>
-			</div>
-		</div>
-	);
+                    <h2>{__('After setup you can:', 'give')}</h2>
+                    <ul>
+                        <li>
+                            <Bullet />
+                            {__('Customize the text, color and image', 'give')}
+                        </li>
+                        <li>
+                            <Bullet />
+                            {__('Modify donation amounts and add a fundraising goal', 'give')}
+                        </li>
+                        <li>
+                            <Bullet />
+                            {__('Add or remove payment options', 'give')}
+                        </li>
+                        <li>
+                            <Bullet />
+                            {__('Extend functionality with add-ons and more', 'give')}
+                        </li>
+                    </ul>
+                    <ContinueButton testId="preview-continue-button" />
+                </div>
+            </div>
+        </div>
+    );
 };
 
 export default DonationForm;

--- a/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/donation-form/style.scss
@@ -55,17 +55,17 @@
 			font-family: Montserrat, Arial, Helvetica, sans-serif;
 			font-weight: 500;
 			font-size: 16px;
-			line-height: 2;
+			line-height: 1.5;
 			color: #333;
 
 			padding: 0;
-			margin: 2px 0;
+			margin: 8px 0 0;
 
 			display: flex;
 			align-items: center;
 
 			svg {
-				margin: 0 8px 0 4px;
+				margin-right: 8px;
 			}
 		}
 	}

--- a/assets/src/js/admin/onboarding-wizard/components/icons/bullet/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/icons/bullet/index.js
@@ -1,0 +1,9 @@
+const Bullet = () => {
+    return (
+        <svg width="8" height="8" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="4" cy="4" r="4" fill="#737373" />
+        </svg>
+    );
+};
+
+export default Bullet;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-968]

## Description
This PR replaces the carets in the Preview step of the onboarding wizard with bullets, as the carets give the impression that those items are expandable.

## Affects
List in the Preview step of the Onboarding Wizard

## Visuals
![dev givewp local_wp-admin__page=give-onboarding-wizard(Desktop_ 1280x1024) (11)](https://github.com/impress-org/givewp/assets/3921017/eb5bee3f-b7df-491a-82ad-e1255e2df7ee)
_Before_

![dev givewp local_wp-admin__page=give-onboarding-wizard(Desktop_ 1280x1024) (12)](https://github.com/impress-org/givewp/assets/3921017/bfe38398-c924-4a1c-9cdb-2c3fe2d699ce)
_After_

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-968]: https://stellarwp.atlassian.net/browse/GIVE-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ