### PR TITLE
Fix: goal creation modal should not highlight previous button

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
@@ -112,4 +112,9 @@
     background-color: transparent;
     border: solid 1px #9ca0af;
     color: #060c1a;
+
+    &:hover {
+        border: solid 1px #9ca0af;
+        color: #060c1a;
+    }
 }

--- a/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
@@ -104,5 +104,12 @@
     }
 }
 
+.button:is(:global(.button)) {
+    border-radius: var(--givewp-rounded-8)
+}
 
-
+.previousButton:is(:global(.button)) {
+    background-color: transparent;
+    border: solid 1px #9ca0af;
+    color: #060c1a;
+}

--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -9,7 +9,7 @@ import {
     GoalInputAttributes,
     GoalTypeOption as GoalTypeOptionType,
 } from './types';
-import {useEffect, useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {Currency, Upload} from '../Inputs';
 import {
     AmountFromSubscriptionsIcon,
@@ -146,7 +146,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
     const goal = watch('goal');
 
     const getFormModalTitle = () => {
-        switch(step) {
+        switch (step) {
             case 1:
                 return __('Tell us about your fundraising cause', 'give');
             case 2:
@@ -154,7 +154,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
         }
 
         return null;
-    }
+    };
 
     const goalInputAttributes: {[selectedGoalType: string]: GoalInputAttributes} = {
         amount: {
@@ -423,14 +423,23 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                             <input type="datetime-local" {...register('endDateTime')} />
                         </div>
                     </div>*/}
-                        <div className="givewp-campaigns__form-row givewp-campaigns__form-row--half">
-                            <button type="submit" onClick={() => setStep(1)} className={`button button-secondary`}>
+                        <div
+                            className="givewp-campaigns__form-row givewp-campaigns__form-row--half"
+                            style={{marginBottom: 0}}
+                        >
+                            <button
+                                type="submit"
+                                onClick={() => setStep(1)}
+                                className={`button button-secondary ${styles.button} ${styles.previousButton}`}
+                            >
                                 {__('Previous', 'give')}
                             </button>
 
                             <button
                                 type="submit"
-                                className={`button button-primary ${!goal || isSubmitting ? 'disabled' : ''}`}
+                                className={`button button-primary ${styles.button} ${
+                                    !goal || isSubmitting ? 'disabled' : ''
+                                }`}
                                 aria-disabled={!goal || isSubmitting}
                                 disabled={!goal || isSubmitting}
                             >


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1340]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR implements a few CSS tweaks to make the "previous" button from the Create Campaign modal match the design.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The creation of new campaigns.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Demo video:** https://www.loom.com/share/175097c6f0e142388f37afcf23a904e6?sid=a3c9ec94-56ba-41f0-9561-2a9ec5040325

![image](https://github.com/user-attachments/assets/b4d7082c-40bd-425b-a584-85c13d510efa)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. On the campaigns page click on the "Create Campaign" button;
2. Go to the second step of the form and make sure the "previous" button looks like on design.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1340]: https://stellarwp.atlassian.net/browse/GIVE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ