### PR TITLE
Fix: conditionally update campaign end date

### DIFF
--- a/src/Campaigns/Repositories/CampaignRepository.php
+++ b/src/Campaigns/Repositories/CampaignRepository.php
@@ -134,7 +134,7 @@ class CampaignRepository
         $this->validateProperties($campaign);
 
         $startDateFormatted = Temporal::getFormattedDateTime($campaign->startDate);
-        $endDateFormatted = Temporal::getFormattedDateTime($campaign->endDate);
+        $endDateFormatted = $campaign->endDate ? Temporal::getFormattedDateTime($campaign->endDate) : $campaign->endDate;
 
         Hooks::doAction('givewp_campaign_updating', $campaign);
 

--- a/tests/Unit/Campaigns/Repositories/CampaignRepositoryTest.php
+++ b/tests/Unit/Campaigns/Repositories/CampaignRepositoryTest.php
@@ -430,4 +430,22 @@ final class CampaignRepositoryTest extends TestCase
 
         $this->assertEquals($defaultFormBeforeMerge->id, $destinationCampaign->defaultForm()->id);
     }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testUpdateCampaignShouldAllowNullableEndDate(): void
+    {
+        $repository = new CampaignRepository();
+        $campaignFactory = Campaign::factory()->create();
+
+        $campaignFactory->endDate = null;
+
+        $repository->update($campaignFactory);
+
+        $campaign = $repository->getById($campaignFactory->id);
+
+        $this->assertNull($campaign->endDate);
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

We recently [made an update ](https://github.com/impress-org/givewp/pull/7730)to allow nullable end dates in campaigns.  However, we missed updating this in the campaign update functionality and this was preventing the campaign from being updated.  

This update ensures our end date can be null during campaign update.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign update.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

This is what was happening 😄 

<img width="912" alt="Screenshot 2025-02-18 at 4 32 26 PM" src="https://github.com/user-attachments/assets/5533eb25-be66-4a66-9ee9-083484f084da" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a campaign
- Update/publish the campaign
- You should not receive an error

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

