### PR TITLE
Feature: Register campaign theme color settings

### DIFF
--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -45,7 +45,6 @@ class RegisterCampaignBlocks
         wp_enqueue_style(
             $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlocks.css',
-            /** @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-components/#usage */
             ['wp-components'],
             $scriptAsset['version']
         );

--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -14,8 +14,8 @@ $donateButtonText = $attributes['donateButtonText'] ?? __('Donate', 'give');
 
 $blockInlineStyles = sprintf(
     '--givewp-primary-color: %s; --givewp-secondary-color: %s;',
-    esc_attr('#0b72d9'),
-    esc_attr('#27ae60')
+    esc_attr($campaign->primaryColor ?? '#0b72d9'),
+    esc_attr($campaign->secondaryColor ?? '#27ae60')
 );
 ?>
 <div

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -16,8 +16,8 @@ $donateButtonText = $attributes['donateButtonText'] ?? __('Join the list', 'give
 
 $blockInlineStyles = sprintf(
     '--givewp-primary-color: %s; --givewp-secondary-color: %s;',
-    esc_attr('#0b72d9'),
-    esc_attr('#27ae60')
+    esc_attr($campaign->primaryColor ?? '#0b72d9'),
+    esc_attr($campaign->secondaryColor ?? '#27ae60')
 );
 ?>
 <div

--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -16,6 +16,11 @@ if (
     return;
 }
 
+$blockInlineStyles = sprintf(
+    '--givewp-primary-color: %s;',
+    esc_attr($campaign->primaryColor ?? '#0b72d9')
+);
+
 $params = [
     'formId' => $attributes['useDefaultForm']
         ? $campaign->defaultFormId
@@ -23,5 +28,13 @@ $params = [
     'openFormButton' => $attributes['buttonText'],
     'formFormat' => 'modal',
 ];
+?>
 
-echo (new BlockRenderController())->render($params);
+<div
+    <?php
+    echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block'])); ?>
+    style="<?php
+    echo esc_attr($blockInlineStyles); ?>">
+    <?php
+    echo (new BlockRenderController())->render($params); ?>
+</div>

--- a/src/Campaigns/Controllers/CampaignRequestController.php
+++ b/src/Campaigns/Controllers/CampaignRequestController.php
@@ -3,7 +3,6 @@
 namespace Give\Campaigns\Controllers;
 
 use Exception;
-use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\Campaigns\ValueObjects\CampaignGoalType;
@@ -186,8 +185,8 @@ class CampaignRequestController
             'longDescription' => '',
             'logo' => '',
             'image' => $request->get_param('image') ?? '',
-            'primaryColor' => '',
-            'secondaryColor' => '',
+            'primaryColor' => '#0b72d9',
+            'secondaryColor' => '#27ae60',
             'goal' => (int)$request->get_param('goal'),
             'goalType' => new CampaignGoalType($request->get_param('goalType')),
             'status' => CampaignStatus::DRAFT(),

--- a/src/Campaigns/Routes/RegisterCampaignRoutes.php
+++ b/src/Campaigns/Routes/RegisterCampaignRoutes.php
@@ -252,6 +252,14 @@ class RegisterCampaignRoutes
                     'type' => 'string',
                     'description' => esc_html__('Campaign short description', 'give'),
                 ],
+                'primaryColor' => [
+                    'type' => 'string',
+                    'description' => esc_html__('Primary color for the campaign', 'give'),
+                ],
+                'secondaryColor' => [
+                    'type' => 'string',
+                    'description' => esc_html__('Secondary color for the campaign', 'give'),
+                ],
                 'goal' => [
                     'type' => 'number',
                     'minimum' => 1,

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -471,6 +471,10 @@ select[name="campaignId"] {
             width: 1.25rem;
         }
     }
+
+    .colorControl {
+        margin-top: var(--givewp-spacing-3);
+    }
 }
 
 .loadingContainer {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/Icons/CheckIcon.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/Icons/CheckIcon.tsx
@@ -1,0 +1,24 @@
+export default function CheckIcon({refColor}) {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M20.707 5.293a1 1 0 0 1 0 1.414l-11 11a1 1 0 0 1-1.414 0l-5-5a1 1 0 1 1 1.414-1.414L9 15.586 19.293 5.293a1 1 0 0 1 1.414 0z"
+                fill={getContrastColor(refColor)}
+            />
+        </svg>
+    );
+}
+
+function getContrastColor(hexColor){
+    hexColor = hexColor.replace(/^#/, '');
+
+    let r = parseInt(hexColor.substring(0, 2), 16);
+    let g = parseInt(hexColor.substring(2, 4), 16);
+    let b = parseInt(hexColor.substring(4, 6), 16);
+
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+    return luminance > 0.5 ? '#000000' : '#FFFFFF';
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/Icons/EditIcon.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/Icons/EditIcon.tsx
@@ -1,0 +1,12 @@
+export default function EditIcon() {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M7.114 8.5H4V7h3.114a2.501 2.501 0 0 1 4.772 0H20v1.5h-8.114a2.501 2.501 0 0 1-4.772 0zM4 17h8.114a2.501 2.501 0 0 0 4.771 0H20v-1.5h-3.114a2.501 2.501 0 0 0-4.771 0H4V17z"
+                fill="currentColor"
+            />
+        </svg>
+    );
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -1,4 +1,4 @@
-import {ColorIndicator, Popover} from '@wordpress/components';
+import {ColorIndicator, ColorPalette, Popover} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {useState} from 'react';
 import {Controller, useFormContext} from 'react-hook-form';
@@ -7,6 +7,16 @@ import classnames from 'classnames';
 import EditIcon from './Icons/EditIcon';
 import CheckIcon from './Icons/CheckIcon';
 import './styles.scss';
+
+const defaultColors = [
+    {name: 'Blue', slug: 'blue', color: '#0b72d9'},
+    {name: 'Green', slug: 'green', color: '#27ae60'},
+    {name: 'Purple', slug: 'purple', color: '#19078c'},
+    {name: 'Orange', slug: 'orange', color: '#f29718'},
+    {name: 'Lavender', slug: 'lavender', color: '#9b51e0'},
+    {name: 'Terracotta', slug: 'terracotta', color: '#e26f56'},
+    {name: 'Red', slug: 'red', color: '#cc1818'},
+];
 
 const ColorControl = ({name, disabled, className}) => {
     const [popoverIsVisible, setPopoverIsVisible] = useState<boolean>(false);
@@ -21,7 +31,6 @@ const ColorControl = ({name, disabled, className}) => {
             name={name}
             control={control}
             render={({field}) => {
-                console.log('field', field);
                 return (
                     <div className={classnames('givewp-color-control', className)}>
                         <div className="givewp-color-control__indicator">
@@ -31,11 +40,35 @@ const ColorControl = ({name, disabled, className}) => {
 
                         {!disabled && (
                             <div className="givewp-color-control__popover">
-                                <button className="givewp-color-control__edit-button" onClick={toggleVisible}>
+                                <button
+                                    className={classnames('givewp-color-control__edit-button', {
+                                        'givewp-color-control__edit-button--active': popoverIsVisible,
+                                    })}
+                                    onClick={toggleVisible}
+                                >
                                     <EditIcon />
                                     {__('Edit', 'give')}
                                 </button>
-                                {popoverIsVisible && <Popover>This is the content inside the popover</Popover>}
+                                {popoverIsVisible && (
+                                    <Popover
+                                        className="givewp-color-control__popover-content"
+                                        offset={8}
+                                        onClose={toggleVisible}
+                                        placement="right"
+                                    >
+                                        <ColorPalette
+                                            clearable={false}
+                                            colors={[
+                                                {
+                                                    colors: defaultColors,
+                                                    name: __('Theme', 'give'),
+                                                },
+                                            ]}
+                                            value={field.value}
+                                            onChange={(color) => field.onChange(color)}
+                                        />
+                                    </Popover>
+                                )}
                             </div>
                         )}
                     </div>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -1,8 +1,14 @@
-import {Popover} from '@wordpress/components';
+import {ColorIndicator, Popover} from '@wordpress/components';
+import {__} from '@wordpress/i18n';
 import {useState} from 'react';
 import {Controller, useFormContext} from 'react-hook-form';
+import classnames from 'classnames';
 
-const ColorControl = ({name, isDisabled}) => {
+import EditIcon from './Icons/EditIcon';
+import CheckIcon from './Icons/CheckIcon';
+import './styles.scss';
+
+const ColorControl = ({name, disabled, className}) => {
     const [popoverIsVisible, setPopoverIsVisible] = useState<boolean>(false);
     const {control} = useFormContext();
 
@@ -17,11 +23,21 @@ const ColorControl = ({name, isDisabled}) => {
             render={({field}) => {
                 console.log('field', field);
                 return (
-                    <div className="givewp-color-control">
-                        <div className="givewp-color-control__popover">
-                            <button onClick={toggleVisible}>Toggle</button>
-                            {popoverIsVisible && <Popover>This is the content inside the popover</Popover>}
+                    <div className={classnames('givewp-color-control', className)}>
+                        <div className="givewp-color-control__indicator">
+                            <ColorIndicator colorValue={field.value} />
+                            {field.value && <CheckIcon refColor={field.value} />}
                         </div>
+
+                        {!disabled && (
+                            <div className="givewp-color-control__popover">
+                                <button className="givewp-color-control__edit-button" onClick={toggleVisible}>
+                                    <EditIcon />
+                                    {__('Edit', 'give')}
+                                </button>
+                                {popoverIsVisible && <Popover>This is the content inside the popover</Popover>}
+                            </div>
+                        )}
                     </div>
                 );
             }}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -1,0 +1,32 @@
+import {Popover} from '@wordpress/components';
+import {useState} from 'react';
+import {Controller, useFormContext} from 'react-hook-form';
+
+const ColorControl = ({name, isDisabled}) => {
+    const [popoverIsVisible, setPopoverIsVisible] = useState<boolean>(false);
+    const {control} = useFormContext();
+
+    const toggleVisible = () => {
+        setPopoverIsVisible((state) => !state);
+    };
+
+    return (
+        <Controller
+            name={name}
+            control={control}
+            render={({field}) => {
+                console.log('field', field);
+                return (
+                    <div className="givewp-color-control">
+                        <div className="givewp-color-control__popover">
+                            <button onClick={toggleVisible}>Toggle</button>
+                            {popoverIsVisible && <Popover>This is the content inside the popover</Popover>}
+                        </div>
+                    </div>
+                );
+            }}
+        />
+    );
+};
+
+export default ColorControl

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -1,14 +1,30 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import {useCallback, useState} from 'react';
+import {Controller, useFormContext} from 'react-hook-form';
+
+/**
+ * WordPress dependencies
+ */
 import {ColorIndicator, ColorPalette, Popover} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
-import {useState} from 'react';
-import {Controller, useFormContext} from 'react-hook-form';
-import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
 import EditIcon from './Icons/EditIcon';
 import CheckIcon from './Icons/CheckIcon';
 import './styles.scss';
 
-const defaultColors = [
+interface ColorOption {
+    name: string;
+    slug: string;
+    color: string;
+}
+
+const defaultColors: ColorOption[] = [
     {name: 'Blue', slug: 'blue', color: '#0b72d9'},
     {name: 'Green', slug: 'green', color: '#27ae60'},
     {name: 'Purple', slug: 'purple', color: '#19078c'},
@@ -18,64 +34,67 @@ const defaultColors = [
     {name: 'Red', slug: 'red', color: '#cc1818'},
 ];
 
-const ColorControl = ({name, disabled, className}) => {
+/**
+ * @unreleased
+ */
+function ColorControl({name, disabled = false, className}: { name: string; disabled?: boolean; className?: string }) {
     const [popoverIsVisible, setPopoverIsVisible] = useState<boolean>(false);
     const {control} = useFormContext();
 
-    const toggleVisible = () => {
-        setPopoverIsVisible((state) => !state);
-    };
+    const toggleVisible = useCallback(() => {
+        setPopoverIsVisible((prev) => !prev);
+    }, []);
 
     return (
         <Controller
             name={name}
             control={control}
-            render={({field}) => {
-                return (
-                    <div className={classnames('givewp-color-control', className)}>
-                        <div className="givewp-color-control__indicator">
-                            <ColorIndicator colorValue={field.value} />
-                            {field.value && <CheckIcon refColor={field.value} />}
-                        </div>
-
-                        {!disabled && (
-                            <div className="givewp-color-control__popover">
-                                <button
-                                    className={classnames('givewp-color-control__edit-button', {
-                                        'givewp-color-control__edit-button--active': popoverIsVisible,
-                                    })}
-                                    onClick={toggleVisible}
-                                >
-                                    <EditIcon />
-                                    {__('Edit', 'give')}
-                                </button>
-                                {popoverIsVisible && (
-                                    <Popover
-                                        className="givewp-color-control__popover-content"
-                                        offset={8}
-                                        onClose={toggleVisible}
-                                        placement="right"
-                                    >
-                                        <ColorPalette
-                                            clearable={false}
-                                            colors={[
-                                                {
-                                                    colors: defaultColors,
-                                                    name: __('Theme', 'give'),
-                                                },
-                                            ]}
-                                            value={field.value}
-                                            onChange={(color) => field.onChange(color)}
-                                        />
-                                    </Popover>
-                                )}
-                            </div>
-                        )}
+            render={({field}) => (
+                <div className={classnames('givewp-color-control', className)}>
+                    <div className="givewp-color-control__indicator">
+                        <ColorIndicator colorValue={field.value} />
+                        {field.value && <CheckIcon refColor={field.value} />}
                     </div>
-                );
-            }}
+
+                    {!disabled && (
+                        <div className="givewp-color-control__popover">
+                            <button
+                                type="button"
+                                className={classnames('givewp-color-control__edit-button', {
+                                    'givewp-color-control__edit-button--active': popoverIsVisible,
+                                })}
+                                onClick={toggleVisible}
+                                aria-label={__('Edit color', 'give')}
+                            >
+                                <EditIcon />
+                                {__('Edit', 'give')}
+                            </button>
+                            {popoverIsVisible && (
+                                <Popover
+                                    className="givewp-color-control__popover-content"
+                                    offset={8}
+                                    onClose={toggleVisible}
+                                    placement="right"
+                                >
+                                    <ColorPalette
+                                        clearable={false}
+                                        colors={[
+                                            {
+                                                colors: defaultColors,
+                                                name: __('Theme', 'give'),
+                                            },
+                                        ]}
+                                        value={field.value}
+                                        onChange={field.onChange}
+                                    />
+                                </Popover>
+                            )}
+                        </div>
+                    )}
+                </div>
+            )}
         />
     );
 };
 
-export default ColorControl
+export default ColorControl;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
@@ -42,5 +42,22 @@
             background: var(--givewp-neutral-50);
             cursor: pointer;
         }
+
+        &--active {
+            background: var(--givewp-neutral-700);
+            border: solid 1px var(--givewp-neutral-700);
+            color: var(--givewp-neutral-25);
+
+            &:hover {
+                background: var(--givewp-neutral-900);
+            }
+        }
+    }
+
+    &__popover-content {
+        .components-popover__content {
+            padding: var(--givewp-spacing-4);
+            width: auto;
+        }
     }
 }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
@@ -1,0 +1,46 @@
+.givewp-color-control {
+    align-items: center;
+    display: flex;
+    gap: var(--givewp-spacing-4);
+
+    &__indicator {
+        align-items: center;
+        display: flex;
+        position: relative;
+
+        span {
+            border-radius: 0.5rem;
+            border: 0;
+            box-shadow: none;
+            height: 3rem;
+            width: 3rem;
+        }
+
+        svg {
+            left: 50%;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%, -50%);
+        }
+    }
+
+    &__edit-button {
+        align-items: center;
+        background: none;
+        border-radius: 0.5rem;
+        border: solid 1px var(--givewp-neutral-300);
+        color: var(--givewp-neutral-900);
+        display: flex;
+        font-size: 1rem;
+        font-weight: 500;
+        gap: var(--givewp-spacing-2);
+        height: 3rem;
+        line-height: 1.5;
+        padding: var(--givewp-spacing-3) var(--givewp-spacing-6) var(--givewp-spacing-3) var(--givewp-spacing-4);
+
+        &:hover {
+            background: var(--givewp-neutral-50);
+            cursor: pointer;
+        }
+    }
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -225,7 +225,7 @@ export default () => {
                             )}
                         </div>
 
-                        <ColorControl name="primaryColor" disabled={isDisabled} />
+                        <ColorControl name="primaryColor" disabled={isDisabled} className={styles.colorControl} />
                     </div>
                     <div className={styles.sectionField}>
                         <div className={styles.sectionSubtitle}>
@@ -235,7 +235,7 @@ export default () => {
                             {__('This will affect your goal progress indicator, badges, icons, etc', 'give')}
                         </div>
 
-                        <ColorControl name="secondaryColor" disabled={isDisabled} />
+                        <ColorControl name="secondaryColor" disabled={isDisabled} className={styles.colorControl} />
                     </div>
                 </div>
             </div>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -6,6 +6,7 @@ import styles from '../CampaignDetailsPage.module.scss';
 import {ToggleControl} from '@wordpress/components';
 import campaignPageImage from './images/campaign-page.svg';
 import {WarningIcon} from '@givewp/campaigns/admin/components/Icons';
+import ColorControl from '@givewp/campaigns/admin/components/CampaignDetailsPage/Components/ColorControl';
 
 declare const window: {
     GiveCampaignDetails: GiveCampaignDetails;
@@ -199,6 +200,42 @@ export default () => {
                         )}
 
                         {errors.goal && <div className={styles.errorMsg}>{`${errors.goal.message}`}</div>}
+                    </div>
+                </div>
+            </div>
+
+            {/* Campaign Theme */}
+            <div className={styles.section}>
+                <div className={styles.leftColumn}>
+                    <div className={styles.sectionTitle}>{__('Campaign Theme', 'give')}</div>
+                    <div className={styles.sectionDescription}>
+                        {__('Choose a preferred theme for your campaign.', 'give')}
+                    </div>
+                </div>
+
+                <div className={styles.rightColumn}>
+                    <div className={styles.sectionField}>
+                        <div className={styles.sectionSubtitle}>
+                            {__('Select your preferred primary color', 'give')}
+                        </div>
+                        <div className={styles.sectionFieldDescription}>
+                            {__(
+                                'This will affect your main cta’s like your donate button, active and focus states of other UI elements.',
+                                'give'
+                            )}
+                        </div>
+
+                        <ColorControl name="primaryColor" disabled={isDisabled} />
+                    </div>
+                    <div className={styles.sectionField}>
+                        <div className={styles.sectionSubtitle}>
+                            {__('Select your preferred secondary color', 'give')}
+                        </div>
+                        <div className={styles.sectionFieldDescription}>
+                            {__('This will affect your goal progress indicator, badges, icons, etc', 'give')}
+                        </div>
+
+                        <ColorControl name="secondaryColor" disabled={isDisabled} />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-1385]

## Description
This Pull Request introduces new fields in Campaign Settings for setting Theme Colors, which will be used in related UI elements such as Campaign Donations, Campaign Donors, and Campaign Donate Button blocks.

It is important to note that colors must be applied individually to each block, as each block renders in a different Campaign context.

## Affects
Campaign Settings page

## Visuals
![CleanShot 2025-02-12 at 22 12 01](https://github.com/user-attachments/assets/6f841e41-0af8-4671-b280-1f1752065890)
_Theme Color Settings_

![CleanShot 2025-02-12 at 22 12 51](https://github.com/user-attachments/assets/21fe5d6e-1dda-4313-b791-05d5db998049)
_Sample of color being applied to a campaign block_

## Testing Instructions
- Go to the Campaign Settings tab
- Set theme colors for that campaign
- Edit the campaign page, adding some campaign specific blocks like Campaign Donors, Campaign Donations and Donate Button blocks
- See how those blocks follow the color selected in the Campaign Settings

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1385]: https://stellarwp.atlassian.net/browse/GIVE-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ