### PR TITLE
Fix: add nonce to paypal disconnect

### DIFF
--- a/assets/src/js/admin/paypal-commerce/index.js
+++ b/assets/src/js/admin/paypal-commerce/index.js
@@ -314,6 +314,7 @@ window.addEventListener('DOMContentLoaded', function () {
                     formData.append('action', 'give_paypal_commerce_disconnect_account');
                     formData.append('mode', button.getAttribute('data-mode'));
                     formData.append('keep-webhooks', Boolean(keepWebhooks));
+                    formData.append('_ajax_nonce', button.getAttribute('data-nonce'));
 
                     requestData.method = 'POST';
                     requestData.body = formData;

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -474,7 +474,7 @@ class AdminSettingFields
                                     <button
                                         class="js-give-paypal-disconnect-paypal-account"
                                         data-mode="<?php echo $paypalSetting->mode; ?>"
-                                        data-nonce="<?php echo wp_create_nonce('give_paypal_commerce_disconnect_account'); ?>"
+                                        data-nonce="<?php echo esc_attr(wp_create_nonce('give_paypal_commerce_disconnect_account')); ?>"
                                     >
                                         <?php esc_html_e('Disconnect', 'give'); ?>
                                     </button>

--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -13,6 +13,7 @@ use Give_License;
  * Class AdminSettingFields
  * @package Give\PaymentGateways\PayPalCommerce
  *
+ * @unreleased added nonce to disconnect button
  * @since 2.9.0
  */
 class AdminSettingFields
@@ -472,7 +473,9 @@ class AdminSettingFields
                                 <span class="actions">
                                     <button
                                         class="js-give-paypal-disconnect-paypal-account"
-                                        data-mode="<?php echo $paypalSetting->mode; ?>">
+                                        data-mode="<?php echo $paypalSetting->mode; ?>"
+                                        data-nonce="<?php echo wp_create_nonce('give_paypal_commerce_disconnect_account'); ?>"
+                                    >
                                         <?php esc_html_e('Disconnect', 'give'); ?>
                                     </button>
                                 </span>

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -184,6 +184,7 @@ class AjaxRequestHandler
     /**
      * give_paypal_commerce_disconnect_account ajax request handler.
      *
+     * @unreleased added security nonce check
      * @since 3.13.0 Add new $keepWebhooks option
      * @since 2.30.0 Add support for mode param.
      * @since 2.25.0 Remove merchant seller token.
@@ -191,6 +192,8 @@ class AjaxRequestHandler
      */
     public function removePayPalAccount()
     {
+        check_ajax_referer( 'give_paypal_commerce_disconnect_account');
+
         if (! current_user_can('manage_give_settings')) {
             wp_send_json_error(['error' => esc_html__('You are not allowed to perform this action.', 'give')]);
         }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1135]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the paypal commerce disconnect button with a nonce.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The PayPal commerce disconnect button

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure the disconnect button still works as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1135]: https://stellarwp.atlassian.net/browse/GIVE-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ