### PR TITLE
Feature: add Campaign Cover Block

### DIFF
--- a/src/Campaigns/Blocks/CampaignCover/Icon.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/Icon.tsx
@@ -1,0 +1,16 @@
+import {Path, SVG} from "@wordpress/components";
+
+export function GalleryIcon() {
+    return (
+        <SVG
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM5 4.5h14c.3 0 .5.2.5.5v8.4l-3-2.9c-.3-.3-.8-.3-1 0L11.9 14 9 12c-.3-.2-.6-.2-.8 0l-3.6 2.6V5c-.1-.3.1-.5.4-.5zm14 15H5c-.3 0-.5-.2-.5-.5v-2.4l4.1-3 3 1.9c.3.2.7.2.9-.1L16 12l3.5 3.4V19c0 .3-.2.5-.5.5z"></Path>
+        </SVG>
+    );
+}

--- a/src/Campaigns/Blocks/CampaignCover/block.json
+++ b/src/Campaigns/Blocks/CampaignCover/block.json
@@ -23,10 +23,7 @@
         },
         "align": {
             "type": "string",
-            "default": "none"
-        },
-        "duotone": {
-            "type": "string"
+            "default": ""
         }
     },
     "supports": {

--- a/src/Campaigns/Blocks/CampaignCover/block.json
+++ b/src/Campaigns/Blocks/CampaignCover/block.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "givewp/campaign-cover-block",
+    "version": "1.0.0",
+    "title": "Campaign Cover",
+    "category": "give",
+    "description": "Displays the cover image of the campaign.",
+    "attributes": {
+        "campaignId": {
+            "type": "integer"
+        },
+        "alt": {
+            "type": "string"
+        }
+    },
+    "supports": {
+        "align": [
+            "wide",
+            "full",
+            "left",
+            "center",
+            "right"
+        ],
+        "anchor": true,
+        "className": true,
+        "splitting": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalWritingMode": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    },
+    "textdomain": "give",
+    "render": "file:./render.php"
+}

--- a/src/Campaigns/Blocks/CampaignCover/block.json
+++ b/src/Campaigns/Blocks/CampaignCover/block.json
@@ -38,7 +38,6 @@
             "duotone": true
         },
         "selectors": {
-            "root": ".give-block-campaign-cover",
             "filter": {
                 "duotone": ".wp-block-givewp-campaign-cover-block img"
             }

--- a/src/Campaigns/Blocks/CampaignCover/block.json
+++ b/src/Campaigns/Blocks/CampaignCover/block.json
@@ -12,6 +12,21 @@
         },
         "alt": {
             "type": "string"
+        },
+        "width": {
+            "type": "number",
+            "default": 645
+        },
+        "height": {
+            "type": "number",
+            "default": 865
+        },
+        "align": {
+            "type": "string",
+            "default": "none"
+        },
+        "duotone": {
+            "type": "string"
         }
     },
     "supports": {
@@ -22,6 +37,15 @@
             "center",
             "right"
         ],
+        "filter": {
+            "duotone": true
+        },
+        "selectors": {
+            "root": ".give-block-campaign-cover",
+            "filter": {
+                "duotone": ".wp-block-givewp-campaign-cover-block img"
+            }
+        },
         "anchor": true,
         "className": true,
         "splitting": true,
@@ -63,5 +87,6 @@
         }
     },
     "textdomain": "give",
-    "render": "file:./render.php"
+    "render": "file:./render.php",
+    "style": "file:./style.css"
 }

--- a/src/Campaigns/Blocks/CampaignCover/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/edit.tsx
@@ -1,0 +1,72 @@
+import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
+import {__} from '@wordpress/i18n';
+import {useSelect} from '@wordpress/data';
+import {external} from '@wordpress/icons';
+import {BaseControl, Icon, PanelBody, TextareaControl} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import {BlockEditProps} from '@wordpress/blocks';
+
+import {CampaignSelector} from '../shared/components/CampaignSelector';
+import useCampaign from '../shared/hooks/useCampaign';
+import './editor.scss';
+
+export default function Edit({
+    attributes,
+    setAttributes,
+}: BlockEditProps<{
+    campaignId: number;
+    alt: string;
+}>) {
+    const blockProps = useBlockProps();
+    const {campaign, hasResolved} = useCampaign(attributes.campaignId);
+
+    const adminBaseUrl = useSelect(
+        // @ts-ignore
+        (select) => select('core').getSite()?.url + '/wp-admin/edit.php?post_type=give_forms&page=give-campaigns',
+        []
+    );
+
+    const editCampaignUrl = `${adminBaseUrl}&id=${attributes.campaignId}&tab=settings`;
+
+    return (
+        <div {...blockProps}>
+            <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
+                {campaign?.image && <ServerSideRender block="givewp/campaign-cover-block" attributes={attributes} />}
+            </CampaignSelector>
+
+            {hasResolved && campaign && (
+                <InspectorControls>
+                    <PanelBody title="Settings" initialOpen={true}>
+                        <BaseControl label={__('Cover', 'give')} id="givewp-campaign-cover-block__title-field">
+                            {campaign?.image && (
+                                <img
+                                    className={'givewp-campaign-cover-block__image'}
+                                    src={campaign?.image}
+                                    alt={attributes.alt ?? __('Campaign Cover image', 'give')}
+                                />
+                            )}
+                            <p className={'givewp-campaign-cover-block__help-text'}>
+                                {__('Shows the cover image of the campaign.', 'give')}
+                            </p>
+                            <a
+                                href={editCampaignUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="givewp-campaign-cover-block__edit-campaign-link"
+                                aria-label={__('Edit campaign settings in a new tab', 'give')}
+                            >
+                                {__('Change campaign cover', 'give')}
+                                <Icon icon={external} />
+                            </a>
+                        </BaseControl>
+                        <TextareaControl
+                            label={__('Alternative text', 'give')}
+                            value={attributes.alt}
+                            onChange={(value: string) => setAttributes({alt: value})}
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            )}
+        </div>
+    );
+}

--- a/src/Campaigns/Blocks/CampaignCover/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/edit.tsx
@@ -16,7 +16,6 @@ interface EditProps extends BlockEditProps<{
     width: number;
     height: number;
     align: string;
-    duotone: any;
 }> {
     toggleSelection: (isSelected: boolean) => void;
 }

--- a/src/Campaigns/Blocks/CampaignCover/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/edit.tsx
@@ -2,13 +2,14 @@ import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
 import {useSelect} from '@wordpress/data';
 import {external} from '@wordpress/icons';
-import {BaseControl, Icon, PanelBody, TextareaControl} from '@wordpress/components';
+import {BaseControl, Icon, PanelBody, Placeholder, TextareaControl} from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import {BlockEditProps} from '@wordpress/blocks';
 
 import {CampaignSelector} from '../shared/components/CampaignSelector';
 import useCampaign from '../shared/hooks/useCampaign';
 import './editor.scss';
+import {GalleryIcon} from './Icon';
 
 export default function Edit({
     attributes,
@@ -31,7 +32,15 @@ export default function Edit({
     return (
         <div {...blockProps}>
             <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
-                {campaign?.image && <ServerSideRender block="givewp/campaign-cover-block" attributes={attributes} />}
+                {campaign?.image ? (
+                    <ServerSideRender block="givewp/campaign-cover-block" attributes={attributes} />
+                ) : (
+                    <Placeholder
+                        icon={<GalleryIcon />}
+                        label={__('Campaign Cover Image', 'give')}
+                        instructions={__('Upload a cover image for your campaign.', 'give')}
+                    />
+                )}
             </CampaignSelector>
 
             {hasResolved && campaign && (

--- a/src/Campaigns/Blocks/CampaignCover/editor.scss
+++ b/src/Campaigns/Blocks/CampaignCover/editor.scss
@@ -1,0 +1,61 @@
+.givewp-campaign-cover-block {
+    &__button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 32px;
+        width: 100%;
+        margin-bottom: .5rem;
+        color: #2271b1;
+        border: 1px solid #2271b1;
+        border-radius: 2px;
+    }
+
+    &__image {
+        flex-grow: 1;
+        display: flex;
+        max-height: 4.44rem;
+        width: 100%;
+        object-fit: cover;
+        margin-bottom: .5rem;
+        border-radius: 2px;
+    }
+
+    &__help-text {
+        font-size: 0.75rem;
+        font-weight: normal;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.4;
+        letter-spacing: normal;
+        text-align: left;
+        color: #4b5563;
+    }
+
+    &__edit-campaign-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.125rem;
+        font-size: 0.75rem;
+        font-weight: normal;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.4;
+
+        svg {
+            fill: currentColor;
+            height: 1.25rem;
+            width: 1.25rem;
+        }
+    }
+}
+
+.givewp-campaign-cover-block-preview {
+    &__image {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/src/Campaigns/Blocks/CampaignCover/index.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/index.tsx
@@ -1,0 +1,14 @@
+import metadata from './block.json';
+import Edit from './edit';
+import initBlock from '../shared/utils/init-block';
+import {GalleryIcon} from './Icon';
+
+const {name} = metadata;
+
+export {metadata, name};
+export const settings = {
+    edit: Edit,
+    icon: <GalleryIcon />,
+};
+
+export const init = () => initBlock({name, metadata, settings});

--- a/src/Campaigns/Blocks/CampaignCover/render.php
+++ b/src/Campaigns/Blocks/CampaignCover/render.php
@@ -16,7 +16,7 @@ if ( ! $campaign) {
 
 $campaignMediaSetting = $campaign->image;
 
-$altText = $attributes['alt'] ?? 'Campaign cover image';
+$altText = $attributes['alt'] ?? __('Campaign cover image', 'give');
 $alignment = isset($attributes['align']) ? 'align' . $attributes['align'] : '';
 
 // Only assign width and height if the alignment is NOT "full" or "wide"

--- a/src/Campaigns/Blocks/CampaignCover/render.php
+++ b/src/Campaigns/Blocks/CampaignCover/render.php
@@ -3,25 +3,40 @@
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 
-if (!isset($attributes['campaignId'])) {
+if ( ! isset($attributes['campaignId'])) {
     return;
 }
 
 /** @var Campaign $campaign */
 $campaign = give(CampaignRepository::class)->getById($attributes['campaignId']);
 
-if (!$campaign) {
+if ( ! $campaign) {
     return;
 }
 
 $campaignMediaSetting = $campaign->image;
-$altText = $attributes['alt'] ?? 'campaign cover image';
 
+$altText = $attributes['alt'] ?? 'Campaign cover image';
+$alignment = isset($attributes['align']) ? 'align' . $attributes['align'] : '';
+
+// Only assign width and height if the alignment is NOT "full" or "wide"
+if ($attributes['align'] !== 'full' && $attributes['align'] !== 'wide') {
+    $width = isset($attributes['width']) ? $attributes['width'] : '100%';
+    $height = isset($attributes['height']) ? $attributes['height'] : '100%';
+} else {
+    $width = 'auto';
+    $height = 'auto';
+}
 ?>
 
-<figure>
-        <img src="<?php echo esc_url($campaign->image); ?>"
-             alt="<?php echo esc_attr($altText); ?>"
-             style="width: 100%; height: 100%; border-radius: 8px;"
-        />
+
+<figure class="wp-block-givewp-campaign-cover-block <?php echo esc_attr($alignment) ?>">
+    <img
+        src="<?php echo esc_url($campaign->image); ?>"
+        alt="<?php echo esc_attr($altText); ?>"
+        style="
+            width:<?php echo $width ?>px;
+            height: <?php echo $height ?>px;
+            border-radius: 8px;"
+    />
 </figure>

--- a/src/Campaigns/Blocks/CampaignCover/render.php
+++ b/src/Campaigns/Blocks/CampaignCover/render.php
@@ -1,0 +1,27 @@
+<?php
+
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\Repositories\CampaignRepository;
+
+if (!isset($attributes['campaignId'])) {
+    return;
+}
+
+/** @var Campaign $campaign */
+$campaign = give(CampaignRepository::class)->getById($attributes['campaignId']);
+
+if (!$campaign) {
+    return;
+}
+
+$campaignMediaSetting = $campaign->image;
+$altText = $attributes['alt'] ?? 'campaign cover image';
+
+?>
+
+<figure>
+        <img src="<?php echo esc_url($campaign->image); ?>"
+             alt="<?php echo esc_attr($altText); ?>"
+             style="width: 100%; height: 100%; border-radius: 8px;"
+        />
+</figure>

--- a/src/Campaigns/Blocks/blocks.ts
+++ b/src/Campaigns/Blocks/blocks.ts
@@ -1,7 +1,8 @@
 import * as campaignTitleBlock from './CampaignTitleBlock';
+import * as campaignCover from './CampaignCover';
 
 const getAllBlocks = () => {
-    return [campaignTitleBlock];
+    return [campaignTitleBlock, campaignCover];
 };
 
 getAllBlocks().forEach((block) => {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -126,10 +126,10 @@ export default () => {
 
                     <div className={styles.sectionField}>
                         <div className={styles.sectionSubtitle}>
-                            {__('Add a cover image or video for your campaign.', 'give')}
+                            {__('Add a cover image for your campaign.', 'give')}
                         </div>
                         <div className={styles.sectionFieldDescription}>
-                            {__('Upload an image or video to represent and inspire your campaign.', 'give')}
+                            {__('Upload an image to represent and inspire your campaign.', 'give')}
                         </div>
                         <div className={styles.upload}>
                             <Upload

--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -267,9 +267,9 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                             />
                         </div>
                         <div className="givewp-campaigns__form-row">
-                            <label htmlFor="image">{__('Add a cover image or video for your campaign.', 'give')}</label>
+                            <label htmlFor="image">{__('Add a cover image for your campaign.', 'give')}</label>
                             <span>
-                                {__('Upload an image or video to represent and inspire your campaign.', 'give')}
+                                {__('Upload an image to represent and inspire your campaign.', 'give')}
                             </span>
                             <Upload
                                 id="givewp-campaigns-upload-cover-image"

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -36,6 +36,9 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
             button: {
                 text: __('Use this media', 'gie'),
             },
+            library: {
+                type: 'image', // Restricts media library to image files only
+            },
             multiple: false, // Set to true to allow multiple files to be selected
         });
 
@@ -130,7 +133,7 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
                     <button className={'givewp-media-library-control__button'} onClick={openMediaLibrary}>
                         {actionLabel}
                     </button>
-                    <p>{__('or drag your image or video here', 'give')}</p>
+                    <p>{__('or drag your image here', 'give')}</p>
                 </div>
             )}
         </div>

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -4,19 +4,23 @@ div.media-modal.wp-core-ui {
 
 .givewp-media-library-drop-area {
     text-align: center;
-    padding: 1rem 0 0 0;
+    padding: var(--givewp-spacing-8) 0;
     border: 1px dotted;
-    border-radius: 4px;
+    border-radius: var(--givewp-rounded-4);
 
     button {
         cursor: pointer;
         width: fit-content;
-        margin: 8px auto;
-        background: #E5E7EB;
+        margin: var(--givewp-spacing-4) auto var(--givewp-spacing-2);
+        background: var(--givewp-neutral-100);
         height: initial;
         border: initial;
-        padding: 4px 8px 4px 8px;
-        border-radius: 4px
+        padding: var(--givewp-spacing-1) var(--givewp-spacing-2);
+        border-radius: var(--givewp-rounded-4);
+    }
+
+    p, svg {
+        margin: 0;
     }
 }
 
@@ -66,7 +70,7 @@ div.media-modal.wp-core-ui {
         object-fit: cover;
         object-position: center;
         transition: filter 0.3s ease;
-        border-radius: 4px;
+        border-radius: var(--givewp-rounded-4);
         cursor: pointer;
 
         &:hover {
@@ -96,7 +100,7 @@ div.media-modal.wp-core-ui {
         align-items: center;
         gap: 0.5rem;
         cursor: pointer;
-        border-radius: 4px;
+        border-radius: var(--givewp-rounded-4);
 
         button {
             margin-top: var(--givewp-spacing-2);


### PR DESCRIPTION
Resolves [GIVE-1505] /  [GIVE-1973]
## Description
- Removes references of video support on the  media `Uploader` from the campaign settings and creation modal. 
  Slack conversation reference: https://lw.slack.com/archives/C04SLRDD9CK/p1738173558503109
- Improved styles on the `Uploader` components.
- Adds Campaign Cover Block to the block editor. This block's image can only be updated from the campaign settings.  A placeholder will be displayed if no image is set from the campaign settings. The image supports alignment, resizing & duotone.

## Affects
Campaign settings & Campaign Cover Block

## Visuals
https://www.loom.com/share/b168317f31ef40ba9a3a1add7cea7b81?sid=70ad126a-bde3-476a-8b0f-31e9b76d5773

## Testing Instructions
- Add the campaign cover block without an image, verify a placeholder is displayed.
- Add the campaign cover block with an image verify the image is can be resized, aligned and supports duotone. These blocks settings need to be verified on both the frontend page & in the admin editor.
- Verify the UI/UX does not imply that videos can be supported from the block uploader.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1505]: https://stellarwp.atlassian.net/browse/GIVE-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GIVE-1973]: https://stellarwp.atlassian.net/browse/GIVE-1973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ