### PR TITLE
Feature: add campaigns menu item and initial empty page

### DIFF
--- a/src/Campaigns/CampaignsAdminPage.php
+++ b/src/Campaigns/CampaignsAdminPage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Give\Campaigns;
+
+/**
+ * @unreleased
+ */
+class CampaignsAdminPage
+{
+    /**
+     * @unreleased
+     */
+    public function addCampaignsSubmenuPage()
+    {
+        add_submenu_page(
+            'edit.php?post_type=give_forms',
+            esc_html__('Campaigns', 'give'),
+            esc_html__('Campaigns', 'give'),
+            'edit_give_forms',
+            'campaigns',
+            [$this, 'renderCampaignsPage'],
+            0
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function renderCampaignsPage()
+    {
+        echo '<div id="give-admin-campaigns-root"><p style="padding: 200px 30px">The campaigns list table will be loaded here...</p></div>';
+    }
+}

--- a/src/Campaigns/CampaignsAdminPage.php
+++ b/src/Campaigns/CampaignsAdminPage.php
@@ -17,7 +17,7 @@ class CampaignsAdminPage
             esc_html__('Campaigns', 'give'),
             esc_html__('Campaigns', 'give'),
             'edit_give_forms',
-            'campaigns',
+            'give-campaigns',
             [$this, 'renderCampaignsPage'],
             0
         );

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -27,5 +27,15 @@ class ServiceProvider implements ServiceProviderInterface
     {
         // Hooks::addAction('init', Actions\MyAction::class);
         // Hooks::addAction('rest_api_init', Controllers\MyEndpoint::class);
+
+        $this->registerMenus();
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerMenus()
+    {
+        Hooks::addAction('admin_menu', CampaignsAdminPage::class, 'addCampaignsSubmenuPage', 999);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1122]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a submenu item under the Give main menu and an initial empty page where the new campaigns list table will be loaded.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Give admin menus/submenus.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/d5f439a2-17c0-463f-aeda-930900826c9d)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. In the admin area click on the new `Give > Campaigns` item;
2. Make sure a new empty page with the _"The campaigns list table will be loaded here..."_ temp text is loaded.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1122]: https://stellarwp.atlassian.net/browse/GIVE-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ