### PR TITLE
Fix: load the form template only on single pages

### DIFF
--- a/src/DonationForms/FormPage/TemplateHandler.php
+++ b/src/DonationForms/FormPage/TemplateHandler.php
@@ -27,11 +27,12 @@ class TemplateHandler
     }
 
     /**
+     * @unreleased Check if is a single page
      * @since 3.0.0
      */
     public function handle($template)
     {
-        return $this->isNextGenForm()
+        return is_single() && $this->isNextGenForm()
             ? $this->formPageTemplatePath
             : $template;
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-928]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that prevents the archive page get loading properly due to a wrong load of the single template for donation forms. Now we are ensuring that the donation form is loaded only for single pages which prevents the bug on the archive page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The archive donation forms pag.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/95b73a73-0087-4266-a7a6-75573ca9e597)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a V2 form, then a VFB form.
2. Check the `/donations/` page and **NOT** only the VFB form will show (as was happening before) but both

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

