### PR TITLE
Refactor: update Stripe subscription model decorator to use subscription model methods directly

### DIFF
--- a/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php
+++ b/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php
@@ -138,8 +138,6 @@ class InvoicePaymentSucceededTest extends TestCase
 
         //refresh subscription model
         $subscription = Subscription::find($subscription->id);
-        // cache donations
-        $subscriptionDonations = $subscription->donations;
         //refresh donation model
         $donation = Donation::find($donation->id);
 
@@ -178,7 +176,7 @@ class InvoicePaymentSucceededTest extends TestCase
         // Refresh subscription model
         $subscription = Subscription::find($subscription->id);
 
-        $this->assertCount(1, $subscriptionDonations);
+        $this->assertSame(1, $subscription->totalDonations());
         $this->assertTrue($subscription->status->isCompleted());
     }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2167]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This pull request includes changes to the `SubscriptionModelDecorator` class and its related tests to simplify the code and improve maintainability. The most important changes include the removal of unused imports, updating methods to use model methods, and refactoring the test cases.

Code simplification and maintainability improvements:

* [`src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Decorators/SubscriptionModelDecorator.php`](diffhunk://#diff-7046fcff8ed3257b07f95e6183405f4e095366411d17d33f4c11ae192be9cbf6L5-L7): Removed unused imports to clean up the code.
* [`src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Decorators/SubscriptionModelDecorator.php`](diffhunk://#diff-7046fcff8ed3257b07f95e6183405f4e095366411d17d33f4c11ae192be9cbf6R26-R60): Updated `shouldEndSubscription`, `shouldCreateRenewal`, and `handleRenewal` methods to use model methods for better encapsulation and maintainability.
* [`tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php`](diffhunk://#diff-a952e8f7cfb7e03bbbaa2c7ed734ee1b676b59b32a31403a43f4d8693b73a279L141-L142): Refactored the `testShouldCompleteSubscription` method to remove unnecessary caching of donations.
* [`tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php`](diffhunk://#diff-a952e8f7cfb7e03bbbaa2c7ed734ee1b676b59b32a31403a43f4d8693b73a279L181-R179): Updated assertions to use the `totalDonations` method for clarity and accuracy.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The logic for handling the Stripe subscription webhook listener `InvoicePaymentSucceeded`
- shouldCreateRenewal
- handleRenewal
- shouldEndSubscription

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

QA
- Setup Stripe webhooks and create subscription
- Trigger webhook event to create renewal (InvoicePaymentSucceeded)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2167]: https://stellarwp.atlassian.net/browse/GIVE-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ