### PR TITLE
Fix: include custom option within Manual Donation levels select element

### DIFF
--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -698,7 +698,7 @@ class Give_Donate_Form {
 
 		$ret    = 0;
 
-		if ( give_is_setting_enabled( $option ) || Utils::isV3Form($this->ID)) {
+		if ( give_is_setting_enabled( $option )) {
 			$ret = 1;
 		}
 

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -10,7 +10,6 @@
  */
 
 // Exit if accessed directly.
-use Give\Helpers\Form\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -698,7 +697,7 @@ class Give_Donate_Form {
 
 		$ret    = 0;
 
-		if ( give_is_setting_enabled( $option )) {
+		if ( give_is_setting_enabled( $option ) ) {
 			$ret = 1;
 		}
 

--- a/includes/class-give-donate-form.php
+++ b/includes/class-give-donate-form.php
@@ -10,6 +10,8 @@
  */
 
 // Exit if accessed directly.
+use Give\Helpers\Form\Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -693,9 +695,10 @@ class Give_Donate_Form {
 	public function is_custom_price_mode() {
 
 		$option = give_get_meta( $this->ID, '_give_custom_amount', true );
+
 		$ret    = 0;
 
-		if ( give_is_setting_enabled( $option ) ) {
+		if ( give_is_setting_enabled( $option ) || Utils::isV3Form($this->ID)) {
 			$ret = 1;
 		}
 

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -13,6 +13,7 @@
 use Give\Donations\Models\Donation;
 use Give\Helpers\Form\Utils;
 use Give\ValueObjects\Money;
+use Give\DonationForms\Models\DonationForm;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -1671,6 +1672,7 @@ function give_get_form_dropdown( $args = [], $echo = false ) {
  * @param array $args Arguments for form dropdown.
  * @param bool  $echo This parameter decide if print form dropdown html output or not.
  *
+ * @unreleased Show "Custom" choice in select field if v3 form has donation levels.
  * @since 1.6
  * @since 2.12.0 Show "Custom" choice in select field if donation created with cusotm amount
  *
@@ -1693,11 +1695,23 @@ function give_get_form_variable_price_dropdown( $args = [], $echo = false ) {
 	$variable_prices        = $form->get_prices();
 	$variable_price_options = [];
 
-	// Check if multi donation form support custom donation or not.
+    $v3Form = DonationForm::find($args['id']);
+    $v3FormDonationLevels = false;
+
+    if ($v3Form) {
+        $amountBlock = $v3Form->blocks->findByName('givewp/donation-amount');
+
+        if ($amountBlock) {
+            $v3FormDonationLevels = $amountBlock->getAttribute('priceOption') === 'multi';
+        }
+    }
+
+    // Check if multi donation form support custom donation or not.
 	// Check if donation amount is a custom or not.
 	if (
 		$form->is_custom_price_mode() ||
-		'custom' === $args['selected']
+		'custom' === $args['selected'] ||
+        $v3FormDonationLevels
 	) {
 		$variable_price_options['custom'] = _x( 'Custom', 'custom donation dropdown item', 'give' );
 	}


### PR DESCRIPTION
Resolves [GIVE-1290]

## Description
This PR updates the `is_custom_price_mode` to include v3 donation forms in its conditional check.  This will enable the "Custom" option inside v3 Donation levels select element.

## Acceptance criteria
When I want to add a manual donation for a custom amount on a Visual Builder form, I can select Custom from the Donation Level drop-down before entering the custom amount under Donation Amount, so I am sure that the correct amount will be saved.

## Affects
Custom price modes
Manual Donations - donation level options

## Visuals
### Testing v3
https://github.com/user-attachments/assets/fa8a5d1d-0837-4fb3-a416-95ff20f0cf98

### Testing v2
https://github.com/user-attachments/assets/17b21a14-de08-408a-a273-e06bec1274d3

## Testing Instructions
### v3
- Install & activate Manual Donations add-on.
- Create a v3 donation form & enable donation levels.
- Go to donations & add a manual donation.
- Select the v3 form from the dropdown.
- Verify within the donation levels that custom can be chosen.
- Testing v3 forms without Donation Levels will require ( https://github.com/impress-org/give-manual-donations/pull/181 )

### v2
- Create a v2 form enable custom amount
- Go to donations & add a manual donation.
- Select the v2 form from the dropdown.
- Verify within the donation levels that custom can be chosen.
- Disable custom amount through v2 form editing.
- Verify within the donation levels that custom is not an option.


## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1290]: https://stellarwp.atlassian.net/browse/GIVE-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ