### PR TITLE
Fix: persists "Supported Gateways" field on the settings of the "Subscription Payment Failed" email 

### DIFF
--- a/assets/src/js/admin/admin-scripts.js
+++ b/assets/src/js/admin/admin-scripts.js
@@ -3149,7 +3149,7 @@ const gravatar = require('gravatar');
                                 orderedOptions.push({
                                     text: option.textContent,
                                     value: option.value,
-                                    selected: false,
+                                    selected: option.selected,
                                 });
                             }
                         });


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-789]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that prevents the _"Supported Gateways"_ field be saved on the settings of the _"Subscription Payment Failed"_ email. The problem was introduced in the following PR: https://github.com/impress-org/givewp/pull/6237

So, the solution was to change how to set the "selected" attribute of the select options to make it work in the same way as before the changes introduced in the PR mentioned above. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The `multiselect` fields spread on the codebase.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/6eabb134dc0940ec8af9d893d079ac9c?sid=e68abf36-b943-40ed-b512-9ade95bbfa95

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Go to Give > Settings > Emails > Subscription Payment Failed  page;
2. On the "Supported Gateways" field select a few gateways;
3. Save the changes and make sure the selected gateways are saved.

**Additional test:** Please, follow the test instructions from [**this related PR**](https://github.com/impress-org/givewp/pull/6237) and make sure the changes introduced there keep working as before.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-789]: https://stellarwp.atlassian.net/browse/GIVE-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ