### PR TITLE
Fix: use email to get avatar URL

### DIFF
--- a/src/Donors/ListTable/Columns/DonorInformationColumn.php
+++ b/src/Donors/ListTable/Columns/DonorInformationColumn.php
@@ -38,6 +38,7 @@ class DonorInformationColumn extends ModelColumn
     }
 
     /**
+     * @unreleased Use email to get avatar URL
      * @since 2.24.0
      *
      * @inheritDoc
@@ -56,7 +57,7 @@ class DonorInformationColumn extends ModelColumn
 
         return sprintf(
             $template,
-            get_avatar_url($model->id, ['size' => 64]),
+            get_avatar_url($model->email, ['size' => 64]),
             admin_url("edit.php?post_type=give_forms&page=give-donors&view=overview&id=$model->id"),
             trim("$model->firstName $model->lastName"),
             $model->email


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1165]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR change how we retrieve the donor avar URL in the Donor view, now instead of use the donor ID we are using the donor e-mail to make sure that the proper profile URL will be used.

As a note, the `get_avatar_url()` function, which is used under the hood, accepts the user e-mail or user id, so we were using it wrong before the changes implemented on this PR because the donor id is not the same one of the user id.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donor's view.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/df5a8009-b133-4031-aba5-2704f4d214aa)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a test donation using a donor's email that has a Gravatar account set up.
2. Go to the donor's view page and make sure the proper avatar image (the same one from Gravatar) is displayed there.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1165]: https://stellarwp.atlassian.net/browse/GIVE-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ