### PR TITLE
Feature: Add deferred resolution to model factory definitions

### DIFF
--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -101,7 +101,7 @@ abstract class ModelFactory
     /**
      * @unreleased
      */
-    public function createAndResolveTo($property)
+    public function createAndResolveTo($property): Closure
     {
         return function() use ($property) {
             return is_array($results = $this->create())

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -113,7 +113,7 @@ abstract class ModelFactory
     /**
      * Creates an instance of the model from the attributes and definition.
      *
-     * @unreleased Add support for resolving callables.
+     * @unreleased Add support for resolving Closures.
      * @since 2.23.0
      *
      * @return M

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -121,7 +121,7 @@ abstract class ModelFactory
     protected function makeInstance(array $attributes)
     {
         return new $this->model(array_map(function($attribute) {
-            return is_callable($attribute) ? $attribute() : $attribute;
+            return $attribute instanceof Closure ? $attribute() : $attribute;
         }, array_merge($this->definition(), $attributes)));
     }
 

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -113,6 +113,7 @@ abstract class ModelFactory
     /**
      * Creates an instance of the model from the attributes and definition.
      *
+     * @unreleased Add support for resolving callables.
      * @since 2.23.0
      *
      * @return M

--- a/src/Framework/Models/Factories/ModelFactory.php
+++ b/src/Framework/Models/Factories/ModelFactory.php
@@ -2,6 +2,7 @@
 
 namespace Give\Framework\Models\Factories;
 
+use Closure;
 use Exception;
 use Give\Vendors\Faker\Generator;
 use Give\Framework\Database\DB;
@@ -64,6 +65,18 @@ abstract class ModelFactory
     }
 
     /**
+     * @unreleased
+     */
+    public function makeAndResolveTo($property): Closure
+    {
+        return function() use ($property) {
+            return is_array($results = $this->make())
+                ? array_column($results, $property)
+                : $results->$property;
+        };
+    }
+
+    /**
      * @since 2.20.0
      *
      * @param  array  $attributes
@@ -86,6 +99,18 @@ abstract class ModelFactory
     }
 
     /**
+     * @unreleased
+     */
+    public function createAndResolveTo($property)
+    {
+        return function() use ($property) {
+            return is_array($results = $this->create())
+                ? array_column($results, $property)
+                : $results->$property;
+        };
+    }
+
+    /**
      * Creates an instance of the model from the attributes and definition.
      *
      * @since 2.23.0
@@ -94,7 +119,9 @@ abstract class ModelFactory
      */
     protected function makeInstance(array $attributes)
     {
-        return new $this->model(array_merge($this->definition(), $attributes));
+        return new $this->model(array_map(function($attribute) {
+            return is_callable($attribute) ? $attribute() : $attribute;
+        }, array_merge($this->definition(), $attributes)));
     }
 
     /**

--- a/src/Framework/Models/Factories/README.md
+++ b/src/Framework/Models/Factories/README.md
@@ -1,0 +1,114 @@
+# Model Factory
+
+## Introduction
+
+Factory classes are used to programmatically create instances of models. This is useful for seeding databases, creating test data, and other situations where you need to create a lot of model instances.
+
+```php
+<?php
+
+namespace Give\Campaigns\Factories;
+
+class CampaignFactory extends Give\Framework\Models\Factories\ModelFactory
+{
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'description' => $this->faker->paragraph(),
+        ];
+    }
+}
+```
+
+Each instance of a model created by a factory class is populated with default values defined in the `definition` method, which can be hard-coded or generated dynamically using integrated the `fakerphp/faker` library.
+
+## Creating Models with Factories
+
+A model can be instantiated using the factory `make()` method, which uses the defaults provided by the `definition()` method to create the model instance.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign = Campaign::factory()->make();
+```
+
+Additionally, multiple model instances can be created using the `count()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaigns = Campaign::factory()->count(3)->make();
+```
+
+### Overriding Attributes
+
+You can override these default values by passing an array of attributes to the factory's `make()` or `create()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign Campaign::factory()->create([
+    'title' => 'My Custom Campaign',
+]);
+```
+
+### Persisting Models
+
+The `create()` method instantiates model instances and persists them to the database using model's `save()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign Campaign::factory()->create();
+```
+
+### Deferred Resolution
+
+Sometimes you may need to defer the resolution of an attribute until the model is being created. Either the attribute definition is not a simple value or is otherwise expensive to instantiate.
+
+Factory attribute definitions can be deferred using `Closure` callbacks instead of a hard-coded or generated value.
+
+```php
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'description' => function() {
+                return prompt('Write a short description for a fundraising campaign.')
+            },
+        ];
+    }
+```
+
+Additionally, deferred attributes are not resolved when the attribute is overridden, which prevents unnecessary computation when the default value is not used.
+
+```php
+$campaign = Campaign::factory()->create([
+    'description' => 'My custom description',
+]);
+```
+
+## Model Relationships with Factories
+
+Attribute definitions can also be other model factories, which can be resolved to a property value, such as an ID, to create required dependencies.
+
+```php
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'formId' => DonationForm::factory()->createAndResolveTo('id'),
+        ];
+    }
+```
+
+This is particularly useful when defining model relationships, where the related model is only instantiated when a model is not explicity provided as an override.
+
+If an existing model (or model ID) is provided as an override, the factory will not instantiate an additional model.
+
+```php
+Campaign::factory()->create([
+    'formId' => $donationForm->id,
+]);
+```

--- a/tests/Unit/Framework/Models/Factories/TestModelFactory.php
+++ b/tests/Unit/Framework/Models/Factories/TestModelFactory.php
@@ -15,12 +15,18 @@ class TestModelFactory extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @unreleased
+     */
     public function setUp()
     {
         parent::setUp();
         MockModel::resetAutoIncrementId();
     }
 
+    /**
+     * @unreleased
+     */
     public function testDefinitionAsAttributes()
     {
         $factory = new class(MockModel::class) extends ModelFactory {
@@ -36,6 +42,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(123, $object->id);
     }
 
+    /**
+     * @unreleased
+     */
     public function testPassedAttributesOverrideDefinition()
     {
         $factory = new class(MockModel::class) extends ModelFactory {
@@ -53,6 +62,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(456, $object->id);
     }
 
+    /**
+     * @unreleased
+     */
     public function testResolvesCallableDefinitions()
     {
         $factory = new class(MockModel::class) extends ModelFactory {
@@ -70,6 +82,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(123, $object->id);
     }
 
+    /**
+     * @unreleased
+     */
     public function testDoesNotResolveCallableWhenPassedAttribute()
     {
         $factory = new class(MockModel::class) extends ModelFactory {
@@ -89,6 +104,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(123, $object->id);
     }
 
+    /**
+     * @unreleased
+     */
     public function testMakeResolvesDependencyDefinition()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {
@@ -114,6 +132,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(789, $object->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testMakeResolvesDependencyDefinitionWithCount()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {
@@ -142,6 +163,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(2, $instances[1]->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testMakeDoesNotResolveDependencyWhenPassedAttribute()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {
@@ -174,6 +198,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(789, $object->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testCreateResolvesDependencyDefinition()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {
@@ -199,6 +226,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(1, $object->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testCreateResolvesDependencyDefinitionWithCount()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {
@@ -226,6 +256,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(2, $instances[1]->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testCreateDoesNotResolveDependencyWhenPassedAttribute()
     {
         $factory = new class(MockModelWithDependency::class) extends ModelFactory {

--- a/tests/Unit/Framework/Models/Factories/TestModelFactory.php
+++ b/tests/Unit/Framework/Models/Factories/TestModelFactory.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Give\Tests\Unit\Framework\Models\Factories;
+
+use Exception;
+use Give\Framework\Models\Factories\ModelFactory;
+use Give\Framework\Models\Model;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ */
+class TestModelFactory extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp()
+    {
+        parent::setUp();
+        MockModel::resetAutoIncrementId();
+    }
+
+    public function testDefinitionAsAttributes()
+    {
+        $factory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $object = $factory->make();
+
+        $this->assertEquals(123, $object->id);
+    }
+
+    public function testPassedAttributesOverrideDefinition()
+    {
+        $factory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $object = $factory->make([
+            'id' => 456,
+        ]);
+
+        $this->assertEquals(456, $object->id);
+    }
+
+    public function testResolvesCallableDefinitions()
+    {
+        $factory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => function() {
+                        return 123;
+                    },
+                ];
+            }
+        };
+
+        $object = $factory->make();
+
+        $this->assertEquals(123, $object->id);
+    }
+
+    public function testDoesNotResolveCallableWhenPassedAttribute()
+    {
+        $factory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => function() {
+                        throw new Exception('Should not be called');
+                    },
+                ];
+            }
+        };
+
+        $object = $factory->make([
+            'id' => 123,
+        ]);
+
+        $this->assertEquals(123, $object->id);
+    }
+
+    public function testMakeResolvesDependencyDefinition()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $nestedFactory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 789,
+                ];
+            }
+        };
+
+        $object = $factory->make([
+            'nestedId' => $nestedFactory->makeAndResolveTo('id'),
+        ]);
+
+        $this->assertEquals(789, $object->nestedId);
+    }
+
+    public function testMakeResolvesDependencyDefinitionWithCount()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $nestedFactory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                static $counter = 1;
+                return [
+                    'id' => $counter++,
+                ];
+            }
+        };
+
+        $instances = $factory->count(2)->make([
+            'nestedId' => $nestedFactory->makeAndResolveTo('id'),
+        ]);
+
+        $this->assertIsArray($instances);
+        $this->assertEquals(1, $instances[0]->nestedId);
+        $this->assertEquals(2, $instances[1]->nestedId);
+    }
+
+    public function testMakeDoesNotResolveDependencyWhenPassedAttribute()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+
+                $nestedFactory = new class(MockModel::class) extends ModelFactory {
+                    public function definition(): array {
+                        return [
+                            'id' => 456,
+                        ];
+                    }
+
+                    public function make(array $attributes = [])
+                    {
+                        throw new Exception('Should not be called');
+                    }
+                };
+
+                return [
+                    'id' => 123,
+                    'nestedId' => $nestedFactory->makeAndResolveTo('id')
+                ];
+            }
+        };
+
+        $object = $factory->make([
+            'nestedId' => 789,
+        ]);
+
+        $this->assertEquals(789, $object->nestedId);
+    }
+
+    public function testCreateResolvesDependencyDefinition()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $nestedFactory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    // Defer id assignment until save
+                ];
+            }
+        };
+
+        $object = $factory->create([
+            'nestedId' => $nestedFactory->createAndResolveTo('id'),
+        ]);
+
+        $this->assertEquals(1, $object->nestedId);
+    }
+
+    public function testCreateResolvesDependencyDefinitionWithCount()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    'id' => 123,
+                ];
+            }
+        };
+
+        $nestedFactory = new class(MockModel::class) extends ModelFactory {
+            public function definition(): array {
+                return [
+                    // Defer id assignment until save
+                ];
+            }
+        };
+
+        $instances = $factory->count(2)->make([
+            'nestedId' => $nestedFactory->createAndResolveTo('id'),
+        ]);
+
+        $this->assertIsArray($instances);
+        $this->assertEquals(1, $instances[0]->nestedId);
+        $this->assertEquals(2, $instances[1]->nestedId);
+    }
+
+    public function testCreateDoesNotResolveDependencyWhenPassedAttribute()
+    {
+        $factory = new class(MockModelWithDependency::class) extends ModelFactory {
+            public function definition(): array {
+
+                $nestedFactory = new class(MockModel::class) extends ModelFactory {
+                    public function definition(): array {
+                        return [
+                            // Defer id assignment until save
+                        ];
+                    }
+
+                    public function create(array $attributes = [])
+                    {
+                        throw new Exception('Should not be called');
+                    }
+                };
+
+                return [
+                    'id' => 123,
+                    'nestedId' => $nestedFactory->createAndResolveTo('id')
+                ];
+            }
+        };
+
+        $object = $factory->make([
+            'nestedId' => 789,
+        ]);
+
+        $this->assertEquals(789, $object->nestedId);
+    }
+}
+
+/**
+ * @unreleased
+ *
+ * @property int $id
+ */
+class MockModel extends Model
+{
+    protected static $autoIncrementId = 1;
+
+    protected $properties = [
+        'id' => 'int',
+    ];
+
+    public function save() {
+        $this->id = $this->id ?: self::$autoIncrementId++;
+        return $this;
+    }
+
+    public static function resetAutoIncrementId() {
+        self::$autoIncrementId = 1;
+    }
+}
+
+/**
+ * @unreleased
+ *
+ * @property int $id
+ * @property int $nestedId
+ */
+class MockModelWithDependency extends MockModel
+{
+    protected $properties = [
+        'id' => 'int',
+        'nestedId' => 'int',
+    ];
+}
+

--- a/tests/Unit/Framework/Models/Factories/TestModelFactory.php
+++ b/tests/Unit/Framework/Models/Factories/TestModelFactory.php
@@ -289,6 +289,9 @@ class TestModelFactory extends TestCase
         $this->assertEquals(789, $object->nestedId);
     }
 
+    /**
+     * @unreleased
+     */
     public function testDoesNotResolveInvokableClasses()
     {
         $factory = new class(MockModelWithInvokableProperty::class) extends ModelFactory {
@@ -346,11 +349,19 @@ class MockModelWithDependency extends MockModel
     ];
 }
 
+/**
+ * @unreleased
+ */
 abstract class MockInvokableClass
 {
     abstract public function __invoke();
 }
 
+/**
+ * @unreleased
+ *
+ * @property MockInvokableClass $invokable
+ */
 class MockModelWithInvokableProperty extends MockModel
 {
     protected $properties = [

--- a/tests/Unit/Framework/Models/Factories/TestModelFactory.php
+++ b/tests/Unit/Framework/Models/Factories/TestModelFactory.php
@@ -6,14 +6,12 @@ use Exception;
 use Give\Framework\Models\Factories\ModelFactory;
 use Give\Framework\Models\Model;
 use Give\Tests\TestCase;
-use Give\Tests\TestTraits\RefreshDatabase;
 
 /**
  * @unreleased
  */
 class TestModelFactory extends TestCase
 {
-    use RefreshDatabase;
 
     /**
      * @unreleased


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds deferred resolution to model factory definitions, such as nested model factories, so that defaults can be overridden without instantiating unused model instances.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Updates `Give\Framework\Models\Factories\ModelFactory::makeInstance()` to support resolving attributes that are `callable`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```php
public function definition(): array
{
    return [
        'title' => __('GiveWP Campaign', 'give'),
        'formId' => DonationForm::factory()->createAndResolveTo('id'),
    ];
}
```

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This feature is covered by unit tests and does not have a customer facing application.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

