### PR TITLE
Fix: Explicitly execute script with PHP for Windows compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "unreleased": "./vendor/bin/since-unreleased.sh",
         "strauss": [
             "bin/strauss-installar.sh",
-            "vendor/stellarwp/validation/bin/set-domain domain=give",
+            "@php vendor/stellarwp/validation/bin/set-domain domain=give",
             "@php bin/strauss.phar",
             "@composer dump-autoload"
         ],


### PR DESCRIPTION
fix: 'vendor\stellarwp\validation\bin\set-domain' is not recognized as an internal or external command, operable program or batch file.

## Description

When I want to install the plugin on dev Windows setup, the `composer install` throws this issue :

```shell
> vendor/stellarwp/validation/bin/set-domain domain=give
'vendor\stellarwp\validation\bin\set-domain' is not recognized as an internal or external command, operable program or batch file.
```

## Affects

Installation.

## Testing Instructions

1. On Windows setup
2. `git clone git@github.com:impress-org/givewp.git give`
3. `cd give`
4. `composer install`
