### PR TITLE
Fix: ensure DonorDashboard mobile navigation opens as expected

### DIFF
--- a/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
+++ b/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
@@ -42,7 +42,10 @@ const MobileMenu = ({children}) => {
                     className={`give-donor-dashboard-mobile-menu__toggle ${
                         isOpen ? 'give-donor-dashboard-mobile-menu__toggle--toggled' : ''
                     }`}
-                    onClick={() => setIsOpen(!isOpen)}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        setIsOpen(!isOpen);
+                    }}
                 >
                     <FontAwesomeIcon icon="bars" />
                 </div>

--- a/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
+++ b/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
@@ -8,11 +8,11 @@ import './style.scss';
 const MobileMenu = ({children}) => {
     const [isOpen, setIsOpen] = useState(false);
 
-    const contentRef = useRef(null);
+    const toggleRef = useRef(null);
 
     useEffect(() => {
         const handleClick = (evt) => {
-            if (contentRef.current && !contentRef.current.contains(evt.target)) {
+            if (toggleRef.current && !toggleRef.current.contains(evt.target)) {
                 setIsOpen(false);
             }
         };
@@ -26,7 +26,7 @@ const MobileMenu = ({children}) => {
                 document.removeEventListener('click', handleClick);
             }
         };
-    }, [isOpen, contentRef]);
+    }, [isOpen, toggleRef]);
 
     const location = useLocation();
     const tabsSelector = useSelector((state) => state.tabs);
@@ -39,11 +39,11 @@ const MobileMenu = ({children}) => {
             <div className="give-donor-dashboard-mobile-menu__header">
                 <div className="give-donor-dashboard-mobile-menu__label">{label}</div>
                 <div
+                    ref={toggleRef}
                     className={`give-donor-dashboard-mobile-menu__toggle ${
                         isOpen ? 'give-donor-dashboard-mobile-menu__toggle--toggled' : ''
                     }`}
-                    onClick={(event) => {
-                        event.stopPropagation();
+                    onClick={() => {
                         setIsOpen(!isOpen);
                     }}
                 >
@@ -51,7 +51,7 @@ const MobileMenu = ({children}) => {
                 </div>
             </div>
             {isOpen && (
-                <div className="give-donor-dashboard-mobile-menu__content" ref={contentRef}>
+                <div className="give-donor-dashboard-mobile-menu__content">
                     {children}
                 </div>
             )}


### PR DESCRIPTION
Resolves: [GIVE-1288]

## Description
This PR resolves an issue with the mobile navigation in the DonorDashboard where the hamburger menu was unresponsive, preventing donors from accessing other sections of the dashboard on mobile devices.

The problem stemmed from a handleClick function inside a useEffect hook, which unintentionally caused the menu to close immediately upon interaction, preventing it from staying open when clicked.

## Affects
The DonorDashboard in mobile view.

## Visuals
https://github.com/user-attachments/assets/3bced2d3-1d95-4c69-8a1b-c28f3f56a255

## Testing Instructions
- Open the donor dashboard in mobile view.
- Click the hamburger menu/icon to open the navigation items.
- Click outside the navigation links to verify the menu closes.
- Navigate to a new page to ensure the menu works properly.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1288]: https://stellarwp.atlassian.net/browse/GIVE-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ