### PR TITLE
Fix: resolve give_totals fatal error when using multiple form IDs

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -739,8 +739,8 @@ function give_totals_shortcode( $atts ) {
 
 		if ( isset( $forms->posts ) ) {
 			$total = 0;
-            $query = new DonationQuery();
 			foreach ( $forms->posts as $post ) {
+                $query = new DonationQuery();
 				$form_earning = $query->form($post)->sumAmount();
 				$form_earning = ! empty( $form_earning ) ? $form_earning : 0;
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: [GIVE-1049]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves a SQL query error by moving the instantiation of the query outside the loop to prevent continuous query statements being added to the original query.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The give_totals shortcode

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/10048657226

Use the give_totals shortcode with multiple form ids

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1049]: https://stellarwp.atlassian.net/browse/GIVE-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ