### PR TITLE
Feature: Add campaign title block

### DIFF
--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -2,6 +2,8 @@
 
 namespace Give\Campaigns\Actions;
 
+use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+
 class RegisterCampaignBlocks
 {
     public function __invoke()
@@ -11,5 +13,30 @@ class RegisterCampaignBlocks
         foreach ($blocks as $block) {
             register_block_type(dirname(__DIR__) . '/Blocks/' . basename($block));
         }
+
+        $this->enqueueBlocksAssets();
+    }
+
+    private function enqueueBlocksAssets()
+    {
+        $handleName = 'givewp-campaign-blocks';
+        $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignBlocks.asset.php');
+
+        wp_register_script(
+            $handleName,
+            GIVE_PLUGIN_URL . 'build/campaignBlocks.js',
+            $scriptAsset['dependencies'],
+            $scriptAsset['version'],
+            true
+        );
+
+        wp_enqueue_script($handleName);
+        wp_enqueue_style(
+            $handleName,
+            GIVE_PLUGIN_URL . 'build/campaignBlocks.css',
+            /** @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-components/#usage */
+            ['wp-components'],
+            $scriptAsset['version']
+        );
     }
 }

--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Give\Campaigns\Actions;
+
+class RegisterCampaignBlocks
+{
+    public function __invoke()
+    {
+        $blocks = glob(dirname(__DIR__) . '/Blocks/*', GLOB_ONLYDIR);
+
+        foreach ($blocks as $block) {
+            register_block_type(dirname(__DIR__) . '/Blocks/' . basename($block));
+        }
+    }
+}

--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -4,8 +4,14 @@ namespace Give\Campaigns\Actions;
 
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 
+/**
+ * @unreleased
+ */
 class RegisterCampaignBlocks
 {
+    /**
+     * @unreleased
+     */
     public function __invoke()
     {
         $blocks = glob(dirname(__DIR__) . '/Blocks/*', GLOB_ONLYDIR);
@@ -17,6 +23,9 @@ class RegisterCampaignBlocks
         $this->enqueueBlocksAssets();
     }
 
+    /**
+     * @unreleased
+     */
     private function enqueueBlocksAssets()
     {
         $handleName = 'givewp-campaign-blocks';

--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -16,9 +16,7 @@ class RegisterCampaignBlocks
     {
         $blocks = glob(dirname(__DIR__) . '/Blocks/*', GLOB_ONLYDIR);
 
-        foreach ($blocks as $block) {
-            register_block_type(dirname(__DIR__) . '/Blocks/' . basename($block));
-        }
+        array_map('register_block_type', $blocks);
 
         $this->enqueueBlocksAssets();
     }

--- a/src/Campaigns/Actions/RegisterCampaignIdRestField.php
+++ b/src/Campaigns/Actions/RegisterCampaignIdRestField.php
@@ -2,8 +2,14 @@
 
 namespace Give\Campaigns\Actions;
 
+/**
+ * @unreleased
+ */
 class RegisterCampaignIdRestField
 {
+    /**
+     * @unreleased
+     */
     public function __invoke()
     {
         register_rest_field(

--- a/src/Campaigns/Actions/RegisterCampaignIdRestField.php
+++ b/src/Campaigns/Actions/RegisterCampaignIdRestField.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Give\Campaigns\Actions;
+
+class RegisterCampaignIdRestField
+{
+    public function __invoke()
+    {
+        register_rest_field(
+            'give_campaign_page',
+            'campaignId',
+            [
+                'get_callback' => function ($object) {
+                    return get_post_meta($object['id'], 'campaignId', true);
+                },
+                'update_callback' => function ($value, $object) {
+                    return update_post_meta($object->ID, 'campaignId', (int) $value);
+                },
+                'schema' => [
+                    'description' => 'Campaign ID',
+                    'type' => 'string',
+                    'context' => ['view', 'edit'],
+                ],
+            ]
+        );
+    }
+}

--- a/src/Campaigns/Blocks/CampaignTitleBlock/block.json
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/block.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "givewp/campaign-title-block",
+    "version": "1.0.0",
+    "title": "Campaign Title",
+    "category": "give",
+    "icon": "heading",
+    "description": "Displays the title of the campaign.",
+    "supports": {
+        "html": false
+    },
+    "attributes": {
+        "campaignId": {
+            "type": "integer"
+        },
+        "headingLevel": {
+            "type": "number",
+            "default": 1
+        }
+    },
+    "textdomain": "give",
+    "editorScript": "file:./../../../../build/Campaigns/Blocks/campaignTitleBlock.js",
+    "editorStyle": "file:./../../../../build/Campaigns/Blocks/campaignTitleBlock.css",
+    "render": "file:./render.php"
+}

--- a/src/Campaigns/Blocks/CampaignTitleBlock/block.json
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/block.json
@@ -7,9 +7,6 @@
     "category": "give",
     "icon": "heading",
     "description": "Displays the title of the campaign.",
-    "supports": {
-        "html": false
-    },
     "attributes": {
         "campaignId": {
             "type": "integer"
@@ -17,10 +14,56 @@
         "headingLevel": {
             "type": "number",
             "default": 1
+        },
+        "textAlign": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "align": [
+            "wide",
+            "full"
+        ],
+        "anchor": true,
+        "className": true,
+        "splitting": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalWritingMode": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
         }
     },
     "textdomain": "give",
-    "editorScript": "file:./../../../../build/Campaigns/Blocks/campaignTitleBlock.js",
-    "editorStyle": "file:./../../../../build/Campaigns/Blocks/campaignTitleBlock.css",
     "render": "file:./render.php"
 }

--- a/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
@@ -20,6 +20,7 @@ export default function Edit({attributes, setAttributes}) {
     const {campaign, hasResolved} = useCampaign(attributes.campaignId);
 
     const adminBaseUrl = useSelect(
+        // @ts-ignore
         (select) => select('core').getSite()?.url + '/wp-admin/edit.php?post_type=give_forms&page=give-campaigns',
         []
     );

--- a/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
@@ -1,0 +1,62 @@
+import {BlockControls, HeadingLevelDropdown, InspectorControls, useBlockProps} from '@wordpress/block-editor';
+import {BaseControl, Icon, PanelBody, TextareaControl} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import {CampaignSelector} from '../shared/components/CampaignSelector';
+import useCampaign from '../shared/hooks/useCampaign';
+import {__} from '@wordpress/i18n';
+import {useSelect} from '@wordpress/data';
+import {external} from '@wordpress/icons';
+
+import './editor.scss';
+
+export default function Edit({attributes, setAttributes}) {
+    const blockProps = useBlockProps();
+    const {campaign, hasResolved} = useCampaign(attributes.campaignId);
+
+    const adminBaseUrl = useSelect(
+        (select) => select('core').getSite()?.url + '/wp-admin/edit.php?post_type=give_forms&page=give-campaigns',
+        []
+    );
+
+    const editCampaignUrl = `${adminBaseUrl}&id=${attributes.campaignId}&tab=settings`;
+
+    return (
+        <div {...blockProps}>
+            <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
+                <ServerSideRender block="givewp/campaign-title-block" attributes={attributes} />
+            </CampaignSelector>
+
+            {hasResolved && campaign && (
+                <InspectorControls>
+                    <PanelBody title="Settings" initialOpen={true}>
+                        <BaseControl label="Title">
+                            <TextareaControl
+                                value={campaign.title}
+                                readOnly={true}
+                                onChange={() => null}
+                                help={
+                                    <a
+                                        href={editCampaignUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="givewp-campaign-title-block__edit-campaign-link"
+                                    >
+                                        {__('Edit campaign title', 'give')}
+                                        <Icon icon={external} />
+                                    </a>
+                                }
+                            />
+                        </BaseControl>
+                    </PanelBody>
+                </InspectorControls>
+            )}
+
+            <BlockControls>
+                <HeadingLevelDropdown
+                    value={attributes.headingLevel}
+                    onChange={(newLevel: string) => setAttributes({headingLevel: newLevel})}
+                />
+            </BlockControls>
+        </div>
+    );
+}

--- a/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
@@ -36,7 +36,7 @@ export default function Edit({attributes, setAttributes}) {
             {hasResolved && campaign && (
                 <InspectorControls>
                     <PanelBody title="Settings" initialOpen={true}>
-                        <BaseControl label="Title">
+                        <BaseControl label="Title" id="givewp-campaign-title-block__title-field">
                             <TextareaControl
                                 value={campaign.title}
                                 readOnly={true}
@@ -47,6 +47,7 @@ export default function Edit({attributes, setAttributes}) {
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="givewp-campaign-title-block__edit-campaign-link"
+                                        aria-label={__('Edit campaign settings in a new tab', 'give')}
                                     >
                                         {__('Edit campaign title', 'give')}
                                         <Icon icon={external} />

--- a/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
@@ -5,6 +5,7 @@ import {
     InspectorControls,
     useBlockProps,
 } from '@wordpress/block-editor';
+import {BlockEditProps} from '@wordpress/blocks';
 import {BaseControl, Icon, PanelBody, TextareaControl} from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import {CampaignSelector} from '../shared/components/CampaignSelector';
@@ -15,7 +16,14 @@ import {external} from '@wordpress/icons';
 
 import './editor.scss';
 
-export default function Edit({attributes, setAttributes}) {
+export default function Edit({
+    attributes,
+    setAttributes,
+}: BlockEditProps<{
+    campaignId: number;
+    headingLevel: string;
+    textAlign: string;
+}>) {
     const blockProps = useBlockProps();
     const {campaign, hasResolved} = useCampaign(attributes.campaignId);
 
@@ -66,9 +74,7 @@ export default function Edit({attributes, setAttributes}) {
                 />
                 <AlignmentControl
                     value={attributes.textAlign}
-                    onChange={(nextAlign) => {
-                        setAttributes({textAlign: nextAlign});
-                    }}
+                    onChange={(nextAlign: string) => setAttributes({textAlign: nextAlign})}
                 />
             </BlockControls>
         </div>

--- a/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/edit.tsx
@@ -1,4 +1,10 @@
-import {BlockControls, HeadingLevelDropdown, InspectorControls, useBlockProps} from '@wordpress/block-editor';
+import {
+    AlignmentControl,
+    BlockControls,
+    HeadingLevelDropdown,
+    InspectorControls,
+    useBlockProps,
+} from '@wordpress/block-editor';
 import {BaseControl, Icon, PanelBody, TextareaControl} from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import {CampaignSelector} from '../shared/components/CampaignSelector';
@@ -55,6 +61,12 @@ export default function Edit({attributes, setAttributes}) {
                 <HeadingLevelDropdown
                     value={attributes.headingLevel}
                     onChange={(newLevel: string) => setAttributes({headingLevel: newLevel})}
+                />
+                <AlignmentControl
+                    value={attributes.textAlign}
+                    onChange={(nextAlign) => {
+                        setAttributes({textAlign: nextAlign});
+                    }}
                 />
             </BlockControls>
         </div>

--- a/src/Campaigns/Blocks/CampaignTitleBlock/editor.scss
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/editor.scss
@@ -1,0 +1,13 @@
+.givewp-campaign-title-block {
+    &__edit-campaign-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.125rem;
+
+        svg {
+            fill: currentColor;
+            height: 1.25rem;
+            width: 1.25rem;
+        }
+    }
+}

--- a/src/Campaigns/Blocks/CampaignTitleBlock/index.ts
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/index.ts
@@ -1,0 +1,8 @@
+import {registerBlockType} from '@wordpress/blocks';
+import metadata from './block.json';
+import Edit from './edit';
+
+// @ts-ignore
+registerBlockType(metadata.name, {
+    edit: Edit
+});

--- a/src/Campaigns/Blocks/CampaignTitleBlock/index.ts
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/index.ts
@@ -1,8 +1,12 @@
-import {registerBlockType} from '@wordpress/blocks';
 import metadata from './block.json';
 import Edit from './edit';
+import initBlock from '../shared/utils/init-block';
 
-// @ts-ignore
-registerBlockType(metadata.name, {
-    edit: Edit
-});
+const {name} = metadata;
+
+export {metadata, name};
+export const settings = {
+    edit: Edit,
+};
+
+export const init = () => initBlock({name, metadata, settings});

--- a/src/Campaigns/Blocks/CampaignTitleBlock/render.php
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/render.php
@@ -16,8 +16,12 @@ if (! $campaign) {
 
 $headingLevel = isset($attributes['headingLevel']) ? (int) $attributes['headingLevel'] : 1;
 $headingTag = 'h' . min(6, max(1, $headingLevel));
+
+$textAlignClass = isset($attributes['textAlign']) ? 'has-text-align-' . $attributes['textAlign'] : '';
 ?>
 
-<<?php echo $headingTag; ?> <?php echo wp_kses_data(get_block_wrapper_attributes()); ?>>
+<<?php
+echo $headingTag; ?> <?php
+echo wp_kses_data(get_block_wrapper_attributes(['class' => $textAlignClass])); ?>>
 <?php echo esc_html($campaign->title); ?>
 </<?php echo $headingTag; ?>>

--- a/src/Campaigns/Blocks/CampaignTitleBlock/render.php
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/render.php
@@ -3,7 +3,7 @@
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 
-if (empty($attributes) || !isset($attributes['campaignId'])) {
+if ( ! isset($attributes['campaignId'])) {
     return;
 }
 

--- a/src/Campaigns/Blocks/CampaignTitleBlock/render.php
+++ b/src/Campaigns/Blocks/CampaignTitleBlock/render.php
@@ -1,0 +1,23 @@
+<?php
+
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\Repositories\CampaignRepository;
+
+if (empty($attributes) || !isset($attributes['campaignId'])) {
+    return;
+}
+
+/** @var Campaign $campaign */
+$campaign = give(CampaignRepository::class)->getById($attributes['campaignId']);
+
+if (! $campaign) {
+    return;
+}
+
+$headingLevel = isset($attributes['headingLevel']) ? (int) $attributes['headingLevel'] : 1;
+$headingTag = 'h' . min(6, max(1, $headingLevel));
+?>
+
+<<?php echo $headingTag; ?> <?php echo wp_kses_data(get_block_wrapper_attributes()); ?>>
+<?php echo esc_html($campaign->title); ?>
+</<?php echo $headingTag; ?>>

--- a/src/Campaigns/Blocks/blocks.ts
+++ b/src/Campaigns/Blocks/blocks.ts
@@ -1,0 +1,9 @@
+import * as campaignTitleBlock from './CampaignTitleBlock';
+
+const getAllBlocks = () => {
+    return [campaignTitleBlock];
+};
+
+getAllBlocks().forEach((block) => {
+    block.init();
+});

--- a/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
@@ -1,0 +1,48 @@
+import {PanelBody, SelectControl} from '@wordpress/components';
+import {InspectorControls} from '@wordpress/block-editor';
+import useCampaigns from '../hooks/useCampaigns';
+import {Campaign} from '@givewp/campaigns/admin/components/types';
+import {__} from '@wordpress/i18n';
+
+export default function CampaignDropdown({campaignId, setAttributes, placement = 'sidebar'}) {
+    const {campaigns, hasResolved} = useCampaigns();
+
+    const options = (() => {
+        if (!hasResolved) {
+            return [{label: __('Loading...', 'give'), value: ''}];
+        }
+
+        if (campaigns.length) {
+            const campaignOptions = campaigns.map((campaign) => ({
+                label: campaign.title,
+                value: campaign.id.toString(),
+            }));
+
+            return [{label: __('Select...', 'give'), value: ''}, ...campaignOptions];
+        }
+
+        return [{label: __('No campaigns found.', 'give'), value: ''}];
+    })();
+
+    const dropdown = (
+        <SelectControl
+            label={__('Select a Campaign', 'give')}
+            value={campaignId || ''}
+            options={options}
+            disabled={options.length === 1}
+            onChange={(newValue) => setAttributes({campaignId: newValue ? parseInt(newValue) : null})}
+        />
+    );
+
+    if (placement === 'sidebar') {
+        return (
+            <InspectorControls>
+                <PanelBody title={__('Campaign', 'give')} initialOpen={true}>
+                    {dropdown}
+                </PanelBody>
+            </InspectorControls>
+        );
+    }
+
+    return dropdown;
+}

--- a/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
@@ -1,7 +1,6 @@
 import {PanelBody, SelectControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
 import useCampaigns from '../hooks/useCampaigns';
-import {Campaign} from '@givewp/campaigns/admin/components/types';
 import {__} from '@wordpress/i18n';
 
 export default function CampaignDropdown({campaignId, setAttributes, placement = 'sidebar'}) {

--- a/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignDropdown.tsx
@@ -30,7 +30,7 @@ export default function CampaignDropdown({campaignId, setAttributes, placement =
             value={campaignId || ''}
             options={options}
             disabled={options.length === 1}
-            onChange={(newValue) => setAttributes({campaignId: newValue ? parseInt(newValue) : null})}
+            onChange={(newValue: string) => setAttributes({campaignId: newValue ? parseInt(newValue) : null})}
         />
     );
 

--- a/src/Campaigns/Blocks/shared/components/CampaignSelector.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignSelector.tsx
@@ -1,0 +1,28 @@
+import useCampaignId from '../hooks/useCampaignId';
+import CampaignDropdown from './CampaignDropdown';
+
+export function CampaignSelector({attributes, setAttributes, children}) {
+    const campaignId = useCampaignId(attributes, setAttributes);
+
+    return (
+        <>
+            {!campaignId && !attributes?.campaignId && (
+                <CampaignDropdown
+                    campaignId={attributes?.campaignId}
+                    setAttributes={setAttributes}
+                    placement="inline"
+                />
+            )}
+
+            {!campaignId && (
+                <CampaignDropdown
+                    campaignId={attributes?.campaignId}
+                    setAttributes={setAttributes}
+                    placement="sidebar"
+                />
+            )}
+
+            {attributes?.campaignId && children}
+        </>
+    );
+}

--- a/src/Campaigns/Blocks/shared/hooks/useCampaign.ts
+++ b/src/Campaigns/Blocks/shared/hooks/useCampaign.ts
@@ -1,0 +1,11 @@
+import {useEntityRecord} from '@wordpress/core-data';
+import {Campaign} from '@givewp/campaigns/admin/components/types';
+
+export default function useCampaign(campaignId) {
+    const data = useEntityRecord('givewp', 'campaign', campaignId);
+
+    return {
+        campaign: data?.record as Campaign,
+        hasResolved: data?.hasResolved,
+    };
+}

--- a/src/Campaigns/Blocks/shared/hooks/useCampaign.ts
+++ b/src/Campaigns/Blocks/shared/hooks/useCampaign.ts
@@ -1,7 +1,7 @@
 import {useEntityRecord} from '@wordpress/core-data';
 import {Campaign} from '@givewp/campaigns/admin/components/types';
 
-export default function useCampaign(campaignId) {
+export default function useCampaign(campaignId: number) {
     const data = useEntityRecord('givewp', 'campaign', campaignId);
 
     return {

--- a/src/Campaigns/Blocks/shared/hooks/useCampaignId.ts
+++ b/src/Campaigns/Blocks/shared/hooks/useCampaignId.ts
@@ -2,9 +2,11 @@ import {useSelect} from '@wordpress/data';
 
 export default function useCampaignId(attributes, setAttributes) {
     const campaignIdFromContext = useSelect((select) => {
+        // @ts-ignore
         const postType = select('core/editor').getCurrentPostType();
 
         if (postType === 'give_campaign_page') {
+            // @ts-ignore
             return select('core/editor').getEditedPostAttribute('campaignId');
         }
         return null;

--- a/src/Campaigns/Blocks/shared/hooks/useCampaignId.ts
+++ b/src/Campaigns/Blocks/shared/hooks/useCampaignId.ts
@@ -1,0 +1,18 @@
+import {useSelect} from '@wordpress/data';
+
+export default function useCampaignId(attributes, setAttributes) {
+    const campaignIdFromContext = useSelect((select) => {
+        const postType = select('core/editor').getCurrentPostType();
+
+        if (postType === 'give_campaign_page') {
+            return select('core/editor').getEditedPostAttribute('campaignId');
+        }
+        return null;
+    }, []);
+
+    if (campaignIdFromContext && campaignIdFromContext !== attributes?.campaignId) {
+        setAttributes({campaignId: campaignIdFromContext});
+    }
+
+    return campaignIdFromContext;
+}

--- a/src/Campaigns/Blocks/shared/hooks/useCampaigns.ts
+++ b/src/Campaigns/Blocks/shared/hooks/useCampaigns.ts
@@ -1,0 +1,11 @@
+import {useEntityRecords} from '@wordpress/core-data';
+import {Campaign} from '@givewp/campaigns/admin/components/types';
+
+export default function useCampaigns() {
+    const data = useEntityRecords('givewp', 'campaign');
+
+    return {
+        campaigns: data?.records as Campaign[],
+        hasResolved: data?.hasResolved,
+    };
+}

--- a/src/Campaigns/Blocks/shared/utils/init-block.ts
+++ b/src/Campaigns/Blocks/shared/utils/init-block.ts
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import {registerBlockType} from '@wordpress/blocks';
+
+/**
+ * Function to register an individual block.
+ *
+ * @param {Object} block The block to be registered.
+ *
+ * @return {WPBlockType | undefined} The block, if it has been successfully registered;
+ *                        otherwise `undefined`.
+ */
+export default function initBlock(block) {
+    if (!block) {
+        return;
+    }
+    const {metadata, settings, name} = block;
+    return registerBlockType({name, ...metadata}, settings);
+}

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -47,6 +47,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerMigrations();
         $this->registerRoutes();
         $this->registerCampaignEntity();
+        $this->registerCampaignBlocks();
         $this->setupCampaignForms();
     }
 
@@ -147,5 +148,13 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('save_post_give_forms', AddCampaignFormFromRequest::class, 'optionBasedFormEditor', 10, 3);
         Hooks::addAction('givewp_donation_form_created', AddCampaignFormFromRequest::class, 'visualFormBuilder');
         Hooks::addAction('givewp_campaign_created', CreateDefaultCampaignForm::class);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerCampaignBlocks()
+    {
+        Hooks::addAction('init', Actions\RegisterCampaignBlocks::class);
     }
 }

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -155,6 +155,7 @@ class ServiceProvider implements ServiceProviderInterface
      */
     private function registerCampaignBlocks()
     {
+        Hooks::addAction('rest_api_init', Actions\RegisterCampaignIdRestField::class);
         Hooks::addAction('init', Actions\RegisterCampaignBlocks::class);
     }
 }

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+const fs = require('fs');
 const path = require('path');
 
 /**
@@ -63,6 +64,7 @@ module.exports = {
         campaignEntity: srcPath('Campaigns/resources/entity.ts'),
         campaignDetails: srcPath('Campaigns/resources/admin/campaign-details.tsx'),
         adminBlocks: path.resolve(process.cwd(), 'blocks', 'load.js'),
+        ...getDynamicEntries(srcPath('Campaigns/Blocks'), 'Campaigns/Blocks/'),
     },
 };
 
@@ -74,4 +76,23 @@ module.exports = {
  */
 function srcPath(relativePath) {
     return path.resolve(process.cwd(), 'src', relativePath);
+}
+
+function getDynamicEntries(basePath, destinationPath = '') {
+    const entries = {};
+    const directories = fs.readdirSync(basePath, {withFileTypes: true});
+
+    directories.forEach((dir) => {
+        if (dir.isDirectory()) {
+            const blockPath = path.join(basePath, dir.name);
+            const indexPath = path.join(blockPath, 'index.ts');
+            const entryKey = dir.name.charAt(0).toLowerCase() + dir.name.slice(1);
+
+            if (fs.existsSync(indexPath)) {
+                entries[`${destinationPath}${entryKey}`] = indexPath;
+            }
+        }
+    });
+
+    return entries;
 }

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
         campaignEntity: srcPath('Campaigns/resources/entity.ts'),
         campaignDetails: srcPath('Campaigns/resources/admin/campaign-details.tsx'),
         adminBlocks: path.resolve(process.cwd(), 'blocks', 'load.js'),
-        ...getDynamicEntries(srcPath('Campaigns/Blocks'), 'Campaigns/Blocks/'),
+        campaignBlocks: srcPath('Campaigns/Blocks/blocks.ts'),
     },
 };
 
@@ -76,23 +76,4 @@ module.exports = {
  */
 function srcPath(relativePath) {
     return path.resolve(process.cwd(), 'src', relativePath);
-}
-
-function getDynamicEntries(basePath, destinationPath = '') {
-    const entries = {};
-    const directories = fs.readdirSync(basePath, {withFileTypes: true});
-
-    directories.forEach((dir) => {
-        if (dir.isDirectory()) {
-            const blockPath = path.join(basePath, dir.name);
-            const indexPath = path.join(blockPath, 'index.ts');
-            const entryKey = dir.name.charAt(0).toLowerCase() + dir.name.slice(1);
-
-            if (fs.existsSync(indexPath)) {
-                entries[`${destinationPath}${entryKey}`] = indexPath;
-            }
-        }
-    });
-
-    return entries;
 }

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-const fs = require('fs');
 const path = require('path');
 
 /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1959]

## Description
This pull request lays the foundation for future Campaign-related blocks by introducing key structural elements. The updates in this PR include:
- **Dynamic Block Registration**: Registers blocks dynamically based on their block.json files.
- **Campaign Page REST API**: Adds `campaignId` as a field to the REST API response for the Campaign Page CPT.
- **Custom Hooks and Shared Components**: Introduces reusable hooks and components to simplify campaign selection or retrieval from context within campaign blocks.
- **Initial Campaign Title Block**: Adds a basic Campaign Title block to serve as a reference and model for upcoming blocks.

These changes establish a scalable and flexible structure for Campaign blocks, enabling more streamlined development of future features.

## Visuals
![CleanShot 2024-12-12 at 11 30 34](https://github.com/user-attachments/assets/e6e5c4ed-ff18-42df-a69e-1076523d0245)

## Testing Instructions
1.	**Test on a Campaign Page**:
- Open a Campaign Page.
- Add the Campaign Title block.
- Verify that the block renders automatically, displaying the corresponding campaign title.
2.	**Test on Other Pages**:
- Open any other page type (not a Campaign Page).
- Add the Campaign Title block.
- Ensure that a campaign selector is displayed.
- Select a campaign from the selector.
- Verify that the block updates and renders the title of the selected campaign.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1959]: https://stellarwp.atlassian.net/browse/GIVE-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ