### PR TITLE
chore: remove unused dynamic property assignment of $auto_updater_obj from Give_License constructor

### DIFF
--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -196,6 +196,7 @@ if ( ! class_exists('Give_License') ) :
 		 * @param string $_account_url
 		 * @param int    $_item_id
 		 *
+		 * @unreleased removed unused auto_updater_obj property assignment
 		 * @since  1.0
 		 */
 		public function __construct(
@@ -230,7 +231,6 @@ if ( ! class_exists('Give_License') ) :
 			self::$api_url          = is_null( $_api_url ) ? self::$api_url : $_api_url;
 			self::$checkout_url     = is_null( $_checkout_url ) ? self::$checkout_url : $_checkout_url;
 			self::$account_url      = is_null( $_account_url ) ? self::$account_url : $_account_url;
-			$this->auto_updater_obj = null;
 
 			// Add plugin to registered licenses list.
 			array_push( self::$licensed_addons, plugin_basename( $this->file ) );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves the follow PHP deprecation notice:

```
PHP Deprecated:  Creation of dynamic property Give_License::$auto_updater_obj is deprecated in /Users/jonwaldstein/Herd/givewp/wp-content/plugins/give/includes/class-give-license-handler.php on line 233
```

This property appears to be leftover from the early days of Give when there was an auto updater.  I could not find this method or any use of the property anymore, furthermore it was being assigned to null in construct.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This technically touches the Give License class however, nothing should be affected as this is dead code.

<img width="1507" alt="Screenshot 2024-10-24 at 5 13 38 PM" src="https://github.com/user-attachments/assets/16f7e917-b83f-4daf-bef5-9ee8cd6cccfb">

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure there is no more php warning
- Make sure our license system works as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

