### PR TITLE
Feature: automatically activates bundled add-on licenses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,8 @@
             ],
             "exclude_from_copy": {
                 "packages": [
-                    "symfony/deprecation-contracts"
+                    "symfony/deprecation-contracts",
+                    "psr/container"
                 ],
                 "file_patterns": [
                     "/Tests/"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
         "symfony/polyfill-ctype": "^1.19",
         "symfony/polyfill-mbstring": "^1.19",
         "woocommerce/action-scheduler": "^3.6",
-        "ext-json": "*"
+        "psr/container": "1.1.1",
+        "ext-json": "*",
+        "stellarwp/admin-notices": "^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9",
@@ -94,6 +96,7 @@
             "classmap_prefix": "Give_Vendors_",
             "constant_prefix": "GIVE_VENDORS_",
             "packages": [
+                "stellarwp/admin-notices",
                 "stellarwp/validation",
                 "stellarwp/field-conditions",
                 "symfony/polyfill-ctype",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10c4fd2ef90d119df27b9ba2eb291515",
+    "content-hash": "2925ae35b3fa0513bedfb3876189d982",
     "packages": [
         {
             "name": "composer/installers",
@@ -372,6 +372,107 @@
                 "source": "https://github.com/paypal/paypalhttp_php/tree/1.0.1"
             },
             "time": "2021-09-14T21:35:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "stellarwp/admin-notices",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stellarwp/admin-notices.git",
+                "reference": "5c1302fb1de5b212ec6e05385e48e3859fd6b690"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stellarwp/admin-notices/zipball/5c1302fb1de5b212ec6e05385e48e3859fd6b690",
+                "reference": "5c1302fb1de5b212ec6e05385e48e3859fd6b690",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "1.1.1"
+            },
+            "require-dev": {
+                "codeception/module-asserts": "^1.0",
+                "codeception/module-cli": "^1.0",
+                "codeception/module-db": "^1.0",
+                "codeception/module-filesystem": "^1.0",
+                "codeception/module-phpbrowser": "^1.0",
+                "codeception/module-rest": "^1.0",
+                "codeception/module-webdriver": "^1.0",
+                "codeception/util-universalframework": "^1.0",
+                "lucatume/wp-browser": "^3.6.5",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpstan-wordpress": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellarWP\\AdminNotices\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jason Adams",
+                    "email": "jason.adams@stellarwp.com"
+                }
+            ],
+            "description": "A handy package for easily displaying admin notices in WordPress with simple to complex visibility conditions",
+            "support": {
+                "issues": "https://github.com/stellarwp/admin-notices/issues",
+                "source": "https://github.com/stellarwp/admin-notices/tree/2.0.0"
+            },
+            "time": "2024-11-20T00:41:13+00:00"
         },
         {
             "name": "stellarwp/container-contract",
@@ -3554,59 +3655,6 @@
             },
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/2ae37329ee82f91efadc282cc2d527fd6065a5ef",
-                "reference": "2ae37329ee82f91efadc282cc2d527fd6065a5ef",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.1"
-            },
-            "time": "2021-03-24T13:40:57+00:00"
         },
         {
             "name": "psr/log",

--- a/give.php
+++ b/give.php
@@ -90,6 +90,7 @@ use Give\Subscriptions\Repositories\SubscriptionRepository;
 use Give\Subscriptions\ServiceProvider as SubscriptionServiceProvider;
 use Give\TestData\ServiceProvider as TestDataServiceProvider;
 use Give\Tracking\TrackingServiceProvider;
+use Give\VendorOverrides\AdminNotices\AdminNoticesServiceProvider;
 use Give\VendorOverrides\FieldConditions\FieldConditionsServiceProvider;
 use Give\VendorOverrides\Validation\ValidationServiceProvider;
 
@@ -229,6 +230,7 @@ final class Give
         GlobalStylesServiceProvider::class,
         ValidationServiceProvider::class,
         ValidationRulesServiceProvider::class,
+        AdminNoticesServiceProvider::class,
         HttpServiceProvider::class,
         DesignSystemServiceProvider::class,
         FieldConditionsServiceProvider::class,
@@ -301,6 +303,9 @@ final class Give
          *
          */
         do_action('give_init', $this);
+
+        // Activate any bundled licenses if not already activated.
+        add_action('admin_init', 'Give_License::activate_bundled_licenses');
     }
 
     /**

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -248,7 +248,7 @@ if ( ! class_exists('Give_License') ) :
 			$this->license_data     = self::get_license_by_plugin_dirname( $this->plugin_dirname );
 			$this->version          = $_version;
 			$this->license          = ! empty( $this->license_data['license_key'] ) ? $this->license_data['license_key'] : '';
-            $this->bundled_license = self::get_bundled_license($this->plugin_dirname);
+            $this->bundled_license = self::get_bundled_license($this->file);
 			$this->author           = $_author;
 			self::$api_url          = is_null( $_api_url ) ? self::$api_url : $_api_url;
 			self::$checkout_url     = is_null( $_checkout_url ) ? self::$checkout_url : $_checkout_url;
@@ -280,10 +280,10 @@ if ( ! class_exists('Give_License') ) :
          *
          * @unreleased
          */
-        public static function get_bundled_license(string $plugin_dirname): ?string
+        public static function get_bundled_license(string $plugin_file): ?string
         {
             $license   = null;
-            $file_path = plugin_dir_path($plugin_dirname) . 'PLUGIN_LICENSE.php';
+            $file_path = plugin_dir_path($plugin_file) . 'PLUGIN_LICENSE.php';
             if (is_readable($file_path)) {
                 $license = include $file_path;
             }

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -204,6 +204,9 @@ if ( ! class_exists('Give_License') ) :
          *
          * @access public
          *
+         * @since 3.17.2 removed unused auto_updater_obj property assignment
+         * @since  1.0
+         *
          * @param string $_file
          * @param string $_item_name
          * @param string $_version
@@ -211,11 +214,10 @@ if ( ! class_exists('Give_License') ) :
          * @param string $_optname
          * @param string $_api_url
 		 * @param string $_checkout_url
-		 * @param string $_account_url
+         * @param string $_account_url
 		 * @param int    $_item_id
 		 *
-		 * @since 3.17.2 removed unused auto_updater_obj property assignment
-		 * @since  1.0
+         * @unreleased adds plugin_basename property
 		 */
 		public function __construct(
 			$_file,
@@ -281,7 +283,7 @@ if ( ! class_exists('Give_License') ) :
         public static function get_bundled_license(string $plugin_dirname): ?string
         {
             $license   = null;
-            $file_path = WP_PLUGIN_DIR . '/' . $plugin_dirname . '/GIVE_LICENSE.php';
+            $file_path = plugin_dir_path($plugin_dirname) . 'GIVE_LICENSE.php';
             if (is_readable($file_path)) {
                 $license = include $file_path;
             }

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -11,6 +11,7 @@
 
 // Exit if accessed directly.
 use Give\Log\Log;
+use Give\Vendors\StellarWP\AdminNotices\AdminNotices;
 
 if ( ! defined('ABSPATH') ) {
     exit;
@@ -48,6 +49,15 @@ if ( ! class_exists('Give_License') ) :
          * @var    string
          */
         private $license;
+
+        /**
+         * The license bundled with the premium add-on.
+         *
+         * @unreleased
+         *
+         * @var string|null
+         */
+        private $bundled_license;
 
         /**
          * Item name
@@ -227,6 +237,7 @@ if ( ! class_exists('Give_License') ) :
 			$this->license_data     = self::get_license_by_plugin_dirname( $this->plugin_dirname );
 			$this->version          = $_version;
 			$this->license          = ! empty( $this->license_data['license_key'] ) ? $this->license_data['license_key'] : '';
+            $this->bundled_license = self::get_bundled_license($this->plugin_dirname);
 			$this->author           = $_author;
 			self::$api_url          = is_null( $_api_url ) ? self::$api_url : $_api_url;
 			self::$checkout_url     = is_null( $_checkout_url ) ? self::$checkout_url : $_checkout_url;
@@ -235,7 +246,6 @@ if ( ! class_exists('Give_License') ) :
 			// Add plugin to registered licenses list.
 			array_push( self::$licensed_addons, plugin_basename( $this->file ) );
 		}
-
 
 		/**
 		 * Get plugin shortname
@@ -253,7 +263,138 @@ if ( ! class_exists('Give_License') ) :
 			return $plugin_name;
 		}
 
-		/**
+        /**
+         * Checks to see if the license was bundled with the add-on and if so, returns it. This is meant to be a
+         * convenience, so any errors are ignored and the user can still manually enter their license key.
+         *
+         * @unreleased
+         */
+        public static function get_bundled_license(string $plugin_dirname): ?string
+        {
+            $license   = null;
+            $file_path = WP_PLUGIN_DIR . '/' . $plugin_dirname . '/GIVE_LICENSE.php';
+            if (is_readable($file_path)) {
+                $license = include $file_path;
+            }
+
+            return $license ?: null;
+        }
+
+        /**
+         * This sorts through all the registered add-ons and checks to see if any of them have bundled licenses, but
+         * aren't set up with a license key. If so, it will attempt to activate the license key for them.
+         *
+         * It's likely that many add-ons will have the same license key which is a plan, so the license key will only be
+         * activated once for all add-ons using it.
+         *
+         * If any sort of error occurs, an admin notice will be shown to the user providing the error and instructions
+         * to manually activate the license key.
+         *
+         * Note: much of this code is taken directly from give_get_license_info_handler()
+         *
+         * @unreleased
+         */
+        public static function activate_bundled_licenses(): void
+        {
+            $unactivated_bundled_licenses = [];
+            foreach (self::$licensed_addons as $addon) {
+                if ($addon->bundled_license && empty($addon->license)) {
+                    // Store a unique associative array where the key is the license key and the value is an array of
+                    // addons using that license
+                    if ( ! isset($unactivated_bundled_licenses[$addon->bundled_license])) {
+                        $unactivated_bundled_licenses[$addon->bundled_license] = [];
+                    }
+
+                    $unactivated_bundled_licenses[$addon->bundled_license][] = $addon;
+                }
+            }
+
+            if (empty($unactivated_bundled_licenses)) {
+                return;
+            }
+
+            $show_failed_activation_notice = static function ($license_key, $reason) {
+                AdminNotices::show(
+                    "license-bundle-activation-error-$license_key",
+                    "An error occurred while attempting to activate license $license_key: $reason. Please activate the license manually."
+                )->asError()->isDismissible();
+            };
+
+            foreach ($unactivated_bundled_licenses as $license => $addons) {
+                $check_license_res = Give_License::request_license_api(
+                    [
+                        'edd_action' => 'check_license',
+                        'license'    => $license,
+                    ],
+                    true
+                );
+                $is_plan_license   = ! empty($check_license_res['is_all_access_pass']);
+
+                if (is_wp_error($check_license_res)) {
+                    $show_failed_activation_notice($license, $check_license_res->get_error_message());
+                    continue;
+                }
+
+                if ( ! $check_license_res['success']) {
+                    $show_failed_activation_notice($license, $check_license_res['error']);
+                    continue;
+                }
+
+                if ( ! $is_plan_license) {
+                    if (count($addons) > 1) {
+                        $show_failed_activation_notice(
+                            $license,
+                            'A single add-on license cannot be used for multiple add-ons'
+                        );
+                        continue;
+                    }
+
+                    if ($check_license_res['plugin_slug'] !== $addons[0]->plugin_dirname) {
+                        $show_failed_activation_notice(
+                            $license,
+                            'The license is not valid for this add-on'
+                        );
+                        continue;
+                    }
+                }
+
+                $activate_license_res = Give_License::request_license_api(
+                    [
+                        'edd_action' => 'activate_license',
+                        'item_name'  => $check_license_res['item_name'],
+                        'license'    => $license,
+                    ],
+                    true
+                );
+
+                if (is_wp_error($activate_license_res)) {
+                    $show_failed_activation_notice($license, $activate_license_res->get_error_message());
+                    continue;
+                }
+
+                $check_license_res['license']          = $activate_license_res['license'];
+                $check_license_res['site_count']       = $activate_license_res['site_count'];
+                $check_license_res['activations_left'] = $activate_license_res['activations_left'];
+                $licenses                              = get_option('give_licenses', []);
+
+                if ($is_plan_license) {
+                    $addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense($check_license_res);
+                    foreach ($licenses as $license_key => $data) {
+                        if (in_array($data['plugin_slug'], $addonSlugs, true) || ! empty($data['is_all_access_pass'])) {
+                            unset($licenses[$license_key]);
+                        }
+                    }
+                }
+
+                $licenses[$check_license_res['license_key']] = $check_license_res;
+                update_option('give_licenses', $licenses);
+            }
+
+            // Have WordPress check for updates
+            give_refresh_licenses();
+        }
+
+        /**
 		 * Activate License
 		 *
 		 * Activate the license key.

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -120,6 +120,13 @@ if ( ! class_exists('Give_License') ) :
         private $author;
 
         /**
+         * Plugin basename (as provided by plugin_basename() function)
+         *
+         * @var string
+         */
+        private $plugin_basename;
+
+        /**
          * Plugin directory name
          *
          * @access private
@@ -152,10 +159,11 @@ if ( ! class_exists('Give_License') ) :
         /**
          * array of licensed addons
          *
+         * @unreleased store the Give_License instances, not just the plugin basenames
          * @since  2.1.4
          * @access private
          *
-         * @var    array
+         * @var    Give_License[]
          */
         private static $licensed_addons = [];
 
@@ -232,6 +240,7 @@ if ( ! class_exists('Give_License') ) :
 
 			$this->file             = $_file;
 			$this->item_name        = $_item_name;
+            $this->plugin_basename = plugin_basename($this->file);
 			$this->plugin_dirname   = dirname( plugin_basename( $this->file ) );
 			$this->item_shortname   = self::get_short_name( $this->item_name );
 			$this->license_data     = self::get_license_by_plugin_dirname( $this->plugin_dirname );
@@ -244,7 +253,7 @@ if ( ! class_exists('Give_License') ) :
 			self::$account_url      = is_null( $_account_url ) ? self::$account_url : $_account_url;
 
 			// Add plugin to registered licenses list.
-			array_push( self::$licensed_addons, plugin_basename( $this->file ) );
+            array_push(self::$licensed_addons, $this);
 		}
 
 		/**
@@ -454,14 +463,14 @@ if ( ! class_exists('Give_License') ) :
          *
          * Note: note only for internal logic
          *
+         * @unreleased plucks the basename for backwards compatibility
          * @since 2.1.4
-         * @return array
+         * @return string[]
          */
-        static function get_licensed_addons()
+        static function get_licensed_addons(): array
         {
-            return self::$licensed_addons;
+            return wp_list_pluck(self::$licensed_addons, 'plugin_basename');
         }
-
 
         /**
          * Check if license key attached to subscription

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -332,7 +332,7 @@ if ( ! class_exists('Give_License') ) :
             };
 
             foreach ($unactivated_bundled_licenses as $license => $addons) {
-                $check_license_res = Give_License::request_license_api(
+                $check_license_res = self::request_license_api(
                     [
                         'edd_action' => 'check_license',
                         'license'    => $license,
@@ -369,7 +369,7 @@ if ( ! class_exists('Give_License') ) :
                     }
                 }
 
-                $activate_license_res = Give_License::request_license_api(
+                $activate_license_res = self::request_license_api(
                     [
                         'edd_action' => 'activate_license',
                         'item_name'  => $check_license_res['item_name'],
@@ -389,7 +389,7 @@ if ( ! class_exists('Give_License') ) :
                 $licenses                              = get_option('give_licenses', []);
 
                 if ($is_plan_license) {
-                    $addonSlugs = Give_License::getAddonSlugsFromAllAccessPassLicense($check_license_res);
+                    $addonSlugs = self::getAddonSlugsFromAllAccessPassLicense($check_license_res);
                     foreach ($licenses as $license_key => $data) {
                         if (in_array($data['plugin_slug'], $addonSlugs, true) || ! empty($data['is_all_access_pass'])) {
                             unset($licenses[$license_key]);

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -283,7 +283,7 @@ if ( ! class_exists('Give_License') ) :
         public static function get_bundled_license(string $plugin_dirname): ?string
         {
             $license   = null;
-            $file_path = plugin_dir_path($plugin_dirname) . 'GIVE_LICENSE.php';
+            $file_path = plugin_dir_path($plugin_dirname) . 'PLUGIN_LICENSE.php';
             if (is_readable($file_path)) {
                 $license = include $file_path;
             }

--- a/src/VendorOverrides/AdminNotices/AdminNoticesServiceProvider.php
+++ b/src/VendorOverrides/AdminNotices/AdminNoticesServiceProvider.php
@@ -7,12 +7,29 @@ namespace Give\VendorOverrides\AdminNotices;
 use Give\ServiceProviders\ServiceProvider;
 use Give\Vendors\StellarWP\AdminNotices\AdminNotices;
 
+/**
+ * Registers and boots the Admin Notices library
+ *
+ * @unreleased
+ *
+ * @see https://github.com/stellarwp/admin-notices
+ */
 class AdminNoticesServiceProvider implements ServiceProvider {
+    /**
+     * {@inheritDoc}
+     *
+     * @unreleased
+     */
     public function register()
     {
         AdminNotices::initialize('givewp', GIVE_PLUGIN_URL . 'vendor/vendor-prefixed/stellarwp/admin-notices/');
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @unreleased
+     */
     public function boot()
     {
     }

--- a/src/VendorOverrides/AdminNotices/AdminNoticesServiceProvider.php
+++ b/src/VendorOverrides/AdminNotices/AdminNoticesServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\VendorOverrides\AdminNotices;
+
+use Give\ServiceProviders\ServiceProvider;
+use Give\Vendors\StellarWP\AdminNotices\AdminNotices;
+
+class AdminNoticesServiceProvider implements ServiceProvider {
+    public function register()
+    {
+        AdminNotices::initialize('givewp', GIVE_PLUGIN_URL . 'vendor/vendor-prefixed/stellarwp/admin-notices/');
+    }
+
+    public function boot()
+    {
+    }
+}


### PR DESCRIPTION
## Description

Presently, when a customer purchases a plan or add-on license, they have to manually activate the license within the product after installing it. This hasn't been a major pain point, but it's certainly an extra step and may confuse some folks. Further, as we support cross-sells, it becomes a nuisance to receive the product and have to take extra steps.

This PR introduces support for add-ons to come bundled with a `GIVE_LICENSE.php` file that contains the license. If this file is found and hasn't been activated, then it's automatically activated.

https://www.loom.com/share/51c0a14786c044c8bb85aa35b5fbb733

### License File
The contents of the license file will be:
```php
<?php return 'license-hash-goes-here'
```
The reason this is a PHP file and not just a plan text file is because this allows the PHP server to optimize and cache these files automatically. It's similar to the `dependencies.php` file generated by WP Scripts.

### Single vs Plan Licenses
A specific add-on can only have a single or plan license associated with it. It's possible that an add-on will have a single license and another add-on have a plan license. If an add-on is covered by a plan license (even if included by another), then the single license will be ignored in favor of the plan license.

Also, many add-ons may have a plan license, in which case the license will only be activated once and applied to all relevant products.

### Manual Activations
This is regarded as a convenience and not a critical path. As such, it's important that manual activation still works. If there's some sort of error while working with the bundled license the admin will be notified and will be directed to manually activate their license.


### Admin Notices
This does introduce the [Admin Notices library](https://github.com/stellarwp/admin-notices) as well to display errors to the admin. But hopefully that's a fun bonus to be enjoyed in future GiveWP PRs! 😄 

## Affects

The licensing flows

## Testing Instructions

I will provide you with some add-ons that contain the necessary license file to test. Once you have this:
1. Make sure no licenses are activated
2. Activate the add-on
3. Make sure it is now activated in the licenses screen

Also, make sure that manually activating a license still works.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

