### PR TITLE
Fix: Campaign pages support titles

### DIFF
--- a/src/Campaigns/Actions/RegisterCampaignPagePostType.php
+++ b/src/Campaigns/Actions/RegisterCampaignPagePostType.php
@@ -19,6 +19,7 @@ class RegisterCampaignPagePostType
             'show_in_menu' => false,
             'show_in_rest' => true,
             'supports' => [
+                'title',
                 'editor'
             ],
             'rewrite' => [

--- a/src/Campaigns/Repositories/CampaignPageRepository.php
+++ b/src/Campaigns/Repositories/CampaignPageRepository.php
@@ -62,6 +62,7 @@ class CampaignPageRepository
         try {
             DB::table('posts')
                 ->insert([
+                    'post_title' => $campaignPage->campaign()->title,
                     'post_date' => $dateCreatedFormatted,
                     'post_date_gmt' => get_gmt_from_date($dateCreatedFormatted),
                     'post_modified' => $dateUpdatedFormatted,
@@ -70,7 +71,7 @@ class CampaignPageRepository
                     'post_type' => 'give_campaign_page',
                 ]);
 
-            $campaignPage->id = DB::last_insert_id();;
+            $campaignPage->id = DB::last_insert_id();
             $campaignPage->createdAt = $dateCreated;
             $campaignPage->updatedAt = $dateUpdated;
 

--- a/tests/Unit/Campaigns/Repositories/CampaignPageRepositoryTest.php
+++ b/tests/Unit/Campaigns/Repositories/CampaignPageRepositoryTest.php
@@ -128,4 +128,19 @@ final class CampaignPageRepositoryTest extends TestCase
 
         $this->assertNull($campaignPageFresh);
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testCampaignPageShouldBeCreatedWithCampaignTitle()
+    {
+        $campaign = Campaign::factory()->create();
+        $campaignPage = CampaignPage::create([
+            'campaignId' => $campaign->id,
+        ]);
+
+        $this->assertEquals($campaign->title, get_the_title($campaignPage->id));
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2141]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR enables `title` support for Campaign Pages, which default to the title of the related Campaign.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a new Campaign and edit the Campaign Page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2141]: https://stellarwp.atlassian.net/browse/GIVE-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ