### PR TITLE
Fix: Handle 8.2 depreciation warnings in the Donation `SessionObjects`

### DIFF
--- a/src/Session/SessionDonation/SessionObjects/Donation.php
+++ b/src/Session/SessionDonation/SessionObjects/Donation.php
@@ -74,6 +74,30 @@ class Donation implements Objects
     public $paymentGateway;
 
     /**
+     * Donation-related objects.
+     *
+     * @unreleased
+     * @var FormEntry
+     */
+    public $formEntry;
+
+    /**
+     * Donor information.
+     *
+     * @unreleased
+     * @var DonorInfo
+     */
+    public $donorInfo;
+
+    /**
+     * Card information.
+     *
+     * @unreleased
+     * @var CardInfo
+     */
+    public $cardInfo;
+
+    /**
      * Array of properties and their cast type.
      *
      * @var ValueObjects[]

--- a/src/Session/SessionDonation/SessionObjects/FormEntry.php
+++ b/src/Session/SessionDonation/SessionObjects/FormEntry.php
@@ -5,6 +5,8 @@ namespace Give\Session\SessionDonation\SessionObjects;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Helpers\ArrayDataSet;
 use Give\Session\Objects;
+use Give\ValueObjects\CardInfo;
+use Give\ValueObjects\DonorInfo;
 
 /**
  * Class FormEntry
@@ -91,6 +93,101 @@ class FormEntry implements Objects
      * @var string
      */
     public $paymentGateway;
+
+    /**
+     * Donation-related session objects.
+     *
+     * @unreleased
+     * @var FormEntry
+     */
+    public $formEntry;
+
+    /**
+     * Donor information.
+     *
+     * @unreleased
+     * @var DonorInfo
+     */
+    public $donorInfo;
+
+    /**
+     * Card information.
+     *
+     * @unreleased
+     * @var CardInfo
+     */
+    public $cardInfo;
+
+    /**
+     * Honeypot value to detect spam submissions.
+     *
+     * @var string|null
+     */
+    public $honeypot;
+
+    /**
+     * Form ID prefix.
+     *
+     * @var string|null
+     */
+    public $formIdPrefix;
+
+    /**
+     * Form URL.
+     *
+     * @var string|null
+     */
+        public $formUrl;
+
+    /**
+     * Minimum donation amount.
+     *
+     * @var float|null
+     */
+        public $formMinimum;
+
+    /**
+     * Maximum donation amount.
+     *
+     * @var float|null
+     */
+    public $formMaximum;
+
+    /**
+     * Form hash.
+     *
+     * @var string|null
+     */
+    public $formHash;
+
+    /**
+     * Payment mode.
+     *
+     * @var string|null
+     */
+    public $paymentMode;
+
+    /**
+     * Stripe Payment Method.
+     *
+     * @var string|null
+     */
+    public $stripePaymentMethod;
+    /*
+
+    /**
+     * Constant Contact signup status.
+     *
+     * @var bool|null
+     */
+    public $constantContactSignup;
+
+    /**
+     * Action property.
+     *
+     * @var string|null
+     */
+    public $action;
 
     /**
      * Take array and return object.

--- a/src/Session/SessionDonation/SessionObjects/FormEntry.php
+++ b/src/Session/SessionDonation/SessionObjects/FormEntry.php
@@ -137,14 +137,14 @@ class FormEntry implements Objects
      *
      * @var string|null
      */
-        public $formUrl;
+    public $formUrl;
 
     /**
      * Minimum donation amount.
      *
      * @var float|null
      */
-        public $formMinimum;
+    public $formMinimum;
 
     /**
      * Maximum donation amount.


### PR DESCRIPTION
Resolves: [GIVE-226]

## Description
This PR declares the dynamic properties in the `FormEntry` & `Donation` Session Object classes to handle depreciation warnings that arise from PHP@8.2. Dynamic properties will no longer be supported with the release of PHP@9.0.

Reference:
-  https://www.php.net/manual/en/migration82.deprecated.php
- https://php.watch/versions/8.2/dynamic-properties-deprecated

## Affects
Deprecation Warnings in the admin screens.

## Testing Instructions
- Install Give on server that runs PHP 8.2.
- Enable WP_DEBUG and WP_DEBUG_LOG.
- View admin settings for deprecation warnings.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-226]: https://stellarwp.atlassian.net/browse/GIVE-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ