### PR TITLE
Feature: Add new Insert Into method to the Query Builder

### DIFF
--- a/src/Framework/QueryBuilder/Concerns/CRUD.php
+++ b/src/Framework/QueryBuilder/Concerns/CRUD.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\QueryBuilder\Concerns;
 
 use Give\Framework\Database\DB;
+use Give\Framework\QueryBuilder\QueryBuilder;
 
 /**
  * @since 2.19.0
@@ -27,6 +28,20 @@ trait CRUD
             $data,
             $format
         );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param array        $columns
+     * @param QueryBuilder $query
+     *
+     * @return bool|int
+     */
+    public function insertInto(array $columns, QueryBuilder $query)
+    {
+        $columns = implode(', ', $columns);
+        return DB::query("INSERT INTO {$this->getTable()} ({$columns}) {$query->getSQL()}");
     }
 
     /**

--- a/tests/Unit/Framework/QueryBuilder/CRUDTest.php
+++ b/tests/Unit/Framework/QueryBuilder/CRUDTest.php
@@ -58,6 +58,30 @@ final class CRUDTest extends TestCase
     }
 
     /**
+     * @unreleased
+     */
+    public function testInsertIntoShouldAddMultipleRowsToTheDatabase()
+    {
+        DB::table('posts')->insert(['post_title' => 'Aye Post']);
+        $postIdAye = DB::last_insert_id();
+
+        DB::table('posts')->insert(['post_title' => 'Bee Post']);
+        $postIdBee = DB::last_insert_id();
+
+        DB::table('postmeta')
+            ->insertInto(
+                ['post_id', 'meta_key', 'meta_value'],
+                DB::table('posts') // SELECT ID AS post_id, (SELECT "postTitle") as meta_key, post_title AS meta_value FROM wp_posts
+                    ->select(['ID', 'post_id'])
+                    ->selectRaw('(SELECT "postTitle") as meta_key')
+                    ->select(['post_title', 'meta_value'])
+            );
+
+        $this->assertEquals('Aye Post', get_post_meta($postIdAye, 'postTitle', true));
+        $this->assertEquals('Bee Post', get_post_meta($postIdBee, 'postTitle', true));
+    }
+
+    /**
      * @since 2.19.0
      *
      * @return void


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds support for inserting the results on a query into another table using `INSERT INTO`.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Adds a new `insertInto()` method to the `CRUD` trait of the `QueryBuilder`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```php
DB::table('postmeta')
    ->insertInto(
        ['post_id', 'meta_key', 'meta_value'],
        DB::table('posts')
            ->select(['ID', 'post_id'])
            ->selectRaw('(SELECT "postTitle") as meta_key')
            ->select(['post_title', 'meta_value'])
    );
```

```

```sql
INSERT INTO wp_postmeta (post_id, meta_key, meta_value)
    SELECT
        ID AS post_id,
        (SELECT "postTitle") as meta_key,
        post_title AS meta_value
    FROM wp_posts;
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

