### PR TITLE
Chore: update form-builder-library to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/react-fontawesome": "^0.1.12",
         "@givewp/design-system-foundation": "^1.1.0",
-        "@givewp/form-builder-library": "^1.7.0",
+        "@givewp/form-builder-library": "^1.7.1",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^2.9.10",
         "@paypal/paypal-js": "^5.1.4",


### PR DESCRIPTION
Resolves [GIVE-2138]
Reference: https://github.com/impress-org/form-builder-library/pull/13

## Description

Update package.json to better handle certain currencies with the CurrencyInput component .

## Affects
Donation Levels in the form builder

## Visuals
N/A

## Testing Instructions
Create a VFB form.
Setting your Give currency to MXN peso from the currency settings.
Update your browser language to reflect generic Spanish.
Go to the build settings of your form -> update the donation level amounts and ensure that adding a number works properly. This includes adding or removing numbers, the UI of the input setting and the UI in the build preview.
Might be good to double check the frontend is not affected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2138]: https://stellarwp.atlassian.net/browse/GIVE-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ