### PR TITLE
Feature: display uploaded donor avatar on donor wall

### DIFF
--- a/templates/shortcode-donor-wall.php
+++ b/templates/shortcode-donor-wall.php
@@ -38,6 +38,17 @@ $tribute_background_color = !empty($atts['color']) ? $atts['color'] . '20' : '#2
                                 <img class='give-donor-container__image__anonymous' src='$imageUrl' alt='$alt' style='height: {$avatarSize}px;'/>
                             </div>
                         ";
+                } elseif (($avatar = $donor->get_meta('_give_donor_avatar_id', true))) {
+                    // Donor has an avatar
+                    $imageUrl = wp_get_attachment_image_url($avatar, 'thumbnail');
+                    $alt = __('Donor Avatar', 'give');
+
+                    echo "
+                            <div class='give-donor-container__image' >
+                                <img src='$imageUrl' alt='$alt' style='height: {$avatarSize}px;'/>
+                            </div>
+                        ";
+
                 } elseif ($donation['_give_payment_donor_email'] && give_validate_gravatar(
                         $donation['_give_payment_donor_email']
                     )) {


### PR DESCRIPTION
## Description

The donor has had the ability to upload a profile image for years, since the Donor Dashboard was introduce. But the Donor Wall was never updated to make use of this — which is a bummer!

This PR has the Donor Wall check for an uploaded image and prioritizes it above the Gravatar image if available.

## Affects

The donor dashboard shortcode template

## Visuals

**Uploaded in donor dashboard:**
<img width="514" alt="image" src="https://github.com/user-attachments/assets/6d65fb66-148b-4e22-84c2-8a4ed9468a0e">

**Showing in Donor wall:**
<img width="693" alt="image" src="https://github.com/user-attachments/assets/60d2e71e-b70f-4f7a-84fe-e47ae205a141">


## Testing Instructions

1. Go to the Donor Dashboard and upload an image
2. Save your profile
3. Go to a donor wall showing that user, and see if the image shows up
4. Double-check that removing the image doesn't break anything

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

