### PR TITLE
Feature: add campaign stats block

### DIFF
--- a/src/Campaigns/Blocks/CampaignStats/Icon.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/Icon.tsx
@@ -1,0 +1,20 @@
+import {Path, SVG} from '@wordpress/components';
+
+export function StatsIcon() {
+    return (
+        <SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <Path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M3 2a1 1 0 0 1 1 1v14.8c0 .577 0 .949.024 1.232.022.272.06.372.085.422a1 1 0 0 0 .437.437c.05.025.15.063.422.085C5.25 20 5.623 20 6.2 20H21a1 1 0 1 1 0 2H6.162c-.528 0-.982 0-1.357-.03-.395-.033-.789-.104-1.167-.297a3 3 0 0 1-1.311-1.311c-.193-.378-.264-.772-.296-1.167A17.9 17.9 0 0 1 2 17.838V3a1 1 0 0 1 1-1z"
+                fill="#000"
+            />
+            <Path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M7 13.5a1 1 0 0 1 1 1v3a1 1 0 1 1-2 0v-3a1 1 0 0 1 1-1zM11.5 10.5a1 1 0 0 1 1 1v6a1 1 0 1 1-2 0v-6a1 1 0 0 1 1-1zM16 7.5a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0v-9a1 1 0 0 1 1-1zM20.5 4.5a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0v-12a1 1 0 0 1 1-1z"
+                fill="#000"
+            />
+        </SVG>
+    );
+}

--- a/src/Campaigns/Blocks/CampaignStats/app.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/app.tsx
@@ -1,0 +1,1 @@
+import './styles.scss';

--- a/src/Campaigns/Blocks/CampaignStats/block.json
+++ b/src/Campaigns/Blocks/CampaignStats/block.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "givewp/campaign-stats-block",
+    "version": "1.0.0",
+    "title": "Campaign Statistics",
+    "category": "give",
+    "description": "Displays the campaign’s statistics.",
+    "attributes": {
+        "campaignId": {
+            "type": "integer"
+        },
+        "statistic": {
+            "type": "string",
+            "enum": [
+                "top-donation",
+                "average-donation"
+            ],
+            "default": "top-donation"
+        }
+    },
+    "supports": {
+        "align": [
+            "wide",
+            "full"
+        ],
+        "anchor": true,
+        "className": true,
+        "splitting": true,
+        "__experimentalBorder": {
+            "color": true,
+            "radius": true,
+            "style": true,
+            "width": true
+        },
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true
+            }
+        },
+        "spacing": {
+            "margin": true,
+            "padding": true,
+            "__experimentalDefaultControls": {
+                "margin": false,
+                "padding": false
+            }
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontStyle": true,
+            "__experimentalFontWeight": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalWritingMode": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        }
+    },
+    "textdomain": "give",
+    "render": "file:./render.php",
+    "viewScript": "file:../../../../build/campaignStatsApp.js",
+    "style": "file:../../../../build/campaignStatsApp.css"
+}

--- a/src/Campaigns/Blocks/CampaignStats/block.json
+++ b/src/Campaigns/Blocks/CampaignStats/block.json
@@ -67,5 +67,5 @@
     "textdomain": "give",
     "render": "file:./render.php",
     "viewScript": "file:../../../../build/campaignStatsApp.js",
-    "style": "file:../../../../build/campaignStatsApp.css"
+    "style": "file:../../../../build/campaignStatsBlockApp.css"
 }

--- a/src/Campaigns/Blocks/CampaignStats/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/edit.tsx
@@ -25,7 +25,7 @@ export default function Edit({
         : __('Displays the average donation of the selected campaign.', 'give');
 
     return (
-        <figure {...blockProps}>
+        <div {...blockProps}>
             <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
                 <ServerSideRender block="givewp/campaign-stats-block" attributes={attributes} />
             </CampaignSelector>
@@ -46,6 +46,6 @@ export default function Edit({
                     </PanelBody>
                 </InspectorControls>
             )}
-        </figure>
+        </div>
     );
 }

--- a/src/Campaigns/Blocks/CampaignStats/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/edit.tsx
@@ -20,6 +20,10 @@ export default function Edit({
     const blockProps = useBlockProps();
     const {campaign, hasResolved} = useCampaign(attributes?.campaignId);
 
+    const statsHelpText = attributes.statistic === 'top-donation'
+        ? __('Displays the top donation of the selected campaign.', 'give')
+        : __('Displays the average donation of the selected campaign.', 'give');
+
     return (
         <figure {...blockProps}>
             <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
@@ -31,7 +35,7 @@ export default function Edit({
                     <PanelBody title="Settings" initialOpen={true}>
                         <SelectControl
                             label={__('Type', 'give')}
-                            help={__('Displays the top donation of the selected campaign.', 'give')}
+                            help={statsHelpText}
                             value={attributes.statistic}
                             options={[
                                 {value: 'top-donation', label: __('Top Donation', 'give')},

--- a/src/Campaigns/Blocks/CampaignStats/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/edit.tsx
@@ -1,0 +1,47 @@
+import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
+import {__} from '@wordpress/i18n';
+import {BlockEditProps} from '@wordpress/blocks';
+import {PanelBody, SelectControl} from '@wordpress/components';
+import {CampaignSelector} from '../shared/components/CampaignSelector';
+import ServerSideRender from '@wordpress/server-side-render';
+import useCampaign from '../shared/hooks/useCampaign';
+
+import './styles.scss';
+
+type statisticType = 'top-donation' | 'average-donation';
+
+export default function Edit({
+    attributes,
+    setAttributes,
+}: BlockEditProps<{
+    campaignId: number;
+    statistic: statisticType;
+}>) {
+    const blockProps = useBlockProps();
+    const {campaign, hasResolved} = useCampaign(attributes?.campaignId);
+
+    return (
+        <figure {...blockProps}>
+            <CampaignSelector attributes={attributes} setAttributes={setAttributes}>
+                <ServerSideRender block="givewp/campaign-stats-block" attributes={attributes} />
+            </CampaignSelector>
+
+            {hasResolved && campaign?.id && (
+                <InspectorControls>
+                    <PanelBody title="Settings" initialOpen={true}>
+                        <SelectControl
+                            label={__('Type', 'give')}
+                            help={__('Displays the top donation of the selected campaign.', 'give')}
+                            value={attributes.statistic}
+                            options={[
+                                {value: 'top-donation', label: __('Top Donation', 'give')},
+                                {value: 'average-donation', label: __('Average Donation', 'give')},
+                            ]}
+                            onChange={(value: statisticType) => setAttributes({statistic: value})}
+                        />
+                    </PanelBody>
+                </InspectorControls>
+            )}
+        </figure>
+    );
+}

--- a/src/Campaigns/Blocks/CampaignStats/index.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/index.tsx
@@ -1,0 +1,16 @@
+import {paragraph as icon} from '@wordpress/icons';
+import schema from './block.json';
+import Edit from './edit';
+
+/**
+ * @unreleased
+ */
+const settings = {
+    icon,
+    edit: Edit,
+};
+
+export default {
+    schema,
+    settings,
+};

--- a/src/Campaigns/Blocks/CampaignStats/index.tsx
+++ b/src/Campaigns/Blocks/CampaignStats/index.tsx
@@ -1,12 +1,12 @@
-import {paragraph as icon} from '@wordpress/icons';
 import schema from './block.json';
 import Edit from './edit';
+import {StatsIcon} from './Icon';
 
 /**
  * @unreleased
  */
 const settings = {
-    icon,
+    icon: <StatsIcon />,
     edit: Edit,
 };
 

--- a/src/Campaigns/Blocks/CampaignStats/render.php
+++ b/src/Campaigns/Blocks/CampaignStats/render.php
@@ -1,0 +1,40 @@
+<?php
+
+use Give\Campaigns\CampaignDonationQuery;
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\Repositories\CampaignRepository;
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Framework\Support\ValueObjects\Money;
+
+/**
+ * @unreleased
+ *
+ * @var array    $attributes
+ * @var Campaign $campaign
+ */
+
+if (
+    !isset($attributes['campaignId'])
+    || !$campaign = give(CampaignRepository::class)->getById($attributes['campaignId'])
+) {
+    return;
+}
+
+$query = (new CampaignDonationQuery($campaign))
+    ->select(
+        $attributes['statistic'] === 'top-donation'
+            ? 'MAX(amountMeta.meta_value) as amount'
+            : 'AVG(amountMeta.meta_value) as amount'
+    )
+    ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta');
+
+$donationStat = $query->get();
+
+$amount = Money::fromDecimal($donationStat->amount, give_get_currency());
+$title = $attributes['statistic'] === 'top-donation' ? __('Top Donation', 'give') : __('Average Donation', 'give');
+?>
+
+<div class="givewp-campaign-stats-block">
+    <span><?php echo $title ?></span>
+    <strong><?php echo esc_html($amount->formatToLocale()) ?></strong>
+</div>

--- a/src/Campaigns/Blocks/CampaignStats/render.php
+++ b/src/Campaigns/Blocks/CampaignStats/render.php
@@ -30,7 +30,10 @@ $query = (new CampaignDonationQuery($campaign))
 
 $donationStat = $query->get();
 
-$amount = Money::fromDecimal($donationStat->amount, give_get_currency());
+$amount = $donationStat && $donationStat->amount
+    ? Money::fromDecimal($donationStat->amount, give_get_currency())
+    : Money::fromDecimal(0, give_get_currency());
+
 $title = $attributes['statistic'] === 'top-donation' ? __('Top Donation', 'give') : __('Average Donation', 'give');
 ?>
 

--- a/src/Campaigns/Blocks/CampaignStats/styles.scss
+++ b/src/Campaigns/Blocks/CampaignStats/styles.scss
@@ -9,7 +9,7 @@
         line-height: 1.5;
         letter-spacing: 0.48px;
         text-align: left;
-        color: var(--giewp-neutral-500);
+        color: var(--givewp-neutral-500);
     }
 
     strong {

--- a/src/Campaigns/Blocks/CampaignStats/styles.scss
+++ b/src/Campaigns/Blocks/CampaignStats/styles.scss
@@ -1,5 +1,4 @@
 .givewp-campaign-stats-block {
-    font-family: Inter;
 
     span {
         display: block;

--- a/src/Campaigns/Blocks/CampaignStats/styles.scss
+++ b/src/Campaigns/Blocks/CampaignStats/styles.scss
@@ -1,0 +1,24 @@
+.givewp-campaign-stats-block {
+    font-family: Inter;
+
+    span {
+        display: block;
+        margin-bottom: 2px;
+        height: 18px;
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 1.5;
+        letter-spacing: 0.48px;
+        text-align: left;
+        color: var(--giewp-neutral-500);
+    }
+
+    strong {
+        height: 32px;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.6;
+        letter-spacing: normal;
+        color: var(--givewp-neutral-900);
+    }
+}

--- a/src/Campaigns/Blocks/blocks.ts
+++ b/src/Campaigns/Blocks/blocks.ts
@@ -11,9 +11,10 @@ import campaignDonateButton from './DonateButton';
 import campaignDonations from './CampaignDonations';
 import campaignDonors from './CampaignDonors';
 import campaignTitle from './CampaignTitle';
+import campaignStats from './CampaignStats';
 
 export const getAllBlocks = () => {
-    return [campaignCover, campaignDonateButton, campaignDonations, campaignDonors, campaignTitle];
+    return [campaignCover, campaignDonateButton, campaignDonations, campaignDonors, campaignTitle, campaignStats];
 };
 
 getAllBlocks().forEach((block) => {

--- a/wordpress-scripts-webpack.config.js
+++ b/wordpress-scripts-webpack.config.js
@@ -66,6 +66,7 @@ module.exports = {
         campaignBlocks: srcPath('Campaigns/Blocks/blocks.ts'),
         campaignDonationsBlockApp: srcPath('Campaigns/Blocks/CampaignDonations/app.tsx'),
         campaignDonorsBlockApp: srcPath('Campaigns/Blocks/CampaignDonors/app.tsx'),
+        campaignStatsBlockApp: srcPath('Campaigns/Blocks/CampaignStats/app.tsx'),
     },
 };
 


### PR DESCRIPTION
Resolves: [GIVE-1987]

## Description
This add the Campaign Stats block. Users should be able to filter between "Top Donation" & "Average Donation" for the selected campaign.

## Visuals
https://github.com/user-attachments/assets/7cb1fdc1-050c-4e5b-b7b6-94319ba7e908

## Testing Instructions
- Create a campaign
- Add the Campaign Stats block
- Filter between  "Top Donation" & "Average Donation" - verify the amounts and title change
- Verify changes on frontend & in admin
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1987]: https://stellarwp.atlassian.net/browse/GIVE-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ