### PR TITLE
Fix: update honeypot field setting to be enabled by default

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -68,11 +68,12 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 			 * For example: if you register a setting page with give-settings menu slug
 			 *              then filter will be give-settings_get_settings_pages
 			 *
+			 * @unreleased cast to array
 			 * @since 1.8
 			 *
 			 * @param array $settings Array of settings class object.
 			 */
-			self::$settings = apply_filters( self::$setting_filter_prefix . '_get_settings_pages', [] );
+			self::$settings = (array)apply_filters( self::$setting_filter_prefix . '_get_settings_pages', [] );
 
 			return self::$settings;
 		}

--- a/src/Settings/Security/Actions/RegisterSettings.php
+++ b/src/Settings/Security/Actions/RegisterSettings.php
@@ -38,6 +38,7 @@ class RegisterSettings
     }
 
     /**
+     * @unreleased enable by default
      * @since 3.17.0
      */
     public function getHoneypotSettings(): array
@@ -50,7 +51,7 @@ class RegisterSettings
             ),
             'id' => 'givewp_donation_forms_honeypot_enabled',
             'type' => 'radio_inline',
-            'default' => 'disabled',
+            'default' => 'enabled',
             'options' => [
                 'enabled' => __('Enabled', 'give'),
                 'disabled' => __('Disabled', 'give'),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1331]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

During the [settings PR](https://github.com/impress-org/givewp/pull/7546) the honeypot field was added and used as enabled by default (without saving the settings).  However, the default state of the setting is disabled visually.  This makes sure the default state matches the default behavior.

For folks who updated to the version that includes the honeypot field, it will fallback to enabled because the setting has not been physically saved yet.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The honeypot setting UI

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="907" alt="Screenshot 2024-10-18 at 5 32 19 PM" src="https://github.com/user-attachments/assets/217132f9-310c-41d6-864a-eed1e1729cb0">

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the honeypot field setting is visually enabled by default.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1331]: https://stellarwp.atlassian.net/browse/GIVE-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ