### PR TITLE
Feature: Add endpoint for Campaign Overview Statistics

### DIFF
--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -9,6 +9,7 @@ use Give\API\RestRoute;
 use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\Framework\Support\Facades\DateTime\Temporal;
+use WP_REST_Server;
 
 /**
  * @unreleased
@@ -28,7 +29,7 @@ class CampaignOverviewStatistics implements RestRoute
             $this->endpoint,
             [
                 [
-                    'methods' => 'GET',
+                    'methods' => WP_REST_Server::READABLE,
                     'callback' => [$this, 'handleRequest'],
                     'permission_callback' => function () {
                         return current_user_can('manage_options');

--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -5,6 +5,7 @@ namespace Give\Campaigns\Routes;
 use DateInterval;
 use DatePeriod;
 use DateTimeImmutable;
+use Exception;
 use Give\API\RestRoute;
 use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
@@ -56,6 +57,8 @@ class CampaignOverviewStatistics implements RestRoute
 
     /**
      * @unreleased
+     *
+     * @throws Exception
      */
     public function handleRequest($request)
     {

--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -39,13 +39,15 @@ class CampaignOverviewStatistics implements RestRoute
                     'campaignId' => [
                         'type' => 'integer',
                         'required' => true,
+                        'sanitize_callback' => 'absint',
                         'validate_callback' => 'is_numeric',
                     ],
                     'rangeInDays' => [
                         'type' => 'integer',
                         'required' => false,
-                        'validate_callback' => 'is_numeric',
+                        'sanitize_callback' => 'absint',
                         'default' => 0, // Zero to mean "all time".
+                        'validate_callback' => 'is_numeric',
                     ],
                 ],
             ]

--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Give\Campaigns\Routes;
+
+use DateInterval;
+use DatePeriod;
+use DateTimeImmutable;
+use Give\API\RestRoute;
+use Give\Campaigns\CampaignDonationQuery;
+use Give\Campaigns\Models\Campaign;
+use Give\Framework\Support\Facades\DateTime\Temporal;
+
+class CampaignOverviewStatistics implements RestRoute
+{
+    /** @var string */
+    protected $endpoint = 'campaign-overview-statistics';
+
+    /**
+     * @unreleased
+     */
+    public function registerRoute()
+    {
+        register_rest_route(
+            'give-api/v2',
+            $this->endpoint,
+            [
+                [
+                    'methods' => 'GET',
+                    'callback' => [$this, 'handleRequest'],
+                    'permission_callback' => function () {
+                        return current_user_can('manage_options');
+                    },
+                ],
+                'args' => [
+                    'campaignId' => [
+                        'type' => 'integer',
+                        'required' => true,
+                        'validate_callback' => 'is_numeric',
+                    ],
+                    'rangeInDays' => [
+                        'type' => 'integer',
+                        'required' => false,
+                        'validate_callback' => 'is_numeric',
+                        'default' => 0, // Zero to mean "all time".
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    public function handleRequest($request)
+    {
+        $campaign = Campaign::find($request->get_param('campaignId'));
+
+        $query = new CampaignDonationQuery($campaign);
+
+        if(!$request->get_param('rangeInDays')) {
+            return [[
+                'amountRaised' => $query->sumIntendedAmount(),
+                'donationCount' => $query->countDonations(),
+                'donorCount' => $query->countDonors(),
+            ]];
+        }
+
+        $days = $request->get_param('rangeInDays');
+        $date = new DateTimeImmutable('now', wp_timezone());
+        $interval = DateInterval::createFromDateString("-$days days");
+        $period = new DatePeriod($date, $interval, 1);
+
+        return array_map(function($targetDate) use ($query, $interval) {
+
+            $query = $query->between(
+                Temporal::withStartOfDay($targetDate->add($interval)),
+                Temporal::withEndOfDay($targetDate)
+            );
+
+            return [
+                'amountRaised' => $query->sumIntendedAmount(),
+                'donationCount' => $query->countDonations(),
+                'donorCount' => $query->countDonors(),
+            ];
+        }, iterator_to_array($period) );
+    }
+}

--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -10,6 +10,9 @@ use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\Framework\Support\Facades\DateTime\Temporal;
 
+/**
+ * @unreleased
+ */
 class CampaignOverviewStatistics implements RestRoute
 {
     /** @var string */

--- a/src/Campaigns/Routes/CampaignOverviewStatistics.php
+++ b/src/Campaigns/Routes/CampaignOverviewStatistics.php
@@ -10,6 +10,7 @@ use Give\API\RestRoute;
 use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\Framework\Support\Facades\DateTime\Temporal;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**
@@ -60,18 +61,18 @@ class CampaignOverviewStatistics implements RestRoute
      *
      * @throws Exception
      */
-    public function handleRequest($request)
+    public function handleRequest($request): WP_REST_Response
     {
         $campaign = Campaign::find($request->get_param('campaignId'));
 
         $query = new CampaignDonationQuery($campaign);
 
         if(!$request->get_param('rangeInDays')) {
-            return [[
+            return new WP_REST_Response([[
                 'amountRaised' => $query->sumIntendedAmount(),
                 'donationCount' => $query->countDonations(),
                 'donorCount' => $query->countDonors(),
-            ]];
+            ]]);
         }
 
         $days = $request->get_param('rangeInDays');
@@ -79,7 +80,7 @@ class CampaignOverviewStatistics implements RestRoute
         $interval = DateInterval::createFromDateString("-$days days");
         $period = new DatePeriod($date, $interval, 1);
 
-        return array_map(function($targetDate) use ($query, $interval) {
+        return new WP_REST_Response(array_map(function($targetDate) use ($query, $interval) {
 
             $query = $query->between(
                 Temporal::withStartOfDay($targetDate->add($interval)),
@@ -91,6 +92,6 @@ class CampaignOverviewStatistics implements RestRoute
                 'donationCount' => $query->countDonations(),
                 'donorCount' => $query->countDonors(),
             ];
-        }, iterator_to_array($period) );
+        }, iterator_to_array($period) ));
     }
 }

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -46,6 +46,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('rest_api_init', Routes\CreateCampaign::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\GetCampaignsListTable::class, 'registerRoute');
         Hooks::addAction('rest_api_init', Routes\DeleteCampaignListTable::class, 'registerRoute');
+        Hooks::addAction('rest_api_init', Routes\CampaignOverviewStatistics::class, 'registerRoute');
     }
 
     /**

--- a/src/Framework/Support/Facades/DateTime/Temporal.php
+++ b/src/Framework/Support/Facades/DateTime/Temporal.php
@@ -14,6 +14,9 @@ use Give\Framework\Support\Facades\Facade;
  * @method static string getFormattedDateTime(DateTimeInterface $dateTime)
  * @method static string getCurrentFormattedDateForDatabase()
  * @method static DateTimeInterface withoutMicroseconds(DateTimeInterface $dateTime)
+ * @method static DateTimeInterface withStartOfDay(DateTimeInterface $dateTime)
+ * @method static DateTimeInterface withEndOfDay(DateTimeInterface $dateTime)
+ * @method static DateTimeInterface immutableOrClone(DateTimeInterface $dateTime)
  */
 class Temporal extends Facade
 {

--- a/src/Framework/Support/Facades/DateTime/TemporalFacade.php
+++ b/src/Framework/Support/Facades/DateTime/TemporalFacade.php
@@ -54,26 +54,51 @@ class TemporalFacade
     /**
      * Immutably returns a new DateTime instance with the microseconds set to 0.
      *
+     * @unreleased Extracted new immutableOrClone method.
      * @since 2.20.0
      */
     public function withoutMicroseconds(DateTimeInterface $dateTime)
     {
-        if ($dateTime instanceof DateTimeImmutable) {
-            return $dateTime->setTime(
+        return $this
+            ->immutableOrClone($dateTime)
+            ->setTime(
                 $dateTime->format('H'),
                 $dateTime->format('i'),
                 $dateTime->format('s')
             );
-        }
+    }
 
-        $newDateTime = clone $dateTime;
+    /**
+     * Immutably returns a new DateTime instance with the time set to the start of the day.
+     *
+     * @unreleased
+     */
+    public function withStartOfDay(DateTimeInterface $dateTime): DateTimeInterface
+    {
+        return $this
+            ->immutableOrClone($dateTime)
+            ->setTime(0, 0, 0, 0);
+    }
 
-        $newDateTime->setTime(
-            $newDateTime->format('H'),
-            $newDateTime->format('i'),
-            $newDateTime->format('s')
-        );
+    /**
+     * Immutably returns a new DateTime instance with the time set to the end of the day.
+     *
+     * @unreleased
+     */
+    public function withEndOfDay(DateTimeInterface $dateTime): DateTimeInterface
+    {
+        return $this
+            ->immutableOrClone($dateTime)
+            ->setTime(23, 59, 59, 999999);
+    }
 
-        return $newDateTime;
+    /**
+     * @unreleased
+     */
+    public function immutableOrClone(DateTimeInterface $dateTime): DateTimeInterface
+    {
+        return $dateTime instanceof DateTimeImmutable
+            ? $dateTime
+            : clone $dateTime;
     }
 }

--- a/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
+++ b/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
@@ -32,24 +32,29 @@ final class CampaignOverviewStatisticsTest extends TestCase
         $db = DB::table('give_campaign_forms');
         $db->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
 
-        Donation::factory()->create([
+        $donation1 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-35 days'),
         ]);
-        Donation::factory()->create([
+        give_update_meta($donation1->id, '_give_completed_date', $donation1->createdAt->format('Y-m-d H:i:s'));
+
+        $donation2 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-5 days'),
         ]);
-        Donation::factory()->create([
+        give_update_meta($donation2->id, '_give_completed_date', $donation2->createdAt->format('Y-m-d H:i:s'));
+
+        $donation3 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('now'),
         ]);
+        give_update_meta($donation3->id, '_give_completed_date', $donation3->createdAt->format('Y-m-d H:i:s'));
 
         $request = new WP_REST_Request('GET', '/give-api/v2/campaign-overview-statistics');
         $request->set_param('campaignId', $campaign->id);
@@ -73,24 +78,29 @@ final class CampaignOverviewStatisticsTest extends TestCase
         $db = DB::table('give_campaign_forms');
         $db->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
 
-        Donation::factory()->create([
+        $donation1 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-35 days'),
         ]);
-        Donation::factory()->create([
+        give_update_meta($donation1->id, '_give_completed_date', $donation1->createdAt->format('Y-m-d H:i:s'));
+
+        $donation2 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-5 days'),
         ]);
-        Donation::factory()->create([
+        give_update_meta($donation2->id, '_give_completed_date', $donation2->createdAt->format('Y-m-d H:i:s'));
+
+        $donation3 = Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('now'),
         ]);
+        give_update_meta($donation3->id, '_give_completed_date', $donation3->createdAt->format('Y-m-d H:i:s'));
 
         $request = new WP_REST_Request('GET', '/give-api/v2/campaign-overview-statistics');
         $request->set_param('campaignId', $campaign->id);

--- a/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
+++ b/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
@@ -62,9 +62,9 @@ final class CampaignOverviewStatisticsTest extends TestCase
         $route = new CampaignOverviewStatistics;
         $response = $route->handleRequest($request);
 
-        $this->assertEquals(3, $response[0]['donorCount']);
-        $this->assertEquals(3, $response[0]['donationCount']);
-        $this->assertEquals(30, $response[0]['amountRaised']);
+        $this->assertEquals(3, $response->data[0]['donorCount']);
+        $this->assertEquals(3, $response->data[0]['donationCount']);
+        $this->assertEquals(30, $response->data[0]['amountRaised']);
     }
 
     /**
@@ -109,12 +109,12 @@ final class CampaignOverviewStatisticsTest extends TestCase
         $route = new CampaignOverviewStatistics;
         $response = $route->handleRequest($request);
 
-        $this->assertEquals(2, $response[0]['donorCount']);
-        $this->assertEquals(2, $response[0]['donationCount']);
-        $this->assertEquals(20, $response[0]['amountRaised']);
+        $this->assertEquals(2, $response->data[0]['donorCount']);
+        $this->assertEquals(2, $response->data[0]['donationCount']);
+        $this->assertEquals(20, $response->data[0]['amountRaised']);
 
-        $this->assertEquals(1, $response[1]['donorCount']);
-        $this->assertEquals(1, $response[1]['donationCount']);
-        $this->assertEquals(10, $response[1]['amountRaised']);
+        $this->assertEquals(1, $response->data[1]['donorCount']);
+        $this->assertEquals(1, $response->data[1]['donationCount']);
+        $this->assertEquals(10, $response->data[1]['amountRaised']);
     }
 }

--- a/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
+++ b/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Give\Tests\Unit\Campaigns\Routes;
+
+use DateTime;
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\Routes\CampaignOverviewStatistics;
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\Database\DB;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+
+final class CampaignOverviewStatisticsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testReturnsAllTimeDonationsStatistics()
+    {
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::factory()->create();
+
+        $db = DB::table('give_campaign_forms');
+        $db->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
+
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('-35 days'),
+        ]);
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('-5 days'),
+        ]);
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('now'),
+        ]);
+
+        $request = new WP_REST_Request('GET', '/give-api/v2/campaign-overview-statistics');
+        $request->set_param('campaignId', $campaign->id);
+
+        $route = new CampaignOverviewStatistics;
+        $response = $route->handleRequest($request);
+
+        $this->assertEquals(3, $response[0]['donorCount']);
+        $this->assertEquals(3, $response[0]['donationCount']);
+        $this->assertEquals(30, $response[0]['amountRaised']);
+    }
+
+    public function testReturnsPeriodStatisticsWithPreviousPeriod()
+    {
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::factory()->create();
+
+        $db = DB::table('give_campaign_forms');
+        $db->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
+
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('-35 days'),
+        ]);
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('-5 days'),
+        ]);
+        Donation::factory()->create([
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+            'createdAt' => new DateTime('now'),
+        ]);
+
+        $request = new WP_REST_Request('GET', '/give-api/v2/campaign-overview-statistics');
+        $request->set_param('campaignId', $campaign->id);
+        $request->set_param('rangeInDays', 30);
+
+        $route = new CampaignOverviewStatistics;
+        $response = $route->handleRequest($request);
+
+        $this->assertEquals(2, $response[0]['donorCount']);
+        $this->assertEquals(2, $response[0]['donationCount']);
+        $this->assertEquals(20, $response[0]['amountRaised']);
+
+        $this->assertEquals(1, $response[1]['donorCount']);
+        $this->assertEquals(1, $response[1]['donationCount']);
+        $this->assertEquals(10, $response[1]['amountRaised']);
+    }
+}

--- a/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
+++ b/tests/Unit/Campaigns/Routes/CampaignOverviewStatisticsTest.php
@@ -14,10 +14,16 @@ use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 use WP_REST_Request;
 
+/**
+ * @unreleased
+ */
 final class CampaignOverviewStatisticsTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @unreleased
+     */
     public function testReturnsAllTimeDonationsStatistics()
     {
         $campaign = Campaign::factory()->create();
@@ -56,6 +62,9 @@ final class CampaignOverviewStatisticsTest extends TestCase
         $this->assertEquals(30, $response[0]['amountRaised']);
     }
 
+    /**
+     * @unreleased
+     */
     public function testReturnsPeriodStatisticsWithPreviousPeriod()
     {
         $campaign = Campaign::factory()->create();

--- a/tests/Unit/Framework/Support/Facades/DateTime/TemporalFacadeTest.php
+++ b/tests/Unit/Framework/Support/Facades/DateTime/TemporalFacadeTest.php
@@ -7,8 +7,14 @@ use DateTimeImmutable;
 use Give\Framework\Support\Facades\DateTime\TemporalFacade;
 use Give\Tests\TestCase;
 
+/**
+ * @unreleased
+ */
 final class TemporalFacadeTest extends TestCase
 {
+    /**
+     * @unreleased
+     */
     public function testImmutableOrCloneReturnsCloneOfDateTimeObject()
     {
         $dateTime = new DateTime;
@@ -20,6 +26,9 @@ final class TemporalFacadeTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $newDateTime);
     }
 
+    /**
+     * @unreleased
+     */
     public function testImmutableOrCloneReturnsSameImmutableDateTimeObject()
     {
         $dateTime = new DateTimeImmutable;
@@ -31,6 +40,9 @@ final class TemporalFacadeTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $newDateTime);
     }
 
+    /**
+     * @unreleased
+     */
     public function testImmutableStartOfDay()
     {
         $dateTime = new DateTime('2020-01-01 12:34:56');
@@ -42,6 +54,9 @@ final class TemporalFacadeTest extends TestCase
         $this->assertEquals('2020-01-01 00:00:00', $newDateTime->format('Y-m-d H:i:s'));
     }
 
+    /**
+     * @unreleased
+     */
     public function testImmutableEndOfDay()
     {
         $dateTime = new DateTime('2020-01-01 12:34:56');

--- a/tests/Unit/Framework/Support/Facades/DateTime/TemporalFacadeTest.php
+++ b/tests/Unit/Framework/Support/Facades/DateTime/TemporalFacadeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Give\Tests\Unit\Framework\Support\Facades\DateTime;
+
+use DateTime;
+use DateTimeImmutable;
+use Give\Framework\Support\Facades\DateTime\TemporalFacade;
+use Give\Tests\TestCase;
+
+final class TemporalFacadeTest extends TestCase
+{
+    public function testImmutableOrCloneReturnsCloneOfDateTimeObject()
+    {
+        $dateTime = new DateTime;
+        $temporal = new TemporalFacade;
+
+        $newDateTime = $temporal->immutableOrClone($dateTime);
+
+        $this->assertNotSame($dateTime, $newDateTime);
+        $this->assertInstanceOf(DateTime::class, $newDateTime);
+    }
+
+    public function testImmutableOrCloneReturnsSameImmutableDateTimeObject()
+    {
+        $dateTime = new DateTimeImmutable;
+        $temporal = new TemporalFacade;
+
+        $newDateTime = $temporal->immutableOrClone($dateTime);
+
+        $this->assertSame($dateTime, $newDateTime);
+        $this->assertInstanceOf(DateTimeImmutable::class, $newDateTime);
+    }
+
+    public function testImmutableStartOfDay()
+    {
+        $dateTime = new DateTime('2020-01-01 12:34:56');
+        $temporal = new TemporalFacade;
+
+        $newDateTime = $temporal->withStartOfDay($dateTime);
+
+        $this->assertNotSame($dateTime, $newDateTime);
+        $this->assertEquals('2020-01-01 00:00:00', $newDateTime->format('Y-m-d H:i:s'));
+    }
+
+    public function testImmutableEndOfDay()
+    {
+        $dateTime = new DateTime('2020-01-01 12:34:56');
+        $temporal = new TemporalFacade;
+
+        $newDateTime = $temporal->withEndOfDay($dateTime);
+
+        $this->assertNotSame($dateTime, $newDateTime);
+        $this->assertEquals('2020-01-01 23:59:59.999999', $newDateTime->format('Y-m-d H:i:s.u'));
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related [GIVE-1221]
Related [GIVE-1222]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the `GET \give-api\v2\campaign-overview-statistics` endpoint for fetching campaign statistics, such as Amount Raised, Donation Count, and Donor Count.

If a range in days (`rangeInDays`) is provided then a pair of values are returned to include the previous period of the range.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- `Campaigns\CampaignDonationQuery` has been updated with support for immutability.

- `Framework\Support\Facades\DateTime\TemporalFacade` has been updated to include new helper methods `withStartOfDay` and `withEndOfDay`, which set the appropriate time for inclusively querying dates in a range. Additionally, the `immutableOrClone` method has been added to encapsulate support for immutability that accounts for either `DateTime` or `DateTimeImmutable`, both of which implement the `DateTimeInterface`.

- `Framework\Support\Facades\DateTime\Temporal` has been updated with available methods using `@method` annotations in the docblock.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```php
// "All time"
[
    [
        'amountRaised' => 20,
        'donationCount' => 2,
        'donorCount' => 2,
    ],
]
```

```php
// Period of time with previous period
[
    [
        // Current period
        'amountRaised' => 20,
        'donationCount' => 2,
        'donorCount' => 2,
    ],
    [
        // Previous period
        'amountRaised' => 10,
        'donationCount' => 1,
        'donorCount' => 1,
    ],
]
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1221]: https://stellarwp.atlassian.net/browse/GIVE-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-1222]: https://stellarwp.atlassian.net/browse/GIVE-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ