### PR TITLE
Fix: Validate Stripe card info in legacy adapter

### DIFF
--- a/src/PaymentGateways/Gateways/ServiceProvider.php
+++ b/src/PaymentGateways/Gateways/ServiceProvider.php
@@ -120,6 +120,7 @@ class ServiceProvider implements ServiceProviderInterface
 
     /**
      * @since 3.0.0
+     * @unreleased Add validation of card info.
      */
     private function addLegacyStripeAdapter()
     {
@@ -128,6 +129,7 @@ class ServiceProvider implements ServiceProviderInterface
 
         $legacyStripeAdapter->addDonationDetails();
         $legacyStripeAdapter->loadLegacyStripeWebhooksAndFilters();
+        $legacyStripeAdapter->validateCardInformation();
     }
 
     /**

--- a/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
+++ b/src/PaymentGateways/Gateways/Stripe/LegacyStripeAdapter.php
@@ -4,6 +4,7 @@ namespace Give\PaymentGateways\Gateways\Stripe;
 
 use Give\Donations\Models\Donation;
 use Give\Helpers\Gateways\Stripe;
+use Give\PaymentGateways\DataTransferObjects\FormData;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
 use Give_Stripe;
 
@@ -108,6 +109,27 @@ class LegacyStripeAdapter
 
             if ($donation->gatewayId === StripePaymentElementGateway::id()) {
                 Stripe::addAccountDetail($donationId, $donation->formId);
+            }
+        });
+    }
+
+    /**
+     * @unreleased
+     */
+    public function validateCardInformation()
+    {
+        add_action('give_donation_form_processing_start', function(FormData $data) {
+            if('stripe' === $data->paymentGateway) {
+                /**
+                 * Validate card information to prevent spam donations and fake donors.
+                 */
+                if(! $data->cardInfo->number || ! $data->cardInfo->expMonth || ! $data->cardInfo->expYear || ! $data->cardInfo->cvc) {
+                    wp_die(
+                        esc_html__('Incomplete card information.', 'give'),
+                        esc_html__('Error', 'give'),
+                        ['response' => 403]
+                    );
+                }
             }
         });
     }

--- a/tests/Unit/PaymentGateways/Gateways/Stripe/LegacyStripeAdapterTest.php
+++ b/tests/Unit/PaymentGateways/Gateways/Stripe/LegacyStripeAdapterTest.php
@@ -10,7 +10,7 @@ class LegacyStripeAdapterTest extends \Give\Tests\TestCase
         $formData = new FormData;
         $formData->paymentGateway = 'stripe';
         $formData->cardInfo = CardInfo::fromArray([
-            'name' => 'Spammer P. Spam',
+            'name' => 'Tester T. Test',
             'cvc' => '123',
             'expMonth' => '01',
             'expYear' => '99',

--- a/tests/Unit/PaymentGateways/Gateways/Stripe/LegacyStripeAdapterTest.php
+++ b/tests/Unit/PaymentGateways/Gateways/Stripe/LegacyStripeAdapterTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Give\PaymentGateways\DataTransferObjects\FormData;
+use Give\ValueObjects\CardInfo;
+
+class LegacyStripeAdapterTest extends \Give\Tests\TestCase
+{
+    public function testValidatesCardInformationExists()
+    {
+        $formData = new FormData;
+        $formData->paymentGateway = 'stripe';
+        $formData->cardInfo = CardInfo::fromArray([
+            'name' => 'Spammer P. Spam',
+            'cvc' => '123',
+            'expMonth' => '01',
+            'expYear' => '99',
+            'number' => '4242 4242 4242 4242',
+        ]);
+
+        do_action('give_donation_form_processing_start', $formData);
+
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testThrowsExceptionForEmptyCardInformation()
+    {
+        $formData = new FormData;
+        $formData->paymentGateway = 'stripe';
+        $formData->cardInfo = CardInfo::fromArray([
+            'name' => 'Spammer P. Spam',
+            'cvc' => '',
+            'expMonth' => '',
+            'expYear' => '',
+            'number' => '',
+        ]);
+
+        $this->expectException(WPDieException::class);
+
+        do_action('give_donation_form_processing_start', $formData);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1096]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR validates that the card fields have been filled when using the Stripe gateway on a "legacy" donation form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Adds a new hook in the legacy gateway adapter.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

See [GIVE-1096] for replication steps.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1096]: https://stellarwp.atlassian.net/browse/GIVE-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-1096]: https://stellarwp.atlassian.net/browse/GIVE-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ