### PR TITLE
Fix: adjust Subscription Manager styles for custom amount

### DIFF
--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/index.js
@@ -105,7 +105,6 @@ const AmountControl = ({currency, onChange, value, options, min, max}) => {
                         value={selectValue}
                         onChange={setSelectValue}
                     />
-                <div>
                     {selectValue === CUSTOM_AMOUNT && (
                         <div className="give-donor-dashboard-currency-control">
                             <label
@@ -133,7 +132,6 @@ const AmountControl = ({currency, onChange, value, options, min, max}) => {
                             </div>
                         </div>
                     )}
-                </div>
             </FieldRow>
             {validationError && (
                 <FieldRow>

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/style.scss
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/style.scss
@@ -10,24 +10,26 @@ $errorColor: #c91f1f;
 }
 
 .give-donor-dashboard-amount-inputs {
+    flex: 1;
     display: flex;
     flex-direction: column;
 
-
     .give-donor-dashboard-field-row {
+        flex: 1;
         display: flex;
+        align-items: center;
         padding: 0;
 
         .give-donor-dashboard-select-control {
             display: flex;
-            min-width: 100%;
+            width: 100%;
             margin: 0;
         }
     }
 }
 
 .give-donor-dashboard-currency-control {
-    margin-top: 10px;
+    margin-bottom: 2px;
 
     .give-donor-dashboard-currency-control__label {
         font-family: Montserrat, Arial, Helvetica, sans-serif;
@@ -47,10 +49,10 @@ $errorColor: #c91f1f;
         outline: 0 !important;
         min-width: 190px;
         width: 100%;
-        margin-top: 8px;
+        margin-top: 6px;
         border: 1px solid #b8b8b8;
         overflow: hidden;
-        padding: 0;
+        padding: 1px;
         box-shadow: 0 0 0 0 var(--give-donor-dashboard-accent-color);
         transition: box-shadow 0.1s ease;
 


### PR DESCRIPTION
## Description
This PR addresses style changes that were made in the `Subscription Manager` page of the Donor Dashboard. By allowing the Select amount dropdown to expand full width when alone, but also split the `FieldRow` when the custom amount option is available.

## Affects
Donor Dashboard Subscriptions

## Visuals
![Screenshot 2024-10-21 at 4 46 18 PM](https://github.com/user-attachments/assets/24307aa0-1ff0-4fe1-b8cc-756638706b5a)
![Screenshot 2024-10-21 at 4 39 34 PM](https://github.com/user-attachments/assets/b33315e5-c636-447b-81f7-dba5c514f7c8)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

