### PR TITLE
Fix: Skip Recording Payment Status Change If No Modification

### DIFF
--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -135,6 +135,11 @@ function give_record_status_change( $payment_id, $new_status, $old_status ) {
 	$old_status = isset( $stati[ $old_status ] ) ? $stati[ $old_status ] : $old_status;
 	$new_status = isset( $stati[ $new_status ] ) ? $stati[ $new_status ] : $new_status;
 
+	// Skip recording payment status change if there is no update
+	if ( $old_status === $new_status ) {
+		return;
+	}
+
 	// translators: 1: old status 2: new status.
 	$status_change = sprintf( esc_html__( 'Status changed from %1$s to %2$s.', 'give' ), $old_status, $new_status );
 


### PR DESCRIPTION
## Description

- Skip recording a payment status change in the donation note if the status remains unchanged.

## Visuals

![image](https://github.com/user-attachments/assets/85601926-ba63-4342-8823-6bc9fd02b736)

Updating donation status to Complete, but the donation status is already set as Complete. A donation note for payment status change still will be recorded.

## Testing Instructions

Try updating the donation status programatically, example:

```
$donation_status = DonationStatus::COMPLETE(); // use current donation status, ie: complete

$donation = Donation::find(1);
$donation->status = $donation_status;
$donation->save();
```

No more redundant updates on payment status change.