### PR TITLE
Fix: remove factory method from form migration process

### DIFF
--- a/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
+++ b/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
@@ -2,9 +2,12 @@
 
 namespace Give\FormMigration\DataTransferObjects;
 
+use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\Models\DonationForm as DonationFormV3;
+use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\V2\Models\DonationForm as DonationFormV2;
 use Give\DonationForms\ValueObjects\DonationFormStatus;
+use Give\FormBuilder\Actions\GenerateDefaultDonationFormBlockCollection;
 
 class FormMigrationPayload
 {
@@ -22,8 +25,13 @@ class FormMigrationPayload
 
     public static function fromFormV2(DonationFormV2 $formV2): self
     {
-        return new self($formV2, DonationFormV3::factory()->create([
+        $formV3 = DonationForm::create([
+            'title' => $formV2->title,
             'status' => DonationFormStatus::DRAFT(),
-        ]));
+            'settings' => FormSettings::fromArray([]),
+            'blocks' => (new GenerateDefaultDonationFormBlockCollection())(),
+        ]);
+
+        return new self($formV2, $formV3);
     }
 }

--- a/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
+++ b/src/FormMigration/DataTransferObjects/FormMigrationPayload.php
@@ -2,6 +2,7 @@
 
 namespace Give\FormMigration\DataTransferObjects;
 
+use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\Models\DonationForm as DonationFormV3;
 use Give\DonationForms\Properties\FormSettings;
@@ -28,7 +29,9 @@ class FormMigrationPayload
         $formV3 = DonationForm::create([
             'title' => $formV2->title,
             'status' => DonationFormStatus::DRAFT(),
-            'settings' => FormSettings::fromArray([]),
+            'settings' => FormSettings::fromArray([
+                'designId' => ClassicFormDesign::id(),
+            ]),
             'blocks' => (new GenerateDefaultDonationFormBlockCollection())(),
         ]);
 


### PR DESCRIPTION
Resolves [GIVE-2009]

## Description

https://lw.slack.com/archives/C02RH0J92HK/p1731953344285929 
related: https://github.com/impress-org/givewp/pull/7595

We have removed the faker dependency from production. The factory method should be removed from uses outside of testing.

## Affects
Form migration process.

## Testing Instructions
- Create a v2 form.
- Attempt to migrate to a v3 form.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2009]: https://stellarwp.atlassian.net/browse/GIVE-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ