### PR TITLE
Fix: add showToggle to amount descriptions option panel

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -227,6 +227,7 @@ const Inspector = ({attributes, setAttributes}) => {
                         toggleEnabled={descriptionsEnabled}
                         onHandleToggle={(value) => setAttributes({descriptionsEnabled: value})}
                         maxLabelLength={120}
+                        showToggle
                     />
                 )}
             </PanelBody>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1325]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We recently updated the form builder library in core which included an update to the option panel component with a prop for `showToggle` that was not explicitly added to the amount level/description option panel implementation. This adds the prop to show the toggle.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
- V3 forms amount block level settings

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1115" alt="Screenshot 2024-10-21 at 11 01 11 AM" src="https://github.com/user-attachments/assets/9270e8c3-b8a6-472e-a8f6-bb2de2a63df0">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- In form builder, Interact with the amount block and make sure the amount description work as expected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1325]: https://stellarwp.atlassian.net/browse/GIVE-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ