### PR TITLE
Feature: add campaign details page

### DIFF
--- a/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Give\Campaigns\Actions;
+
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\ViewModels\CampaignDetails;
+
+/**
+ * @unreleased
+ */
+class LoadCampaignDetailsAssets
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(Campaign $campaign)
+    {
+        $handleName = 'givewp-admin-campaign-details';
+
+        wp_register_script(
+            $handleName,
+            GIVE_PLUGIN_URL . 'assets/dist/js/give-admin-campaign-details.js',
+            [],
+            GIVE_VERSION,
+            true
+        );
+
+        wp_localize_script($handleName, 'GiveCampaignDetails',
+            [
+                'apiRoot' => esc_url_raw(rest_url('give-api/v2/campaigns')),
+                'apiNonce' => wp_create_nonce('wp_rest'),
+                'adminUrl' => admin_url(),
+                'pluginUrl' => GIVE_PLUGIN_URL,
+                'campaign' => (new CampaignDetails($campaign))->exports(),
+            ]
+        );
+
+        wp_enqueue_script($handleName);
+        wp_enqueue_style('givewp-design-system-foundation');
+    }
+}

--- a/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
@@ -3,7 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\Models\Campaign;
-use Give\Campaigns\ViewModels\CampaignDetails;
+use Give\Campaigns\ViewModels\CampaignDetailsPage;
 
 /**
  * @unreleased
@@ -31,7 +31,7 @@ class LoadCampaignDetailsAssets
                 'apiNonce' => wp_create_nonce('wp_rest'),
                 'adminUrl' => admin_url(),
                 'pluginUrl' => GIVE_PLUGIN_URL,
-                'campaign' => (new CampaignDetails($campaign))->exports(),
+                'campaignDetailsPage' => (new CampaignDetailsPage($campaign))->exports(),
             ]
         );
 

--- a/src/Campaigns/CampaignsAdminPage.php
+++ b/src/Campaigns/CampaignsAdminPage.php
@@ -2,7 +2,9 @@
 
 namespace Give\Campaigns;
 
+use Give\Campaigns\Actions\LoadCampaignDetailsAssets;
 use Give\Campaigns\Actions\LoadCampaignsListTableAssets;
+use Give\Campaigns\Models\Campaign;
 
 /**
  * @unreleased
@@ -30,7 +32,17 @@ class CampaignsAdminPage
      */
     public function renderCampaignsPage()
     {
-        give(LoadCampaignsListTableAssets::class)();
+        if (isset($_GET['id'])) {
+            $campaign = Campaign::find(absint($_GET['id']));
+
+            if ( ! $campaign) {
+                wp_die(__('Campaign not found', 'give'), 404);
+            }
+
+            give(LoadCampaignDetailsAssets::class)($campaign);
+        } else {
+            give(LoadCampaignsListTableAssets::class)();
+        }
 
         echo '<div id="give-admin-campaigns-root"></div>';
     }

--- a/src/Campaigns/Routes/CreateCampaign.php
+++ b/src/Campaigns/Routes/CreateCampaign.php
@@ -77,7 +77,6 @@ class CreateCampaign implements RestRoute
     public function handleRequest(WP_REST_Request $request): WP_REST_Response
     {
         $campaign = Campaign::create([
-            'pageId' => 0,
             'type' => CampaignType::CORE(),
             'title' => $request->get_param('title'),
             'shortDescription' => $request->get_param('shortDescription'),

--- a/src/Campaigns/ViewModels/CampaignDetails.php
+++ b/src/Campaigns/ViewModels/CampaignDetails.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Give\Campaigns\ViewModels;
+
+use Give\Campaigns\Models\Campaign;
+
+/**
+ * @unreleased
+ */
+class CampaignDetails
+{
+    /**
+     * @unreleased
+     *
+     * @var Campaign
+     */
+    protected $campaign;
+
+    /**
+     * @unreleased
+     */
+    public function __construct(Campaign $campaign)
+    {
+        $this->campaign = $campaign;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function exports(): array
+    {
+        return $this->campaign->toArray();
+    }
+}

--- a/src/Campaigns/ViewModels/CampaignDetailsPage.php
+++ b/src/Campaigns/ViewModels/CampaignDetailsPage.php
@@ -7,7 +7,7 @@ use Give\Campaigns\Models\Campaign;
 /**
  * @unreleased
  */
-class CampaignDetails
+class CampaignDetailsPage
 {
     /**
      * @unreleased
@@ -29,6 +29,13 @@ class CampaignDetails
      */
     public function exports(): array
     {
-        return $this->campaign->toArray();
+        return [
+            'overviewTab' => $this->campaign->toArray(),
+            'settingsTab' => [
+                'landingPageUrl' => admin_url('?action=edit_campaign_page&campaign_id=' . $this->campaign->id),
+            ],
+            'reportTab' => [],
+            'updatesTab' => [],
+        ];
     }
 }

--- a/src/Campaigns/resources/admin/campaign-details.tsx
+++ b/src/Campaigns/resources/admin/campaign-details.tsx
@@ -1,11 +1,6 @@
 import {createRoot} from 'react-dom/client';
+import CampaignsDetailsPage from './components/CampaignDetailsPage';
 
 const container = document.getElementById('give-admin-campaigns-root');
 const root = createRoot(container!);
-root.render(
-    <div style={{marginTop: '6rem', padding: '1rem'}}>
-        <p>
-            <strong>Campaign details goes here...</strong>
-        </p>
-    </div>
-);
+root.render(<CampaignsDetailsPage />);

--- a/src/Campaigns/resources/admin/campaign-details.tsx
+++ b/src/Campaigns/resources/admin/campaign-details.tsx
@@ -1,0 +1,11 @@
+import {createRoot} from 'react-dom/client';
+
+const container = document.getElementById('give-admin-campaigns-root');
+const root = createRoot(container!);
+root.render(
+    <div style={{marginTop: '6rem', padding: '1rem'}}>
+        <p>
+            <strong>Campaign details goes here...</strong>
+        </p>
+    </div>
+);

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -1,0 +1,4 @@
+.container {
+    margin-top: 6rem;
+    padding: 1rem;
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -1,4 +1,4 @@
 .container {
-    margin-top: 6rem;
-    padding: 1rem;
+    margin-top: 3rem;
+    padding: 3rem;
 }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -22,7 +22,7 @@ export default function CampaignsDetailsPage() {
             <p>Just below you can see a few data from the details page separated by tabs.</p>
             <br />
             <h2>
-                <strong>Overview Tab Data</strong>
+                <strong>Overview Tab</strong>
             </h2>
             <ul>
                 {Object.entries(campaignDetailsPage.overviewTab).map(([property, value], index) => (
@@ -35,7 +35,7 @@ export default function CampaignsDetailsPage() {
             </ul>
             <br />
             <h2>
-                <strong>Settings Tab Data</strong>
+                <strong>Settings Tab</strong>
             </h2>
             <p>
                 <a
@@ -44,7 +44,7 @@ export default function CampaignsDetailsPage() {
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    Campaign Landing Page ⭷
+                    Edit Campaign Landing Page ⭷
                 </a>
             </p>
         </div>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -1,0 +1,52 @@
+import {GiveCampaignDetails} from './types';
+import styles from './CampaignDetailsPage.module.scss';
+
+declare const window: {
+    GiveCampaignDetails: GiveCampaignDetails;
+} & Window;
+
+export function getGiveCampaignDetailsWindowData() {
+    return window.GiveCampaignDetails;
+}
+
+const {campaignDetailsPage} = getGiveCampaignDetailsWindowData();
+
+console.log(Object.values(campaignDetailsPage.overviewTab));
+
+export default function CampaignsDetailsPage() {
+    return (
+        <div className={styles.container}>
+            <h1>
+                <strong>Campaign details goes here...</strong>
+            </h1>
+            <p>Just below you can see a few data from the details page separated by tabs.</p>
+            <br />
+            <h2>
+                <strong>Overview Tab Data</strong>
+            </h2>
+            <ul>
+                {Object.entries(campaignDetailsPage.overviewTab).map(([property, value], index) => (
+                    <li key={index}>
+                        <span>
+                            <strong>{property}:</strong> {String(value)}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+            <br />
+            <h2>
+                <strong>Settings Tab Data</strong>
+            </h2>
+            <p>
+                <a
+                    style={{fontSize: '1.5rem'}}
+                    href={campaignDetailsPage.settingsTab.landingPageUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Campaign Landing Page ⭷
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/types.ts
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/types.ts
@@ -1,0 +1,12 @@
+export interface GiveCampaignDetails {
+    apiRoot: string;
+    apiNonce: string;
+    adminUrl: string;
+    pluginUrl: string;
+    campaignDetailsPage: {
+        overviewTab: any;
+        settingsTab: {
+            landingPageUrl: string;
+        };
+    };
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -61,6 +61,7 @@ mix.setPublicPath('assets/dist')
     .ts('src/Promotions/InPluginUpsells/resources/js/payment-gateway.ts', 'js/payment-gateway.js')
     .ts('src/Promotions/WelcomeBanner/resources/js/index.tsx', 'js/welcome-banner.js')
     .ts('src/Campaigns/resources/admin/campaigns-list-table.tsx', 'js/give-admin-campaigns-list-table.js')
+    .ts('src/Campaigns/resources/admin/campaign-details.tsx', 'js/give-admin-campaign-details.js')
 
     .react()
     .sourceMaps(false, 'source-map')


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1152]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds an initial campaign details page that loads a few data from the overview and settings tab and only displays on the screen in a raw format - the design should be implemented in subsequent PRs.

For reference about the information architecture, check this design prototype:
https://www.figma.com/design/KN4DmHaBWDylrq1EbVXw3n/Campaigns?node-id=299-10474&node-type=FRAME&t=7fGtZY2l39rnL5Ou-0

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign details page.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/ddd319eb-f622-4b70-823e-1b64c0629dba)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Go to `Give > Campaigns` page;
2. Create a new campaign or Edit a campaign created previously;
3. You should see a screen with details about the campaign and a link to edit the landing page;
4. Click on the `Edit Campaign Landing Page ⭷` link and a a new tab should be open.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1152]: https://stellarwp.atlassian.net/browse/GIVE-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ