### PR TITLE
Fix: the "Offline donations" section in the controls of the Payment Gateways block should be visible when Offline gateway for v3 forms is enabled

### DIFF
--- a/src/PaymentGateways/Gateways/Offline/Actions/EnqueueOfflineFormBuilderScripts.php
+++ b/src/PaymentGateways/Gateways/Offline/Actions/EnqueueOfflineFormBuilderScripts.php
@@ -9,6 +9,8 @@ class EnqueueOfflineFormBuilderScripts
     /**
      * Enqueues the Stripe scripts and styles for the Form Builder.
      *
+     * @unreleased On the "offlineEnabled" option check if the offline gateway is enabled  for v3 forms instead of v2 forms
+     *
      * @return void
      */
     public function __invoke()
@@ -34,7 +36,7 @@ class EnqueueOfflineFormBuilderScripts
             'givewp-offline-gateway-form-builder',
             'window.giveOfflineGatewaySettings = ' . wp_json_encode(
                 [
-                    'offlineEnabled' => give_is_gateway_active(OfflineGateway::id()),
+                    'offlineEnabled' => give_is_gateway_active(OfflineGateway::id(), 3),
                     'offlineSettingsUrl' => admin_url(
                         'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=offline-donations'
                     ),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1106]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The problem was happening because we were checking if the offline gateway for v2 forms was enabled instead of checking the offline gateway for v3 forms.

Now we changed it to check the v3 version and the problem is not happening anymore.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Payment Gateways block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/8d202ffa-3810-43b4-8445-f089de9d58a3)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Disable the offline gateway for v2 forms;
2. Enable the offline gateway for v3 forms;
3. Go to the form builder and make sure the "Offline donations" section is visible in the controls of the Payment Gateways block settings.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1106]: https://stellarwp.atlassian.net/browse/GIVE-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ