### PR TITLE
Hot Fix: prevent PHP 8+ fatal errors when Tributes add-on is enabled

### DIFF
--- a/includes/process-donation.php
+++ b/includes/process-donation.php
@@ -418,6 +418,7 @@ function give_donation_form_validate_fields() {
 /**
  * Detect serialized fields.
  *
+ * @unreleased Make sure only string parameters are used with the ltrim() method to prevent PHP 8+ fatal errors
  * @since 3.16.4 updated to check all values for serialized fields
  * @since 3.16.2 added additional check for stripslashes_deep
  * @since 3.14.2 add give-form-title, give_title
@@ -426,7 +427,7 @@ function give_donation_form_validate_fields() {
 function give_donation_form_has_serialized_fields(array $post_data): bool
 {
     foreach ($post_data as $value) {
-        if (is_serialized(ltrim($value, '\\'))) {
+        if (is_string($value) && is_serialized(ltrim($value, '\\'))) {
           return true;
         }
 
@@ -1622,6 +1623,7 @@ function give_validate_required_form_fields( $form_id ) {
  *
  * @param array $post_data List of post data.
  *
+ * @unreleased Check if "give_title" is set to prevent PHP warnings
  * @since 3.16.4 Add additional validation for company name field
  * @since 3.16.3 Add additional validations for name title prefix field
  * @since 2.1
@@ -1646,7 +1648,7 @@ function give_donation_form_validate_name_fields( $post_data ) {
 
     $is_alpha_first_name = ( ! is_email( $post_data['give_first'] ) && ! preg_match( '~[0-9]~', $post_data['give_first'] ) );
     $is_alpha_last_name  = ( ! is_email( $post_data['give_last'] ) && ! preg_match( '~[0-9]~', $post_data['give_last'] ) );
-    $is_alpha_title = ( ! is_email( $post_data['give_title'] ) && ! preg_match( '~[0-9]~', $post_data['give_title'] ) );
+    $is_alpha_title = ( isset($post_data['give_title']) && ! is_email( $post_data['give_title'] ) && ! preg_match( '~[0-9]~', $post_data['give_title'] ) );
 
     if (!$is_alpha_first_name || ( ! empty( $post_data['give_last'] ) && ! $is_alpha_last_name) || ( ! empty( $post_data['give_title'] ) && ! $is_alpha_title) ) {
         give_set_error( 'invalid_name', esc_html__( 'The First Name and Last Name fields cannot contain an email address or numbers.', 'give' ) );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1306]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The problem was happening on PHP 8+ because the `ltrim()` method on those versions is more restrictive about which type of parameter is accepted. In previous versions, not-string values only threw wanings but in PHP 8+ version it threw a fatal error that prevented the donation workflow. 

So, the solution was to prevent the use of values different from a string on the `ltrim()` method.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Option-based forms with the Tributes add-on enabled.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a v2 form and enable Tributes;
2. Make a donation but do not opt-in for Tributes;
3. The donation should be finished without fatal errors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1306]: https://stellarwp.atlassian.net/browse/GIVE-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ