### PR TITLE
Feature: add global settings for honeypot field

### DIFF
--- a/give.php
+++ b/give.php
@@ -190,6 +190,7 @@ final class Give
     private $container;
 
     /**
+     * @unreleased added Settings service provider
      * @since      2.25.0 added HttpServiceProvider
      * @since      2.19.6 added Donors, Donations, and Subscriptions
      * @since      2.8.0

--- a/give.php
+++ b/give.php
@@ -241,6 +241,7 @@ final class Give
         Give\BetaFeatures\ServiceProvider::class,
         Give\FormTaxonomies\ServiceProvider::class,
         Give\DonationSpam\ServiceProvider::class,
+        Give\Settings\ServiceProvider::class
     ];
 
     /**

--- a/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
+++ b/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
@@ -20,9 +20,10 @@ class AddHoneyPotFieldToDonationForms
     {
         $formNodes = $form->all();
         $lastSection = $form->count() ? $formNodes[$form->count() - 1] : null;
+        $honeypotFieldName = apply_filters('givewp_donation_forms_honeypot_field_name', 'donationBirthday');
 
-        if ($lastSection) {
-            $field = Honeypot::make('donationBirthday')
+        if ($lastSection && is_null($form->getNodeByName($honeypotFieldName))) {
+            $field = Honeypot::make($honeypotFieldName)
                 ->label('Donation Birthday')
                 ->scope('honeypot')
                 ->showInAdmin(false)

--- a/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
+++ b/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
@@ -13,6 +13,7 @@ use Give\Framework\FieldsAPI\Honeypot;
 class AddHoneyPotFieldToDonationForms
 {
     /**
+     * @unreleased added parameter $honeypotFieldName
      * @since 3.16.2
      * @throws EmptyNameException
      */

--- a/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
+++ b/src/DonationForms/Actions/AddHoneyPotFieldToDonationForms.php
@@ -16,15 +16,14 @@ class AddHoneyPotFieldToDonationForms
      * @since 3.16.2
      * @throws EmptyNameException
      */
-    public function __invoke(DonationForm $form): void
+    public function __invoke(DonationForm $form, string $honeypotFieldName): void
     {
         $formNodes = $form->all();
         $lastSection = $form->count() ? $formNodes[$form->count() - 1] : null;
-        $honeypotFieldName = apply_filters('givewp_donation_forms_honeypot_field_name', 'donationBirthday');
 
         if ($lastSection && is_null($form->getNodeByName($honeypotFieldName))) {
             $field = Honeypot::make($honeypotFieldName)
-                ->label('Donation Birthday')
+                ->label($this->generateLabelFromFieldName($honeypotFieldName))
                 ->scope('honeypot')
                 ->showInAdmin(false)
                 ->showInReceipt(false)
@@ -32,5 +31,13 @@ class AddHoneyPotFieldToDonationForms
 
             $lastSection->append($field);
         }
+    }
+
+    /**
+     * @unreleased
+     */
+    private function generateLabelFromFieldName(string $honeypotFieldName): string
+    {
+        return ucwords(trim(implode(" ", preg_split("/(?=[A-Z])/", $honeypotFieldName))));
     }
 }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -363,8 +363,22 @@ class ServiceProvider implements ServiceProviderInterface
     private function registerHoneyPotField(): void
     {
         add_action('givewp_donation_form_schema', function (DonationFormModel $form, int $formId) {
+            /**
+             * Check if the honeypot field is enabled
+             * @param int $formId
+             *
+             * @since 3.16.2
+             */
             if (apply_filters('givewp_donation_forms_honeypot_enabled', give_is_setting_enabled(give_get_option( 'givewp_donation_forms_honeypot_enabled', 'enabled')), $formId)) {
-                (new AddHoneyPotFieldToDonationForms())($form);
+                /**
+                 * Filter the honeypot field name
+                 * @param int $formId
+                 *
+                 * @unreleased
+                 */
+                $honeypotFieldName = (string)apply_filters('givewp_donation_forms_honeypot_field_name', 'donationBirthday', $formId);
+
+                (new AddHoneyPotFieldToDonationForms())($form, $honeypotFieldName);
             }
         }, 10, 2);
     }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -365,6 +365,7 @@ class ServiceProvider implements ServiceProviderInterface
         add_action('givewp_donation_form_schema', function (DonationFormModel $form, int $formId) {
             /**
              * Check if the honeypot field is enabled
+             * @param bool $enabled
              * @param int $formId
              *
              * @since 3.16.2
@@ -372,6 +373,7 @@ class ServiceProvider implements ServiceProviderInterface
             if (apply_filters('givewp_donation_forms_honeypot_enabled', give_is_setting_enabled(give_get_option( 'givewp_donation_forms_honeypot_enabled', 'enabled')), $formId)) {
                 /**
                  * Filter the honeypot field name
+                 * @param string $honeypotFieldName
                  * @param int $formId
                  *
                  * @unreleased

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -363,7 +363,7 @@ class ServiceProvider implements ServiceProviderInterface
     private function registerHoneyPotField(): void
     {
         add_action('givewp_donation_form_schema', function (DonationFormModel $form, int $formId) {
-            if (apply_filters('givewp_donation_forms_honeypot_enabled', give_is_setting_enabled(give_get_option( 'givewp_donation_forms_honeypot_enabled', 'disabled')), $formId)) {
+            if (apply_filters('givewp_donation_forms_honeypot_enabled', give_is_setting_enabled(give_get_option( 'givewp_donation_forms_honeypot_enabled', 'enabled')), $formId)) {
                 (new AddHoneyPotFieldToDonationForms())($form);
             }
         }, 10, 2);

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -363,7 +363,7 @@ class ServiceProvider implements ServiceProviderInterface
     private function registerHoneyPotField(): void
     {
         add_action('givewp_donation_form_schema', function (DonationFormModel $form, int $formId) {
-            if (apply_filters('givewp_donation_forms_honeypot_enabled', false, $formId)) {
+            if (apply_filters('givewp_donation_forms_honeypot_enabled', give_is_setting_enabled(give_get_option( 'givewp_donation_forms_honeypot_enabled', 'disabled')), $formId)) {
                 (new AddHoneyPotFieldToDonationForms())($form);
             }
         }, 10, 2);

--- a/src/Settings/Security/Actions/RegisterPage.php
+++ b/src/Settings/Security/Actions/RegisterPage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Give\Settings\Security\Actions;
+
+use Give\Settings\Security\SecuritySettingsPage;
+
+/**
+ * @unreleased
+ */
+class RegisterPage
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(array $settingsPages): array
+    {
+        $settingsPages[] = new SecuritySettingsPage();
+
+        return $settingsPages;
+    }
+}

--- a/src/Settings/Security/Actions/RegisterSection.php
+++ b/src/Settings/Security/Actions/RegisterSection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Give\Settings\Security\Actions;
+
+/**
+ * @unreleased
+ */
+class RegisterSection
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(array $sections): array
+    {
+        $sections['security'] = __('Security', 'give');
+
+        return $sections;
+    }
+}

--- a/src/Settings/Security/Actions/RegisterSettings.php
+++ b/src/Settings/Security/Actions/RegisterSettings.php
@@ -26,12 +26,12 @@ class RegisterSettings
     {
         return [
             [
-                'id' => 'give_title_settings_advanced_security_1',
+                'id' => 'give_title_settings_security_1',
                 'type' => 'title',
             ],
             $this->getHoneypotSettings(),
             [
-                'id' => 'give_title_settings_advanced_security_1',
+                'id' => 'give_title_settings_security_1',
                 'type' => 'sectionend',
             ],
         ];

--- a/src/Settings/Security/Actions/RegisterSettings.php
+++ b/src/Settings/Security/Actions/RegisterSettings.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Give\Settings\Security\Actions;
+
+/**
+ * @unreleased
+ */
+class RegisterSettings
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(array $settings): array
+    {
+        if ('security' !== give_get_current_setting_section()) {
+            return $settings;
+        }
+
+        return $this->getSettings();
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function getSettings(): array
+    {
+        return [
+            [
+                'id' => 'give_title_settings_advanced_security_1',
+                'type' => 'title',
+            ],
+            $this->getHoneypotSettings(),
+            [
+                'id' => 'give_title_settings_advanced_security_1',
+                'type' => 'sectionend',
+            ],
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getHoneypotSettings(): array
+    {
+        return [
+            'name' => __('Enable Honeypot Field', 'give'),
+            'desc' => __(
+                'If enabled, this option will add a honeypot security measure to all donation forms',
+                'give'
+            ),
+            'id' => 'givewp_donation_forms_honeypot_enabled',
+            'type' => 'radio_inline',
+            'default' => 'disabled',
+            'options' => [
+                'enabled' => __('Enabled', 'give'),
+                'disabled' => __('Disabled', 'give'),
+            ],
+        ];
+    }
+}

--- a/src/Settings/Security/SecuritySettingsPage.php
+++ b/src/Settings/Security/SecuritySettingsPage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Give\Settings\Security;
+
+use Give_Settings_Page;
+
+/**
+ * @unreleased
+ */
+class SecuritySettingsPage extends Give_Settings_Page {
+
+    /**
+     * @unreleased
+     */
+    public function __construct() {
+        $this->id    = 'security';
+        $this->label = __( 'Security', 'give' );
+        $this->default_tab = 'security';
+
+        parent::__construct();
+    }
+}

--- a/src/Settings/ServiceProvider.php
+++ b/src/Settings/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Give\Settings;
 
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give\Settings\Security\Actions\RegisterPage;
 use Give\Settings\Security\Actions\RegisterSection;
 use Give\Settings\Security\Actions\RegisterSettings;
 
@@ -34,7 +35,8 @@ class ServiceProvider implements ServiceProviderInterface
      */
     private function registerSecuritySettings(): void
     {
-        Hooks::addFilter('give_get_sections_general', RegisterSection::class);
-        Hooks::addFilter('give_get_settings_general', RegisterSettings::class);
+        Hooks::addFilter('give-settings_get_settings_pages', RegisterPage::class);
+        Hooks::addFilter('give_get_sections_security', RegisterSection::class);
+        Hooks::addFilter('give_get_settings_security', RegisterSettings::class);
     }
 }

--- a/src/Settings/ServiceProvider.php
+++ b/src/Settings/ServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Give\Settings;
+
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give\Settings\Security\Actions\RegisterSection;
+use Give\Settings\Security\Actions\RegisterSettings;
+
+/**
+ * Class ServiceProvider
+ *
+ * @unreleased
+ */
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @unreleased
+     */
+    public function register()
+    {
+    }
+
+    /**
+     * @unreleased
+     */
+    public function boot()
+    {
+        $this->registerSecuritySettings();
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerSecuritySettings(): void
+    {
+        Hooks::addFilter('give_get_sections_advanced', RegisterSection::class);
+        Hooks::addFilter('give_get_settings_advanced', RegisterSettings::class);
+    }
+}

--- a/src/Settings/ServiceProvider.php
+++ b/src/Settings/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider implements ServiceProviderInterface
      */
     private function registerSecuritySettings(): void
     {
-        Hooks::addFilter('give_get_sections_advanced', RegisterSection::class);
-        Hooks::addFilter('give_get_settings_advanced', RegisterSettings::class);
+        Hooks::addFilter('give_get_sections_general', RegisterSection::class);
+        Hooks::addFilter('give_get_settings_general', RegisterSettings::class);
     }
 }

--- a/tests/Unit/DataTransferObjects/DonateFormDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonateFormDataTest.php
@@ -26,6 +26,7 @@ class DonateFormDataTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @unreleased updated to ignore honeypot field
      * @since 3.0.0
      *
      * @return void
@@ -43,6 +44,8 @@ class DonateFormDataTest extends TestCase
         add_filter('give_default_gateway', static function () {
             return TestGateway::id();
         });
+
+        add_filter("givewp_donation_forms_honeypot_enabled", "__return_false");
 
         $data = (object)[
             'gatewayId' => TestGateway::id(),

--- a/tests/Unit/DataTransferObjects/DonateFormRouteDataTest.php
+++ b/tests/Unit/DataTransferObjects/DonateFormRouteDataTest.php
@@ -23,6 +23,7 @@ class DonateFormRouteDataTest extends TestCase
 {
 
     /**
+     * @unreleased updated to ignore honeypot field
      * @since 3.0.0
      */
     public function testValidatedShouldReturnValidatedData()
@@ -37,6 +38,8 @@ class DonateFormRouteDataTest extends TestCase
         add_filter('give_default_gateway', static function () {
             return TestGateway::id();
         });
+
+        add_filter("givewp_donation_forms_honeypot_enabled", "__return_false");
 
         $customFieldBlockModel = BlockModel::make([
             'name' => 'givewp/section',
@@ -96,6 +99,7 @@ class DonateFormRouteDataTest extends TestCase
     }
 
     /**
+     * @unreleased updated to ignore honeypot field
      * @since 3.0.0
      */
     public function testValidatedShouldReturnValidatedDataWithSubscriptionData()
@@ -110,6 +114,8 @@ class DonateFormRouteDataTest extends TestCase
         add_filter('give_default_gateway', static function () {
             return TestGateway::id();
         });
+
+        add_filter("givewp_donation_forms_honeypot_enabled", "__return_false");
 
         $customFieldBlockModel = BlockModel::make([
             'name' => 'givewp/section',

--- a/tests/Unit/DonationForms/Actions/TestAddHoneyPotFieldToDonationForms.php
+++ b/tests/Unit/DonationForms/Actions/TestAddHoneyPotFieldToDonationForms.php
@@ -20,20 +20,28 @@ class TestAddHoneyPotFieldToDonationForms extends TestCase
     use RefreshDatabase;
 
     /**
+     * @unreleased updated to assert field attributes
      * @since 3.16.2
      * @throws NameCollisionException|EmptyNameException|TypeNotSupported
      */
     public function testShouldAddHoneyPotFieldToDonationForms(): void
     {
+        $fieldName = 'myHoneypotFieldName';
         $formNode = new DonationForm('donation-form');
         $formNode->append(Section::make('section-1'), Section::make('section-2'), Section::make('section-3'));
         $action = new AddHoneyPotFieldToDonationForms();
-        $action($formNode, 1);
-
+        $action($formNode, $fieldName);
 
         /** @var Section $lastSection */
         $lastSection = $formNode->getNodeByName('section-3');
-        $this->assertNotNull($lastSection->getNodeByName('donationBirthday'));
-        $this->assertInstanceOf(Honeypot::class, $lastSection->getNodeByName('donationBirthday'));
+
+        /** @var Honeypot $field */
+        $field = $lastSection->getNodeByName($fieldName);
+        $this->assertNotNull($field);
+        $this->assertInstanceOf(Honeypot::class, $field);
+        $this->assertSame('My Honeypot Field Name', $field->getLabel());
+        $this->assertTrue($field->hasRule('honeypot'));
+        $this->assertFalse($field->shouldShowInAdmin());
+        $this->assertFalse($field->shouldShowInReceipt());
     }
 }

--- a/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
+++ b/tests/Unit/DonationForms/Repositories/TestDonationFormRepository.php
@@ -252,6 +252,7 @@ final class TestDonationFormRepository extends TestCase
 
 
     /**
+     * @unreleased updated to disable honeypot
      * @since 3.0.0
      *
      * @return void
@@ -285,6 +286,8 @@ final class TestDonationFormRepository extends TestCase
         $formId = 1;
 
         $blocks = BlockCollection::make([$block]);
+
+        add_filter("givewp_donation_forms_honeypot_enabled", "__return_false");
 
         /** @var Form $formSchema */
         $formSchema = $this->repository->getFormSchemaFromBlocks($formId, $blocks);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1252]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a global setting to enable the honeypot field for v3 forms. This introduces a new section to the "general" tab called _security_.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

When this settings is enabled, it will affects v3 forms by programmatically adding a honeypot field.

Additional filter added for the honeypot field name:

```php
apply_filters('givewp_donation_forms_honeypot_field_name', $fieldName, $formId)
```

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


<img width="1512" alt="Screenshot 2024-10-15 at 10 08 31 AM" src="https://github.com/user-attachments/assets/c34bc01e-34b2-43d9-afcb-b298aa623440">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Enable the new settings
- Interact with a v3 form


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1252]: https://stellarwp.atlassian.net/browse/GIVE-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ