### PR TITLE
Refactor: Improve SalesBanner Maintainability

### DIFF
--- a/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
+++ b/src/Promotions/InPluginUpsells/Endpoints/HideSaleBannerRoute.php
@@ -3,7 +3,7 @@
 namespace Give\Promotions\InPluginUpsells\Endpoints;
 
 use Give\API\RestRoute;
-use Give\Promotions\InPluginUpsells\SaleBanners;
+use Give\Promotions\InPluginUpsells\StellarSaleBanners;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -48,7 +48,7 @@ class HideSaleBannerRoute implements RestRoute
      */
     public function handleRequest(WP_REST_Request $request)
     {
-        give(SaleBanners::class)->hideBanner(
+        give(StellarSaleBanners::class)->hideBanner(
             $request->get_param('id') . get_current_user_id()
         );
 

--- a/src/Promotions/InPluginUpsells/GivingTuesdayBanners.php
+++ b/src/Promotions/InPluginUpsells/GivingTuesdayBanners.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Give\Promotions\InPluginUpsells;
+
+use Give\Log\Log;
+
+class GivingTuesdayBanners extends SaleBanners
+{
+    public function getBanners(): array
+    {
+        return [
+            [
+                'id' => 'bfgt2023',
+                'giveIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/give-logo-icon.svg',
+                'discountIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/discount-icon.svg',
+                'backgroundImageLargeURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-lg.svg',
+                'backgroundImageMediumURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-md.svg',
+                'backgroundImageSmallURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-s.svg',
+                'shoppingCartIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/shopping-cart-icon.svg',
+                'dismissIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/dismiss-icon.svg',
+                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
+                'leadText' => self::getDataByPricingPlan(
+                    [
+                        'Free' => __(
+                            'Upgrade to a Pricing Plan for Recurring Donations, Fee Recovery, and more.',
+                            'give'
+                        ),
+                        'Basic' => __(
+                            'Upgrade to a Plus Plan to get all must-have add-ons.',
+                            'give'
+                        ),
+                        'Plus' => __(
+                            'Upgrade to Pro and get Peer-to-Peer fundraising.',
+                            'give'
+                        ),
+                        'default' => __(
+                            'Upgrade to a Pricing Plan for Recurring Donations, Fee Recovery, and more.',
+                            'give'
+                        ),
+                    ]
+                ),
+                'actionText' => __('Shop Now', 'give'),
+                'actionURL' => self::getDataByPricingPlan(
+                    [
+                        'Free' => 'https://go.givewp.com/bf23',
+                        'Basic' => 'https://go.givewp.com/bfup23',
+                        'Plus' => 'https://go.givewp.com/bfup23',
+                        'default' => 'https://go.givewp.com/bfup23',
+                    ]
+                ),
+                'startDate' => '2023-11-20 00:00',
+                'endDate' => '2023-11-29 23:59',
+            ],
+        ];
+    }
+
+    /**
+     * Render admin page
+     *
+     * @since 2.17.0
+     */
+    public function render(): void
+    {
+        $banners = $this->getVisibleBanners();
+
+        if (!empty($banners)) {
+            include __DIR__ . '/resources/views/sale-banners.php';
+        }
+    }
+
+    /**
+     * Helper function to determine if the current page Give admin page
+     *
+     * @unreleased only display on the Give forms page and while visible banners are available.
+     * @since 2.17.0
+     */
+    public static function isShowing(): bool
+    {
+        $saleBanners = new self();
+
+        // Check if the current post type is 'give_forms'
+        if (isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms') {
+            // Check if there are visible banners
+            $visibleBanners = $saleBanners->getVisibleBanners();
+            return !empty($visibleBanners);
+        }
+
+        return false;
+    }
+}

--- a/src/Promotions/InPluginUpsells/SaleBanners.php
+++ b/src/Promotions/InPluginUpsells/SaleBanners.php
@@ -7,9 +7,10 @@ use DateTimeZone;
 use Exception;
 
 /**
+ * @unreleased create abstract class.
  * @since 2.17.0
  */
-class SaleBanners
+abstract class SaleBanners
 {
     /**
      * @var string
@@ -30,61 +31,26 @@ class SaleBanners
     }
 
     /**
-     * Get banners definitions
+     * Get banners definitions/details.
      *
-     * @since 3.1.0 add Giving Tuesday 2023 banner
-     * @since 2.23.2 add Giving Tuesday 2022 banner
-     * @since 2.17.0
-     *
-     * @note id must be unique for each definition
+     * @unreleased
      */
-    public function getBanners(): array
-    {
-        return [
-            [
-                'id' => 'bfgt2023',
-                'giveIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/give-logo-icon.svg',
-                'discountIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/discount-icon.svg',
-                'backgroundImageLargeURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-lg.svg',
-                'backgroundImageMediumURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-md.svg',
-                'backgroundImageSmallURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/background-image-s.svg',
-                'shoppingCartIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/shopping-cart-icon.svg',
-                'dismissIconURL' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/promotions/bfcm-banner/dismiss-icon.svg',
-                'accessibleLabel' => __('Black Friday/Giving Tuesday Sale', 'give'),
-                'leadText' => self::getDataByPricingPlan(
-                    [
-                        'Free' => __(
-                            'Upgrade to a Pricing Plan for Recurring Donations, Fee Recovery, and more.',
-                            'give'
-                        ),
-                        'Basic' => __(
-                            'Upgrade to a Plus Plan to get all must-have add-ons.',
-                            'give'
-                        ),
-                        'Plus' => __(
-                            'Upgrade to Pro and get Peer-to-Peer fundraising.',
-                            'give'
-                        ),
-                        'default' => __(
-                            'Upgrade to a Pricing Plan for Recurring Donations, Fee Recovery, and more.',
-                            'give'
-                        ),
-                    ]
-                ),
-                'actionText' => __('Shop Now', 'give'),
-                'actionURL' => self::getDataByPricingPlan(
-                    [
-                        'Free' => 'https://go.givewp.com/bf23',
-                        'Basic' => 'https://go.givewp.com/bfup23',
-                        'Plus' => 'https://go.givewp.com/bfup23',
-                        'default' => 'https://go.givewp.com/bfup23',
-                    ]
-                ),
-                'startDate' => '2023-11-20 00:00',
-                'endDate' => '2023-11-29 23:59',
-            ],
-        ];
-    }
+    abstract public function getBanners(): array;
+
+    /**
+     * Pages/when to render banner.
+     *
+     * @unreleased
+     */
+    abstract public function render(): void;
+
+    /**
+     * Helper function to determine when to load/display the banner.
+     *
+     * @unreleased
+     */
+    abstract public static function isShowing(): bool;
+
 
     /**
      * Get the banners that should be displayed.
@@ -116,7 +82,7 @@ class SaleBanners
     }
 
     /**
-     * Marks the given banner id as hidden for the current user so it will not display again.
+     * Marks the given banner id as hidden for the current user, so it will not display again.
      *
      * @since 2.17.0
      *
@@ -130,20 +96,6 @@ class SaleBanners
             $this->optionName,
             array_unique($this->hiddenBanners)
         );
-    }
-
-    /**
-     * Render admin page
-     *
-     * @since 2.17.0
-     */
-    public function render()
-    {
-        $banners = $this->getVisibleBanners();
-
-        if (!empty($banners)) {
-            include __DIR__ . '/resources/views/sale-banners.php';
-        }
     }
 
     /**
@@ -171,16 +123,6 @@ class SaleBanners
         );
 
         wp_enqueue_style('givewp-admin-fonts');
-    }
-
-    /**
-     * Helper function to determine if the current page Give admin page
-     *
-     * @since 2.17.0
-     */
-    public static function isShowing(): bool
-    {
-        return isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms';
     }
 
     /**

--- a/src/Promotions/InPluginUpsells/StellarSaleBanners.php
+++ b/src/Promotions/InPluginUpsells/StellarSaleBanners.php
@@ -105,6 +105,23 @@ class StellarSaleBanners extends SaleBanners
      */
     public function loadScripts(): void
     {
+        wp_enqueue_script(
+            'give-in-plugin-upsells-sale-banners',
+            GIVE_PLUGIN_URL . 'assets/dist/js/admin-upsell-sale-banner.js',
+            [],
+            GIVE_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'give-in-plugin-upsells-sale-banners',
+            'GiveSaleBanners',
+            [
+                'apiRoot' => esc_url_raw(rest_url('give-api/v2/sale-banner')),
+                'apiNonce' => wp_create_nonce('wp_rest'),
+            ]
+        );
+
         wp_enqueue_style(
             'give-in-plugin-upsells-stellar-sales-banner',
             GIVE_PLUGIN_URL . 'assets/dist/css/admin-stellarwp-sales-banner.css',

--- a/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
+++ b/src/Promotions/ReportsWidgetBanner/ReportsWidgetBanner.php
@@ -61,4 +61,12 @@ class ReportsWidgetBanner extends SaleBanners
 
         return $hasBanners && $isDashboardWidgetPage;
     }
+
+    /**
+     * @unreleased required abstract class method.
+     */
+    public function render(): void
+    {
+        // Rendering managed in public/wp-content/plugins/givewp/assets/src/js/admin/reports/widget
+    }
 }

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -7,9 +7,9 @@ use Give\Promotions\FreeAddonModal\Controllers\CompleteRestApiEndpoint;
 use Give\Promotions\InPluginUpsells\AddonsAdminPage;
 use Give\Promotions\InPluginUpsells\Endpoints\HideSaleBannerRoute;
 use Give\Promotions\InPluginUpsells\Endpoints\ProductRecommendationsRoute;
+use Give\Promotions\InPluginUpsells\GivingTuesdayBanners;
 use Give\Promotions\InPluginUpsells\LegacyFormEditor;
 use Give\Promotions\InPluginUpsells\PaymentGateways;
-use Give\Promotions\InPluginUpsells\SaleBanners;
 use Give\Promotions\InPluginUpsells\StellarSaleBanners;
 use Give\Promotions\ReportsWidgetBanner\ReportsWidgetBanner;
 use Give\Promotions\WelcomeBanner\Endpoints\DismissWelcomeBannerRoute;
@@ -57,13 +57,13 @@ class ServiceProvider implements ServiceProviderContract
             Hooks::addAction('admin_enqueue_scripts', AddonsAdminPage::class, 'loadScripts');
         }
 
-        if (SaleBanners::isShowing()) {
-            Hooks::addAction('admin_notices', SaleBanners::class, 'render');
-            Hooks::addAction('admin_enqueue_scripts', SaleBanners::class, 'loadScripts');
+        if (GivingTuesdayBanners::isShowing()) {
+            Hooks::addAction('admin_notices', GivingTuesdayBanners::class, 'render');
+            Hooks::addAction('admin_enqueue_scripts', GivingTuesdayBanners::class, 'loadScripts');
         }
 
         if (StellarSaleBanners::isShowing()) {
-            Hooks::addAction('admin_init', SaleBanners::class, 'startSession');
+            Hooks::addAction('admin_init', StellarSaleBanners::class, 'startSession');
             Hooks::addAction('admin_notices', StellarSaleBanners::class, 'render');
             Hooks::addAction('admin_enqueue_scripts', StellarSaleBanners::class, 'loadScripts');
         }


### PR DESCRIPTION
Resolves: [GIVE-1020]

## Description
This pull request enhances the extensibility of the main SalesBanner class by refactoring the GivingTuesdayBanner details into its own dedicated class. This separation improves maintainability and makes it easier to extend the functionality in the future.

In relation to GIVE-1020, a user was encountering a fatal error that we were unable to replicate. However, Rick provided a workaround that alleviated the issue for the user. This involved ensuring that the isShowing logic for GivingTuesdayBanner returns false when it should not load. One issue we noticed in the original implementation is that the `SalesBanner` class was unnecessarily loading scripts because this logic only checked if a user was on a "give-forms" page.

In the newly created GivingTuesdayBanner class, the isShowing method has been updated with a conditional check, ensuring that banner scripts only load when banners are available. This change aims to provide relief to users experiencing similar issues and improves the overall maintainability of the class.

## Affects
SalesBanners

## Visuals

## Testing Instructions
We should retest the current banners to ensure they continue to work.

### Admin Banners

- Create a new test site & install/activate GiveWP or use a local server.
- Add New Plugin > Upload Plugin > upload the attached file or activate the give plugin.
- Click through the Donations, Donors, and Reports pages.
- Verify the banners alternate between: GiveWP Plus plan & Peer-to-Peer.
- Add a Basic license.
- Click back through the same pages.
- Verify you see the same banners that were shown before you added a license.
- Now, add a Plus license instead.
- Click back through the same pages.
- Verify the banners alternate between: GiveWP Pro plan & Peer-to-Peer.
- Now, add a Pro and Agency license instead.
- Click back through the same pages.
- Verify only a stellar banner is shown.
- Test that the P2P banner never displays if P2P is active.
- Test that once a banner is closed it remains closed.
- Verify the links for each banner match the pricing plan.

### Reports Widget Banners

- Visit the WordPress dashboard.
- Locate the GiveWP widget on the page.
- Verify the banner is displayed and the link takes you to the appropriate page.
- Verify after closing the banner, it is removed and remains closed.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1020]: https://stellarwp.atlassian.net/browse/GIVE-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ