### PR TITLE
Fix: Force campaign save on initial publish

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -114,8 +114,8 @@ export default function CampaignsDetailsPage({campaignId}) {
     const onSubmit: SubmitHandler<Campaign> = async (data) => {
 
         const shouldSave = formState.isDirty
-            // Force save if the status is active to account for a first publish race condition.
-            || data.status === 'active';
+            // Force save if first publish to account for a race condition.
+            || (campaign.status === 'draft' && data.status === 'active');
 
         if (shouldSave) {
             setIsSaving(data.status);

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -112,7 +112,12 @@ export default function CampaignsDetailsPage({campaignId}) {
     }, [campaign?.status]);
 
     const onSubmit: SubmitHandler<Campaign> = async (data) => {
-        if (formState.isDirty) {
+
+        const shouldSave = formState.isDirty
+            // Force save if the status is active to account for a first publish race condition.
+            || data.status === 'active';
+
+        if (shouldSave) {
             setIsSaving(data.status);
 
             edit(data);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves GIVE-2143

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR addresses a bug on initial publish of a campaign where the status update is not persisted due to a race condition with the `isDirty` check in the submit handler.

This is resolved by adding a fallback check for an updated status when `!isDirty`.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a new Campaign and click "Publish campaign".

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

