### PR TITLE
Feature: add support to server validations for PayPal Donations gateway

### DIFF
--- a/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
+++ b/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
@@ -15,7 +15,7 @@ const generateRequestErrors = (values: Record<string, any>, errors: object[], se
             if (!canFocus) {
                 // In fields that aren't inputs by default or are hidden inputs, we need to use this workaround because the "shouldFocus" option will not work in these cases.
                 if (!fieldElement) {
-                    const fieldElementContainer = document.querySelector('.givewp-fields-' + String(field)); //E.g: <div class="givewp-fields-giftAid">content...</div>
+                    const fieldElementContainer = document.querySelector('.givewp-fields-' + field); //E.g: <div class="givewp-fields-giftAid">content...</div>
                     fieldElementContainer?.scrollIntoView({behavior: 'smooth'});
                 } else {
                     fieldElement.parentElement.scrollIntoView({behavior: 'smooth'}); // E.g: <input type="hidden" name="state">

--- a/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
+++ b/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
@@ -16,7 +16,7 @@ const generateRequestErrors = (values: Record<string, any>, errors: object[], se
                 // In fields that aren't inputs by default or are hidden inputs, we need to use this workaround because the "shouldFocus" option will not work in these cases.
                 if (!fieldElement) {
                     const fieldElementContainer = document.querySelector('.givewp-fields-' + String(field)); //E.g: <div class="givewp-fields-giftAid">content...</div>
-                    fieldElementContainer && fieldElementContainer.scrollIntoView({behavior: 'smooth'});
+                    fieldElementContainer?.scrollIntoView({behavior: 'smooth'});
                 } else {
                     fieldElement.parentElement.scrollIntoView({behavior: 'smooth'}); // E.g: <input type="hidden" name="state">
                 }

--- a/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
+++ b/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
@@ -7,7 +7,20 @@ import {__} from '@wordpress/i18n';
 const generateRequestErrors = (values: Record<string, any>, errors: object[], setError: UseFormSetError<any>) => {
     Object.entries(errors).forEach(([field, value]) => {
         if (Object.keys(values).includes(field)) {
-            setError(field, {message: Array.isArray(value) ? value[0] : value});
+            const fieldElement: HTMLInputElement = document.querySelector('input[name="' + field + '"]');
+            const canFocus = fieldElement && fieldElement.type !== 'hidden';
+
+            setError(field, {message: Array.isArray(value) ? value[0] : value}, {shouldFocus: canFocus});
+
+            if (!canFocus) {
+                // In custom fields that aren't inputs by default or hidden inputs, we need to use this workaround because the "shouldFocus" option will not work on these cases.
+                if (!fieldElement) {
+                    const fieldElementContainer = document.querySelector('.givewp-fields-' + String(field)); //E.g: <div class="givewp-fields-giftAid">content...</div>
+                    fieldElementContainer.scrollIntoView({behavior: 'smooth'});
+                } else {
+                    fieldElement.parentElement.scrollIntoView({behavior: 'smooth'}); // E.g: <input type="hidden" name="state">
+                }
+            }
         } else if (field === 'gateway_error') {
             setError('FORM_ERROR', {message: Array.isArray(value) ? value[0] : value});
         } else {

--- a/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
+++ b/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
@@ -16,7 +16,7 @@ const generateRequestErrors = (values: Record<string, any>, errors: object[], se
                 // In fields that aren't inputs by default or are hidden inputs, we need to use this workaround because the "shouldFocus" option will not work in these cases.
                 if (!fieldElement) {
                     const fieldElementContainer = document.querySelector('.givewp-fields-' + String(field)); //E.g: <div class="givewp-fields-giftAid">content...</div>
-                    fieldElementContainer.scrollIntoView({behavior: 'smooth'});
+                    fieldElementContainer && fieldElementContainer.scrollIntoView({behavior: 'smooth'});
                 } else {
                     fieldElement.parentElement.scrollIntoView({behavior: 'smooth'}); // E.g: <input type="hidden" name="state">
                 }

--- a/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
+++ b/src/DonationForms/resources/app/utilities/generateRequestErrors.ts
@@ -13,7 +13,7 @@ const generateRequestErrors = (values: Record<string, any>, errors: object[], se
             setError(field, {message: Array.isArray(value) ? value[0] : value}, {shouldFocus: canFocus});
 
             if (!canFocus) {
-                // In custom fields that aren't inputs by default or hidden inputs, we need to use this workaround because the "shouldFocus" option will not work on these cases.
+                // In fields that aren't inputs by default or are hidden inputs, we need to use this workaround because the "shouldFocus" option will not work in these cases.
                 if (!fieldElement) {
                     const fieldElementContainer = document.querySelector('.givewp-fields-' + String(field)); //E.g: <div class="givewp-fields-giftAid">content...</div>
                     fieldElementContainer.scrollIntoView({behavior: 'smooth'});

--- a/src/Framework/Migrations/Controllers/ManualMigration.php
+++ b/src/Framework/Migrations/Controllers/ManualMigration.php
@@ -36,16 +36,17 @@ class ManualMigration
     }
 
     /**
+     * @unreleased sanitize params
      * @since 2.9.2
      */
     public function __invoke()
     {
         if ( ! empty($_GET['give-run-migration'])) {
-            $migrationToRun = $_GET['give-run-migration'];
+            $migrationToRun = give_clean($_GET['give-run-migration']);
         }
 
         if ( ! empty($_GET['give-clear-update'])) {
-            $migrationToClear = $_GET['give-clear-update'];
+            $migrationToClear = give_clean($_GET['give-clear-update']);
         }
 
         $hasMigration = isset($migrationToRun) || isset($migrationToClear);

--- a/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/PayPalCommerceGateway.php
@@ -2,6 +2,8 @@
 
 namespace Give\PaymentGateways\Gateways\PayPalCommerce;
 
+use Exception;
+use Give\DonationForms\Actions\GenerateDonationFormValidationRouteUrl;
 use Give\Framework\Support\Scripts\Concerns\HasScriptAssetFile;
 use Give\Helpers\Language;
 use Give\PaymentGateways\PayPalCommerce\Models\MerchantDetail;
@@ -51,7 +53,9 @@ class PayPalCommerceGateway extends PayPalCommerce
     }
 
     /**
-     * @throws \Exception
+     * @unreleased Add validate URL
+     *
+     * @throws Exception
      */
     public function formSettings(int $formId): array
     {
@@ -60,6 +64,7 @@ class PayPalCommerceGateway extends PayPalCommerce
             'donationFormId' => $formId,
             'donationFormNonce' => wp_create_nonce("give_donation_form_nonce_{$formId}"),
             'sdkOptions' => $this->getPayPalSDKOptions($formId),
+            'validateUrl' => (new GenerateDonationFormValidationRouteUrl())(),
         ];
     }
 
@@ -67,7 +72,7 @@ class PayPalCommerceGateway extends PayPalCommerce
      * List of PayPal query parameters: https://developer.paypal.com/docs/checkout/reference/customize-sdk/#query-parameters
      *
      * @since 3.0.0
-     * @throws \Exception
+     * @throws Exception
      */
     private function getPayPalSDKOptions(int $formId): array
     {

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -316,34 +316,6 @@ import handleValidationRequest from '@givewp/forms/app/utilities/handleValidatio
         return children;
     };
 
-    /**
-     * @since 3.12.2
-     */
-    const getRequiredValidationMessage = () => {
-        return __('This is a required field', 'give');
-    };
-
-    /**
-     * @since 3.12.2
-     */
-    const isCityRequired = () => {
-        return Boolean(document.querySelector('.givewp-fields-text-city .givewp-field-required'));
-    };
-
-    /**
-     * @since 3.12.2
-     */
-    const isStateRequired = () => {
-        return Boolean(document.querySelector('.givewp-fields-select-state .givewp-field-required'));
-    };
-
-    /**
-     * @since 3.12.2
-     */
-    const isZipRequired = () => {
-        return Boolean(document.querySelector('.givewp-fields-text-zip .givewp-field-required'));
-    };
-
     const SmartButtonsContainer = () => {
         const {useWatch, useFormState} = window.givewp.form.hooks;
         const donationType = useWatch({name: 'donationType'});
@@ -397,7 +369,22 @@ import handleValidationRequest from '@givewp/forms/app/utilities/handleValidatio
                     return actions.reject();
                 }
 
-                // Validate the form values in the server side before proceeding.
+                /**
+                 * Validate the form values in the server side before proceeding - this is important to prevent problems with some blocks.
+                 *
+                 * Ideally, the client-side validations should be enough. However, in some cases, these validations are reached
+                 * later when the donation is already created on the PayPal side. This way, we need the request below to check
+                 * it earlier and prevent the donation creation on the PayPal side if the required fields are missing.
+                 *
+                 * Know cases:
+                 *
+                 * #1 - Billing Address Block: depending on the selected country, the city, state, and zip fields
+                 * can be required or not and there are custom validation rules on the server side that check it.
+                 *
+                 * #2 - Gift Aid Block: when users opt-in to the gift aid checkbox, it will display some
+                 * required fields that should be filled, but as this block is not a group and even so has
+                 * "children" fields, the validation rules for it live only on the server.
+                 */
                 const isServerValidationSuccessful = await handleValidationRequest(
                     payPalDonationsSettings.validateUrl,
                     getValues(),
@@ -407,45 +394,6 @@ import handleValidationRequest from '@givewp/forms/app/utilities/handleValidatio
 
                 if (!isServerValidationSuccessful) {
                     return actions.reject();
-                }
-
-                /**
-                 * Depending on the selected country, the city, state, and zip fields can be required or not and there are custom
-                 * validation rules on the server side that check that. However, in this case, these validations are reached later
-                 * when the donation is already created on the PayPal side. This way, we need the conditions below to check it earlier
-                 * and prevent the donation creation on the PayPal side if the required billing address fields are missing.
-                 */
-                if (country) {
-                    if (city.length === 0 && isCityRequired()) {
-                        setError(
-                            'city',
-                            {
-                                type: 'custom',
-                                message: getRequiredValidationMessage(),
-                            },
-                            {shouldFocus: true}
-                        );
-                        return actions.reject();
-                    }
-
-                    if (state.length === 0 && isStateRequired()) {
-                        setError(
-                            'state',
-                            {
-                                type: 'custom',
-                                message: getRequiredValidationMessage(),
-                            },
-                            {shouldFocus: true}
-                        );
-                        // As the state is a hidden field we need to use this workaround because the "shouldFocus" option does not work in hidden fields.
-                        document.querySelector('.givewp-fields-select-state').scrollIntoView({behavior: 'smooth'});
-                        return actions.reject();
-                    }
-
-                    if (postalCode.length === 0 && isZipRequired()) {
-                        setError('zip', {type: 'custom', message: getRequiredValidationMessage()}, {shouldFocus: true});
-                        return actions.reject();
-                    }
                 }
 
                 orderCreated = true;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2043]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a request to validate the donation form on the server side when the donor clicks on the PayPal Donations smart buttons, this way we can prevent the creation of donations on the PayPal side if the form has some invalid data with custom validation rules that only can be triggered on the server side.

Also, it removes the work around implemented a while ago to validate the billing address block before creating the PayPal donation, this is not more necessary now that we have the validations being triggered on the server-side.

This change can potentially prevent any future problem related to validations not being triggered for the PayPal Donations gateway because now we can ensure that all validations on both sides (client and server) will always be triggered before the payment process.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The PayPal Donations gateway.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/08784812-e9ec-4cd8-8a5c-914747707511)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add the billing address block to a donation form; 
2. Leave some required address fields empty; 
3. Try to create a test donation using the PayPal Donations gateway;
4. You should have the donation blocked and see some error messages next to the empty fields.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2043]: https://stellarwp.atlassian.net/browse/GIVE-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ