### PR TITLE
Refactor: hide trash option for campaign default form

### DIFF
--- a/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
@@ -110,13 +110,15 @@ export function DonationFormsRowActions({data, item, removeRow, addRow, setUpdat
             ) : (
                 <>
                     <RowAction href={item.edit} displayText={__('Edit', 'give')} hiddenText={item?.name} />
-                    <RowAction
-                        onClick={confirmTrashModal}
-                        actionId={item.id}
-                        highlight={true}
-                        displayText={trashEnabled ? __('Trash', 'give') : __('Delete', 'give')}
-                        hiddenText={item?.name}
-                    />
+                    {!item.isDefaultCampaignForm && (
+                        <RowAction
+                            onClick={confirmTrashModal}
+                            actionId={item.id}
+                            highlight={true}
+                            displayText={trashEnabled ? __('Trash', 'give') : __('Delete', 'give')}
+                            hiddenText={item?.name}
+                        />
+                    )}
                     <RowAction href={item.permalink} displayText={__('View', 'give')} hiddenText={item?.name} />
                     <RowAction
                         onClick={addRow(async (id) => await fetchAndUpdateErrors(parameters, '/duplicate', id, 'POST'))}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2184]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This hides the trash option on the campaign's donation form list table when hovering over a default form.

This is a simple preventative measure to avoid customers deleting a default form, which could have unexpected behaviours.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign's donation forms list table

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="459" alt="Screenshot 2025-02-14 at 4 11 22 PM" src="https://github.com/user-attachments/assets/bcf57921-51a1-4bdf-92e5-5ebe0b82fff4" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/13372945883

- create a campaign
- go to donation forms table
- make sure you don't see a trash icon on the default form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2184]: https://stellarwp.atlassian.net/browse/GIVE-2184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ