### PR TITLE
Refactor: update meta persistence in donor and donation repositories

### DIFF
--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -166,6 +166,7 @@ class DonationRepository
     }
 
     /**
+     * @unreleased store meta using native WP functions
      * @since 2.23.0 retrieve the post_parent instead of relying on parentId property
      * @since 2.21.0 replace actions with givewp_donation_creating and givewp_donation_created
      * @since 2.20.0 mutate model and return void
@@ -204,12 +205,7 @@ class DonationRepository
             $donationMeta = $this->getCoreDonationMetaForDatabase($donation);
 
             foreach ($donationMeta as $metaKey => $metaValue) {
-                DB::table('give_donationmeta')
-                    ->insert([
-                        'donation_id' => $donationId,
-                        'meta_key' => $metaKey,
-                        'meta_value' => $metaValue,
-                    ]);
+                give()->payment_meta->add_meta($donationId, $metaKey, $metaValue);
             }
         } catch (Exception $exception) {
             DB::query('ROLLBACK');

--- a/src/Donors/Repositories/DonorRepository.php
+++ b/src/Donors/Repositories/DonorRepository.php
@@ -97,6 +97,7 @@ class DonorRepository
     }
 
     /**
+     * @unreleased store meta using native WP functions
      * @since 3.7.0 Add support to "phone" property
      * @since 2.24.0 add support for $donor->totalAmountDonated and $donor->totalNumberOfDonation
      * @since 2.21.0 add actions givewp_donor_creating and givewp_donor_created
@@ -142,22 +143,12 @@ class DonorRepository
             $donorId = DB::last_insert_id();
 
             foreach ($this->getCoreDonorMeta($donor) as $metaKey => $metaValue) {
-                DB::table('give_donormeta')
-                    ->insert([
-                        'donor_id' => $donorId,
-                        'meta_key' => $metaKey,
-                        'meta_value' => $metaValue,
-                    ]);
+                give()->donor_meta->add_meta($donorId, $metaKey, $metaValue);
             }
 
             if (isset($donor->additionalEmails)) {
                 foreach ($donor->additionalEmails as $additionalEmail) {
-                    DB::table('give_donormeta')
-                        ->insert([
-                            'donor_id' => $donorId,
-                            'meta_key' => DonorMetaKeys::ADDITIONAL_EMAILS,
-                            'meta_value' => $additionalEmail,
-                        ]);
+                    give()->donor_meta->add_meta($donorId, DonorMetaKeys::ADDITIONAL_EMAILS, $additionalEmail);
                 }
             }
         } catch (Exception $exception) {
@@ -411,6 +402,7 @@ class DonorRepository
      * Additional emails are assigned to the same additional_email meta key.
      * In order to update them we need to delete and re-insert.
      *
+     * @unreleased store meta using native WP functions
      * @since 2.19.6
      *
      * @return void
@@ -426,13 +418,7 @@ class DonorRepository
         }
 
         foreach ($donor->additionalEmails as $additionalEmail) {
-            DB::table('give_donormeta')
-                ->where('donor_id', $donor->id)
-                ->insert([
-                    'donor_id' => $donor->id,
-                    'meta_key' => DonorMetaKeys::ADDITIONAL_EMAILS,
-                    'meta_value' => $additionalEmail,
-                ]);
+            give()->donor_meta->add_meta($donor->id, DonorMetaKeys::ADDITIONAL_EMAILS, $additionalEmail);
         }
     }
 

--- a/tests/Unit/Donations/Repositories/TestDonationRepository.php
+++ b/tests/Unit/Donations/Repositories/TestDonationRepository.php
@@ -276,7 +276,7 @@ final class TestDonationRepository extends TestCase
     public function testInsertShouldSafelyStoreMetaValues(): void
     {
         $name = (object)['first' => 'Jon', 'last' => 'Doe'];
-        
+
         $serializedFirstName = serialize($name);
 
         $donation = new Donation(array_merge(Donation::factory()->definition(), [
@@ -288,7 +288,12 @@ final class TestDonationRepository extends TestCase
         $repository->insert($donation);
 
         $metaValue = give()->payment_meta->get_meta($donation->id, DonationMetaKeys::FIRST_NAME, true);
+        $metaQuery = DB::table('give_donationmeta')
+            ->where('donation_id', $donation->id)
+            ->where('meta_key', DonationMetaKeys::FIRST_NAME)
+            ->get();
 
         $this->assertSame($serializedFirstName, $metaValue);
+        $this->assertSame(serialize($serializedFirstName), $metaQuery->meta_value);
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2075](https://stellarwp.atlassian.net/browse/GIVE-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates our donor and donation repositories to use the native WP meta functions for adding meta instead of directly inserting using SQL.  

Before this, we were innocently deviating from how WordPress stores meta values, effectively bypasses some of the extra filters/sanitization of values.  This resulted in problems downstream when retrieving the data.  

So the lesson learned here is to _always_ use the native WordPress api functions for storing and retrieving meta 😄.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Creating new donations and donors (v2 and v3 forms)

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="856" alt="Screenshot 2025-01-16 at 10 09 14 AM" src="https://github.com/user-attachments/assets/23b0f6fc-d157-4a58-b9ca-26dd03c7a23d" />

<img width="825" alt="Screenshot 2025-01-16 at 10 11 43 AM" src="https://github.com/user-attachments/assets/b73901db-8070-4c8d-9593-f95fb4500ac1" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

_Make sure both v2 and v3 forms are working as expected._

- Create donation using v3 form and make sure core blocks/fields and custom fields are processing correctly
- Check the confirmation page, donation and donor details to make sure
- Repeat for v2 forms

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2075]: https://stellarwp.atlassian.net/browse/GIVE-2075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ