### PR TITLE
Refactor: update text block conversion to use text block type

### DIFF
--- a/src/FormBuilder/BlockTypes/TextBlockType.php
+++ b/src/FormBuilder/BlockTypes/TextBlockType.php
@@ -19,4 +19,12 @@ class TextBlockType extends BlockType
     {
         return 'givewp/text';
     }
+
+    /**
+     * @unreleased
+     */
+    public function getFieldName(int $blockIndex): string
+    {
+        return !empty($this->fieldName) ? $this->fieldName : $this->block->getShortName() . '-' . $blockIndex;
+    }
 }

--- a/src/Framework/Blocks/BlockType.php
+++ b/src/Framework/Blocks/BlockType.php
@@ -221,7 +221,7 @@ abstract class BlockType implements BlockTypeInterface, Arrayable
     }
 
     /**
-     * @unreleased updated to set always default properties
+     * @unreleased updated to always set default properties
      * @since 3.8.0
      */
     private function fillDefaultProperties(): void

--- a/src/Framework/Blocks/BlockType.php
+++ b/src/Framework/Blocks/BlockType.php
@@ -162,14 +162,11 @@ abstract class BlockType implements BlockTypeInterface, Arrayable
     }
 
     /**
+     * @unreleased updated to always cast value even if null
      * @since 3.8.0
      */
     public function castAttributeType(string $key, $value)
     {
-        if (is_null($value)) {
-            return null;
-        }
-
         $type = $this->getPropertyType($key);
 
         switch ($type) {
@@ -178,7 +175,7 @@ abstract class BlockType implements BlockTypeInterface, Arrayable
             case 'string':
                 return (string)($value);
             case 'bool':
-                return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                return (bool)filter_var($value, FILTER_VALIDATE_BOOLEAN);
             case 'array':
                 return (array)($value);
             case 'float':
@@ -224,14 +221,13 @@ abstract class BlockType implements BlockTypeInterface, Arrayable
     }
 
     /**
+     * @unreleased updated to set always default properties
      * @since 3.8.0
      */
     private function fillDefaultProperties(): void
     {
         foreach ($this->setDefaultProperties() as $key => $type) {
-            if ($this->hasAttribute($key)) {
-                $this->properties[$key] = $type;
-            }
+            $this->properties[$key] = $type;
         }
     }
 }

--- a/tests/Unit/FormBuilder/BlockTypes/TestDonationAmountBlockType.php
+++ b/tests/Unit/FormBuilder/BlockTypes/TestDonationAmountBlockType.php
@@ -25,6 +25,7 @@ class TestDonationAmountBlockType extends TestCase
     }
 
     /**
+     * @unreleased updated customAmountMax to expect int value
      * @since 3.12.0 Update test to use the new levels schema
      * @since 3.8.0
      * @throws Exception
@@ -47,7 +48,7 @@ class TestDonationAmountBlockType extends TestCase
         $this->assertSame(25, $block->setPrice);
         $this->assertTrue($block->customAmount);
         $this->assertSame(1, $block->customAmountMin);
-        $this->assertNull($block->customAmountMax);
+        $this->assertSame(0, $block->customAmountMax);
         $this->assertFalse($block->recurringEnabled);
         $this->assertSame(1, $block->recurringBillingInterval);
         $this->assertSame(["month"], $block->recurringBillingPeriodOptions);

--- a/tests/Unit/FormBuilder/BlockTypes/TestTextBlockType.php
+++ b/tests/Unit/FormBuilder/BlockTypes/TestTextBlockType.php
@@ -3,6 +3,7 @@
 namespace Give\Tests\Unit\FormBuilder\BlockTypes;
 
 use Exception;
+use Give\FormBuilder\BlockTypes\TextBlockType;
 use Give\Framework\Blocks\BlockModel;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
@@ -26,7 +27,7 @@ class TestTextBlockType extends TestCase
             ]
         );
 
-        $blockType = new \Give\FormBuilder\BlockTypes\TextBlockType($blockModel);
+        $blockType = new TextBlockType($blockModel);
 
         $this->assertSame('givewp/text', $blockType::name());
     }
@@ -67,7 +68,7 @@ class TestTextBlockType extends TestCase
             ]
         );
 
-        $blockType = new \Give\FormBuilder\BlockTypes\TextBlockType($blockModel);
+        $blockType = new TextBlockType($blockModel);
 
         $this->assertSame('Test Label', $blockType->label);
         $this->assertSame('Test Description', $blockType->description);
@@ -93,5 +94,45 @@ class TestTextBlockType extends TestCase
             ],
             $blockType->conditionalLogic
         );
+    }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testGetFieldNameShouldReturnCustomName(): void
+    {
+        $blockModel = BlockModel::make(
+            [
+                'name' => 'givewp/text',
+                'attributes' => [
+                    'fieldName' => 'custom_field_name',
+                ]
+            ]
+        );
+
+        $blockType = new TextBlockType($blockModel);
+
+        $this->assertSame('custom_field_name', $blockType->getFieldName(1));
+    }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testGetFieldNameShouldReturnNameWithIndex()
+    {
+        $blockModel = BlockModel::make(
+            [
+                'name' => 'givewp/text',
+                'attributes' => [
+                    'fieldName' => '',
+                ]
+            ]
+        );
+
+        $blockType = new TextBlockType($blockModel);
+
+        $this->assertSame('text-1', $blockType->getFieldName(1));
     }
 }

--- a/tests/Unit/Framework/Blocks/TestBlockType.php
+++ b/tests/Unit/Framework/Blocks/TestBlockType.php
@@ -264,6 +264,45 @@ class TestBlockType extends TestCase
     }
 
     /**
+     * @unreleased
+     */
+    public function testShouldCastNullValuesAsIntendedType(): void
+    {
+        $blockModel = BlockModel::make([
+            'name' => 'givewp/donation-amount',
+            'attributes' => [
+                'floatAttribute' => null,
+                'stringAttribute' => null,
+                'intAttribute' => null,
+                'boolAttribute' => null,
+            ]
+        ]);
+
+        $blockType = new class ($blockModel) extends BlockType {
+            protected $properties = [
+                'floatAttribute' => 'float',
+                'stringAttribute' => 'string',
+                'intAttribute' => 'int',
+                'boolAttribute' => 'bool',
+                'extraStringAttribute' => 'string',
+                'extraBoolAttribute' => 'bool',
+            ];
+
+            public static function name(): string
+            {
+                return 'givewp/donation-amount';
+            }
+        };
+
+        $this->assertIsFloat($blockType->floatAttribute);
+        $this->assertIsString($blockType->stringAttribute);
+        $this->assertIsInt($blockType->intAttribute);
+        $this->assertIsBool($blockType->boolAttribute);
+        $this->assertIsBool($blockType->extraBoolAttribute);
+        $this->assertIsString($blockType->extraStringAttribute);
+    }
+
+    /**
      * @since 3.8.0
      *
      * @throws Exception


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2163]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the text block conversion to use the first class `TextBlockType`.

This is the first in series approach to moving away from the untyped `$block->getAttribute()` and toward specific [block types](https://github.com/impress-org/givewp/pull/7195) with typed block attributes in the form of object properties.

This also caught and fixes an issue with the `BlockType` class so it will always cast values as intended.  So if you are expecting a boolean and for some reason the block does not have the attribute it will still return a boolean type instead of null.  This makes sure the block type property types are always valid types and can be confidently used in typed methods in the fields api.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Custom text block fields in the VFB

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Make sure new and existing custom text blocks work as expected on v3 forms

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2163]: https://stellarwp.atlassian.net/browse/GIVE-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ