### PR TITLE
Fix: Adjust design selector card height for Safari compatibility

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_onboarding.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_onboarding.scss
@@ -119,10 +119,9 @@
     }
 
     .givewp-design-selector--card {
-
         position: relative;
 
-        height: 100%;
+        height: auto;
         border-radius: 2px;
         border: solid 1px var(--givewp-grey-50);
 


### PR DESCRIPTION
Resolves: [GIVE-1229]

## Description
This PR sets the height of each design selector card to auto. It would seem the parent elements of the card do not have a set height and Safari is having trouble calculating what it should it be. This can be fixed by changing the parent grid to a flex system or setting the height to auto and allowing it to adjust it self. These changes introduce the latter.

## Affects
Design Selector Card - new form template selecting modal

## Visuals
![template-new](https://github.com/user-attachments/assets/4b46dc65-4e3e-4fdc-b27f-64a9dc095f9e)
![template-previous](https://github.com/user-attachments/assets/1546559a-a795-41bb-9cf2-829bffcbe5cc)

## Testing Instructions
- Add a new form via VFB.
- Verify each form template card is an appropriate height on while using Safari.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1229]: https://stellarwp.atlassian.net/browse/GIVE-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ