### PR TITLE
Refactor: move recipient email above general settings filter

### DIFF
--- a/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
+++ b/includes/gateways/stripe/includes/admin/class-give-stripe-admin-settings.php
@@ -200,6 +200,17 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 						'type' => 'checkbox',
 					];
 
+                    $settings['general'][] = [
+                        'name' => esc_html__( 'Stripe Receipt Emails', 'give' ),
+                        'desc' => sprintf(
+                        /* translators: 1. GiveWP Support URL */
+                            __( 'Check this option if you would like donors to receive receipt emails directly from Stripe. By default, donors will receive GiveWP generated <a href="%1$s" target="_blank">receipt emails</a>. Checking this option does not disable GiveWP emails.', 'give' ),
+                            admin_url( '/edit.php?post_type=give_forms&page=give-settings&tab=emails' )
+                        ),
+                        'id'   => 'stripe_receipt_emails',
+                        'type' => 'checkbox',
+                    ];
+
 					/**
 					 * This filter hook is used to add fields after Stripe General fields.
 					 *
@@ -208,17 +219,6 @@ if ( ! class_exists( 'Give_Stripe_Admin_Settings' ) ) {
 					 * @return array
 					 */
 					$settings = apply_filters( 'give_stripe_add_after_general_fields', $settings );
-
-					$settings['general'][] = [
-						'name' => esc_html__( 'Stripe Receipt Emails', 'give' ),
-						'desc' => sprintf(
-							/* translators: 1. GiveWP Support URL */
-							__( 'Check this option if you would like donors to receive receipt emails directly from Stripe. By default, donors will receive GiveWP generated <a href="%1$s" target="_blank">receipt emails</a>. Checking this option does not disable GiveWP emails.', 'give' ),
-							admin_url( '/edit.php?post_type=give_forms&page=give-settings&tab=emails' )
-						),
-						'id'   => 'stripe_receipt_emails',
-						'type' => 'checkbox',
-					];
 
 					$settings['general'][] = [
 						'name'  => esc_html__( 'Stripe Gateway Documentation', 'give' ),


### PR DESCRIPTION
## Description
The Stripe recipient email setting is placed after the filter that designates the end of the [General] settings. This causes any new settings introduced by the filter `give_stripe_add_after_general_fields` to be placed prior to this setting. The filter should be placed below the last default setting so that additional settings introduced are inserted at the bottom.

## Affects
Stripe Settings

## Visuals
![Screenshot 2024-09-26 at 12 27 47 PM](https://github.com/user-attachments/assets/860ecc24-abff-48c5-9505-c3b52d419b6c)

## Testing Instructions
- Donations->Settings->Paymentgateways->Stripe : Verify the new admin setting for pausing subscriptions is inserted at the bottom. This will require the latest version of Stripe in order for the new setting to be displayed.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

