### PR TITLE
Fix: Prevent duplicated column error in Event Tickets migration

### DIFF
--- a/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
+++ b/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
@@ -50,7 +50,7 @@ class AddAmountColumnToEventTicketsTable extends Migration {
                 ADD COLUMN amount INT UNSIGNED NOT NULL AFTER donation_id";
 
         try {
-            $wpdb->query($sql);
+            maybe_add_column($eventTicketsTable, 'amount', $sql);
         } catch (DatabaseQueryException $exception) {
             throw new DatabaseMigrationException( "An error occurred while adding the amount column to the $eventTicketsTable table", 0, $exception );
         }

--- a/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
+++ b/src/EventTickets/Migrations/AddAmountColumnToEventTicketsTable.php
@@ -9,30 +9,45 @@ use Give\Framework\Migrations\Exceptions\DatabaseMigrationException;
 /**
  * @unreleased
  */
-class AddAmountColumnToEventTicketsTable extends Migration {
+class AddAmountColumnToEventTicketsTable extends Migration
+{
     /**
      * @inheritdoc
+     *
+     * @unreleased
      */
-    public static function id() {
+    public static function id()
+    {
         return 'give-events-add-amount-column-to-events-tickets-table';
     }
 
-    public static function title() {
+    /**
+     * @unreleased
+     */
+    public static function title()
+    {
         return 'Add "amount" column to give_event_tickets table';
     }
 
     /**
      * @inheritdoc
+     *
+     * @unreleased
      */
-    public static function timestamp() {
-        return strtotime( '2022-03-18 12:00:00' );
+    public static function timestamp()
+    {
+        return strtotime('2022-03-18 12:00:00');
     }
 
     /**
      * @inheritdoc
+     *
+     * @unreleased
+     *
      * @throws DatabaseMigrationException
      */
-    public function run() {
+    public function run()
+    {
         global $wpdb;
 
         $eventTicketsTable = $wpdb->give_event_tickets;
@@ -43,23 +58,29 @@ class AddAmountColumnToEventTicketsTable extends Migration {
     }
 
     /**
+     * @unreleased
+     *
      * @throws DatabaseMigrationException
      */
-    private function addAmountColumn($wpdb, $eventTicketsTable) {
+    private function addAmountColumn($wpdb, $eventTicketsTable)
+    {
         $sql = "ALTER TABLE $eventTicketsTable
                 ADD COLUMN amount INT UNSIGNED NOT NULL AFTER donation_id";
 
         try {
             maybe_add_column($eventTicketsTable, 'amount', $sql);
         } catch (DatabaseQueryException $exception) {
-            throw new DatabaseMigrationException( "An error occurred while adding the amount column to the $eventTicketsTable table", 0, $exception );
+            throw new DatabaseMigrationException("An error occurred while adding the amount column to the $eventTicketsTable table", 0, $exception);
         }
     }
 
     /**
+     * @unreleased
+     *
      * @throws DatabaseMigrationException
      */
-    private function migrateTicketPrices($wpdb, $eventTicketsTable, $eventTicketTypesTable) {
+    private function migrateTicketPrices($wpdb, $eventTicketsTable, $eventTicketTypesTable)
+    {
         $sql = "UPDATE $eventTicketsTable eventTickets
                 JOIN $eventTicketTypesTable evenTicketTypes
                 ON eventTickets.ticket_type_id = evenTicketTypes.id
@@ -68,7 +89,7 @@ class AddAmountColumnToEventTicketsTable extends Migration {
         try {
             $wpdb->query($sql);
         } catch (DatabaseQueryException $exception) {
-            throw new DatabaseMigrationException( "An error occurred while migrating data to the amount column in the $eventTicketsTable table", 0, $exception );
+            throw new DatabaseMigrationException("An error occurred while migrating data to the amount column in the $eventTicketsTable table", 0, $exception);
         }
     }
 };


### PR DESCRIPTION
## Description
When running automated tests, database tables are truncated while preserving the effects of migrations. Recently, we introduced a migration that modifies the `give_event_tickets` table by adding a new `amount` column. However, since migrations are executed repeatedly after each database refresh (before most tests run), this led to an error when attempting to add the `amount` column multiple times.

To address this issue, this PR replaces the existing query execution method with a conditional check using `maybe_add_column`. This ensures the `ALTER TABLE` query is only executed if the column does not already exist, preventing redundant operations and errors.

Note: since a reformat operation has been performed in the file, note that the main change is located at the line 71.

## Affects
Event Tickets migrations

## Testing Instructions
1. Run unit tests then ensure no DB errors are returned.
2. Ensure the `give_event_tickets` is still being modified to have the new `amount` column.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

