### PR TITLE
Fix: remove unnecessary error message when selecting the initial goal while creating a new campaign

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -9,7 +9,7 @@ import {
     GoalInputAttributes,
     GoalTypeOption as GoalTypeOptionType,
 } from './types';
-import {useEffect, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {Currency, Upload} from '../Inputs';
 import {
     AmountFromSubscriptionsIcon,
@@ -146,7 +146,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
     const goal = watch('goal');
 
     const getFormModalTitle = () => {
-        switch(step) {
+        switch (step) {
             case 1:
                 return __('Tell us about your fundraising cause', 'give');
             case 2:
@@ -154,7 +154,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
         }
 
         return null;
-    }
+    };
 
     const goalInputAttributes: {[selectedGoalType: string]: GoalInputAttributes} = {
         amount: {
@@ -395,7 +395,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                                 ) : (
                                     <input
                                         type="number"
-                                        {...register('goal', {required: __('The campaign must have a goal!', 'give')})}
+                                        {...register('goal', {valueAsNumber: true})}
                                         aria-invalid={errors.goal ? 'true' : 'false'}
                                         placeholder={goalInputAttributes[selectedGoalType].placeholder}
                                     />


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1339]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR removes the unnecessary validation and sets the goal input, in the same way, using the settings tab from the campaigns details page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The creation of new campaigns.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. In the modal for creating a new campaign select the "Amount raised" goal type option first;
2. Select any other option after the previous step;
3. Repeat the step `#1`;
4. Fill the input with the goal;
5. Click on the “Continue” button;
6. No error should be thrown next to the input.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1339]: https://stellarwp.atlassian.net/browse/GIVE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ