### PR TITLE
Refactor: prevent subscription renewals with gateway transaction IDs already used previously

### DIFF
--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -76,6 +76,14 @@ class DonationRepository
     }
 
     /**
+     * @unreleased
+     */
+    public function getTotalDonationCountByGatewayTransactionId($gatewayTransactionId): int
+    {
+        return $this->queryByGatewayTransactionId($gatewayTransactionId)->count();
+    }
+
+    /**
      * @since 2.21.0
      */
     public function queryByGatewayTransactionId($gatewayTransactionId): ModelQueryBuilder

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
@@ -24,7 +24,13 @@ class SubscriptionRenewalDonationCreated
     ) {
         $subscription = give()->subscriptions->getByGatewaySubscriptionId($gatewaySubscriptionId);
 
-        if ( ! $subscription) {
+        if ( ! $subscription || $subscription->initialDonation()->gatewayTransactionId === $gatewayTransactionId) {
+            return;
+        }
+
+        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+
+        if ($donation) {
             return;
         }
 

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
@@ -47,7 +47,7 @@ class SubscriptionRenewalDonationCreated
                     'Gateway Subscription ID' => $gatewaySubscriptionId,
                     'Gateway Transaction ID' => $gatewayTransactionId,
                     'Message' => $message,
-                    'Subscription' => $subscription,
+                    'Subscription' => $subscription->toArray(),
                 ]
             );
 
@@ -64,7 +64,7 @@ class SubscriptionRenewalDonationCreated
                     'Gateway Subscription ID' => $gatewaySubscriptionId,
                     'Gateway Transaction ID' => $gatewayTransactionId,
                     'Message' => $message,
-                    'Donation' => $donation,
+                    'Donation' => $donation->toArray(),
                 ]
             );
 

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
@@ -64,7 +64,7 @@ class SubscriptionRenewalDonationCreated
                     'Gateway Subscription ID' => $gatewaySubscriptionId,
                     'Gateway Transaction ID' => $gatewayTransactionId,
                     'Message' => $message,
-                    'Subscription' => $subscription,
+                    'Donation' => $donation,
                 ]
             );
 

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php
@@ -15,6 +15,7 @@ use Give\Framework\PaymentGateways\Log\PaymentGatewayLog;
 class SubscriptionRenewalDonationCreated
 {
     /**
+     * @unreleased Add log messages and a defensive approach to prevent duplicated renewals
      * @since 3.6.0
      */
     public function __invoke(
@@ -24,13 +25,49 @@ class SubscriptionRenewalDonationCreated
     ) {
         $subscription = give()->subscriptions->getByGatewaySubscriptionId($gatewaySubscriptionId);
 
-        if ( ! $subscription || $subscription->initialDonation()->gatewayTransactionId === $gatewayTransactionId) {
+        if ( ! $subscription) {
+            PaymentGatewayLog::error(
+                sprintf('The renewal was not created for the gateway transaction ID %s because no subscription with the gateway subscription %s was found.',
+                    $gatewayTransactionId, $gatewaySubscriptionId),
+                [
+                    'Gateway Subscription ID' => $gatewaySubscriptionId,
+                    'Gateway Transaction ID' => $gatewayTransactionId,
+                    'Message' => $message,
+                ]
+            );
+
+            return;
+        }
+
+        if ($subscription->initialDonation()->gatewayTransactionId === $gatewayTransactionId) {
+            PaymentGatewayLog::error(
+                sprintf('The renewal was not created for the gateway transaction ID %s because the initial donation of the subscription %s is already using the informed gateway transaction ID %s.',
+                    $gatewayTransactionId, $subscription->id, $gatewaySubscriptionId),
+                [
+                    'Gateway Subscription ID' => $gatewaySubscriptionId,
+                    'Gateway Transaction ID' => $gatewayTransactionId,
+                    'Message' => $message,
+                    'Subscription' => $subscription,
+                ]
+            );
+
             return;
         }
 
         $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
 
         if ($donation) {
+            PaymentGatewayLog::error(
+                sprintf('The renewal was not created for the gateway transaction ID %s because the donation %s is already using the informed gateway transaction ID %s.',
+                    $gatewayTransactionId, $donation->id, $gatewaySubscriptionId),
+                [
+                    'Gateway Subscription ID' => $gatewaySubscriptionId,
+                    'Gateway Transaction ID' => $gatewayTransactionId,
+                    'Message' => $message,
+                    'Subscription' => $subscription,
+                ]
+            );
+
             return;
         }
 

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreatedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreatedTest.php
@@ -44,4 +44,52 @@ class SubscriptionRenewalDonationCreatedTest extends TestCase
 
         $this->assertEquals($subscription->id, $renewalDonation->subscriptionId);
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldNotCreateRenewalDonationWithFirstGatewayTransactionId()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $donation = $subscription->initialDonation();
+
+        $firstGatewayTransactionId = 'first-gateway-transaction-id';
+
+        $donation->status = DonationStatus::COMPLETE();
+        $donation->gatewayTransactionId = $firstGatewayTransactionId;
+        $donation->save();
+
+        give(SubscriptionRenewalDonationCreated::class)($subscription->gatewaySubscriptionId,
+            $firstGatewayTransactionId);
+
+        $totalDonations = give()->donations->getTotalDonationCountByGatewayTransactionId($firstGatewayTransactionId);
+
+        $this->assertEquals(1, $totalDonations);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldNotCreateRenewalDonationWithDuplicatedGatewayTransactionId()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        $duplicatedGatewayTransactionId = 'duplicated-gateway-transaction-id';
+
+        // #1 Renewal Donation
+        give(SubscriptionRenewalDonationCreated::class)($subscription->gatewaySubscriptionId,
+            $duplicatedGatewayTransactionId);
+
+        // #2 Renewal Donation - This one should not be created
+        give(SubscriptionRenewalDonationCreated::class)($subscription->gatewaySubscriptionId,
+            $duplicatedGatewayTransactionId);
+
+        $totalDonations = give()->donations->getTotalDonationCountByGatewayTransactionId($duplicatedGatewayTransactionId);
+
+        $this->assertEquals(1, $totalDonations);
+    }
 }


### PR DESCRIPTION
Resolves [GIVE-1078]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements a defensive approach to prevent duplicated renewal donations in cases where the `SubscriptionRenewalDonationCreated` class is used in the wrong context.

For example:

1. The donor creates a new subscription and it gets the gateway transaction ID for the first transaction immediately;
2. Even so the gateway sends a webhook notification related to this first transaction;
3. We receive this webhook notification and we don't check if the notification is related to the first transaction or if it's a renewal;
4. The `SubscriptionRenewalDonationCreated` class is used to handle the first transaction instead of the `SubscriptionFirstDonationCompleted` class;
5. As a result a new transaction is created with the same gateway transaction ID from the first donation, in other words, the subscription duplicates the first payment.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Gateways using the webhooks event handler classes for subscriptions

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/30669314-56ec-4ad8-adbe-75cd217ca2af)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

In you console, run the following command: `composer test -- --filter SubscriptionRenewalDonationCreatedTest`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1078]: https://stellarwp.atlassian.net/browse/GIVE-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ