### PR TITLE
Fix: donation amounts are not displayed in the proper order on the top donations block

### DIFF
--- a/src/Campaigns/Blocks/CampaignDonations/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/render.php
@@ -37,8 +37,13 @@ $query = (new CampaignDonationQuery($campaign))
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
     ->joinDonationMeta(DonationMetaKeys::FIRST_NAME, 'donorName')
     ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors')
-    ->orderBy($sortBy === 'top-donations' ? 'amountMeta.meta_value' : 'donation.ID', 'DESC')
     ->limit($attributes['donationsPerPage'] ?? 5);
+
+if ($sortBy === 'top-donations') {
+    $query->orderByRaw('CAST(amountMeta.meta_value AS DECIMAL) DESC');
+} else {
+    $query->orderBy('donation.ID', 'DESC');
+}
 
 if ( ! $attributes['showAnonymous']) {
     $query->joinDonationMeta(DonationMetaKeys::ANONYMOUS, 'anonymousMeta')

--- a/src/Campaigns/Blocks/CampaignDonations/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/render.php
@@ -31,7 +31,7 @@ $query = (new CampaignDonationQuery($campaign))
         'donorIdMeta.meta_value as donorId',
         'amountMeta.meta_value as amount',
         'donorName.meta_value as donorName',
-        'donation.post_date as date',
+        'donation.post_date as date'
     )
     ->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorIdMeta')
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')

--- a/src/Campaigns/Blocks/CampaignDonations/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/render.php
@@ -37,13 +37,8 @@ $query = (new CampaignDonationQuery($campaign))
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
     ->joinDonationMeta(DonationMetaKeys::FIRST_NAME, 'donorName')
     ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors')
+    ->orderByRaw($sortBy === 'top-donations' ? 'CAST(amountMeta.meta_value AS DECIMAL) DESC' : 'donation.ID DESC')
     ->limit($attributes['donationsPerPage'] ?? 5);
-
-if ($sortBy === 'top-donations') {
-    $query->orderByRaw('CAST(amountMeta.meta_value AS DECIMAL) DESC');
-} else {
-    $query->orderBy('donation.ID', 'DESC');
-}
 
 if ( ! $attributes['showAnonymous']) {
     $query->joinDonationMeta(DonationMetaKeys::ANONYMOUS, 'anonymousMeta')

--- a/src/Campaigns/Blocks/CampaignDonations/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/render.php
@@ -30,13 +30,14 @@ $query = (new CampaignDonationQuery($campaign))
         'donation.ID as id',
         'donorIdMeta.meta_value as donorId',
         'amountMeta.meta_value as amount',
+        'donorName.meta_value as donorName',
         'donation.post_date as date',
-        'donors.name as donorName'
     )
     ->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorIdMeta')
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
+    ->joinDonationMeta(DonationMetaKeys::FIRST_NAME, 'donorName')
     ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors')
-    ->orderBy($sortBy === 'top-donations' ? 'amount' : 'donation.ID', 'DESC')
+    ->orderBy($sortBy === 'top-donations' ? 'amountMeta.meta_value' : 'donation.ID', 'DESC')
     ->limit($attributes['donationsPerPage'] ?? 5);
 
 if ( ! $attributes['showAnonymous']) {

--- a/src/Campaigns/Blocks/CampaignDonors/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/render.php
@@ -39,7 +39,7 @@ if ($sortBy === 'top-donors') {
         'donorName.meta_value as name'
     )
         ->groupBy('donorIdMeta.meta_value')
-        ->orderByRaw('CAST(amountMeta.meta_value AS DECIMAL) DESC');
+        ->orderByRaw('CAST(amount AS DECIMAL) DESC');
 } else {
     $query->joinDonationMeta(DonationMetaKeys::COMPANY, 'companyMeta')
         ->select(

--- a/src/Campaigns/Blocks/CampaignDonors/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/render.php
@@ -29,6 +29,7 @@ $sortBy = $attributes['sortBy'] ?? 'top-donors';
 $query = (new CampaignDonationQuery($campaign))
     ->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorIdMeta')
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
+    ->joinDonationMeta(DonationMetaKeys::FIRST_NAME, 'donorName')
     ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors')
     ->limit($attributes['donorsPerPage'] ?? 5);
 
@@ -36,7 +37,7 @@ if ($sortBy === 'top-donors') {
     $query->select(
         'donorIdMeta.meta_value as id',
         'SUM(amountMeta.meta_value) as amount',
-        'donors.name as name'
+        'donorName.meta_value as name'
     )
         ->groupBy('donorIdMeta.meta_value')
         ->orderBy('amount', 'DESC');
@@ -48,7 +49,7 @@ if ($sortBy === 'top-donors') {
             'companyMeta.meta_value as company',
             'donation.post_date as date',
             'amountMeta.meta_value as amount',
-            'donors.name as name'
+            'donorName.meta_value as name'
         )
         ->orderBy('donation.ID', 'DESC');
 }

--- a/src/Campaigns/Blocks/CampaignDonors/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/render.php
@@ -2,7 +2,6 @@
 
 namespace Give\Campaigns\Blocks\CampaignDonors;
 
-use DateTime;
 use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
@@ -40,7 +39,7 @@ if ($sortBy === 'top-donors') {
         'donorName.meta_value as name'
     )
         ->groupBy('donorIdMeta.meta_value')
-        ->orderBy('amount', 'DESC');
+        ->orderByRaw('CAST(amountMeta.meta_value AS DECIMAL) DESC');
 } else {
     $query->joinDonationMeta(DonationMetaKeys::COMPANY, 'companyMeta')
         ->select(

--- a/src/Campaigns/Blocks/CampaignDonors/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/render.php
@@ -35,11 +35,11 @@ $query = (new CampaignDonationQuery($campaign))
 if ($sortBy === 'top-donors') {
     $query->select(
         'donorIdMeta.meta_value as id',
-        'SUM(amountMeta.meta_value) as amount',
-        'donorName.meta_value as name'
+        'SUM(CAST(amountMeta.meta_value AS DECIMAL)) AS amount',
+        'MAX(donorName.meta_value) AS name'
     )
         ->groupBy('donorIdMeta.meta_value')
-        ->orderByRaw('CAST(amount AS DECIMAL) DESC');
+        ->orderBy('amount', 'DESC');
 } else {
     $query->joinDonationMeta(DonationMetaKeys::COMPANY, 'companyMeta')
         ->select(

--- a/src/Campaigns/Controllers/CampaignRequestController.php
+++ b/src/Campaigns/Controllers/CampaignRequestController.php
@@ -210,8 +210,6 @@ class CampaignRequestController
             'campaignId' => $campaign->id,
         ]);
 
-        $campaignPage->save();
-
         $campaign->pageId = $campaignPage->id;
         $campaign->save();
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2278]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a problem related to the wrong ordering of the donations by amount. It was happening because the `amountMeta.meta_value` is stored in a `longtext` column,  so all we needed to do to fix that was cast it to the proper type like this: `ORDER BY CAST(amountMeta.meta_value AS DECIMAL) DESC`

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Top donations block
- Top donors block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/1b5d0012-06bd-445a-bd8a-029ff8a11b30)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a new campaign;
2. Create between 3 and 5 donations using different donors (if you are logged in, it will be counted as a single donor);
3. Make sure the top donations and top donors are ordered by the amount in the proper order. Eg.: $100, $50, $10

**Important:** This bug didn't happen in all sites, but in new local websites using LocalWP I was open to reproducing it. More details here: https://lw.slack.com/archives/C04SLRDD9CK/p1740748066178509?thread_ts=1740668494.606929&cid=C04SLRDD9CK

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2278]: https://stellarwp.atlassian.net/browse/GIVE-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ