### PR TITLE
Feature: add renewal methods to subscription model

### DIFF
--- a/src/Donations/Properties/BillingAddress.php
+++ b/src/Donations/Properties/BillingAddress.php
@@ -2,7 +2,14 @@
 
 namespace Give\Donations\Properties;
 
-final class BillingAddress
+use Give\Framework\Support\Contracts\Arrayable;
+use JsonSerializable;
+
+/**
+ * @unreleased added JsonSerializable an Arrayable
+ * @since 2.19.6
+ */
+final class BillingAddress implements JsonSerializable, Arrayable
 {
     /**
      * @var string
@@ -48,5 +55,29 @@ final class BillingAddress
         $self->zip = $array['zip'];
 
         return $self;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function toArray(): array
+    {
+        return [
+            'country' => $this->country,
+            'address1' => $this->address1,
+            'address2' => $this->address2,
+            'city' => $this->city,
+            'state' => $this->state,
+            'zip' => $this->zip,
+        ];
+    }
+
+    /**
+     * @unreleased
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -186,7 +186,11 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
      */
     public function shouldCreateRenewal(): bool
     {
-        return $this->status->isActive() && ($this->isIndefinite() || $this->totalDonations() < $this->installments);
+        if (!$this->status->isActive()) {
+            return false;
+        }
+
+        return $this->isIndefinite() || $this->totalDonations() < $this->installments;
     }
 
     /**

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -186,10 +186,15 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
      */
     public function shouldCreateRenewal(): bool
     {
-        $billTimes = $this->installments;
-        $totalPayments = count($this->donations);
+        return $this->status->isActive() && ($this->isIndefinite() || $this->totalDonations() < $this->installments);
+    }
 
-        return $this->status->isActive() && (0 === $billTimes || $totalPayments < $billTimes);
+    /**
+     * @unreleased
+     */
+    public function totalDonations(): int
+    {
+        return $this->donations()->count();
     }
 
     /**
@@ -197,9 +202,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
      */
     public function shouldEndSubscription(): bool
     {
-        return $this->installments !== 0 && (count(
-                    $this->donations
-                ) >= $this->installments);
+        return !$this->isIndefinite() && ($this->totalDonations() >= $this->installments);
     }
 
     /**

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -173,6 +173,36 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     }
 
     /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function createRenewal(array $attributes = []): Donation
+    {
+        return give()->subscriptions->createRenewal($this, $attributes);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function shouldCreateRenewal(): bool
+    {
+        $billTimes = $this->installments;
+        $totalPayments = count($this->donations);
+
+        return $this->status->isActive() && (0 === $billTimes || $totalPayments < $billTimes);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function shouldEndSubscription(): bool
+    {
+        return $this->installments !== 0 && (count(
+                    $this->donations
+                ) >= $this->installments);
+    }
+
+    /**
      * @since 2.20.0 mutate model in repository and return void
      * @since 2.19.6
      *

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -206,7 +206,11 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
      */
     public function shouldEndSubscription(): bool
     {
-        return !$this->isIndefinite() && ($this->totalDonations() >= $this->installments);
+        if ($this->isIndefinite()) {
+            return false;
+        }
+
+        return $this->totalDonations() >= $this->installments;
     }
 
     /**

--- a/tests/Unit/Subscriptions/Models/TestSubscription.php
+++ b/tests/Unit/Subscriptions/Models/TestSubscription.php
@@ -155,6 +155,17 @@ class TestSubscription extends TestCase
     }
 
     /**
+     * @throws Exception
+     */
+    public function testGetTotalDonationsShouldReturnTotalDonations(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        Subscription::factory()->createRenewal($subscription, 2);
+
+        $this->assertEquals(3, $subscription->totalDonations());
+    }
+
+    /**
      * @return void
      * @throws Exception
      */

--- a/tests/Unit/Subscriptions/Models/TestSubscription.php
+++ b/tests/Unit/Subscriptions/Models/TestSubscription.php
@@ -8,6 +8,7 @@ use Give\Donors\Models\Donor;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\Subscriptions\Models\Subscription;
 use Give\Subscriptions\ValueObjects\SubscriptionPeriod;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
@@ -35,6 +36,122 @@ class TestSubscription extends TestCase
         $subscriptionFromDatabase = Subscription::find($subscription->id);
 
         $this->assertEquals($subscription->toArray(), $subscriptionFromDatabase->toArray());
+    }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testCreateRenewalShouldCreateRenewalWithAttributes(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        /** @var Subscription $subscriptionFromDatabase */
+        $subscriptionFromDatabase = Subscription::find($subscription->id);
+        $renewal = $subscriptionFromDatabase->createRenewal(['gatewayTransactionId' => 'transaction-id-1234']);
+
+        $this->assertEquals('transaction-id-1234', $renewal->gatewayTransactionId);
+        $this->assertEquals($subscriptionFromDatabase->id, $renewal->subscriptionId);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldCreateRenewalShouldReturnTrueWhenInstallmentsIsZero()
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::ACTIVE(),
+            'installments' => 0,
+        ]);
+
+        $this->assertTrue($subscription->shouldCreateRenewal());
+
+
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldCreateRenewalShouldReturnTrueWhenInstallmentsIsLessThanDonations(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::ACTIVE(),
+            'installments' => 3,
+        ]);
+
+        Subscription::factory()->createRenewal($subscription);
+
+        $this->assertTrue($subscription->shouldCreateRenewal());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldCreateRenewalShouldReturnFalseWhenInstallmentsAreReached(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::ACTIVE(),
+            'installments' => 2,
+        ]);
+
+        Subscription::factory()->createRenewal($subscription);
+
+        $this->assertFalse($subscription->shouldCreateRenewal());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldCreateRenewalShouldReturnFalseWhenStatusIsNotActive(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::PENDING(),
+            'installments' => 0,
+        ]);
+
+        $this->assertFalse($subscription->shouldCreateRenewal());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldEndSubscriptionShouldReturnTrueWhenInstallmentsAreReached(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'installments' => 2,
+        ]);
+
+        Subscription::factory()->createRenewal($subscription);
+
+        $this->assertTrue($subscription->shouldEndSubscription());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldEndSubscriptionShouldReturnFalseWhenInstallmentsAreNotReached(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'installments' => 4,
+        ]);
+
+        Subscription::factory()->createRenewal($subscription);
+
+        $this->assertFalse($subscription->shouldEndSubscription());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldEndSubscriptionShouldReturnFalseWhenInstallmentsAreZero(): void
+    {
+        $subscription = Subscription::factory()->createWithDonation([
+            'installments' => 0,
+        ]);
+
+        Subscription::factory()->createRenewal($subscription);
+
+        $this->assertFalse($subscription->shouldEndSubscription());
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds some quality of life methods to subscription model including:
- `createRenewal`
- `shouldCreateRenewal`
- `shouldEndSubscription`

The goal is to unify the way we are dealing with renewals across our gateways.

I noticed throughout different gateways, we are duplicating a lot of the same logic for handling the renewals and are not consistent with the properties being used in the creation of the donation model.  For example, sometimes we use the donor's first name vs the initial donation's billing first name, the billing address is not often accounted for, various properties are missing, etc..  With a unified api we can be consistent with the renewal values and which properties are being carried over from the subscription, initial donation, donor, invoice, etc.

This was largely inspired by a [SubscriptionModelDecorator](https://github.com/impress-org/givewp/blob/8adc13337a1289e1a30f52dc9ec632c9b543d0d9/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Decorators/SubscriptionModelDecorator.php#L14) I created for Stripe webhooks which is being used in production.  

There is also the[ webhook event handlers](https://github.com/impress-org/givewp/blob/304c495bd0a727b0d8e1149c54e7fb1bfecdbcb0/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionRenewalDonationCreated.php#L75) that @glaubersilva made that could make use of these methods directly.



## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This only introduces new logic to the subscription model and repositories, however will affect gateways in the future as they adopt these methods.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Programmatically test the methods

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

