### PR TITLE
Feature: adds a css class for the form design

### DIFF
--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -252,6 +252,7 @@ class DonationFormViewModel
      * 5. Finally, call the specific WP function wp_print_footer_scripts()
      *  - This will only print the footer scripts that are enqueued within our route.
      *
+     * @unreleased Adds class for form design
      * @since 3.11.0 Sanitize customCSS property
      * @since 3.0.0
      */

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -278,7 +278,7 @@ class DonationFormViewModel
         endif; ?>
 
         <?php
-        $classNames = [ 'givewp-donation-form', "givewp-donation-form-design--{$this->designId()}" ];
+        $classNames = ['givewp-donation-form', "givewp-donation-form-design--{$this->designId()}"];
 
         if ($this->previewMode) {
             $classNames[] = 'givewp-donation-form--preview';

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -277,7 +277,7 @@ class DonationFormViewModel
         endif; ?>
 
         <?php
-        $classNames = ['givewp-donation-form'];
+        $classNames = [ 'givewp-donation-form', "givewp-donation-form-design--{$this->designId()}" ];
 
         if ($this->previewMode) {
             $classNames[] = 'givewp-donation-form--preview';


### PR DESCRIPTION
## Description

This humble PR adds a class to the root div of a v3 form with the Form Design ID. Something like: `givewp-donation-form-design--classic`. It's purpose is so that when folks add custom styles (especially globally via code) they can use CSS to apply styles to only certain form designs.

## Affects

V3 form rendering

## Testing Instructions

1. Make a form
2. View the form on the front-end
3. Check the root div for the Form Design class — it should correspond to your selected Form Design
4. Switch Form Designs and check again

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

