### PR TITLE
Feature: Header image should show in Form Grid and link previews

### DIFF
--- a/src/DonationForms/Actions/PrintFormMetaTags.php
+++ b/src/DonationForms/Actions/PrintFormMetaTags.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Give\DonationForms\Actions;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\Helpers\Form\Utils;
+
+/**
+ * @unreleased
+ */
+class PrintFormMetaTags
+{
+    public function __invoke()
+    {
+        global $post;
+
+        if (
+            $post->post_type === 'give_forms'
+            && Utils::isV3Form($post->ID)
+        ) {
+            $form = DonationForm::find($post->ID);
+
+            // og:image
+            if ( ! empty($form->settings->designSettingsImageUrl)) {
+                printf('<meta property="og:image" content="%s" />', esc_url($form->settings->designSettingsImageUrl));
+            }
+        }
+    }
+}

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Give\DonationForms;
 use Exception;
 use Give\DonationForms\Actions\DispatchDonateControllerDonationCreatedListeners;
 use Give\DonationForms\Actions\DispatchDonateControllerSubscriptionCreatedListeners;
+use Give\DonationForms\Actions\PrintFormMetaTags;
 use Give\DonationForms\Actions\SanitizeDonationFormPreviewRequest;
 use Give\DonationForms\Actions\StoreBackwardsCompatibleFormMeta;
 use Give\DonationForms\Blocks\DonationFormBlock\Block as DonationFormBlock;
@@ -79,6 +80,12 @@ class ServiceProvider implements ServiceProviderInterface
             RemoveDuplicateMeta::class,
             UpdateDonationLevelsSchema::class,
         ]);
+
+        /**
+         * @unreleased
+         * Print form meta tags
+         */
+        Hooks::addAction('wp_head', PrintFormMetaTags::class);
     }
 
     /**

--- a/src/Form/Template.php
+++ b/src/Form/Template.php
@@ -9,7 +9,9 @@
 
 namespace Give\Form;
 
+use Give\DonationForms\Models\DonationForm;
 use Give\Form\Template\Options;
+use Give\Helpers\Form\Utils;
 use Give\Helpers\Form\Utils as FormUtils;
 use Give\Receipt\DonationReceipt;
 
@@ -323,6 +325,10 @@ abstract class Template
      */
     public function getFormFeaturedImage($formId)
     {
+        if (Utils::isV3Form($formId)) {
+            return DonationForm::find($formId)->settings->designSettingsImageUrl;
+        }
+
         return get_the_post_thumbnail_url($formId, 'full');
     }
 


### PR DESCRIPTION
## Description

This PR resolves the issue with the featured image not showing in the form grid for v3 forms. Also, a new action is added to print form meta tags (og:image) to show an image preview for shared links. 

## Affects

Form grid
Donation form


## Testing Instructions

Create v2 form and v3 form
Set featured/header image for both
Create a new page and add a Form Grid block
Verify that both forms show featured/header image

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

