### PR TITLE
Fix: PayPal connect

### DIFF
--- a/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
+++ b/src/PaymentGateways/PayPalCommerce/AdminSettingFields.php
@@ -432,9 +432,7 @@ class AdminSettingFields
                                         <?php esc_html_e('Click to get started!', 'give'); ?>
                                     </span>
                                     <?php // We are using one PayPal button to handle both sandbox and live mode connection.?>
-                                    <a class="give-hidden" target="PPFrame"
-                                       data-paypal-onboard-complete="givePayPalOnBoardedCallback" href="#"
-                                       data-paypal-button="true">
+                                    <a class="give-hidden" target="PPFrame" data-paypal-button="true">
                                         <?php esc_html_e('Sign up for PayPal', 'give'); ?>
                                     </a>
                                 <?php endif; ?>


### PR DESCRIPTION
Resolves: [GIVE-1989]

## Description

This PR resolves the issue of users not being able to link their PayPal accounts. The problem was the incorrect callback set in the `data-paypal-onboard-complete` attribute, which is set dynamically [here](https://github.com/impress-org/givewp/blob/982ead3b3886557ccbb17058140be3728c1f23fa/assets/src/js/admin/paypal-commerce/index.js#L130). For some reason, dynamic attribute update did not work. The issue is resolved by removing the hardcoded data attribute from the button. 

## Affects

PayPal connect account button

## Testing Instructions
Connect PayPal sandbox/live account

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1989]: https://stellarwp.atlassian.net/browse/GIVE-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ