### PR TITLE
Feature: Add support for pausing/resuming subscriptions

### DIFF
--- a/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
+++ b/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
@@ -2,7 +2,6 @@
 
 namespace Give\Framework\PaymentGateways\Contracts\Subscription;
 
-use DateTime;
 use Give\Subscriptions\Models\Subscription;
 
 /**
@@ -15,14 +14,14 @@ interface SubscriptionPausable
      *
      * @unreleased
      */
-    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt);
+    public function pauseSubscription(Subscription $subscription, int $intervalInMonths): void;
 
     /**
      * Resume subscription.
      *
      * @unreleased
      */
-    public function resumeSubscription(Subscription $subscription);
+    public function resumeSubscription(Subscription $subscription): void;
 
     /**
      * Check if subscription can be paused.

--- a/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
+++ b/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
@@ -14,7 +14,7 @@ interface SubscriptionPausable
      *
      * @unreleased
      */
-    public function pauseSubscription(Subscription $subscription, int $intervalInMonths): void;
+    public function pauseSubscription(Subscription $subscription, array $data): void;
 
     /**
      * Resume subscription.

--- a/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
+++ b/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
@@ -23,4 +23,11 @@ interface SubscriptionPausable
      * @unreleased
      */
     public function resumeSubscription(Subscription $subscription);
+
+    /**
+     * Check if subscription can be paused.
+     *
+     * @unreleased
+     */
+    public function canPauseSubscription(): bool;
 }

--- a/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
+++ b/src/Framework/PaymentGateways/Contracts/Subscription/SubscriptionPausable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Give\Framework\PaymentGateways\Contracts\Subscription;
+
+use DateTime;
+use Give\Subscriptions\Models\Subscription;
+
+/**
+ * @unreleased
+ */
+interface SubscriptionPausable
+{
+    /**
+     * Pause subscription.
+     *
+     * @unreleased
+     */
+    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt);
+
+    /**
+     * Resume subscription.
+     *
+     * @unreleased
+     */
+    public function resumeSubscription(Subscription $subscription);
+}

--- a/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
@@ -2,6 +2,7 @@
 
 namespace Give\Framework\PaymentGateways\Contracts;
 
+use DateTime;
 use Give\Donations\Models\Donation;
 use Give\Framework\PaymentGateways\Commands\GatewayCommand;
 use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
@@ -29,6 +30,27 @@ interface SubscriptionModuleInterface
      * @since 2.20.0
      */
     public function cancelSubscription(Subscription $subscription);
+
+    /**
+     * Pause subscription.
+     *
+     * @unreleased
+     */
+    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt);
+
+    /**
+     * Resume subscription.
+     *
+     * @unreleased
+     */
+    public function resumeSubscription(Subscription $subscription);
+
+    /**
+     * Whether the gateway supports pausing subscriptions.
+     *
+     * @unreleased
+     */
+    public function canPauseSubscription(): bool;
 
     /**
      * Returns whether the gateway supports syncing subscriptions.

--- a/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
+++ b/src/Framework/PaymentGateways/Contracts/SubscriptionModuleInterface.php
@@ -2,7 +2,6 @@
 
 namespace Give\Framework\PaymentGateways\Contracts;
 
-use DateTime;
 use Give\Donations\Models\Donation;
 use Give\Framework\PaymentGateways\Commands\GatewayCommand;
 use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
@@ -30,20 +29,6 @@ interface SubscriptionModuleInterface
      * @since 2.20.0
      */
     public function cancelSubscription(Subscription $subscription);
-
-    /**
-     * Pause subscription.
-     *
-     * @unreleased
-     */
-    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt);
-
-    /**
-     * Resume subscription.
-     *
-     * @unreleased
-     */
-    public function resumeSubscription(Subscription $subscription);
 
     /**
      * Whether the gateway supports pausing subscriptions.

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -179,11 +179,11 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
      */
     public function canPauseSubscription(): bool
     {
-        if ($this->subscriptionModule) {
+        if ($this->subscriptionModule instanceof SubscriptionPausable) {
             return $this->subscriptionModule->canPauseSubscription();
         }
 
-        return $this->isFunctionImplementedInGatewayClass('pauseSubscription');
+        return false;
     }
 
     /**

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -144,10 +144,10 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
      *
      * @unreleased
      */
-    public function pauseSubscription(Subscription $subscription, int $intervalInMonths = null): void
+    public function pauseSubscription(Subscription $subscription, array $data = []): void
     {
         if ($this->subscriptionModule instanceof SubscriptionPausable) {
-            $this->subscriptionModule->pauseSubscription($subscription, $intervalInMonths);
+            $this->subscriptionModule->pauseSubscription($subscription, $data);
 
             return;
         }

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -2,12 +2,14 @@
 
 namespace Give\Framework\PaymentGateways;
 
+use DateTime;
 use Give\Donations\Models\Donation;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\PaymentGateways\Actions\GenerateGatewayRouteUrl;
 use Give\Framework\PaymentGateways\Contracts\PaymentGatewayInterface;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionAmountEditable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionDashboardLinkable;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionPausable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionPaymentMethodEditable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 use Give\Framework\PaymentGateways\Routes\RouteSignature;
@@ -136,6 +138,52 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
     public function cancelSubscription(Subscription $subscription)
     {
         $this->subscriptionModule->cancelSubscription($subscription);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @unreleased
+     */
+    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt = null)
+    {
+        if ($this->subscriptionModule instanceof SubscriptionPausable) {
+            $this->subscriptionModule->pauseSubscription($subscription, $resumesAt);
+
+            return;
+        }
+
+        throw new Exception('Gateway does not support pausing the subscription.');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @unreleased
+     */
+    public function resumeSubscription(Subscription $subscription)
+    {
+        if ($this->subscriptionModule instanceof SubscriptionPausable) {
+            $this->subscriptionModule->resumeSubscription($subscription);
+
+            return;
+        }
+
+        throw new Exception('Gateway does not support resuming the subscription.');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @unreleased
+     */
+    public function canPauseSubscription(): bool
+    {
+        if ($this->subscriptionModule) {
+            return $this->subscriptionModule->canPauseSubscription();
+        }
+
+        return $this->isFunctionImplementedInGatewayClass('pauseSubscription');
     }
 
     /**

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -2,7 +2,6 @@
 
 namespace Give\Framework\PaymentGateways;
 
-use DateTime;
 use Give\Donations\Models\Donation;
 use Give\Framework\Exceptions\Primitives\Exception;
 use Give\Framework\PaymentGateways\Actions\GenerateGatewayRouteUrl;
@@ -145,10 +144,10 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
      *
      * @unreleased
      */
-    public function pauseSubscription(Subscription $subscription, DateTime $resumesAt = null)
+    public function pauseSubscription(Subscription $subscription, int $intervalInMonths = null): void
     {
         if ($this->subscriptionModule instanceof SubscriptionPausable) {
-            $this->subscriptionModule->pauseSubscription($subscription, $resumesAt);
+            $this->subscriptionModule->pauseSubscription($subscription, $intervalInMonths);
 
             return;
         }
@@ -161,7 +160,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
      *
      * @unreleased
      */
-    public function resumeSubscription(Subscription $subscription)
+    public function resumeSubscription(Subscription $subscription): void
     {
         if ($this->subscriptionModule instanceof SubscriptionPausable) {
             $this->subscriptionModule->resumeSubscription($subscription);

--- a/src/Framework/PaymentGateways/SubscriptionModule.php
+++ b/src/Framework/PaymentGateways/SubscriptionModule.php
@@ -4,7 +4,9 @@ namespace Give\Framework\PaymentGateways;
 
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionAmountEditable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionDashboardLinkable;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionPausable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionPaymentMethodEditable;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionResumable;
 use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 use Give\Framework\PaymentGateways\Contracts\SubscriptionModuleInterface;
 use Give\Framework\PaymentGateways\Traits\HasRouteMethods;
@@ -29,6 +31,14 @@ abstract class SubscriptionModule implements SubscriptionModuleInterface
     public function setGateway(PaymentGateway $gateway)
     {
         $this->gateway = $gateway;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function canPauseSubscription(): bool
+    {
+        return $this instanceof SubscriptionPausable;
     }
 
     /**

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -790,6 +790,19 @@ class Give_Subscription {
 		return apply_filters( 'give_subscription_can_cancel', false, $this );
 	}
 
+    /**
+     * Can Pause.
+     *
+     * This method is filtered by payment gateways in order to return true on subscriptions
+     * that can be paused with a profile ID through the merchant processor.
+     *
+     * @return mixed
+     */
+    public function can_pause()
+    {
+        return apply_filters('give_subscription_can_pause', false, $this);
+    }
+
 	/**
 	 * Can Sync.
 	 *

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -919,6 +919,22 @@ class Give_Subscription {
 
 	}
 
+    /**
+     * Is Paused.
+     *
+     * @return bool $ret Whether the subscription is paused or not.
+     */
+    public function is_paused()
+    {
+        $ret = false;
+
+        if ('paused' === $this->status) {
+            $ret = true;
+        }
+
+        return apply_filters('give_subscription_is_paused', $ret, $this->id, $this);
+    }
+
 
 	/**
 	 * Is Expired.
@@ -1011,7 +1027,7 @@ class Give_Subscription {
 		$frequency = ! empty( $this->frequency ) ? intval( $this->frequency ) : 1;
 
 		// If renewal date is already in the future it's set so return it.
-		if ( $expires > current_time( 'timestamp' ) && $this->is_active() ) {
+        if ($expires > current_time('timestamp') && ($this->is_active() || $this->is_paused())) {
 			return $localized
 				? date_i18n( give_date_format(), strtotime( $this->expiration ) )
 				: date( 'Y-m-d H:i:s', strtotime( $this->expiration ) );

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -186,6 +186,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add expiration column to update
      * @since 2.24.0 add payment_mode column to update
      * @since 2.21.0 replace actions with givewp_subscription_updating and givewp_subscription_updated
      * @since 2.19.6
@@ -209,6 +210,7 @@ class SubscriptionRepository
             DB::table('give_subscriptions')
                 ->where('id', $subscription->id)
                 ->update([
+                    'expiration' => Temporal::getFormattedDateTime($subscription->renewsAt),
                     'status' => $subscription->status->getValue(),
                     'profile_id' => $subscription->gatewaySubscriptionId,
                     'customer_id' => $subscription->donorId,

--- a/src/Subscriptions/ValueObjects/SubscriptionStatus.php
+++ b/src/Subscriptions/ValueObjects/SubscriptionStatus.php
@@ -5,6 +5,7 @@ namespace Give\Subscriptions\ValueObjects;
 use Give\Framework\Support\ValueObjects\Enum;
 
 /**
+ * @unreleased Added a new "paused" status
  * @since 2.19.6
  *
  * @method static SubscriptionStatus PENDING()
@@ -16,6 +17,7 @@ use Give\Framework\Support\ValueObjects\Enum;
  * @method static SubscriptionStatus FAILING()
  * @method static SubscriptionStatus CANCELLED()
  * @method static SubscriptionStatus SUSPENDED()
+ * @method static SubscriptionStatus PAUSED()
  * @method bool isPending()
  * @method bool isActive()
  * @method bool isExpired()
@@ -25,6 +27,7 @@ use Give\Framework\Support\ValueObjects\Enum;
  * @method bool isFailing()
  * @method bool isCancelled()
  * @method bool isSuspended()
+ * @method bool isPaused()
  */
 class SubscriptionStatus extends Enum {
     const PENDING = 'pending';
@@ -36,8 +39,10 @@ class SubscriptionStatus extends Enum {
     const CANCELLED = 'cancelled';
     const ABANDONED = 'abandoned';
     const SUSPENDED = 'suspended';
+    const PAUSED = 'paused';
 
     /**
+     * @unreleased Added a new "paused" status
      * @since 2.24.0
      *
      * @return array
@@ -54,6 +59,7 @@ class SubscriptionStatus extends Enum {
             self::CANCELLED => __( 'Cancelled', 'give' ),
             self::ABANDONED => __( 'Abandoned', 'give' ),
             self::SUSPENDED => __( 'Suspended', 'give' ),
+            self::PAUSED => __('Paused', 'give'),
         ];
     }
 

--- a/src/Views/Components/ListTable/InterweaveSSR/styles.scss
+++ b/src/Views/Components/ListTable/InterweaveSSR/styles.scss
@@ -40,7 +40,8 @@
 
         &--pending,
         &--processing,
-        &--upgraded {
+        &--upgraded,
+        &--paused {
             background: #0878b0;
         }
 


### PR DESCRIPTION
Resolves [GIVE-1250]

## Description
This Pull Request adds supports for gateways to implement their solutions for pausing/resuming subscriptions. Within this PR we are:
- adding a new "paused" status to subscriptions;
- setting a color for the "paused" status in the subscriptions list table;
- adding a new `SubscriptionPausable` contract to be signed by gateways;
- adding a capability check as `can_pause` to gateways (false by default if not implemented);
- fixing the `SubscriptionRepository` to update the expiration date into the database;
- updating the subscription details screen to show the next renewal date for paused subscriptions as it does for active ones.

This PR is a foundational work that is required for the new implementations on Give Recurring.

## Affects
Subscriptions

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1250]: https://stellarwp.atlassian.net/browse/GIVE-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ