### PR TITLE
Refactor: Reduce spacing between form inputs and error messages

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -24,7 +24,6 @@ select:not(.givewp-fields-amount__currency-select) {
     font-weight: 500;
     line-height: 1.2;
     padding: 0.9rem var(--givewp-spacing-8) 0.9rem 1.1875rem;
-    margin-bottom: 0.5rem;
     appearance: none;
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='13' height='8' viewBox='0 0 13 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.66016 7.19531C5.90625 7.44141 6.31641 7.44141 6.5625 7.19531L11.8945 1.89062C12.1406 1.61719 12.1406 1.20703 11.8945 0.960938L11.2656 0.332031C11.0195 0.0859375 10.6094 0.0859375 10.3359 0.332031L6.125 4.54297L1.88672 0.332031C1.61328 0.0859375 1.20312 0.0859375 0.957031 0.332031L0.328125 0.960938C0.0820312 1.20703 0.0820312 1.61719 0.328125 1.89062L5.66016 7.19531Z' fill='%23A2A3A2'/%3E%3C/svg%3E"),
     linear-gradient(to bottom, #fff 0%, #fff 100%);
@@ -48,7 +47,6 @@ textarea {
     border-radius: 0.25rem;
     padding: 1.1875rem;
     width: 100%;
-    margin-bottom: 0.5rem;
     box-sizing: inherit;
     inline-size: 100%;
     background-color: rgb(255, 255, 255);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-824]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR reduces the spacing between the donation form inputs and their related error messages.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The bottom margin has been removed from the text and select inputs on the donation form.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
| --- | --- |
| ![Screen Shot 2024-07-31 at 12 59 36](https://github.com/user-attachments/assets/751e2370-09c2-4164-a3fe-73c7980e6c8c) | ![Screen Shot 2024-07-31 at 12 58 39](https://github.com/user-attachments/assets/61ed5cae-3a85-4dbd-a574-565c13b6f306) |

| Donor Name Field |
| --- |
| ![Screen Shot 2024-07-31 at 13 00 42](https://github.com/user-attachments/assets/3dc0205d-e5d8-4052-bd61-c8830c933636) |
| ![Screen Shot 2024-07-31 at 12 53 24](https://github.com/user-attachments/assets/f81ded1c-00be-4121-8d42-6c71394808ef) |

| Select Input |
| --- |
| ![Screen Shot 2024-07-31 at 13 01 41](https://github.com/user-attachments/assets/82cbc4b6-3503-4e54-963f-b52120ab0205) |
| ![Screen Shot 2024-07-31 at 12 53 49](https://github.com/user-attachments/assets/f70ff52f-88a1-4849-b690-d5190b2b2692) |


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Empty a required field and submit the form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-824]: https://stellarwp.atlassian.net/browse/GIVE-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ