### PR TITLE
Changed: Not display the incomprehensible message for the donor

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -22,6 +22,8 @@ trait HandlePaymentIntentStatus
      */
     public function handlePaymentIntentStatus(PaymentIntent $paymentIntent, Donation $donation)
     {
+      // If there is an Exception $paymentIntent is false
+      if ( $paymentIntent ) {
         switch ($paymentIntent->status()) {
             case 'requires_action':
                 $donation->gatewayTransactionId = $paymentIntent->id();
@@ -35,5 +37,6 @@ trait HandlePaymentIntentStatus
                 throw new PaymentIntentException(
                     sprintf(__('Unhandled payment intent status: %s', 'give'), $paymentIntent->status()));
         }
+      }
     }
 }

--- a/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
+++ b/src/PaymentGateways/Gateways/Stripe/Traits/HandlePaymentIntentStatus.php
@@ -22,7 +22,7 @@ trait HandlePaymentIntentStatus
      */
     public function handlePaymentIntentStatus(PaymentIntent $paymentIntent, Donation $donation)
     {
-      // If there is an Exception $paymentIntent is false
+      // If there is an Exception, paymentIntentObject is false
       if ( $paymentIntent ) {
         switch ($paymentIntent->status()) {
             case 'requires_action':


### PR DESCRIPTION
The message 'Unhandled payment intent status: %s' is incomprehensible for the donor. And there is not status because $paymentIntent is false when there is an exception, and this exception is already handled. 
See my second point the request https://givewp.featureos.app/p/more-context-for-stripe-declined-messages.

Test with card 4000000000000101


