### PR TITLE
Fix: Set a minimum for the y-axis of the Campaign revenue chart

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -39,6 +39,7 @@ const RevenueChart = () => {
         },
         yaxis: {
             max,
+            min: 0,
         },
         stroke: {
             color: ['#60a1e2'],


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2146]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR sets a minimum value for the y-axis of the Campaign revenue chart to prevent the scale from dropping below 0.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

| Before | After |
| --- | --- |
| ![Screenshot from 2025-02-07 13-20-50](https://github.com/user-attachments/assets/ccda73a9-8ea0-496a-9924-2399d73ea4c3) | ![Screenshot from 2025-02-07 13-21-03](https://github.com/user-attachments/assets/d367fcd0-f706-451a-a262-690397336dde) |

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Create a Campaign and make a couple of donations then view the revenue chart on the campaign overview screen.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2146]: https://stellarwp.atlassian.net/browse/GIVE-2146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ