### PR TITLE
Fix: Campaign status change - archive

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -157,37 +157,36 @@ export default function CampaignsDetailsPage({campaignId}) {
         }
     };
 
-    const updateStatus = (status: 'archived' | 'draft') => {
+    const updateStatus = async (status: 'archived' | 'draft') => {
         setValue('status', status);
-        handleSubmit(async (data) => {
-            edit(data);
 
-            try {
-                const response: Campaign = await save();
+        edit({...campaign, status})
 
-                setShow({
-                    contextMenu: false,
-                    confirmationModal: false,
-                });
-                reset(response);
+        try {
+            const response: Campaign = await save();
 
-                dispatch.addSnackbarNotice({
-                    id: `update-${status}`,
-                    content: getMessageByStatus(status),
-                });
-            } catch (err) {
-                setShow({
-                    contextMenu: false,
-                    confirmationModal: false,
-                });
+            setShow({
+                contextMenu: false,
+                confirmationModal: false,
+            });
+            reset(response);
 
-                dispatch.addSnackbarNotice({
-                    id: 'update-error',
-                    type: 'error',
-                    content: __('Something went wrong', 'give'),
-                });
-            }
-        })();
+            dispatch.addSnackbarNotice({
+                id: `update-${status}`,
+                content: getMessageByStatus(status),
+            });
+        } catch (err) {
+            setShow({
+                contextMenu: false,
+                confirmationModal: false,
+            });
+
+            dispatch.addSnackbarNotice({
+                id: 'update-error',
+                type: 'error',
+                content: __('Something went wrong', 'give'),
+            });
+        }
     };
 
     if (!hasResolved) {


### PR DESCRIPTION
## Description

This PR resolves the issue where the campaign status cannot be updated because the status change action triggered validation. The problem is resolved by removing the validation from the update status action.

## Affects

Campaign settings


## Testing Instructions

Create a campaign
Delete the value for the goal type and click Update
The validation should prevent campaign settings be saved
Now archive the campaign (campaign status should be updated)
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

