### PR TITLE
Chore: Disable Stripe legacy spam validation

### DIFF
--- a/src/PaymentGateways/Gateways/ServiceProvider.php
+++ b/src/PaymentGateways/Gateways/ServiceProvider.php
@@ -120,7 +120,6 @@ class ServiceProvider implements ServiceProviderInterface
 
     /**
      * @since 3.0.0
-     * @since 3.16.0 Add validation of card info.
      */
     private function addLegacyStripeAdapter()
     {
@@ -129,7 +128,6 @@ class ServiceProvider implements ServiceProviderInterface
 
         $legacyStripeAdapter->addDonationDetails();
         $legacyStripeAdapter->loadLegacyStripeWebhooksAndFilters();
-        $legacyStripeAdapter->validateCardInformation();
     }
 
     /**


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR disabled the spam verification for Stripe v2 donations (until another solution can be implemented and tested).
