### PR TITLE
Fix: Adjust Anonymous block styles for WP <= 6.6

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -7,10 +7,9 @@
     }
 
     .components-base-control__help {
-        display: inline-block;
-        margin-inline-start: calc(var(--checkbox-input-size, 20px) + 12px);
+        margin-left: calc(var(--checkbox-input-size, 20px) + 12px);
         font-size: 0.875rem;
-        line-height: 1rem;
+        margin-bottom: 0;
         color: var(--givewp-grey-700);
 
         .components-checkbox-control__help {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -7,9 +7,14 @@
     }
 
     .components-base-control__help {
-        margin-left: 2rem;
+        display: inline-block;
+        margin-inline-start: calc(var(--checkbox-input-size, 20px) + 12px);
         font-size: 0.875rem;
         line-height: 1rem;
         color: var(--givewp-grey-700);
+
+        .components-checkbox-control__help {
+            margin-inline-start: 0;
+        }
     }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/anonymous/styles.scss
@@ -7,9 +7,8 @@
     }
 
     .components-base-control__help {
-        margin-left: calc(var(--checkbox-input-size, 20px) + 12px);
         font-size: 0.875rem;
-        margin-bottom: 0;
+        margin: 0.25rem 0 0 calc(var(--checkbox-input-size, 20px) + 12px);;
         color: var(--givewp-grey-700);
 
         .components-checkbox-control__help {


### PR DESCRIPTION
Resolves: [GIVE-1231]

## Description
In WordPress versions prior to 6.6.1, the help message for the Checkbox control was contained within a single `<p>` tag with the classname `.components-base-control__help`. This message required additional margin adjustments to align properly with the description of the control.

Starting from WordPress version 6.6.1, the html has been updated to include an additional `<span>` element within the `<p>` tag, with the necessary CSS applied to this `<span>` via classname `components-checkbox-control__help`.

To maintain consistent styling across both versions of WordPress, this PR introduces a fix that applies the required styles directly to the `<p>` element and removes the styling from the `<span>` element. This ensures that the styling is consistent and works with both the old and new structures. 

Note: If the styles are applied to both the  `<p>` element & the  `<span>` element on version 6.6 the help message will be offset due to the additional margin.

## Affects
Anonymous block

## Visuals
### WP@6.5
![6 5 5](https://github.com/user-attachments/assets/97e2d562-00bc-4021-a24e-391692e97a5d)

### WP@6.6
![6 6 1](https://github.com/user-attachments/assets/adbe61bf-de67-4f1c-beb8-d5e444372a4f)

## Testing Instructions
- Create a VFB form & add the Anonymous donation block.
- View build preview and verify the help message and description align.
- Test on the current WP version & 2 versions prior.

## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1231]: https://stellarwp.atlassian.net/browse/GIVE-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ