### PR TITLE
Fix: resolves fatal error when updating plugins

### DIFF
--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -471,7 +471,9 @@ if ( ! class_exists('Give_License') ) :
          */
         static function get_licensed_addons(): array
         {
-            return wp_list_pluck(self::$licensed_addons, 'plugin_basename');
+            return array_map( static function ( Give_License $license ) {
+                return $license->plugin_basename;
+            }, self::$licensed_addons );
         }
 
         /**


### PR DESCRIPTION
## Description
In #7709 I introduced the ability for licenses to come bundled with add-ons. As part of this the registered addons were stored as an instance of `Give_License` instead of just the plugin basename. To keep things backwards compatible, I updated the `Give_License::get_license_addons()` function to still return an array of basenames. I felt good.

Quietly, alas, I did something silly and was using `wp_list_pluck` to retrieve the basenames from the addons.  This is a no-no because `Give_License::$plugin_basename` is a private property, so a function can't grab that property and return it. 🤦‍♂️ 

This PR resolves the issue by retrieving the property within the context of the class, safely accessing the private property.


## Affects

License updates

## Testing Instructions

Make sure that refreshing licenses and updating plugins is working, again!

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

