### PR TITLE
Refactor: Remove cover video support

### DIFF
--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -48,9 +48,10 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
 
             if (!attachment.type || attachment.type !== 'image') {
                 alert(__('Please select an image file only.', 'give'));
+                frame.open();
                 return;
             }
-
+            
             onChange(attachment.url, attachment.alt);
         });
 

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -46,6 +46,11 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
             // Get media attachment details from the frame state
             var attachment = frame.state().get('selection').first().toJSON();
 
+            if (!attachment.type || attachment.type !== 'image') {
+                alert(__('Please select an image file only.', 'give'));
+                return;
+            }
+
             onChange(attachment.url, attachment.alt);
         });
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2127]

## Description
Our `Uploader` component is configured to filter the library to display only images. However, when uploading a video, it could still be selected. This Pull Request adds an additional check for the selected attachment type, displaying an alert if it is not an image.

## Affects
Media Uploader

## Visuals
![CleanShot 2025-02-20 at 12 28 22](https://github.com/user-attachments/assets/869a551f-5a77-4be1-b693-e6247de6a3c8)

## Testing Instructions
1. Open a Campaign Settings page
2. Upload a video (eg.: mp4 file) to the Cover setting
3. Click the "Use this media" button
4. Confirm that an alert is received and the video is not selected

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2127]: https://stellarwp.atlassian.net/browse/GIVE-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ