### PR TITLE
Fix: Update sidebar style for WordPress 6.7 compatibility

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/styles/_form-builder.scss
@@ -46,13 +46,6 @@
     //overflow: hidden; // The Inspector Popout needs to be visible.
     overflow-y: scroll;
 
-    // WP 6.6+ - hide the Blocks, Patterns, Media tabs
-    &.givewp-next-gen-sidebar-secondary {
-        .block-editor-inserter__tablist-and-close-button {
-                display: none;
-            }
-    }
-
     &.givewp-next-gen-sidebar-primary {
         .block-editor-block-inspector {
             > h2 {
@@ -315,3 +308,30 @@
 .iti {
     width: 100%;
 }
+
+/**
+ * WordPress 6.6 compatibility
+ */
+.givewp-next-gen-sidebar-secondary {
+    // Hide the Blocks, Patterns, Media tabs
+    .block-editor-inserter__tablist-and-close-button {
+        display: none;
+    }
+}
+
+
+/**
+ * WordPress 6.7 compatibility
+ */
+.givewp-next-gen-sidebar-secondary {
+    // Hide the Blocks, Patterns, Media tabs (css name change)
+    .block-editor-tabbed-sidebar__tablist-and-close-button {
+        display: none;
+    }
+
+    // WP adds a fixed width to the tabbed sidebar, we need to override it
+    .block-editor-inserter__main-area .block-editor-tabbed-sidebar {
+        width: 100%;
+    }
+}
+


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1509]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

WordPress 6.7 introduced some new css classnames to the sidebar we are using that are causing styling issues:
- `block-editor-tabbed-sidebar__tablist-and-close-button`
- `.block-editor-tabbed-sidebar`

This PR adds some specific css tweaks to these classes to prevent:
1. The sidebar tabs from showing (Blocks, Patterns, Media tab)
2. The sidebar width becoming fixed with a scrollbar

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The from builder sidebar on WordPress 6.7

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before**

https://github.com/user-attachments/assets/c412ca78-88f6-4103-8dff-279b617873f0

**After**

<img width="404" alt="Screenshot 2024-11-04 at 12 50 23 PM" src="https://github.com/user-attachments/assets/0f1f12a2-f918-40cb-b75e-1c0ab291877c">


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Install WP 6.7-RC
- Make sure the form builder sidebar works as expected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1509]: https://stellarwp.atlassian.net/browse/GIVE-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ