### PR TITLE
Refactor: Update step 1 of Setup Guide

### DIFF
--- a/assets/src/css/admin/setup.scss
+++ b/assets/src/css/admin/setup.scss
@@ -52,6 +52,10 @@ header {
 	align-items: center;
 	border-bottom: 1px solid #ddd;
 
+    &.current-step h2 {
+        font-weight: 700;
+    }
+
 	h2 {
 		margin: 0;
 		font-size: 22px;

--- a/assets/src/css/admin/setup.scss
+++ b/assets/src/css/admin/setup.scss
@@ -46,18 +46,51 @@ section {
 }
 
 header {
-	padding: 20px 20px 20px 25px;
+	padding: 1.25rem 1.5rem;
 	display: flex;
-	justify-content: space-between;
+    gap: 1rem;
 	align-items: center;
 	border-bottom: 1px solid #ddd;
 
 	h2 {
 		margin: 0;
 		font-size: 22px;
-		line-height: 22px;
+        font-weight: 500;
+		line-height: 1.55;
 		color: #424242;
 	}
+
+    .badge {
+        font-weight: 600;
+        font-size: 14px;
+        line-height: 22px;
+        padding: 0.25rem 0.5rem;
+        border-radius: 10px;
+
+        &.badge-completed {
+            color: #18694C;
+            background: #CEF2CF;
+        }
+
+        &.badge-not-completed {
+            color: #404040;
+            background: #F2F2F2;
+        }
+
+        &.badge-optional {
+            color: #0B72D9;
+            background: #F2F9FF;
+        }
+    }
+
+    .button.button-primary {
+        border-radius: 0.25rem;
+        font-size: 1rem;
+        font-weight: 500;
+        line-height: 1.5;
+        margin-left: auto;
+        padding: 0.5rem 1rem;
+    }
 }
 footer {
 	background-color: #fafafa;
@@ -73,22 +106,6 @@ footer a {
 	> .fa {
 		margin-left: 6px;
 	}
-}
-header .badge {
-	font-weight: 600;
-	font-size: 12px;
-	line-height: 16px;
-	padding: 10px 20px;
-	border-radius: 3px;
-}
-header .badge.badge-complete {
-	color: #18694c;
-	background: #cbf4c9;
-}
-header .badge.badge-review {
-	color: #696969;
-	border: #ddd 1px solid;
-	background: transparent;
 }
 
 article {

--- a/src/Onboarding/Setup/templates/action-button.html
+++ b/src/Onboarding/Setup/templates/action-button.html
@@ -1,0 +1,1 @@
+<a class="button button-primary" href="{{ href }}" target="{{ target }}">{{ text }}</a>

--- a/src/Onboarding/Setup/templates/badge.html
+++ b/src/Onboarding/Setup/templates/badge.html
@@ -1,0 +1,1 @@
+<span class="badge badge-{{ class }}">{{ text }}</span>

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -27,34 +27,36 @@
 
     <!-- Configuration -->
     <?php
+    if ($this->isFormConfigured()) {
+        $form = \Give\DonationForms\Models\DonationForm::find($settings['form_id']);
+        $customizeFormURL = $form->id ? admin_url('post.php?action=edit&post=' . $form->id) : admin_url(
+            'edit.php?post_type=give_forms&page=give-forms'
+        );
+    }
+
     echo $this->render_template(
         'section',
         [
             'title' => sprintf('%s 1: %s', __('Step', 'give'), __('Create your first donation form', 'give')),
-            'badge' => '<span class="badge badge-review">5 Minutes</span>',
-            'contents' => $this->render_template(
-                'row-item',
-                [
-                    'testId' => 'setup-configuration',
-                    'class' => ($this->isFormConfigured(
-                    )) ? 'setup-item-configuration setup-item-completed' : 'setup-item-configuration',
-                    'icon' => ($this->isFormConfigured())
-                        ? $this->image('check-circle.min.png')
-                        : $this->image('configuration@2x.min.png'),
-                    'icon_alt' => esc_html__('First-Time Configuration', 'give'),
-                    'title' => esc_html__('First-Time Configuration', 'give'),
-                    'description' => esc_html__(
-                        'Every fundraising campaign begins with a donation form. Click here to create your first donation form in minutes. Once created you can use it anywhere on your website.',
-                        'give'
-                    ),
-                    'action' => $this->render_template(
-                        'action-link',
-                        [
-                            'href' => admin_url('?page=give-onboarding-wizard'),
-                            'screenReaderText' => 'Configure GiveWP',
-                        ]
-                    ),
-                ]
+            'badge' => ($this->isFormConfigured()
+                ? $this->render_template('badge', [
+                    'class' => 'completed',
+                    'text' => esc_html__('Completed', 'give'),
+                ])
+                : $this->render_template('badge', [
+                    'class' => 'not-completed',
+                    'text' => esc_html__('Not Completed', 'give'),
+                ])
+            ),
+            'button' => ($this->isFormConfigured()
+                ? $this->render_template('action-button', [
+                    'href' => $customizeFormURL,
+                    'text' => __('Customize form', 'give'),
+                ])
+                : $this->render_template('action-button', [
+                    'href' => admin_url('?page=give-onboarding-wizard'),
+                    'text' => __('Configure GiveWP', 'give'),
+                ])
             ),
         ]
     );

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -37,6 +37,7 @@
     echo $this->render_template(
         'section',
         [
+            'class' => !$this->isFormConfigured() ? 'current-step' : '',
             'title' => sprintf('%s 1: %s', __('Step', 'give'), __('Create your first donation form', 'give')),
             'badge' => ($this->isFormConfigured()
                 ? $this->render_template('badge', [

--- a/src/Onboarding/Setup/templates/section.html
+++ b/src/Onboarding/Setup/templates/section.html
@@ -2,6 +2,7 @@
     <header>
         <h2>{{ title }}</h2>
         {{ badge }}
+        {{ button }}
     </header>
     <div>
         {{ contents }}

--- a/src/Onboarding/Setup/templates/section.html
+++ b/src/Onboarding/Setup/templates/section.html
@@ -1,5 +1,5 @@
 <section>
-    <header>
+    <header class="{{ class }}">
         <h2>{{ title }}</h2>
         {{ badge }}
         {{ button }}


### PR DESCRIPTION
Resolves [GIVE-970]

## Description
This pull request updates the Step 1 of the Setup Guide. There are three states for it:

1.	When the wizard has been skipped, it is shown as _Not Completed_, and the action button targets the wizard with the label _Configure GiveWP_.
2.	When the wizard has been completed successfully, the action button targets the new form for editing.
3.	When the wizard has been completed but the created form has already been deleted, the action button targets the list of forms.

## Affects
Step 1: Setup Guide

## Visuals
![dev givewp local_wp-admin_edit php_post_type=give_forms page=give-setup (1)](https://github.com/user-attachments/assets/5ed72ae4-6ded-4d9e-99d5-08571492144d)
![dev givewp local_wp-admin_edit php_post_type=give_forms page=give-setup (2)](https://github.com/user-attachments/assets/9d2771c0-336a-4b00-8322-91433bc00919)

## Testing Instructions
1.	In a new install, close the wizard directly and go to the Setup Guide. State 1 should be presented.
2.	Click on the Configure GiveWP button and follow the wizard. At the end, you’ll be redirected to the Setup Guide, and state 2 should be presented. Clicking the Configure form button should open the edit form page.
3.	Delete the recently created form, then go to the Setup Guide once again. Clicking the Configure form button should open the forms list table.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

