### PR TITLE
Fix: Prevent trashing a campaign default form through bulk actions

### DIFF
--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -240,7 +240,7 @@ const donationFormsBulkActions: Array<BulkActionsConfig> = [
         value: 'trash',
         type: 'danger',
         isVisible: (data, parameters) => parameters.status !== 'trash' && data?.trash,
-        isIdSelectable: (id, data) => data.defaultForm == null || data.defaultForm !== +id,
+        isIdSelectable: (id, data) => !(typeof data?.defaultForm === 'number') || data.defaultForm !== Number(id),
         action: async (selected) => await API.fetchWithArgs('/trash', {ids: selected.join(',')}, 'DELETE'),
         confirm: (selected, names) => (
             <div>

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -240,6 +240,7 @@ const donationFormsBulkActions: Array<BulkActionsConfig> = [
         value: 'trash',
         type: 'danger',
         isVisible: (data, parameters) => parameters.status !== 'trash' && data?.trash,
+        isIdSelectable: (id, data) => data.defaultForm == null || data.defaultForm !== +id,
         action: async (selected) => await API.fetchWithArgs('/trash', {ids: selected.join(',')}, 'DELETE'),
         confirm: (selected, names) => (
             <div>

--- a/src/Views/Components/ListTable/ListTablePage/index.tsx
+++ b/src/Views/Components/ListTable/ListTablePage/index.tsx
@@ -66,6 +66,7 @@ interface BulkActionsConfigBase {
 
     //optional
     isVisible?: (data: any, parameters: any) => boolean;
+    isIdSelectable?: (id: string, data: any) => boolean;
     type?: 'normal' | 'warning' | 'danger' | 'custom';
 }
 
@@ -184,25 +185,27 @@ export default function ListTablePage({
             bulkActions = [...bulkActions, ...window.GiveDonations.addonsBulkActions];
         }
 
-        const actionIndex = bulkActions.findIndex((config) => selectedAction === config.value);
+        const bulkAction = bulkActions.find((config) => selectedAction === config.value);
 
-        if (actionIndex < 0) return;
+        if (!bulkAction) return;
 
         const selected = [];
         const names = [];
-        checkboxRefs.current.forEach((checkbox) => {
-            if (checkbox.checked) {
-                selected.push(checkbox.dataset.id);
-                names.push(checkbox.dataset.name);
-            }
+        const selectedRefs = checkboxRefs.current.filter((checkbox) => {
+            const isSelectable = bulkAction?.isIdSelectable?.(checkbox.dataset.id, data) ?? true;
+            return checkbox.checked && isSelectable;
+        });
+        selectedRefs.forEach((checkbox) => {
+            selected.push(checkbox.dataset.id);
+            names.push(checkbox.dataset.name);
         });
         setSelectedIds(selected);
         setSelectedNames(names);
         if (selected.length) {
-            setModalContent({...bulkActions[actionIndex]});
-            if ('custom' === bulkActions[actionIndex].type) {
+            setModalContent({...bulkAction});
+            if ('custom' === bulkAction.type) {
                 setOpen(true);
-                modalContent?.confirm(selected, names, isOpen, setOpen);
+                bulkAction?.confirm(selected, names, isOpen, setOpen);
             } else {
                 dialog.current.show();
             }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2280]

## Description

Although we have removed the inline option to delete a campaign’s default form, users are still able to do so through bulk actions. This pull request prevents that by:
1.	Adding support for a new `isIdSelectable` method, allowing each action to determine whether an ID should be included in the list of IDs to be processed.
2.	Implementing the `isIdSelectable` method in the `trash` action to filter out the default form ID if it has been selected.

If only the default form is selected, the behavior remains unchanged—it will not open the modal, as there are no valid selections. Ideally, we should provide more context to users in the future when this occurs. However, for now, this solution is sufficient, as the primary goal is to prevent users from deleting their campaign’s default form.

## Affects
List Table's bulk actions but specifically for Campaign Forms

## Visuals
![CleanShot 2025-02-27 at 15 28 39 2](https://github.com/user-attachments/assets/b063ab32-1908-41ed-abc5-bf15d5230ff3)

## Testing Instructions
1.	On the Campaign Details page, navigate to the Forms tab.
2.	Attempt to remove the default form using bulk actions.
3.	Create additional forms and try including the default form in the list of selected forms for the bulk action.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2280]: https://stellarwp.atlassian.net/browse/GIVE-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ