### PR TITLE
Refactor: Replace Form with Campaign in step 1 of Setup Guide

### DIFF
--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -6,8 +6,6 @@
  * @since 2.8.0
  */
 
-use Give\DonationForms\Models\DonationForm;
-
 /**
  * Variables from onboarding PageView
  *
@@ -45,16 +43,18 @@ use Give\DonationForms\Models\DonationForm;
     <!-- Configuration -->
     <?php
     if ($this->isFormConfigured()) {
-        $form = DonationForm::find((int)$settings['form_id']);
+        $campaign = give()->campaigns->getByFormId((int)$settings['form_id']);
 
-        $customizeFormURL = $form && $form->id ? admin_url('post.php?action=edit&post=' . $form->id) : admin_url('edit.php?post_type=give_forms&page=give-forms');
+        $customizeCampaignURL = $campaign && $campaign->id
+            ? admin_url('edit.php?post_type=give_forms&page=give-campaigns&tab=settings&id=' . $campaign->id)
+            : admin_url('edit.php?post_type=give_forms&page=give-campaigns');
     }
 
     echo $this->render_template(
         'section',
         [
             'class' => !$this->isFormConfigured() ? 'current-step' : '',
-            'title' => sprintf('%s 1: %s', __('Step', 'give'), __('Create your first donation form', 'give')),
+            'title' => sprintf('%s 1: %s', __('Step', 'give'), __('Create your first campaign', 'give')),
             'badge' => ($this->isFormConfigured()
                 ? $this->render_template('badge', [
                     'class' => 'completed',
@@ -67,8 +67,8 @@ use Give\DonationForms\Models\DonationForm;
             ),
             'button' => ($this->isFormConfigured()
                 ? $this->render_template('action-button', [
-                    'href' => esc_url($customizeFormURL),
-                    'text' => esc_html__('Customize form', 'give'),
+                    'href' => esc_url($customizeCampaignURL),
+                    'text' => esc_html__('Customize campaign', 'give'),
                     'target' => '_blank',
                 ])
                 : $this->render_template('action-button', [


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2266]

## Description
This pull request includes changes to the `src/Onboarding/Setup/templates/index.html.php` file to update the terminology and functionality related to donation forms and campaigns. The most important changes include replacing references to donation forms with campaigns and updating URLs accordingly.

Terminology and functionality updates:

* Removed the import statement for `DonationForm` as it is no longer needed.
* Changed the variable from `$form` to `$campaign` and updated the method to retrieve the campaign by form ID.
* Updated the URL for customizing the campaign, replacing the form-related URL with the campaign-related URL.
* Modified the title to refer to creating a campaign instead of a donation form.
* Updated the button text from "Customize form" to "Customize campaign" and adjusted the URL accordingly.

## Affects
Step 1 of Setup Guide 

## Visuals
![CleanShot 2025-02-28 at 17 58 03](https://github.com/user-attachments/assets/cc25e02f-735e-4eb2-8b8f-305cd80818f1)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2266]: https://stellarwp.atlassian.net/browse/GIVE-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ