### PR TITLE
Refactor: remove statement_descriptor from Stripe Payment Element Gateway

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/DataTransferObjects/StripePaymentIntentData.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/DataTransferObjects/StripePaymentIntentData.php
@@ -34,18 +34,15 @@ class StripePaymentIntentData
      */
     public $applicationFeeAmount;
     /**
-     * @var string
-     */
-    public $statementDescriptor;
-    /**
      * @var string|null
      */
     public $receiptEmail;
 
     /**
+     * @unreleased removed statement_descriptor. As of 01/02/2024, Stripe no longer supports the `statement_descriptor` parameter on the PaymentIntent API for PaymentIntents in which one of the supported `payment_method_types` is `card`.
      * @since 3.0.0
      *
-     * @param  array{amount: string, currency: string, customer: string, description: string, metadata: array, automatic_payment_methods: array, application_fee_amount: string, statement_descriptor: string, receipt_email: string }  $array
+     * @param  array{amount: string, currency: string, customer: string, description: string, metadata: array, automatic_payment_methods: array, application_fee_amount: string, receipt_email: string }  $array
      */
     public static function fromArray(array $array): self
     {
@@ -57,7 +54,6 @@ class StripePaymentIntentData
         $self->metadata = $array['metadata'];
         $self->automaticPaymentMethods = !empty($array['automatic_payment_methods']) ? $array['automatic_payment_methods'] : null;
         $self->applicationFeeAmount = !empty($array['application_fee_amount']) ? $array['application_fee_amount'] : null;
-        $self->statementDescriptor = $array['statement_descriptor'];
         $self->receiptEmail = !empty($array['receipt_email']) ? $array['receipt_email'] : null;
 
         return $self;
@@ -73,8 +69,7 @@ class StripePaymentIntentData
             'currency' => $this->currency,
             'customer' => $this->customer,
             'description' => $this->description,
-            'metadata' => $this->metadata,
-            'statement_descriptor' => $this->statementDescriptor,
+            'metadata' => $this->metadata
         ];
 
         if ($this->automaticPaymentMethods){

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
@@ -90,6 +90,7 @@ trait StripePaymentElementRepository
     }
 
     /**
+     * @unreleased removed statement_descriptor. As of 01/02/2024, Stripe no longer supports the `statement_descriptor` parameter on the PaymentIntent API for PaymentIntents in which one of the supported `payment_method_types` is `card`.
      * @since 3.0.0
      *
      * @throws InvalidPropertyName
@@ -114,9 +115,6 @@ trait StripePaymentElementRepository
                 $donation->amount->getAmount()
             );
         }
-
-        // Add statement descriptor
-        $intentArgs['statement_descriptor'] = give_stripe_get_statement_descriptor();
 
         // Send Stripe Receipt emails when enabled.
         if (give_is_setting_enabled(give_get_option('stripe_receipt_emails'))) {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: [GIVE-1948]
Related: https://github.com/impress-org/givewp/pull/7259

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This removes the `statement_descriptor` from Stripe Payment Element Gateway.  This is the result of a Stripe api change to the attribute for card payments.  Since Payment Element is dynamic, the safest & simplest option is to remove the attribute and rely on the statement_descriptor set on the account level instead of the request.

https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges

<img width="587" alt="Screenshot 2025-01-09 at 5 27 42 PM" src="https://github.com/user-attachments/assets/dada27d6-971c-4e7b-bf04-ac58a52084c3" />


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe payment element

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/12715146778

- Donate using v3 forms and Stripe Payment Element w/ different payment methods including credit card and make sure everything works properly.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1948]: https://stellarwp.atlassian.net/browse/GIVE-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ