### PR TITLE
Fix: Hide donation form submit button to prevent errors with PayPal Commerce payment flow

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -68,11 +68,12 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 			 * For example: if you register a setting page with give-settings menu slug
 			 *              then filter will be give-settings_get_settings_pages
 			 *
+			 * @unreleased cast to array
 			 * @since 1.8
 			 *
 			 * @param array $settings Array of settings class object.
 			 */
-			self::$settings = apply_filters( self::$setting_filter_prefix . '_get_settings_pages', [] );
+			self::$settings = (array)apply_filters( self::$setting_filter_prefix . '_get_settings_pages', [] );
 
 			return self::$settings;
 		}

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -666,6 +666,21 @@ import {PayPalSubscriber} from './types';
             const donationType = useWatch({name: 'donationType'});
             const isSubscription = donationType === 'subscription';
 
+            useEffect(() => {
+                const submitButton = document.querySelector<HTMLButtonElement>(
+                    'form#give-next-gen button[type="submit"]'
+                );
+
+                if (submitButton) {
+                    submitButton.style.display = 'none';
+                }
+
+                return () => {
+                    if (submitButton) {
+                        submitButton.style.display = '';
+                    }
+                };
+            }, []);
             return (
                 <FormFieldsProvider>
                     <PayPalScriptProvider deferLoading={true} options={getPayPalScriptOptions({isSubscription})}>

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -661,6 +661,10 @@ import {PayPalSubscriber} from './types';
                 throw new Error(sprintf(__('Paypal Donations Error: %s', 'give'), err.message));
             }
         },
+
+        /**
+         * @unreleased Hide submit button when PayPal Commerce is selected.
+         */
         Fields() {
             const {useWatch} = window.givewp.form.hooks;
             const donationType = useWatch({name: 'donationType'});


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1097]

## Description

This PR addresses an issue where donors click the donation form’s submit button instead of PayPal’s “Pay Now” button when filling out credit card fields through PayPal Commerce. This causes an error, as PayPal cannot complete the transaction properly through the form’s submit button.

The solution hides the form’s submit button when PayPal Commerce is selected, ensuring donors interact only with PayPal’s button. The submit button is restored when switching to other gateways and PayPal Commerce fields component unmounts.

## Affects
Visual Builder Forms

## Visuals
![CleanShot 2024-10-18 at 20 37 06](https://github.com/user-attachments/assets/d23193e9-f11c-4f8d-ade4-956484b87972)

## Testing Instructions

1.	Navigate to the donation form page.
2.	Select “Donate with Credit Card” (PayPal Commerce) as the payment gateway.
3.	Verify that the form’s submit button is hidden, ensuring only PayPal’s “Pay Now” button is available for interaction.
4.	Change to a different payment gateway and verify that the submit button is visible again.
5.	Repeat the process and ensure that switching between gateways consistently shows or hides the correct buttons.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1097]: https://stellarwp.atlassian.net/browse/GIVE-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ