### PR TITLE
Feature: Add support for integrating Blink Payment with the Donor Dashboard

### DIFF
--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -175,6 +175,8 @@ class App
             [],
             null
         );
+
+        do_action('give_donor_dashboard_enqueued_assets');
     }
 
     /**

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -129,8 +129,9 @@ class App
     /**
      * Enqueue assets for front-end donor dashboards
      *
+     * @unreleased Add action to allow enqueueing additional assets.
+     * @since      2.11.0 Set script translations.
      * @since 2.10.0
-     * @since 2.11.0 Set script translations.
      *
      * @return void
      */

--- a/src/DonorDashboards/App.php
+++ b/src/DonorDashboards/App.php
@@ -177,7 +177,7 @@ class App
             null
         );
 
-        do_action('give_donor_dashboard_enqueued_assets');
+        do_action('give_donor_dashboard_enqueue_assets');
     }
 
     /**

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -41,6 +41,7 @@ const SubscriptionManager = ({id, subscription}) => {
     const subscriptionStatus = subscription.payment.status?.id || subscription.payment.status.label.toLowerCase();
 
     const showAmountControls = subscription.gateway.can_update;
+    const showPaymentMethodControls = subscription.gateway.can_update_payment_method;
     const showPausingControls =
         subscription.gateway.can_pause && !['Quarterly', 'Yearly'].includes(subscription.payment.frequency);
 
@@ -109,11 +110,13 @@ const SubscriptionManager = ({id, subscription}) => {
                     onChange={setAmount}
                 />
             )}
-            <PaymentMethodControl
-                forwardedRef={gatewayRef}
-                label={__('Payment Method', 'give')}
-                gateway={subscription.gateway}
-            />
+            {showPaymentMethodControls && (
+                <PaymentMethodControl
+                    forwardedRef={gatewayRef}
+                    label={__('Payment Method', 'give')}
+                    gateway={subscription.gateway}
+                />
+            )}
 
             {loading && <DashboardLoadingSpinner />}
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -41,7 +41,7 @@ const SubscriptionManager = ({id, subscription}) => {
     const subscriptionStatus = subscription.payment.status?.id || subscription.payment.status.label.toLowerCase();
 
     const showAmountControls = subscription.gateway.can_update;
-    const showPaymentMethodControls = subscription.gateway.can_update_payment_method;
+    const showPaymentMethodControls = subscription.gateway.can_update_payment_method ?? showAmountControls;
     const showPausingControls =
         subscription.gateway.can_pause && !['Quarterly', 'Yearly'].includes(subscription.payment.frequency);
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -37,6 +37,11 @@ const SubscriptionManager = ({id, subscription}) => {
 
     const subscriptionStatus = subscription.payment.status?.id || subscription.payment.status.label.toLowerCase();
 
+    const showAmountControls = wp.hooks.applyFilters(
+        'give_donor_dashboard_subscription_manager_show_amount_controls',
+        true,
+        subscription
+    );
     const showPausingControls =
         subscription.gateway.can_pause && !['Quarterly', 'Yearly'].includes(subscription.payment.frequency);
 
@@ -95,14 +100,16 @@ const SubscriptionManager = ({id, subscription}) => {
 
     return (
         <div className={'give-donor-dashboard__subscription-manager'}>
-            <AmountControl
-                currency={subscription.payment.currency}
-                options={options}
-                max={max}
-                min={min}
-                value={amount}
-                onChange={setAmount}
-            />
+            {showAmountControls && (
+                <AmountControl
+                    currency={subscription.payment.currency}
+                    options={options}
+                    max={max}
+                    min={min}
+                    value={amount}
+                    onChange={setAmount}
+                />
+            )}
             <PaymentMethodControl
                 forwardedRef={gatewayRef}
                 label={__('Payment Method', 'give')}
@@ -135,7 +142,11 @@ const SubscriptionManager = ({id, subscription}) => {
                     </>
                 )}
 
-                <Button disabled={subscriptionStatus !== 'active'} classnames={subscriptionStatus !== 'active' && 'disabled'} onClick={handleUpdate}>
+                <Button
+                    disabled={subscriptionStatus !== 'active'}
+                    classnames={subscriptionStatus !== 'active' && 'disabled'}
+                    onClick={handleUpdate}
+                >
                     {updated ? (
                         <Fragment>
                             {__('Updated', 'give')} <FontAwesomeIcon icon="check" fixedWidth />

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -40,11 +40,7 @@ const SubscriptionManager = ({id, subscription}) => {
 
     const subscriptionStatus = subscription.payment.status?.id || subscription.payment.status.label.toLowerCase();
 
-    const showAmountControls = wp.hooks.applyFilters(
-        'give_donor_dashboard_subscription_manager_show_amount_controls',
-        true,
-        subscription
-    );
+    const showAmountControls = subscription.gateway.can_update;
     const showPausingControls =
         subscription.gateway.can_pause && !['Quarterly', 'Yearly'].includes(subscription.payment.frequency);
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -23,6 +23,9 @@ import SubscriptionCancelModal from '../subscription-cancel-modal';
  */
 const normalizeAmount = (float, decimals) => Number.parseFloat(float).toFixed(decimals);
 
+/**
+ * @unreleased Add support for hiding amount controls via filter
+ */
 const SubscriptionManager = ({id, subscription}) => {
     const gatewayRef = useRef();
     const [isPauseModalOpen, setIsPauseModalOpen] = useState(false);

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
@@ -25,8 +25,13 @@ const PaymentMethodControl = (props) => {
         case 'paypalpro': {
             return <CardControl {...props} />;
         }
+        case 'blink': {
+            // Donor Dashboard currently loads its own version of React so we need to pass it to the component
+            const Element = wp.hooks.applyFilters('give_donor_dashboard_blink_payment_method_control', null, props);
+            return Element && <Element {...props} React={React} />;
+        }
         default: {
-            return wp.hooks.applyFilters('give_donor_dashboard_payment_method_control', null, props, React);
+            return null;
         }
     }
 };

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
@@ -7,6 +7,9 @@ import CardControl from './card-control';
 
 import './style.scss';
 
+/**
+ * @unreleased Add controller for Blink payment method.
+ */
 const PaymentMethodControl = (props) => {
     switch (props.gateway.id) {
         case 'stripe':

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import AuthorizeControl from './authorize-control';
 import SquareControl from './square-control';
 import StripeControl from './stripe-control';
@@ -24,7 +26,7 @@ const PaymentMethodControl = (props) => {
             return <CardControl {...props} />;
         }
         default: {
-            return null;
+            return wp.hooks.applyFilters('give_donor_dashboard_payment_method_control', null, props, React);
         }
     }
 };

--- a/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
@@ -6,7 +6,7 @@ import {__} from '@wordpress/i18n';
 import {useWindowSize} from '../../hooks';
 import SubscriptionCancelModal from '../subscription-cancel-modal';
 
-import "./style.scss";
+import './style.scss';
 
 const SubscriptionRow = ({subscription}) => {
     const [isCancelModalOpen, setIsCancelModalOpen] = useState<boolean>(false);
@@ -52,14 +52,14 @@ const SubscriptionRow = ({subscription}) => {
                         {__('View Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                     </Link>
                 </div>
-                {gateway.can_update && (
+                {(gateway.can_update || gateway.can_update_payment_method) && (
                     <div className="give-donor-dashboard-table__donation-receipt">
                         <Link to={`/recurring-donations/manage/${id}`}>
                             {__('Manage Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                         </Link>
                     </div>
                 )}
-                {gateway.can_cancel && !gateway.can_update && (
+                {gateway.can_cancel && !(gateway.can_update || gateway.can_update_payment_method) && (
                     <>
                         {isCancelModalOpen && (
                             <SubscriptionCancelModal
@@ -69,7 +69,12 @@ const SubscriptionRow = ({subscription}) => {
                             />
                         )}
                         <div className="give-donor-dashboard-table__donation-receipt">
-                            <a className={'give-donor-dashboard-table__donation-receipt__cancel'} onClick={() => setIsCancelModalOpen(true)}>{__('Cancel Subscription', 'give')}</a>
+                            <a
+                                className={'give-donor-dashboard-table__donation-receipt__cancel'}
+                                onClick={() => setIsCancelModalOpen(true)}
+                            >
+                                {__('Cancel Subscription', 'give')}
+                            </a>
                         </div>
                     </>
                 )}

--- a/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
@@ -14,6 +14,8 @@ const SubscriptionRow = ({subscription}) => {
     const {width} = useWindowSize();
     const {id, payment, form, gateway} = subscription;
 
+    const canUpdateSubscription = gateway.can_update || gateway.can_update_payment_method;
+
     return (
         <div className="give-donor-dashboard-table__row">
             <div className="give-donor-dashboard-table__column">
@@ -52,14 +54,14 @@ const SubscriptionRow = ({subscription}) => {
                         {__('View Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                     </Link>
                 </div>
-                {(gateway.can_update || gateway.can_update_payment_method) && (
+                {canUpdateSubscription && (
                     <div className="give-donor-dashboard-table__donation-receipt">
                         <Link to={`/recurring-donations/manage/${id}`}>
                             {__('Manage Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                         </Link>
                     </div>
                 )}
-                {gateway.can_cancel && !(gateway.can_update || gateway.can_update_payment_method) && (
+                {gateway.can_cancel && !canUpdateSubscription && (
                     <>
                         {isCancelModalOpen && (
                             <SubscriptionCancelModal

--- a/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
@@ -14,7 +14,7 @@ const SubscriptionRow = ({subscription}) => {
     const {width} = useWindowSize();
     const {id, payment, form, gateway} = subscription;
 
-    const canUpdateSubscription = gateway.can_update || gateway.can_update_payment_method;
+    const gatewayCanUpdateSubscription = gateway.can_update || gateway.can_update_payment_method;
 
     return (
         <div className="give-donor-dashboard-table__row">
@@ -54,14 +54,14 @@ const SubscriptionRow = ({subscription}) => {
                         {__('View Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                     </Link>
                 </div>
-                {canUpdateSubscription && (
+                {gatewayCanUpdateSubscription && (
                     <div className="give-donor-dashboard-table__donation-receipt">
                         <Link to={`/recurring-donations/manage/${id}`}>
                             {__('Manage Subscription', 'give')} <FontAwesomeIcon icon="arrow-right" />
                         </Link>
                     </div>
                 )}
-                {gateway.can_cancel && !canUpdateSubscription && (
+                {gateway.can_cancel && !gatewayCanUpdateSubscription && (
                     <>
                         {isCancelModalOpen && (
                             <SubscriptionCancelModal


### PR DESCRIPTION
Needed for https://github.com/impress-org/give-recurring/pull/1212 and https://github.com/impress-org/give-blink/pull/10/files

## Description
Blink Payments does not support updating a subscription amount, only the credit card number. For this reason, this Pull Request adds several WordPress filters that allow us to hide the Amount field on the Subscription Manager page. Additionally, it introduces a filter enabling third parties to enqueue custom scripts in the Donor Dashboard and allowing Blink to render its own `PaymentMethodControl` component.

## Affects
Donor Dashboard

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

