### PR TITLE
Feature: ListTable configuration

### DIFF
--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -117,6 +117,9 @@ class DonationFormsAdminPage
             'supportedAddons' => $this->getSupportedAddons(),
             'supportedGateways' => $this->getSupportedGateways(),
             'isOptionBasedFormEditorEnabled' => OptionBasedFormEditor::isEnabled(),
+            'swrConfig' => [
+                'revalidateOnFocus' => false
+            ]
         ];
 
         EnqueueScript::make('give-admin-donation-forms', 'assets/dist/js/give-admin-donation-forms.js')

--- a/src/Views/Components/ListTable/api.ts
+++ b/src/Views/Components/ListTable/api.ts
@@ -8,7 +8,7 @@ export default class ListTableApi {
     private readonly headers: {'X-WP-Nonce': string; 'Content-Type': string};
     private readonly swrOptions;
 
-    constructor({apiNonce, apiRoot, preload = null}) {
+    constructor({apiNonce, apiRoot, preload = null, swrConfig = {}}) {
         this.controller = null;
         this.apiRoot = apiRoot;
         this.headers = {
@@ -17,6 +17,7 @@ export default class ListTableApi {
         };
         this.swrOptions = {
             use: [lagData],
+            ...swrConfig,
             onErrorRetry: (error, key, config, revalidate, {retryCount}) => {
                 //don't retry if we cancelled the initial request
                 if (error.name == 'AbortError') return;


### PR DESCRIPTION
## Description

This pull request includes changes to support the configuration of SWR options in the `ListTableApi` class. We need this so that we can set the `revalidateOnFocus` SWR option to `false` to prevent list table reloads.


## Affects

 `ListTableApi` class


## Testing Instructions

Go to the campaign page - Forms tab
Then select the Settings tab, and then select the Forms tab again

**The forms list table should not reload** 
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

