### PR TITLE
Fix: Display donation receipt in Form Grid modal after offline gateway redirect

### DIFF
--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -31,7 +31,8 @@ jQuery(
 			}
 		);
 
-        // Donation grid shortcode - reopen current grid modal for donations completed with gateway redirect.
+        // Donation grid shortcode:
+        // Offline gateways like Stripe refresh the page, and we need to programmatically reopen the modal for the confirmation page.
         $(doc).ready(function () {
             function reopenOnGatewayRedirect()
             {

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -22,8 +22,40 @@ jQuery(
 				midClick: true,
 				removalDelay: 300,
 				mainClass: 'modal-fade-slide give-modal',
+                callbacks: {
+                    open: function () {
+                        const modalId = this.currItem.inlineElement[0].id;
+                        sessionStorage.setItem('currentGridModal', modalId);
+                    },
+                }
 			}
 		);
+
+        // Donation grid shortcode - reopen current grid modal for donations completed with gateway redirect.
+        $(doc).ready(function () {
+            function reopenOnGatewayRedirect()
+            {
+                const urlParams = new URLSearchParams(window.location.search);
+
+                const isGatewayRedirect = urlParams.has('givewp-event') &&
+                    urlParams.get('givewp-event') === 'donation-completed' &&
+                    urlParams.has('givewp-receipt-id');
+
+                if (isGatewayRedirect) {
+                    document.querySelectorAll('.js-give-grid-modal-launcher').forEach(function (formGridModalLauncher) {
+                        const gridModal = formGridModalLauncher.nextElementSibling.id;
+                        const currentModal = sessionStorage.getItem('currentGridModal');
+
+                        if (gridModal === currentModal) {
+                            formGridModalLauncher.click();
+                        }
+                    });
+                }
+                sessionStorage.clear();
+            }
+            reopenOnGatewayRedirect();
+        });
+
 		// Compatible for X theme and Cornerstone plugin.
 		if ( typeof window.csGlobal !== 'undefined' ) {
 			window.jQuery( function( $ ) {

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -34,7 +34,10 @@ jQuery(
 
                 const completedFormEmbedId = urlParams.get('givewp-embed-id');
 
-                const isGatewayRedirect = urlParams.has('givewp-embed-id') && urlParams.has('givewp-receipt-id');
+                const isGatewayRedirect = urlParams.has('givewp-embed-id') &&
+                    urlParams.get('givewp-event') === 'donation-completed' &&
+                    urlParams.get('givewp-listener') === 'show-donation-confirmation-receipt' &&
+                    urlParams.has('givewp-receipt-id');
 
                 if (isGatewayRedirect) {
                     document.querySelectorAll('.js-give-grid-modal-launcher').forEach(function (formGridModalLauncher) {

--- a/assets/src/js/frontend/give-misc.js
+++ b/assets/src/js/frontend/give-misc.js
@@ -22,12 +22,6 @@ jQuery(
 				midClick: true,
 				removalDelay: 300,
 				mainClass: 'modal-fade-slide give-modal',
-                callbacks: {
-                    open: function () {
-                        const modalId = this.currItem.inlineElement[0].id;
-                        sessionStorage.setItem('currentGridModal', modalId);
-                    },
-                }
 			}
 		);
 
@@ -38,21 +32,19 @@ jQuery(
             {
                 const urlParams = new URLSearchParams(window.location.search);
 
-                const isGatewayRedirect = urlParams.has('givewp-event') &&
-                    urlParams.get('givewp-event') === 'donation-completed' &&
-                    urlParams.has('givewp-receipt-id');
+                const completedFormEmbedId = urlParams.get('givewp-embed-id');
+
+                const isGatewayRedirect = urlParams.has('givewp-embed-id') && urlParams.has('givewp-receipt-id');
 
                 if (isGatewayRedirect) {
                     document.querySelectorAll('.js-give-grid-modal-launcher').forEach(function (formGridModalLauncher) {
-                        const gridModal = formGridModalLauncher.nextElementSibling.id;
-                        const currentModal = sessionStorage.getItem('currentGridModal');
+                        const modalFormEmbedId = formGridModalLauncher.nextElementSibling.firstElementChild.dataset.givewpEmbedId;
 
-                        if (gridModal === currentModal) {
+                        if (modalFormEmbedId === completedFormEmbedId) {
                             formGridModalLauncher.click();
                         }
                     });
                 }
-                sessionStorage.clear();
             }
             reopenOnGatewayRedirect();
         });


### PR DESCRIPTION
Resolves: [GIVE-931](https://stellarwp.atlassian.net/browse/GIVE-931)

## Description
`DonationFormBlock` Reference: https://github.com/impress-org/givewp/blob/develop/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx

Problem:
The issue occurs when offline gateways (e.g., Stripe Payment Element) trigger a page refresh after a donation is processed. This refresh happens when the gateway redirects the user back to the initial page, causing any open modals (including the modal rendering the donation receipt) to close.

Solution:
To resolve this, the PR introduces the following approach:

An event listener that checks the redirect/donation completed status on page load via the URL search params was included. If the user is coming from a redirected gateway (e.g., after completing the donation), the appropriate modal is programmatically re-opened by matching `givewp-embed-id` from the url params.

## Affects
Donation Form Grid.

## Visuals
https://www.loom.com/share/66a45b64fa2c4e31bbf9280acfc2458d?sid=f63b847a-097f-4a28-9bf5-6f242da06184

## Testing Instructions
Zip: https://github.com/impress-org/givewp/actions/runs/12836850791

- Create a page with the Donation Form Grid block.
- Verify regular donations process, complete and show the correct receipt view within the modal.
- Process a donation specifically with an Offline Gateway (Ex. Stripe payment element), verify the receipt view also displays in the modal and completing a donation. The modal should reopen automatically for the user after completing the donation process.


## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-931]: https://stellarwp.atlassian.net/browse/GIVE-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ