### PR TITLE
Fix: add title attribute to Donation Form block iframes

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/Components/ModalForm.tsx
@@ -1,8 +1,9 @@
 import {useState} from '@wordpress/element';
 import IframeResizer from 'iframe-resizer-react';
+import {__} from '@wordpress/i18n';
+import FormModal from '../../common/FormModal';
 
 import '../../editor/styles/index.scss';
-import FormModal from '../../common/FormModal';
 
 type ModalFormProps = {
     dataSrc: string;
@@ -39,6 +40,7 @@ export default function ModalForm({dataSrc, embedId, openFormButton, isFormRedir
     return (
         <FormModal isOpen={isOpen} onChange={toggleModal} openFormButton={openFormButton}>
             <IframeResizer
+                title={__('Donation Form', 'give')}
                 id={embedId}
                 src={dataSrcUrl}
                 checkOrigin={false}

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -1,9 +1,10 @@
-import {createRoot, render} from '@wordpress/element';
+import {createRoot} from '@wordpress/element';
 import ModalForm from './Components/ModalForm';
 import IframeResizer from 'iframe-resizer-react';
+import {__} from '@wordpress/i18n';
+import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';
 
 import '../editor/styles/index.scss';
-import isRouteInlineRedirect from '@givewp/forms/app/utilities/isRouteInlineRedirect';
 
 /**
  * @since 3.2.1 Revert the display style value of "fullForm" to "onpage".
@@ -70,6 +71,7 @@ function DonationFormBlockApp({
 
     return (
         <IframeResizer
+            title={__('Donation Form', 'give')}
             id={embedId}
             src={dataSrc}
             checkOrigin={false}

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/components/DonationFormBlockPreview.tsx
@@ -1,9 +1,10 @@
 import IframeResizer from 'iframe-resizer-react';
 import {useSelect} from '@wordpress/data';
+import {useState} from '@wordpress/element';
+import {__} from '@wordpress/i18n';
+import FormModal from '../../common/FormModal';
 
 import '../styles/index.scss';
-import FormModal from '../../common/FormModal';
-import {useState} from '@wordpress/element';
 
 /**
  * @since 3.2.1 Revert the display style value of "fullForm" to "onpage"
@@ -46,6 +47,7 @@ export default function DonationFormBlockPreview({
     ) : isModalDisplay ? (
         <FormModal openFormButton={openFormButton} isOpen={isOpen} onChange={() => setIsOpen(!isOpen)}>
             <IframeResizer
+                title={__('Donation Form', 'give')}
                 src={`/?givewp-route=donation-form-view&form-id=${formId}`}
                 checkOrigin={false}
                 style={{
@@ -56,6 +58,7 @@ export default function DonationFormBlockPreview({
         </FormModal>
     ) : (
         <IframeResizer
+            title={__('Donation Form', 'give')}
             src={`/?givewp-route=donation-form-view&form-id=${formId}`}
             checkOrigin={false}
             style={{


### PR DESCRIPTION
Resolves: 
Accessibility Audit: Give-041
https://lw.slack.com/archives/C0355E6LBMZ/p1736794600442929

## Description
The Donation Form block iframes currently lacks a descriptive title attribute and are auto-set to `title="iframe"`

To improve accessibility, I’ve added a descriptive title attribute to the `iframe-resizer` components used in the Donation Form blocks. This change ensures that each iframe used for block previews and different display types is properly labeled, enhancing the user experience for those relying on assistive technologies.

## Affects
- Donation Form block.
- w/ different displays.
- Both frontend and admin screen.

## Visuals

## Testing Instructions
- Create a form.
- Create a page with Donation Form blocks using each display type.
- View the iframes in the console and verify that the title attribute has been updated to "Donation Form".
- Repeat last step in the admin block editor and the frontend webpage.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

