### PR TITLE
Fix: Prevent page refresh when opening the Create Campaign Modal

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignsListTable/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignsListTable/index.tsx
@@ -8,10 +8,23 @@ import {CampaignsRowActions} from './CampaignsRowActions';
 import styles from './CampaignsListTable.module.scss';
 import {GiveCampaignsListTable} from './types';
 import CreateCampaignModal from '../CreateCampaignModal';
+import {useState} from "react";
 
 declare const window: {
     GiveCampaignsListTable: GiveCampaignsListTable;
 } & Window;
+
+/**
+ * Auto open modal if the URL has the query parameter id as new
+ *
+ * @unreleased
+ */
+const autoOpenModal = () => {
+    const queryParams = new URLSearchParams(window.location.search);
+    const newParam = queryParams.get('new');
+
+    return newParam === 'campaign';
+};
 
 export function getGiveCampaignsListTableWindowData() {
     return window.GiveCampaignsListTable;
@@ -92,35 +105,36 @@ const bulkActions: Array<BulkActionsConfig> = [
     },
 ];
 
-/**
- * Displays a blank slate for the Campaigns table.
- *
- * @unreleased
- */
-const ListTableBlankSlate = () => {
-    const imagePath = `${
-        getGiveCampaignsListTableWindowData().pluginUrl
-    }/assets/dist/images/list-table/blank-slate-donation-forms-icon.svg`;
-    return (
-        <div className={styles.container}>
-            <img src={imagePath} alt={__('No campaign created yet', 'give')} />
-            <h3>{__('No campaign created yet', 'give')}</h3>
-            <p className={styles.helpMessage}>{__('Don’t worry, let’s help you setup your first campaign.', 'give')}</p>
-            <p>
-                <a
-                    href={`${
-                        getGiveCampaignsListTableWindowData().adminUrl
-                    }edit.php?post_type=give_forms&page=give-campaigns&new=campaign`}
-                    className={`button button-primary ${styles.button}`}
-                >
-                    {__('Create campaign', 'give')}
-                </a>
-            </p>
-        </div>
-    );
-};
-
 export default function CampaignsListTable() {
+
+    const [isOpen, setOpen] = useState<boolean>(autoOpenModal());
+
+    /**
+     * Displays a blank slate for the Campaigns table.
+     *
+     * @unreleased
+     */
+    const ListTableBlankSlate = () => {
+        const imagePath = `${
+            getGiveCampaignsListTableWindowData().pluginUrl
+        }/assets/dist/images/list-table/blank-slate-donation-forms-icon.svg`;
+        return (
+            <div className={styles.container}>
+                <img src={imagePath} alt={__('No campaign created yet', 'give')} />
+                <h3>{__('No campaign created yet', 'give')}</h3>
+                <p className={styles.helpMessage}>{__('Don’t worry, let’s help you setup your first campaign.', 'give')}</p>
+                <p>
+                    <a
+                        onClick={() => setOpen(true)}
+                        className={`button button-primary ${styles.button}`}
+                    >
+                        {__('Create campaign', 'give')}
+                    </a>
+                </p>
+            </div>
+        );
+    };
+
     return (
         <>
             <ListTablePage
@@ -133,7 +147,7 @@ export default function CampaignsListTable() {
                 rowActions={CampaignsRowActions}
                 listTableBlankSlate={ListTableBlankSlate()}
             >
-                <CreateCampaignModal />
+                <CreateCampaignModal isOpen={isOpen} setOpen={setOpen} />
             </ListTablePage>
         </>
     );

--- a/src/Campaigns/resources/admin/components/CreateCampaignModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CreateCampaignModal/index.tsx
@@ -5,24 +5,12 @@ import CampaignFormModal from '../CampaignFormModal';
 import {getGiveCampaignsListTableWindowData} from '../CampaignsListTable';
 
 /**
- * Auto open modal if the URL has the query parameter id as new
- *
- * @unreleased
- */
-const autoOpenModal = () => {
-    const queryParams = new URLSearchParams(window.location.search);
-    const newParam = queryParams.get('new');
-
-    return newParam === 'campaign';
-};
-
-/**
  * Create Campaign Modal component
  *
  * @unreleased
  */
-export default function CreateCampaignModal() {
-    const [isOpen, setOpen] = useState<boolean>(autoOpenModal());
+export default function CreateCampaignModal({isOpen, setOpen}) {
+
     const openModal = () => setOpen(true);
     const closeModal = (response: ResponseProps = {}) => {
         setOpen(false);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1342]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR prevents a page refresh when clicking the Create Campaign button in the Campaign List Table.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The state for the Create Campaign Modal has been lifted to the `<CampaignsListTable />` parent component so that it can be shared by the `<ListTableBlankSlate />` and the `<CreateCampaignModal />` components.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2024-11-05 22-19](https://github.com/user-attachments/assets/648fb2e9-d401-44e7-8f98-a9043a3632b5)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

With no campaigns created, from the campaign list table click the "create campaign" button within the table's empty state (as opposed to the header).

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1342]: https://stellarwp.atlassian.net/browse/GIVE-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ