### PR TITLE
Fix: Add a message for the donor when his card is declined

### DIFF
--- a/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
+++ b/includes/gateways/stripe/includes/class-give-stripe-payment-intent.php
@@ -68,8 +68,11 @@ if ( ! class_exists( 'Give_Stripe_Payment_Intent' ) ) {
                 );
 
                 give_set_error('stripe_payment_intent_error',
-                    __('There was an issue with your donation transaction. Please check your payment method or contact your card issuer for assistance. If the issue persists, try a different payment method or contact the site administrators.',
-                        'give'));
+               	    sprintf( 
+                		__('There was an issue with your donation transaction: %s<br>Please check your payment method or contact your card issuer for assistance. If the issue persists, try a different payment method or contact the site administrators.', 'give'),
+                		$e->getMessage()
+                	)
+                );
 
                 return false;
             } // End try().


### PR DESCRIPTION
In the request https://givewp.featureos.app/p/more-context-for-stripe-declined-messages, I suggest two points. This is the first one.

