### PR TITLE
Refactor: change font-size for modal input descriptions 

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/CampaignFormModal.module.scss
@@ -12,11 +12,6 @@
     label {
         font-size: 1rem;
     }
-
-    .description {
-        font-size: 14px;
-        margin-bottom: 0.4rem;
-    }
 }
 
 .fieldRequired {

--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -240,9 +240,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                             <label htmlFor="title">
                                 {__("What's the title of your campaign?", 'give')} {requiredAsterisk}
                             </label>
-                            <div className={styles.description}>
-                                {__("Give your campaign a title that tells donors what it's about.", 'give')}
-                            </div>
+                            <span>{__("Give your campaign a title that tells donors what it's about.", 'give')}</span>
                             <input
                                 type="text"
                                 {...register('title', {required: __('The campaign must have a title!', 'give')})}
@@ -258,9 +256,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                         </div>
                         <div className="givewp-campaigns__form-row">
                             <label htmlFor="shortDescription">{__("What's your campaign about?", 'give')}</label>
-                            <div className={styles.description}>
-                                {__('Let your donors know the story behind your campaign.', 'give')}
-                            </div>
+                            <span>{__('Let your donors know the story behind your campaign.', 'give')}</span>
                             <textarea
                                 {...register('shortDescription')}
                                 rows={4}
@@ -272,9 +268,9 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                         </div>
                         <div className="givewp-campaigns__form-row">
                             <label htmlFor="image">{__('Add a cover image or video for your campaign.', 'give')}</label>
-                            <div className={styles.description}>
+                            <span>
                                 {__('Upload an image or video to represent and inspire your campaign.', 'give')}
-                            </div>
+                            </span>
                             <Upload
                                 id="givewp-campaigns-upload-cover-image"
                                 label={__('Cover', 'give')}
@@ -303,9 +299,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                             <label htmlFor="goalType">
                                 {__('How would you like to set your goal?', 'give')} {requiredAsterisk}
                             </label>
-                            <span className={styles.description}>
-                                {__('Set the goal your fundraising efforts will work toward.', 'give')}
-                            </span>
+                            <span>{__('Set the goal your fundraising efforts will work toward.', 'give')}</span>
                             <div className={styles.goalType}>
                                 <GoalTypeOption
                                     type={'amount'}
@@ -383,9 +377,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                                 <label htmlFor="title">
                                     {goalInputAttributes[selectedGoalType].label} {requiredAsterisk}
                                 </label>
-                                <span className={styles.description}>
-                                    {goalInputAttributes[selectedGoalType].description}
-                                </span>
+                                <span>{goalInputAttributes[selectedGoalType].description}</span>
                                 {selectedGoalType === 'amount' || selectedGoalType === 'amountFromSubscriptions' ? (
                                     <Currency
                                         name="goal"

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -43,6 +43,7 @@
                     color: var(--givewp-grey-400);
                     font-size: 0.875rem;
                     line-height: 1.5;
+                    margin-bottom: 0.4rem;
 
                     strong {
                         color: var(--givewp-grey-500);

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -41,7 +41,7 @@
 
                 span:not(.givewp-field-required) {
                     color: var(--givewp-grey-400);
-                    font-size: 0.75rem;
+                    font-size: 0.875rem;
                     line-height: 1.5;
 
                     strong {

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -43,7 +43,7 @@
                     color: var(--givewp-grey-400);
                     font-size: 0.875rem;
                     line-height: 1.5;
-                    margin-bottom: 0.4rem;
+                    margin-bottom: var(--givewp-spacing-2);
 
                     strong {
                         color: var(--givewp-grey-500);

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -40,13 +40,13 @@
                 }
 
                 span:not(.givewp-field-required) {
-                    color: var(--givewp-grey-400);
+                    color: var(--givewp-grey-700);
                     font-size: 0.875rem;
                     line-height: 1.5;
                     margin-bottom: var(--givewp-spacing-2);
 
                     strong {
-                        color: var(--givewp-grey-500);
+                        color: var(--givewp-grey-800);
                         font-weight: 600;
                     }
                 }

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -17,7 +17,7 @@
         .givewp-campaigns {
             &__form {
                 label {
-                    color: var(--givewp-grey-700);
+                    color: var(--givewp-neutral-700);
                     font-size: 1rem;
                     font-weight: 500;
                     line-height: 1.5;
@@ -40,13 +40,13 @@
                 }
 
                 span:not(.givewp-field-required) {
-                    color: var(--givewp-grey-700);
+                    color: var(--givewp-neutral-500);
                     font-size: 0.875rem;
                     line-height: 1.5;
                     margin-bottom: var(--givewp-spacing-2);
 
                     strong {
-                        color: var(--givewp-grey-800);
+                        color: var(--givewp-neutral-600);
                         font-weight: 600;
                     }
                 }

--- a/src/Campaigns/resources/admin/components/MergeCampaign/Form/Form.module.scss
+++ b/src/Campaigns/resources/admin/components/MergeCampaign/Form/Form.module.scss
@@ -38,7 +38,6 @@
     }
 
     .description {
-        font-size: 0.875rem;
         margin-bottom: 0.4rem;
     }
 

--- a/src/Campaigns/resources/admin/components/MergeCampaign/Form/Form.module.scss
+++ b/src/Campaigns/resources/admin/components/MergeCampaign/Form/Form.module.scss
@@ -37,10 +37,6 @@
         max-width: 100%;
     }
 
-    .description {
-        margin-bottom: 0.4rem;
-    }
-
     .notice {
         display: flex;
         margin: 1rem 0 -0.2rem 0;

--- a/src/Campaigns/resources/admin/components/MergeCampaign/Form/index.tsx
+++ b/src/Campaigns/resources/admin/components/MergeCampaign/Form/index.tsx
@@ -142,9 +142,7 @@ export default function MergeCampaignsForm({isOpen, handleClose, title, campaign
                             <label htmlFor="title">
                                 {__('Select your destination campaign', 'give')} {requiredAsterisk}
                             </label>
-                            <span className={styles.description}>
-                                {__('All selected campaigns will be merged into this campaign.', 'give')}
-                            </span>
+                            <span>{__('All selected campaigns will be merged into this campaign.', 'give')}</span>
                             <select {...register('destinationCampaignId', {valueAsNumber: true})} defaultValue="">
                                 <option value="" disabled hidden>
                                     {__('Choose from selected campaigns', 'give')}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2035]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR changes the font size of the input descriptions used inside the modals on the campaigns page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The "create campaign" modal
- The "merge campaign" modal

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/27c4e198-560c-483f-a68f-f66e051c8c97)

![image](https://github.com/user-attachments/assets/3d8bba1f-d4bc-4193-80eb-db1ec6934e98)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Open the "create campaign" and "merge campaign" modals and make sure the font size for the input descriptions is displayed in the proper size.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed





[GIVE-2035]: https://stellarwp.atlassian.net/browse/GIVE-2035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ