### PR TITLE
Fix: make entity prop optional

### DIFF
--- a/src/Campaigns/resources/admin/components/types.ts
+++ b/src/Campaigns/resources/admin/components/types.ts
@@ -29,6 +29,13 @@ export type Campaign = {
     defaultFormTitle: string;
 };
 
+export type CampaignEntity = {
+    campaign: Campaign;
+    hasResolved: boolean;
+    edit: (data: Campaign) => void
+    save: () => any
+}
+
 /*export interface Campaign {
     id: number;
     title: string;

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -14,6 +14,7 @@ import AddCampaignFormModal from './AddCampaignFormModal';
 import DefaultFormNotice
     from '@givewp/campaigns/admin/components/CampaignDetailsPage/Components/Notices/DefaultFormNotice';
 import apiFetch from "@wordpress/api-fetch";
+import {CampaignEntity} from "@givewp/campaigns/admin/components/types";
 
 declare global {
     interface Window {
@@ -268,7 +269,7 @@ const ListTableBlankSlate = (
     />
 );
 
-export default function DonationFormsListTable({entity}) {
+export default function DonationFormsListTable({entity}: {entity?: CampaignEntity}) {
     const [state, setState] = useState<OnboardingStateProps>({
         showFeatureNoticeDialog: false,
         showDefaultFormTooltip: window.GiveDonationForms.showDefaultFormTooltip,


### PR DESCRIPTION
## Description

This PR resolves the issue where the `entity` prop was required for the `DonationFormsListTable` component outside the Campaign context. 

## Affects

DonationFormsListTable component


<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

