### PR TITLE
Refactor: Remove Edit button from default form widget

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/DefaultForm/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/DefaultForm/index.tsx
@@ -1,8 +1,8 @@
-import {__} from "@wordpress/i18n";
+import {__} from '@wordpress/i18n';
 import HeaderText from '../HeaderText';
 import HeaderSubText from '../HeaderSubText';
 
-import styles from "./styles.module.scss"
+import styles from './styles.module.scss';
 
 /**
  * @unreleased
@@ -15,9 +15,6 @@ const DefaultFormWidget = ({defaultForm}: {defaultForm: string}) => {
                     <HeaderText>{__('Default campaign form', 'give')}</HeaderText>
                     <HeaderSubText>{__('Your campaign page and blocks will collect donations through this form by default.', 'give')}</HeaderSubText>
                 </div>
-                <a href='#' className={styles.edit}>
-                    {__('Edit', 'give')}
-                </a>
             </div>
             <div className={styles.formName}>
                 {defaultForm}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2126]

## Description
This Pull Request removes the Edit button from the Default Form widget in the Campaign Overview tab. Since the button’s functionality has not been fully implemented, we have decided to defer its development for now. Removing it prevents confusion and ensures a better user experience until the feature is properly implemented.

## Affects
Campaign Overview tab

## Visuals
![CleanShot 2025-02-13 at 13 12 26](https://github.com/user-attachments/assets/c1451b92-e2c1-4428-9593-4bbf270046ae)
_Before_

![CleanShot 2025-02-13 at 13 13 26](https://github.com/user-attachments/assets/b2722156-56cb-452d-a5cb-a69f82043fca)
_After_

## Testing Instructions
Confirm that there is no Edit button in the Default Form widget in the Campaign Overview tab.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2126]: https://stellarwp.atlassian.net/browse/GIVE-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ