### PR TITLE
Fix: php dynamic property warning of $user_id in Give_Addon_Activation_Banner class

### DIFF
--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -16,11 +16,17 @@ global $give_addons;
 /**
  * Class Give_Addon_Activation_Banner
  *
+ * @unreleased added $user_id property to class
  * @since  2.1.0 Added pleasing interface when multiple add-ons are activated.
  */
 class Give_Addon_Activation_Banner {
+    /**
+     * @unreleased
+     * @var int
+     */
+    protected $user_id;
 
-	/**
+    /**
 	 * Class constructor.
 	 *
 	 * @since  1.0


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1370]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds the $user_id property to the Give_Addon_Activation_Banner class to prevent the following php warning:

```
[24-Oct-2024 21:00:08 UTC] PHP Deprecated:  Creation of dynamic property Give_Addon_Activation_Banner::$user_id is deprecated in /Users/jonwaldstein/Herd/givewp/wp-content/plugins/give/includes/admin/class-addon-activation-banner.php on line 48
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The banner activation banner dismissing functionality (user_id)

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure you can dismiss an addon banner activation

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1370]: https://stellarwp.atlassian.net/browse/GIVE-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ