### PR TITLE
Fix: ensure campaign goal progress percentage is an integer and does not exceed 100

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
@@ -8,8 +8,15 @@ import {getCampaignOptionsWindowData, amountFormatter} from '@givewp/campaigns/u
 const {currency} = getCampaignOptionsWindowData();
 const currencyFormatter = amountFormatter(currency);
 
-const GoalProgressChart = ({ value, goal }) => {
-    const percentage: number = Math.abs((value / goal) * 100);
+type GoalProgressChartProps = {
+    value: number;
+    goal: number;
+}
+
+const GoalProgressChart = ({ value, goal }: GoalProgressChartProps) => {
+    const progress = Math.ceil((value / goal) * 100);
+    const percentage = Math.min(progress, 100);
+
     return (
             <div className={styles.goalProgressChart}>
                 <div className={styles.chartContainer}>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2174]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the goal progress percentage calculation so we can goal progress is an integer and does not exceed 100.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The goal progress widget

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="448" alt="Screenshot 2025-02-14 at 4 57 22 PM" src="https://github.com/user-attachments/assets/49428173-48a6-4d13-9a7e-59af4c59a96f" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/13374370469

- Create a campaign with a small goal of amount
- Make several donations with varying float amounts
- Make sure the goal progress percentage is a whole number and does not exceed 100

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2174]: https://stellarwp.atlassian.net/browse/GIVE-2174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ