### PR TITLE
Refactor: migrate v2 forms to campaigns and add upgraded forms as campaign not-default forms

### DIFF
--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -151,7 +151,7 @@ class MigrateFormsToCampaignForms extends Migration
 
         $campaignId = DB::last_insert_id();
 
-        $this->addCampaignFormRelationship($formId, $campaignId, true);
+        $this->addCampaignFormRelationship($formId, $campaignId);
     }
 
     /**
@@ -165,13 +165,12 @@ class MigrateFormsToCampaignForms extends Migration
     /**
      * @unreleased
      */
-    protected function addCampaignFormRelationship($formId, $campaignId, $isDefault = false)
+    protected function addCampaignFormRelationship($formId, $campaignId)
     {
         DB::table('give_campaign_forms')
             ->insert([
                 'form_id' => $formId,
                 'campaign_id' => $campaignId,
-                'is_default' => $isDefault,
             ]);
     }
 

--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -122,9 +122,9 @@ class MigrateFormsToCampaignForms extends Migration
         $isV3Form = Utils::isV3Form($formId);
 
         /**
-         * The V2 forms with upgraded status should be skipped because their correspondent V3 version already was migrated at this point.
+         * The upgraded V2 forms should be skipped for now because their corresponding V3 version will be used to create the campaign - it will be added later as a non-default form.
          */
-        if ( ! $isV3Form && 'upgraded' == $formStatus) {
+        if ( ! $isV3Form && _give_is_form_migrated($formId)) {
             return;
         }
 
@@ -135,7 +135,7 @@ class MigrateFormsToCampaignForms extends Migration
                 'form_id' => $formId,
                 'campaign_type' => 'core',
                 'campaign_title' => $formTitle,
-                'status' => $this->mapFormToCampaignStatus($formData->status),
+                'status' => $this->mapFormToCampaignStatus($formStatus),
                 'short_desc' => $formSettings->formExcerpt,
                 'long_desc' => $formSettings->description,
                 'campaign_logo' => $formSettings->designSettingsLogoUrl,

--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -78,7 +78,7 @@ class MigrateFormsToCampaignForms extends Migration
             ->whereIsNull('campaigns.id');
 
         /**
-         * Exclude forms with an `upgraded` status, which are WP revisions.
+         * Exclude forms with an "auto-draft" status, which are WP revisions.
          *
          * @see https://wordpress.org/documentation/article/post-status/#auto-draft
          */

--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -206,7 +206,8 @@ class MigrateFormsToCampaignForms extends Migration
     protected function getV2FormSettings(int $formId): stdClass
     {
         $template = give_get_meta($formId, '_give_form_template', true);
-        $templateSettings = give_get_meta($formId, "_give_{$template}_form_template_settings", true) ?? [];
+        $templateSettings = give_get_meta($formId, "_give_{$template}_form_template_settings", true);
+        $templateSettings = is_array($templateSettings) ? $templateSettings : [];
 
         return (object)[
             'formExcerpt' => get_the_excerpt($formId),

--- a/src/FormMigration/Controllers/MigrationController.php
+++ b/src/FormMigration/Controllers/MigrationController.php
@@ -54,8 +54,9 @@ class MigrationController
 
                 // Associate upgraded form to a campaign
                 $campaignRepository = give(CampaignRepository::class);
-                $campaign = $campaignRepository->getByFormId($payload->formV2->id);
-                $campaignRepository->addCampaignForm($campaign, $payload->formV3->id);
+                if ($campaign = $campaignRepository->getByFormId($payload->formV2->id)) {
+                    $campaignRepository->addCampaignForm($campaign, $payload->formV3->id);
+                }
 
                 Log::info(esc_html__('Form migrated from v2 to v3.', 'give'), $this->debugContext);
             });

--- a/src/FormMigration/Controllers/TransferController.php
+++ b/src/FormMigration/Controllers/TransferController.php
@@ -4,13 +4,11 @@ namespace Give\FormMigration\Controllers;
 
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\DonationForms\V2\Models\DonationForm;
-use Give\DonationForms\ValueObjects\DonationFormStatus;
 use Give\FormMigration\Actions\GetMigratedFormId;
 use Give\FormMigration\Actions\TransferDonations;
 use Give\FormMigration\Actions\TransferFormUrl;
 use Give\FormMigration\DataTransferObjects\TransferOptions;
 use Give\Framework\Database\DB;
-use Give\Framework\QueryBuilder\QueryBuilder;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -38,11 +36,12 @@ class TransferController
 
             // Promote upgraded form to default form
             $campaignRepository = give(CampaignRepository::class);
-            $campaign = $campaignRepository->getByFormId($formV2->id);
-            $defaultForm = $campaign->defaultForm();
+            if ($campaign = $campaignRepository->getByFormId($formV2->id)) {
+                $defaultForm = $campaign->defaultForm();
 
-            if ($defaultForm->id === $formV2->id) {
-                $campaignRepository->updateDefaultCampaignForm($campaign, $v3FormId);
+                if ($defaultForm->id === $formV2->id) {
+                    $campaignRepository->updateDefaultCampaignForm($campaign, $v3FormId);
+                }
             }
 
             if($options->shouldDelete()) {

--- a/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
+++ b/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
@@ -78,10 +78,8 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
         $migration = new MigrateFormsToCampaignForms();
         $migration->run();
 
-        $relationship = DB::table('give_campaign_forms')->where('form_id', $upgradedForm->id)->get();
         $campaign = Campaign::findByFormId($upgradedForm->id);
 
-        $this->assertNotNull($relationship);
         $this->assertNotNull($campaign);
         $this->assertEquals(0, DB::table('give_campaigns')->where('form_id', $upgradedForm->id)->count());
         $this->assertEquals(1, DB::table('give_campaigns')->where('form_id', $newForm->id)->count());

--- a/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
+++ b/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
@@ -82,6 +82,7 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
         $campaign = Campaign::findByFormId($upgradedForm->id);
 
         $this->assertNotNull($relationship);
+        $this->assertNotNull($campaign);
         $this->assertEquals(0, DB::table('give_campaigns')->where('form_id', $upgradedForm->id)->count());
         $this->assertEquals(1, DB::table('give_campaigns')->where('form_id', $newForm->id)->count());
         $this->assertEquals(2, DB::table('give_campaign_forms')->where('campaign_id', $campaign->id)->count());

--- a/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
+++ b/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
@@ -41,6 +41,31 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
      *
      * @throws Exception
      */
+    public function testCreatesParentCampaignForOptionBasedDonationForm()
+    {
+        $formId = $this->factory()->post->create(
+            [
+                'post_title' => 'Test Form',
+                'post_type' => 'give_forms',
+                'post_status' => 'publish',
+            ]
+        );
+
+        $migration = new MigrateFormsToCampaignForms();
+
+        $migration->run();
+
+        $relationship = DB::table('give_campaign_forms')->where('form_id', $formId)->get();
+
+        $this->assertNotNull(Campaign::find($relationship->campaign_id));
+        $this->assertEquals($formId, $relationship->form_id);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
     public function testExistingPeerToPeerCampaignFormsAreNotMigrated()
     {
         $form = DonationForm::factory()->create();

--- a/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
+++ b/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
@@ -62,7 +62,7 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
      *
      * @throws Exception
      */
-    public function testUpgradedFormsAreMigrated()
+    public function testUpgradedFormsAreNotMigrated()
     {
         $upgradedForm = DonationForm::factory()->create([
             'status' => DonationFormStatus::UPGRADED(),
@@ -79,9 +79,12 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
         $migration->run();
 
         $relationship = DB::table('give_campaign_forms')->where('form_id', $upgradedForm->id)->get();
+        $campaign = Campaign::findByFormId($upgradedForm->id);
 
         $this->assertNotNull($relationship);
-        $this->assertEquals(2, DB::table('give_campaigns')->count());
+        $this->assertEquals(0, DB::table('give_campaigns')->where('form_id', $upgradedForm->id)->count());
+        $this->assertEquals(1, DB::table('give_campaigns')->where('form_id', $newForm->id)->count());
+        $this->assertEquals(2, DB::table('give_campaign_forms')->where('campaign_id', $campaign->id)->count());
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2032]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR makes the migrations of Forms to Campaigns also consider V2 forms. It also fixed a problem that was preventing forms with the upgraded status from being associated with campaigns as not-default forms in certain scenarios.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The migrations of Forms to Campaigns.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/7bf0d4727f944c0da29fd0df9219d7bc?sid=2b9f341f-c61a-4f13-b088-b8600b09afab

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. In a fresh install create a few V2 and V3 forms;
2. Migrate some V2 forms to V3 forms;
3. Install the Give version of this branch;
4. The migration should convert V2 forms to Campaigns;
5. The migration should associate V2 upgraded forms to Campaigns as not-default forms.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2032]: https://stellarwp.atlassian.net/browse/GIVE-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ