### PR TITLE
Fix: Load textdomain on `init` action hook

### DIFF
--- a/give.php
+++ b/give.php
@@ -268,6 +268,7 @@ final class Give
     /**
      * Init Give when WordPress Initializes.
      *
+     * @unreleased Move the loading of the `give` textdomain to the `init` action hook.
      * @since 1.8.9
      */
     public function init()
@@ -278,9 +279,6 @@ final class Give
          * @since 1.8.9
          */
         do_action('before_give_init');
-
-        // Set up localization.
-        $this->load_textdomain();
 
         $this->bindClasses();
 
@@ -379,6 +377,7 @@ final class Give
     /**
      * Bootstraps the Give Plugin
      *
+     * @unreleased Load the `give` textdomain on the `init` action hook.
      * @since 2.8.0
      */
     public function boot()
@@ -391,6 +390,9 @@ final class Give
         add_action('admin_notices', [$this, 'display_old_recurring_compatibility_notice']);
 
         add_action('plugins_loaded', [$this, 'init'], 0);
+
+        // Set up localization.
+        add_action('init', [$this, 'load_textdomain']);
 
         register_activation_hook(GIVE_PLUGIN_FILE, [$this, 'install']);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2015]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR moves the loading of the `give` textdomain to the `init` action hook, which was previously being loaded during `plugins_loaded`.

The release of WordPress v6.7.0 added a new notice when a textdomain is loaded "too early", see https://github.com/WordPress/wordpress-develop/commit/d42d95856e9ae3f9e2ed0aad176c066d7f8e3229.

>  **Notice**: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the give domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in `/wp-includes/functions.php on line 6114`

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Check that no notice is shown when using WordPress v6.7.0+.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2015]: https://stellarwp.atlassian.net/browse/GIVE-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ