### PR TITLE
Fix: Donation confirmation email - donation description 

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1523,8 +1523,10 @@ function give_get_donation_form_title( $donation_id, $args = [] ) {
         $donation = Donation::find($donation_id);
 
         foreach ( $options as $option ) {
-            if (Money::of($option['_give_amount'], $currency )->getMinorAmount() == $donation->amount->getAmount()) {
-                return sprintf('%s %s %s', $form_title, $args['separator'], $option['_give_text']);
+            if (isset($option['_give_amount'], $option['_give_text'])) {
+                if (Money::of($option['_give_amount'], $currency )->getMinorAmount() == $donation->amount->getAmount()) {
+                    return sprintf('%s %s %s', $form_title, $args['separator'], $option['_give_text']);
+                }
             }
         }
     }

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -10,6 +10,10 @@
  */
 
 // Exit if accessed directly.
+use Give\Donations\Models\Donation;
+use Give\Helpers\Form\Utils;
+use Give\ValueObjects\Money;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -1487,6 +1491,7 @@ function give_filter_where_older_than_week( $where = '' ) {
  *                                   enabled. b. separator  = The separator between the Form Title and the Donation
  *                                   Level.
  *
+ * @unreleased check if donation form is V3 form
  * @since 1.5
  *
  * @return string $form_title Returns the full title if $only_level is false, otherwise returns the levels title.
@@ -1508,9 +1513,24 @@ function give_get_donation_form_title( $donation_id, $args = [] ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
-	$form_id     = give_get_payment_form_id( $donation_id );
+	$form_id = give_get_payment_form_id( $donation_id );
+    $form_title = give_get_meta( $donation_id, '_give_payment_form_title', true );
+
+    // Check if the donation form is V3 form
+    if (Utils::isV3Form($form_id)) {
+        $currency = give_get_option('currency');
+        $options = give()->form_meta->get_meta($form_id, '_give_donation_levels', true) ?? [];
+        $donation = Donation::find($donation_id);
+
+        foreach ( $options as $option ) {
+            if (Money::of($option['_give_amount'], $currency )->getMinorAmount() == $donation->amount->getAmount()) {
+                return sprintf('%s %s %s', $form_title, $args['separator'], $option['_give_text']);
+            }
+        }
+    }
+
 	$price_id    = give_get_meta( $donation_id, '_give_payment_price_id', true );
-	$form_title  = give_get_meta( $donation_id, '_give_payment_form_title', true );
+
 	$only_level  = $args['only_level'];
 	$separator   = $args['separator'];
 	$level_label = '';

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1525,7 +1525,8 @@ function give_get_donation_form_title( $donation_id, $args = [] ) {
         foreach ( $options as $option ) {
             if (isset($option['_give_amount'], $option['_give_text'])) {
                 if (Money::of($option['_give_amount'], $currency )->getMinorAmount() == $donation->amount->getAmount()) {
-                    return sprintf('%s %s %s', $form_title, $args['separator'], $option['_give_text']);
+                    $form_title = sprintf('%s %s %s', $form_title, $args['separator'], $option['_give_text']);
+                    return apply_filters( 'give_get_donation_form_title', $form_title, $donation_id );
                 }
             }
         }


### PR DESCRIPTION
## Description
This PR resolves the issue with the wrong donation description in the confirmation email. The problem affects V3 forms only because there is a missing meta key (_give_payment_price_id) which is used to determine the donation level. The issue is resolved by checking if the donation form is a V3 form and then comparing the donation amount with the donation level amount set in form settings.

## Affects

Donation receipt email

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Testing Instructions

- Create a donation form with multiple donation levels.
- Give each donation level a different description.
- Donate to any level other than the first level.
- Check the donation description in the donation confirmation

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

