### PR TITLE
Fix: Prevent NaN error in Campaign Overview Stat Widget

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -93,7 +93,7 @@ const StatWidget = ({label, values, description, formatter = null}) => {
             </header>
             <div className={styles.statWidgetAmount}>
                 <DisplayText>
-                    {formatter?.format(values[0]) ?? values[0]}
+                    {!isNaN(values[0]) ? formatter?.format(values[0]) ?? values[0] : (<span>&nbsp;</span>)}
                 </DisplayText>
                 {!! values[1] && (
                     <PercentChangePill value={values[0]} comparison={values[1]} />

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -3,7 +3,7 @@ import {useEffect, useState} from "react";
 import RevenueChart from "../RevenueChart";
 import GoalProgressChart from "../GoalProgressChart";
 import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
+import {addQueryArgs} from '@wordpress/url';
 import HeaderText from '../HeaderText';
 import HeaderSubText from '../HeaderSubText';
 import DefaultFormWidget from "../DefaultForm";
@@ -21,11 +21,11 @@ declare const window: {
 const pluck = (array: any[], property: string) => array.map(element => element[property])
 
 const filterOptions = [
-    { label: __('Today', 'give'), value: 1, description: __('from today', 'give') },
-    { label: __('Last 7 days', 'give'), value: 7, description: __('from the last 7 days', 'give') },
-    { label: __('Last 30 days', 'give'), value: 30, description: __('from the last 30 days', 'give') },
-    { label: __('Last 90 days', 'give'), value: 90, description: __('from the last 90 days', 'give') },
-    { label: __('All-time', 'give'), value: 0, description: __('total for all-time', 'give') },
+    {label: __('Today', 'give'), value: 1, description: __('from today', 'give')},
+    {label: __('Last 7 days', 'give'), value: 7, description: __('from the last 7 days', 'give')},
+    {label: __('Last 30 days', 'give'), value: 30, description: __('from the last 30 days', 'give')},
+    {label: __('Last 90 days', 'give'), value: 90, description: __('from the last 90 days', 'give')},
+    {label: __('All-time', 'give'), value: 0, description: __('total for all-time', 'give')},
 ]
 
 const currency = new Intl.NumberFormat('en-US', {
@@ -46,7 +46,7 @@ const CampaignStats = () => {
     const onDayRangeChange = async (days: number) => {
         setDayRange(days)
 
-        apiFetch({path: addQueryArgs( '/give-api/v2/campaigns/' + campaignId +'/statistics', {rangeInDays: days} ) } )
+        apiFetch({path: addQueryArgs('/give-api/v2/campaigns/' + campaignId + '/statistics', {rangeInDays: days})})
             .then(setStats);
     }
 
@@ -56,10 +56,13 @@ const CampaignStats = () => {
         <>
             <DateRangeFilters selected={dayRange} options={filterOptions} onSelect={onDayRangeChange} />
             <div className={styles.mainGrid}>
-                    <StatWidget label={__('Amount raised', 'give')} values={pluck(stats, 'amountRaised')} description={widgetDescription} formatter={currency} />
-                    <StatWidget label={__('Number of donations', 'give')} values={pluck(stats, 'donationCount')} description={widgetDescription} />
-                    <StatWidget label={__('Number of donors', 'give')} values={pluck(stats, 'donorCount')} description={widgetDescription} />
-                    <RevenueWidget />
+                <StatWidget label={__('Amount raised', 'give')} values={pluck(stats, 'amountRaised')}
+                            description={widgetDescription} formatter={currency} />
+                <StatWidget label={__('Number of donations', 'give')} values={pluck(stats, 'donationCount')}
+                            description={widgetDescription} />
+                <StatWidget label={__('Number of donors', 'give')} values={pluck(stats, 'donorCount')}
+                            description={widgetDescription} />
+                <RevenueWidget />
                 <div className={styles.nestedGrid}>
                     <GoalProgressWidget />
                     <DefaultFormWidget defaultForm={campaign.defaultFormTitle} />
@@ -95,7 +98,7 @@ const StatWidget = ({label, values, description, formatter = null}) => {
                 <DisplayText>
                     {!isNaN(values[0]) ? formatter?.format(values[0]) ?? values[0] : (<span>&nbsp;</span>)}
                 </DisplayText>
-                {!! values[1] && (
+                {!!values[1] && (
                     <PercentChangePill value={values[0]} comparison={values[1]} />
                 )}
             </div>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -96,7 +96,10 @@ const StatWidget = ({label, values, description, formatter = null}) => {
             </header>
             <div className={styles.statWidgetAmount}>
                 <DisplayText>
-                    {!isNaN(values[0]) ? formatter?.format(values[0]) ?? values[0] : (<span>&nbsp;</span>)}
+                    {'undefined' !== typeof values[0]
+                        ? formatter?.format(values[0]) ?? values[0]
+                        : <span>&nbsp;</span>
+                    }
                 </DisplayText>
                 {!!values[1] && (
                     <PercentChangePill value={values[0]} comparison={values[1]} />


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves GIVE-2031

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR updates the `<StatWidget>` component to prevent a `NaN` error while fetching data.

Additionally, a non-breaking space is used to prevent content shifting.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![Peek 2025-01-27 15-39-2](https://github.com/user-attachments/assets/24203e4c-09cc-4d23-8c3a-f8b57116ef96)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Hard-reload the page (with cache disabled via browser tools)
- Toggle between tabs in the Overview screen

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

