### PR TITLE
Fix: Apply taggedElement to improve iframe height resizing in v3 forms

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -105,14 +105,6 @@ class BlockRenderController
     protected function loadEmbedScript()
     {
         (new EnqueueScript(
-            'givewp-donation-form-embed',
-            'build/donationFormEmbed.js',
-            GIVE_PLUGIN_DIR,
-            GIVE_PLUGIN_URL,
-            'give'
-        ))->loadInFooter()->enqueue();
-
-        (new EnqueueScript(
             'givewp-donation-form-embed-app',
             'build/donationFormBlockApp.js',
             GIVE_PLUGIN_DIR,

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -42,6 +42,7 @@ export default function ModalForm({dataSrc, embedId, openFormButton, isFormRedir
                 id={embedId}
                 src={dataSrcUrl}
                 checkOrigin={false}
+                heightCalculationMethod={'taggedElement'}
                 style={{
                     minWidth: '100%',
                     border: 'none',

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -73,6 +73,7 @@ function DonationFormBlockApp({
             id={embedId}
             src={dataSrc}
             checkOrigin={false}
+            heightCalculationMethod={'taggedElement'}
             style={{
                 width: '1px',
                 minWidth: '100%',


### PR DESCRIPTION
Resolves [GIVE-1429]

## Description
This includes the `heightCalculation` prop on the Iframe-Resizer-react component for v3 forms. The taggedElement used can be found in the `DonationFormViewModel.php` class. The element can be found via `id="root-givewp-donation-form" `. taggedElements are denoted via `data-iframe-height`

I also noticed the parent page script for the  iframe-resizer JS package in `embed.ts` was enqueued for v3 forms. It is targeting an iframe via `iframe[data-givewp-embed]` which does not align with the iframe currently used to render v3 forms.

The iframe-resizer-react documents do not explicitly mention to load the parent page script. So I have removed the script from enqueuing. Reference: https://www.npmjs.com/package/iframe-resizer-react/v/1.1.0

## Additional Context
- In an earlier `NextGen` version the `BlockRenderController` rendered an iframe with the data attribute`data-givewp-embed`
Reference: [Pull Request](https://github.com/impress-org/givewp-next-gen/pull/58/files#diff-9dabb6fef60593f6f8b8040f0d075d9cd2436df922e4c42eca6b94b0e7bdaef8)
File: `src/NextGen/DonationForm/Blocks/DonationFormBlock/Controllers/BlockRenderController.php`
- v2 forms have there own implementation of iframe-resizer that is passed via the window object.

## Affects
v3 forms on the frontend, including confirmation pages.

## Visuals
###  Testing v3 Forms
https://github.com/user-attachments/assets/8c47cc77-7137-41e8-bff6-19d9aa5a5006

###  Testing v3 Forms as a `Block` & `Shortcode`
https://github.com/user-attachments/assets/9a848ef0-1bd2-4e3b-990d-6566aab9a532

## Testing v2 Forms
https://github.com/user-attachments/assets/6a9f63de-3671-4e82-a66d-779b6560e212

## Testing Instructions
- Create a v3 form to easily view the dynamic changes in height add some simple text fields to the second section.
- Use the MultiStep forms and navigate the pages, we are testing mainly the previous button functionality to ensure the iframe not only expands but reduces height as well.
- Ensure all three forms continue to display as expected.
- Process a donation verify the Confirmation page continues to load in an iframe with the taggedElement.
- Verify v2 form templates also continue to resize dynamically.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1429]: https://stellarwp.atlassian.net/browse/GIVE-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ