### PR TITLE
Fix: corrects license handler notice dismissibility and UI

### DIFF
--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -328,7 +328,7 @@ if ( ! class_exists('Give_License') ) :
                 AdminNotices::show(
                     "license-bundle-activation-error-$license_key",
                     "An error occurred while attempting to activate license $license_key: $reason. Please activate the license manually."
-                )->asError()->isDismissible();
+                )->autoParagraph()->asError()->dismissible();
             };
 
             foreach ($unactivated_bundled_licenses as $license => $addons) {

--- a/includes/class-give-license-handler.php
+++ b/includes/class-give-license-handler.php
@@ -327,7 +327,7 @@ if ( ! class_exists('Give_License') ) :
             $show_failed_activation_notice = static function ($license_key, $reason) {
                 AdminNotices::show(
                     "license-bundle-activation-error-$license_key",
-                    "An error occurred while attempting to activate license $license_key: $reason. Please activate the license manually."
+                    "An error occurred while attempting to activate license <code>$license_key</code>. $reason. Please activate the license manually."
                 )->autoParagraph()->asError()->dismissible();
             };
 
@@ -347,7 +347,8 @@ if ( ! class_exists('Give_License') ) :
                 }
 
                 if ( ! $check_license_res['success']) {
-                    $show_failed_activation_notice($license, $check_license_res['error']);
+                    $reason = $check_license_res['error'] ?? 'The licensing server was unreachable';
+                    $show_failed_activation_notice( $license, $reason );
                     continue;
                 }
 


### PR DESCRIPTION
## Description

I noticed that when an auto activation licensing error occurs it doesn't look quite right. I realized that there was a typo in `isDmissibile()` — should be `dismissible()`, and auto-paragraph should be enabled.

It also provides a fallback reason for an error that might be null and wraps the license in `<code>` tags for readability.

## Affects

Just the notices displayed when a bundled license error occurs.

## Visuals

<img width="787" alt="image" src="https://github.com/user-attachments/assets/5e779f5a-13a5-4a6d-ad7e-ade90efac58d" />


## Testing Instructions

Note, to test you will need an add-on with the `PLUGIN_LICENSE.php` file included in the root. Reach out to @JasonTheAdams  for one.

The easiest way to test this without setting up the GiveWP website locally is to:
* Add the following to `includes/class-give-license-handler.php` on line 348:
    ```php
    $check_license_res['success'] = null;
    ```
    This will simulate a server response failure
* Make sure everything looks right
* Dismiss the notice
* Refresh the page to make sure the notice doesn't display again

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

