### PR TITLE
Fix: When using the Donor Wall shortcode or block, filtering by only_comments returns no donations

### DIFF
--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -479,8 +479,8 @@ class Give_Donor_Wall {
 
 		// exclude donations which does not has donor comment.
 		if ( $query_params['only_comments'] ) {
-			$sql   .= " INNER JOIN {$wpdb->give_comments} as gc1 ON (p1.ID = gc1.comment_parent)";
-			$where .= " AND gc1.comment_type='donor_donation'";
+			$sql   .= " INNER JOIN {$wpdb->donationmeta} as m4 ON (p1.ID = m4.{$donation_id_col})";
+            $where .= " AND m4.meta_key='_give_donation_comment'";
 		}
 
 		// exclude anonymous donation form query based on query parameters.

--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -445,6 +445,7 @@ class Give_Donor_Wall {
 	/**
 	 * Get donation list for specific query
 	 *
+     * @unreleased fix - filter by only_comments attr
 	 * @since 2.3.0
 	 *
 	 * @param  array $atts


### PR DESCRIPTION
## Description
When using the Donor Wall shortcode or block, filtering by `only_comments` returns no donations. 

The problem was that the donor comment was stored in the donation meta table, but we tried to fetch it from the `give_comments` table which resulted in no donations being returned. The issue is fixed by querying the correct table. 

## Affects

Donor Wall block/shortcode

## Visuals

https://github.com/user-attachments/assets/0f124b72-76ee-4af5-8fa9-61ebc0c546c4


## Testing Instructions

-  enable comments either on a per-form basis or at Donations >> Settings >> Default Options
- using GiveWP, create donations both with and without comments.
- use this shortcode [give_donor_wall only_comments="true"]
- or use the Donor Wall block and turn on the Only Comments at Display Elements >> Wall Attributes

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

