### PR TITLE
Fix: standardize field error border styling across form templates

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -44,7 +44,6 @@ input[type="email"],
 textarea {
     border-width: 0.078rem;
     border-style: solid;
-    border-color: rgb(102, 102, 102);
     border-radius: 0.25rem;
     padding: 1.1875rem;
     width: 100%;

--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -58,11 +58,6 @@ textarea {
     font-weight: 500;
     line-height: 1.2;
 
-    &[aria-invalid="true"],
-    &:invalid {
-        border-color: red;
-    }
-
     &::placeholder {
         opacity: 0.6;
     }

--- a/src/DonationForms/resources/styles/_base-overrides.scss
+++ b/src/DonationForms/resources/styles/_base-overrides.scss
@@ -89,4 +89,9 @@ textarea {
         border-color: transparent;
         --box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color);
     }
+
+    &[aria-invalid="true"],
+    &:invalid {
+        border-color: red;
+    }
 }

--- a/src/DonationForms/resources/styles/_base-overrides.scss
+++ b/src/DonationForms/resources/styles/_base-overrides.scss
@@ -83,7 +83,7 @@ input[type="password"],
 input[type="email"],
 input[type="checkbox"],
 textarea {
-    border-color: var(--givewp-primary-color);
+    border-color: rgb(102, 102, 102);
 
     &:focus {
         border-color: transparent;
@@ -94,4 +94,8 @@ textarea {
     &:invalid {
         border-color: red;
     }
+}
+
+input[type='checkbox'] {
+    border-color: var(--givewp-primary-color);
 }


### PR DESCRIPTION
Resolves [GIVE-1099] & [GIVE-1100]

## Description
This PR introduces the standard grey border color & ensurers the border error styling across all form templates by moving these styles out of the specific form designs and into the base-overrides.

## Affects
Form template input fields.

## Visuals

## Testing Instructions
- Create a classic template add some required input fields.
- Process a donation without adding values.
- Verify the error border styling shows.
- Repeat for Classic & Multistep

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

