### PR TITLE
Chore: fix php jsonSerialize warning for currency switcher setting

### DIFF
--- a/src/Framework/FieldsAPI/Properties/DonationForm/CurrencySwitcherSetting.php
+++ b/src/Framework/FieldsAPI/Properties/DonationForm/CurrencySwitcherSetting.php
@@ -44,6 +44,7 @@ class CurrencySwitcherSetting implements JsonSerializable
     /**
      * @since 3.0.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return get_object_vars($this);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds the ReturnTypeWillChange flag to supress this warning:
```php
PHP Deprecated:  Return type of Give\Framework\FieldsAPI\Properties\DonationForm\CurrencySwitcherSetting::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/jonwaldstein/Herd/givewp/wp-content/plugins/give/src/Framework/FieldsAPI/Properties/DonationForm/CurrencySwitcherSetting.php on line 47
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

php 8.1 compatibility with the CurrencySwitcherSetting class

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the warning does not show up when interacting with the form & currency switcher.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

