### PR TITLE
Refactor: Collapse panel bodies by default

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
@@ -133,7 +133,7 @@ export default function Edit({
             </div>
 
             <InspectorControls>
-                <PanelBody title={__('Group', 'give')} initialOpen={false}>
+                <PanelBody title={__('Group', 'give')} initialOpen={true}>
                     <PanelRow>
                         <TextControl
                             label={'Label'}

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
@@ -133,7 +133,7 @@ export default function Edit({
             </div>
 
             <InspectorControls>
-                <PanelBody title={__('Group', 'give')} initialOpen={true}>
+                <PanelBody title={__('Group', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={'Label'}
@@ -142,7 +142,7 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
-                <PanelBody title={__('Country', 'give')} initialOpen={true}>
+                <PanelBody title={__('Country', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={__('Label')}
@@ -151,7 +151,7 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
-                <PanelBody title={__('Address 1', 'give')} initialOpen={true}>
+                <PanelBody title={__('Address 1', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={__('Label')}
@@ -167,7 +167,7 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
-                <PanelBody title={__('Address 2', 'give')} initialOpen={true}>
+                <PanelBody title={__('Address 2', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={__('Label')}
@@ -191,7 +191,7 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
-                <PanelBody title={__('City', 'give')} initialOpen={true}>
+                <PanelBody title={__('City', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={__('Label')}
@@ -207,7 +207,7 @@ export default function Edit({
                         />
                     </PanelRow>
                 </PanelBody>
-                <PanelBody title={__('Zip', 'give')} initialOpen={true}>
+                <PanelBody title={__('Zip', 'give')} initialOpen={false}>
                     <PanelRow>
                         <TextControl
                             label={__('Label')}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-808]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR collapses by default the multiple panel bodies of the Billing Address inspector controls, with the exception of the first.

## Affects

This change is isolated to the Billing Address inspector settings.

## Testing Instructions

Add a Billing Address block to the donation form and view the inspector settings.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/5ebf6cb6-0f85-49f5-98a7-522760f27cc0)



[GIVE-808]: https://stellarwp.atlassian.net/browse/GIVE-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ