### PR TITLE
Feature: allow default custom amount field to dynamically set value

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -7,6 +7,7 @@ import DonationAmountCurrency from './DonationAmountCurrency';
 import DonationAmountLevels from './DonationAmountLevels';
 
 /**
+ * @unreleased updated default custom amount value to respect level amounts
  * @since 3.12.0 Update default level when having distinct default currency
  * @since 3.0.0
  */
@@ -24,8 +25,10 @@ export default function Amount({
     messages,
 }: AmountProps) {
     const isFixedAmount = !allowLevels;
+    const defaultCustomAmountValue = isFixedAmount && fixedAmountValue > 0 ? fixedAmountValue.toString() : defaultValue.toString();
+    const levelsHaveDefaultCustomAmountValue = levels.some((level) => level.value === Number(defaultCustomAmountValue));
     const [customAmountValue, setCustomAmountValue] = useState<string>(
-        isFixedAmount ? fixedAmountValue.toString() : ''
+        !levelsHaveDefaultCustomAmountValue ? defaultCustomAmountValue : ''
     );
     const {useWatch, useFormContext, useDonationFormSettings} = window.givewp.form.hooks;
     const {setValue} = useFormContext();


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2135]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the custom amount input to allow for dynamically setting its default amount.  This will first attempt to use the `fixedAmountValue` as intended but fallback to the general `defaultValue`.  It will also _not_ be set if there is an existing matching level.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The amount field

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1120" alt="Screenshot 2025-02-10 at 10 47 07 AM" src="https://github.com/user-attachments/assets/3237de07-e1e1-44d5-99e8-f1a2c8308a52" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

This can be tested programmatically.
1. Create a default v3 form with mult-level enabled & custom amount enabled
2. Make sure this is the default value of custom amount input

```php
add_action('givewp_donation_form_schema', function ($form) {
    $field = $form->getNodeByName('amount');
    $field->defaultValue(52);
});
```

3. Make sure the custom default value is not set and the level is selected.

```php
add_action('givewp_donation_form_schema', function ($form) {
    $field = $form->getNodeByName('amount');
    $field->defaultValue(50);
});
```

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

