### PR TITLE
Refactor: Remove try the form builder messages on the Donations Form page

### DIFF
--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -102,7 +102,6 @@ class DonationFormsAdminPage
             'table' => give(DonationFormsListTable::class)->toArray(),
             'adminUrl' => $this->adminUrl,
             'pluginUrl' => GIVE_PLUGIN_URL,
-            'showBanner' => !get_user_meta(get_current_user_id(), 'givewp-show-onboarding-banner', true),
             'showUpgradedTooltip' => !get_user_meta(get_current_user_id(), 'givewp-show-upgraded-tooltip', true),
             'supportedAddons' => $this->getSupportedAddons(),
             'supportedGateways' => $this->getSupportedGateways(),

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -22,7 +22,6 @@ declare global {
             authors: Array<{ id: string | number; name: string }>;
             table: { columns: Array<object> };
             pluginUrl: string;
-            showBanner: boolean;
             showUpgradedTooltip: boolean;
             isMigrated: boolean;
             supportedAddons: Array<string>;
@@ -239,7 +238,6 @@ const ListTableBlankSlate = (
 export default function DonationFormsListTable() {
 
     const [state, setState] = useState<OnboardingStateProps>({
-        showBanner: Boolean(window.GiveDonationForms.showBanner),
         showFeatureNoticeDialog: false
     })
 

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -9,7 +9,6 @@ import Select from '@givewp/components/ListTable/Select';
 import {Interweave} from 'interweave';
 import InterweaveSSR from '@givewp/components/ListTable/InterweaveSSR';
 import BlankSlate from '@givewp/components/ListTable/BlankSlate';
-import FormBuilderButton from './Onboarding/Components/FormBuilderButton';
 import {CubeIcon} from '@givewp/components/AdminUI/Icons';
 
 declare global {
@@ -258,14 +257,6 @@ export default function DonationFormsListTable() {
                 columnFilters={columnFilters}
                 banner={Onboarding}
             >
-                <div className={styles.tryNewFormBuilderBtnContainer}>
-                    <FormBuilderButton
-                        onClick={() => setState(prev => ({
-                            ...prev,
-                            showFeatureNoticeDialog: true
-                        }))}
-                    />
-                </div>
                 <a href={'post-new.php?post_type=give_forms'} className={styles.addFormButton}>
                     {__('Add Form', 'give')}
                 </a>

--- a/src/DonationForms/V2/resources/components/Onboarding/Components/FormBuilderButton.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Components/FormBuilderButton.tsx
@@ -8,7 +8,7 @@ export default function FormBuilderButton({onClick}) {
             className={styles.tryNewFormBuilderButton}
             onClick={onClick}
         >
-            <CubeIcon /> {__('Try the new form builder', 'give')}
+            <CubeIcon /> {__('Use the new visual form builder', 'give')}
         </button>
     )
 }

--- a/src/DonationForms/V2/resources/components/Onboarding/index.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/index.tsx
@@ -1,11 +1,9 @@
 import {createContext, useContext} from 'react';
-import Banner from './Components/Banner';
 import {FeatureNoticeDialog} from './Dialogs';
 
 export const OnboardingContext = createContext([]);
 
 export interface OnboardingStateProps {
-    showBanner: boolean;
     showFeatureNoticeDialog: boolean;
 }
 
@@ -14,8 +12,6 @@ export default function Onboarding() {
 
     return (
         <>
-            {state.showBanner && <Banner />}
-
             {state.showFeatureNoticeDialog && (
                 <FeatureNoticeDialog
                     isEditing={false}


### PR DESCRIPTION
Resolves [GIVE-964]

## Description
These changes remove the Try the form builder button and the related banner from displaying on the Donations Form page.

The button is still visible on all v2 form adding/editing pages as well as the DonationForm page legacy view. This buttons text has also been updated to "Use the new visual form builder."

## Affects
Donations Form page

## Visuals


https://github.com/user-attachments/assets/331d45c6-f533-4078-8f0b-d8ebacc5f99a


## Testing Instructions
- Verify the try the form builder button is removed and does NOT display on the Donations Form page, unless in "Legacy view".
- Verify the try the form builder banner is removed and does NOT display on the Donations Form page.
- Verify the try the form builder button is still visible on all v2 Donation Form editing & adding pages.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-964]: https://stellarwp.atlassian.net/browse/GIVE-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ