### PR TITLE
Feature: add new link for the "Add Form" admin menu to create forms with the new visual form builder

### DIFF
--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Give\DonationForms;
+
+/**
+ * @unreleased
+ */
+class DonationFormsAdminPage
+{
+    /**
+     * @unreleased
+     */
+    public function addFormSubmenuLink()
+    {
+        global $submenu;
+
+        $giveParentPageKey = 'edit.php?post_type=give_forms';
+
+        if ( ! isset($submenu[$giveParentPageKey])) {
+            return;
+        }
+
+        /** @var $giveSubmenu array [0: "Add Form", 1: "edit_give_forms", 2: "post-new.php?post_type=give_forms", ...] */
+        foreach ($submenu[$giveParentPageKey] as $giveSubmenuKey => $giveSubmenu) {
+            if ($this->isLegacyAddFormSubmenuLink($giveSubmenu)) {
+                $submenu[$giveParentPageKey][$giveSubmenuKey][2] = 'edit.php?post_type=give_forms&page=givewp-form-builder';
+            }
+        }
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param $giveSubmenu array [0: "Add Form", 1: "edit_give_forms", 2: "post-new.php?post_type=give_forms", ...]
+     */
+    private function isLegacyAddFormSubmenuLink(array $giveSubmenu): bool
+    {
+        return isset($giveSubmenu[2]) && 'post-new.php?post_type=give_forms' === $giveSubmenu[2];
+    }
+}

--- a/src/DonationForms/DonationFormsAdminPage.php
+++ b/src/DonationForms/DonationFormsAdminPage.php
@@ -12,29 +12,9 @@ class DonationFormsAdminPage
      */
     public function addFormSubmenuLink()
     {
-        global $submenu;
-
-        $giveParentPageKey = 'edit.php?post_type=give_forms';
-
-        if ( ! isset($submenu[$giveParentPageKey])) {
-            return;
-        }
-
-        /** @var $giveSubmenu array [0: "Add Form", 1: "edit_give_forms", 2: "post-new.php?post_type=give_forms", ...] */
-        foreach ($submenu[$giveParentPageKey] as $giveSubmenuKey => $giveSubmenu) {
-            if ($this->isLegacyAddFormSubmenuLink($giveSubmenu)) {
-                $submenu[$giveParentPageKey][$giveSubmenuKey][2] = 'edit.php?post_type=give_forms&page=givewp-form-builder';
-            }
-        }
-    }
-
-    /**
-     * @unreleased
-     *
-     * @param $giveSubmenu array [0: "Add Form", 1: "edit_give_forms", 2: "post-new.php?post_type=give_forms", ...]
-     */
-    private function isLegacyAddFormSubmenuLink(array $giveSubmenu): bool
-    {
-        return isset($giveSubmenu[2]) && 'post-new.php?post_type=give_forms' === $giveSubmenu[2];
+        remove_submenu_page('edit.php?post_type=give_forms', 'post-new.php?post_type=give_forms');
+        add_submenu_page('edit.php?post_type=give_forms', __('Add Form', 'give'), __('Add Form', 'give'),
+            'edit_give_forms',
+            'edit.php?post_type=give_forms&page=givewp-form-builder', '', 1);
     }
 }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -68,6 +68,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerSingleFormPage();
         $this->registerShortcodes();
         $this->registerPostStatus();
+        $this->registerAddFormSubmenuLink();
 
         Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class);
         Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class);
@@ -79,6 +80,14 @@ class ServiceProvider implements ServiceProviderInterface
             RemoveDuplicateMeta::class,
             UpdateDonationLevelsSchema::class,
         ]);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerAddFormSubmenuLink()
+    {
+        Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'addFormSubmenuLink', 999);
     }
 
     /**
@@ -168,7 +177,7 @@ class ServiceProvider implements ServiceProviderInterface
             } catch (Exception $e) {
                 Log::error('Error registering form designs', [
                     'message' => $e->getMessage(),
-                    'trace' => $e->getTraceAsString()
+                    'trace' => $e->getTraceAsString(),
                 ]);
             }
         });


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-998]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR replaces the default _"Add Form"_ link [added by the WP Core](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/post-new.php#L36-L51) for custom post types with a new link that uses the visual form builder as default editor. 

As we don't have any filter to change this value, the `global $submenu;` var was used to accomplish that.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The "Add Form" admin menu link.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Here is a sample of how the `global $submenu;` var looks like:

![image](https://github.com/user-attachments/assets/0e550dfe-28a8-4a35-a200-c93ab5c48de1)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Open the WP Admin area;
2. Click on the "Add Form" submenu from Give;
3. A new form using the Visual Form Builder should be created.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-998]: https://stellarwp.atlassian.net/browse/GIVE-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ