### PR TITLE
Refactor: set the v3 settings tab as default in the gateways list view

### DIFF
--- a/includes/admin/settings/class-settings-gateways.php
+++ b/includes/admin/settings/class-settings-gateways.php
@@ -331,6 +331,7 @@ if (! class_exists('Give_Settings_Gateways')) :
         /**
          * Render enabled gateways
          *
+         * @unreleased Set the v3 settings tab as default in the gateways list
          * @since 3.0.0 split gateways into separated tabs for v2 and v3 settings
          * @since  2.0.5
          * @access public
@@ -380,20 +381,6 @@ if (! class_exists('Give_Settings_Gateways')) :
             );
 
             $groups = [
-                'v2' => [
-                    'label' => __('Option-Based Form Editor', 'give'),
-                    'gateways' => $v2Gateways,
-                    'settings' => $settings,
-                    'gatewaysLabel' => give_get_option('gateways_label', []),
-                    'defaultGateway' => give_get_option('default_gateway', current(array_keys($v2Gateways))),
-                    'helper' => [
-                        'text' => __(
-                            'Uses the traditional settings options for creating and customizing a donation form.',
-                            'give'
-                        ),
-                        'image' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/give-settings-gateways-v2.jpg',
-                    ]
-                ],
                 'v3' => [
                     'label' => __('Visual Form Builder', 'give'),
                     'gateways' => $v3Gateways,
@@ -407,6 +394,20 @@ if (! class_exists('Give_Settings_Gateways')) :
                         ),
                         'image' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/give-settings-gateways-v3.jpg',
                     ]
+                ],
+                'v2' => [
+                    'label' => __('Option-Based Form Editor', 'give'),
+                    'gateways' => $v2Gateways,
+                    'settings' => $settings,
+                    'gatewaysLabel' => give_get_option('gateways_label', []),
+                    'defaultGateway' => give_get_option('default_gateway', current(array_keys($v2Gateways))),
+                    'helper' => [
+                        'text' => __(
+                            'Uses the traditional settings options for creating and customizing a donation form.',
+                            'give'
+                        ),
+                        'image' => GIVE_PLUGIN_URL . 'assets/dist/images/admin/give-settings-gateways-v2.jpg',
+                    ],
                 ],
             ];
             $defaultGroup = current(array_keys($groups));


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1024]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR changes the gateways list in the settings page, now by default the tab for V3 settings (only gateways compatible with the Visual Form Builder) will be open by default.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The gateways view on the settings page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/0a92ffcc-614d-4ef2-bdb9-5f902edafbe8)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Go to `Give > Settings > Payment Gateways > Gateways` page;
2. Make sure the "Visual Form Builder" tab is the default one.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

