### PR TITLE
Fix: hide block inserter tabs introduced in WP 6.6

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -46,6 +46,12 @@
     //overflow: hidden; // The Inspector Popout needs to be visible.
     overflow-y: scroll;
 
+    // WP 6.6+ - hide the Blocks, Patterns, Media tabs
+    &.givewp-next-gen-sidebar-secondary {
+        .block-editor-inserter__tablist-and-close-button {
+                display: none;
+            }
+    }
 
     &.givewp-next-gen-sidebar-primary {
         .block-editor-block-inspector {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1021]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This hides the new block inserter tabs introduced in WP 6.6 from our form builder block inserter sidebar.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The block inserter in the form builder

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Before:

<img width="1499" alt="Screenshot 2024-07-17 at 10 20 36 AM" src="https://github.com/user-attachments/assets/1c671861-1651-4880-85d5-813211e1c2d6">

After:

<img width="1512" alt="Screenshot 2024-07-17 at 10 20 43 AM" src="https://github.com/user-attachments/assets/206295b3-6a19-4390-a32c-ccb3da220a7f">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Instal WP 6.6
- View the v3 form block inserter
- There should be no extra tabs and it should work as expected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1021]: https://stellarwp.atlassian.net/browse/GIVE-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ