### PR TITLE
Fix: Check for campaign goal before calculating percentage

### DIFF
--- a/src/Campaigns/DataTransferObjects/CampaignGoalData.php
+++ b/src/Campaigns/DataTransferObjects/CampaignGoalData.php
@@ -80,7 +80,10 @@ class CampaignGoalData implements Arrayable
      */
     private function getPercentage(): float
     {
-        return round($this->actual / $this->campaign->goal * 100, 2);
+        $percentage = $this->campaign->goal
+            ? $this->actual / $this->campaign->goal
+            : 0;
+        return round($percentage * 100, 2);
     }
 
     /**

--- a/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
+++ b/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
@@ -24,15 +24,11 @@ final class CampaignGoalDataTest extends TestCase
      */
     public function testGetPercentageDoesNotDivideByZero()
     {
-        $campaign = Campaign::factory()->create(['goal' => 0]);
-
-        $form = DonationForm::factory()->create();
-        DB::table('give_campaign_forms')
-            ->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
-
-        Donation::factory()->create(['formId' => $form->id]);
-
-        $goalData = new CampaignGoalData($campaign);
+        $goalData = new CampaignGoalData(
+            Campaign::factory()->create([
+                'goal' => 0
+            ])
+        );
 
         $this->assertEquals(0.00, $goalData->percentage);
     }

--- a/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
+++ b/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Give\Tests\Unit\Campaigns\DataTransferObjects;
+
+use Give\Campaigns\DataTransferObjects\CampaignGoalData;
+use Give\Campaigns\Models\Campaign;
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Models\Donation;
+use Give\Donors\Models\Donor;
+use Give\Framework\Database\DB;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use PHPUnit_Framework_MockObject_MockBuilder;
+
+/**
+ * @unreleased
+ */
+final class CampaignGoalDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testGetPercentageDoesNotDivideByZero()
+    {
+        $campaign = Campaign::factory()->create(['goal' => 0]);
+
+        $form1 = DonationForm::factory()->create();
+        DB::table('give_campaign_forms')
+            ->insert(['form_id' => $form1->id, 'campaign_id' => $campaign->id]);
+
+        Donation::factory()->create(['formId' => $form1->id]);
+
+        $goalData = new CampaignGoalData($campaign);
+
+        $this->assertEquals(0.00, $goalData->percentage);
+    }
+}

--- a/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
+++ b/tests/Unit/Campaigns/DataTransferObjects/CampaignGoalDataTest.php
@@ -26,11 +26,11 @@ final class CampaignGoalDataTest extends TestCase
     {
         $campaign = Campaign::factory()->create(['goal' => 0]);
 
-        $form1 = DonationForm::factory()->create();
+        $form = DonationForm::factory()->create();
         DB::table('give_campaign_forms')
-            ->insert(['form_id' => $form1->id, 'campaign_id' => $campaign->id]);
+            ->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
 
-        Donation::factory()->create(['formId' => $form1->id]);
+        Donation::factory()->create(['formId' => $form->id]);
 
         $goalData = new CampaignGoalData($campaign);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1428]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR checks for a campaign goal before calculating a goal progress as a percentage, which might attempt to divide by zero.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a campaign
- Set the campaign goal to zero
- Load the Campaign List Table

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1428]: https://stellarwp.atlassian.net/browse/GIVE-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ