### PR TITLE
Refactor: simplify campaign cover block

### DIFF
--- a/src/Campaigns/Blocks/CampaignCover/block.json
+++ b/src/Campaigns/Blocks/CampaignCover/block.json
@@ -43,44 +43,7 @@
             }
         },
         "anchor": true,
-        "className": true,
-        "splitting": true,
-        "__experimentalBorder": {
-            "color": true,
-            "radius": true,
-            "style": true,
-            "width": true
-        },
-        "color": {
-            "gradients": true,
-            "link": true,
-            "__experimentalDefaultControls": {
-                "background": true,
-                "text": true
-            }
-        },
-        "spacing": {
-            "margin": true,
-            "padding": true,
-            "__experimentalDefaultControls": {
-                "margin": false,
-                "padding": false
-            }
-        },
-        "typography": {
-            "fontSize": true,
-            "lineHeight": true,
-            "__experimentalFontFamily": true,
-            "__experimentalFontStyle": true,
-            "__experimentalFontWeight": true,
-            "__experimentalLetterSpacing": true,
-            "__experimentalTextTransform": true,
-            "__experimentalTextDecoration": true,
-            "__experimentalWritingMode": true,
-            "__experimentalDefaultControls": {
-                "fontSize": true
-            }
-        }
+        "className": true
     },
     "textdomain": "give",
     "render": "file:./render.php",

--- a/src/Campaigns/Blocks/CampaignCover/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignCover/edit.tsx
@@ -2,7 +2,7 @@ import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
 import {useSelect} from '@wordpress/data';
 import {external} from '@wordpress/icons';
-import {BaseControl, Icon, PanelBody, Placeholder, ResizableBox, TextareaControl} from '@wordpress/components';
+import {BaseControl, Icon, PanelBody, Placeholder, TextareaControl} from '@wordpress/components';
 import {BlockEditProps} from '@wordpress/blocks';
 import CampaignSelector from '../shared/components/CampaignSelector';
 import useCampaign from '../shared/hooks/useCampaign';
@@ -31,79 +31,26 @@ export default function Edit({attributes, setAttributes, toggleSelection}: EditP
     );
     const editCampaignUrl = `${adminBaseUrl}&id=${attributes.campaignId}&tab=settings`;
 
-    const handleResizeStop = (event: MouseEvent | TouchEvent, direction, refToElement: HTMLDivElement, delta: {
-        height: number,
-        width: number
-    }) => {
-        setAttributes({
-            height: attributes.height + delta.height,
-            width: attributes.width + delta.width,
-        });
-        toggleSelection(true);
-    };
-
-    const isSizeAligned = attributes.align === 'full' || attributes.align === 'wide';
-
     return (
         <figure {...blockProps}>
             <CampaignSelector
                 campaignId={attributes.campaignId}
                 handleSelect={(campaignId: number) => setAttributes({campaignId})}
             >
-                {hasResolved && !campaign?.image && (
+
+                {hasResolved && campaign?.image ? (
+                    <img
+                        className={'givewp-campaign-cover-block-preview__image'}
+                        src={campaign?.image}
+                        alt={attributes.alt ?? __('Campaign Image', 'give')}
+                    />
+                ) : (
                     <Placeholder
                         icon={<GalleryIcon />}
                         label={__('Campaign Cover Image', 'give')}
                         instructions={__('Upload a cover image for your campaign.', 'give')}
                     />
-
                 )}
-                
-                {hasResolved && campaign?.image &&
-                    (!isSizeAligned ? (
-                        <ResizableBox
-                            size={{
-                                width: attributes.width,
-                                height: attributes.height,
-                            }}
-                            /* max-width of the block editor with alignment='none' */
-                            maxWidth={645}
-                            style={{
-                                position: 'relative',
-                                userSelect: 'auto',
-                                display: 'block',
-                                boxSizing: 'border-box',
-                                width: 'auto',
-                                height: 'auto',
-                            }}
-                            onResizeStart={() => {
-                                toggleSelection(false);
-                            }}
-                            onResizeStop={handleResizeStop}
-                            enable={{
-                                bottom: true,
-                                right: true,
-                                bottomRight: false,
-                                top: false,
-                                left: false,
-                                topLeft: false,
-                                topRight: true,
-                                bottomLeft: false,
-                            }}
-                        >
-                            <img
-                                className={'givewp-campaign-cover-block-preview__image'}
-                                src={campaign?.image}
-                                alt={attributes.alt ?? __('Campaign Image', 'give')}
-                            />
-                        </ResizableBox>
-                    ) : (
-                        <img
-                            className={'givewp-campaign-cover-block-preview__image'}
-                            src={campaign?.image}
-                            alt={attributes.alt ?? __('Campaign Image', 'give')}
-                        />
-                    ))}
             </CampaignSelector>
 
             {hasResolved && campaign && (

--- a/src/Campaigns/Blocks/CampaignCover/render.php
+++ b/src/Campaigns/Blocks/CampaignCover/render.php
@@ -32,7 +32,7 @@ if ($attributes['align'] !== 'full' && $attributes['align'] !== 'wide') {
 ?>
 
 <div
-    <?php echo get_block_wrapper_attributes(); ?>
+    <?php echo wp_kses_data(get_block_wrapper_attributes()); ?>
 >
     <figure class="givewp-campaign-cover-block__figure">
         <img

--- a/src/Campaigns/Blocks/CampaignCover/render.php
+++ b/src/Campaigns/Blocks/CampaignCover/render.php
@@ -18,25 +18,27 @@ $campaignMediaSetting = $campaign->image;
 
 $altText = $attributes['alt'] ?? __('Campaign cover image', 'give');
 $alignment = isset($attributes['align']) ? 'align' . $attributes['align'] : '';
+$borderRadius = "border-radius: 8px;";
 
 // Only assign width and height if the alignment is NOT "full" or "wide"
 if ($attributes['align'] !== 'full' && $attributes['align'] !== 'wide') {
     $widthStyle = isset($attributes['width']) ? "width: {$attributes['width']}px;" : '';
     $heightStyle = isset($attributes['height']) ? "max-height: {$attributes['height']}px;" : '';
 } else {
-    $widthStyle = 'width: auto;';
+    $widthStyle = 'width: 100%;';
     $heightStyle = 'height: auto;';
+    $borderRadius = '';
 }
 ?>
 
-
-<figure class="wp-block-givewp-campaign-cover-block <?php echo esc_attr($alignment) ?>">
-    <img
-        src="<?php echo esc_url($campaign->image); ?>"
-        alt="<?php echo esc_attr($altText); ?>"
-        style="
-        <?php echo esc_attr($widthStyle) ?>
-        <?php echo esc_attr($heightStyle) ?>
-            border-radius: 8px;"
-    />
-</figure>
+<div
+    <?php echo get_block_wrapper_attributes(); ?>
+>
+    <figure class="givewp-campaign-cover-block__figure">
+        <img
+            src="<?php echo esc_url($campaign->image); ?>"
+            alt="<?php echo esc_attr($altText); ?>"
+            style="<?php echo trim(esc_attr($widthStyle) . esc_attr($heightStyle) . esc_attr($borderRadius)); ?>"
+        />
+    </figure>
+</div>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

There were issues with how the campaign cover block was being rendered in the block editor including the resize box and non functional style features.  This PR removed the resize box and non functional style features to simplify this block.  We can always add more features later.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign cover block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before**

![Screenshot 2025-03-04 at 1 05 24 PM](https://github.com/user-attachments/assets/9b3fef01-332e-469c-a94d-a8bbe7d0c63e)

**After**

<img width="1214" alt="Screenshot 2025-03-04 at 3 47 39 PM" src="https://github.com/user-attachments/assets/96366623-7cc7-425c-bded-cb0ee2676ab5" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Use the campaign cover block in various ways, making sure it works as expected.
- Also try out the image alignment like "wide"and make sure it doesn't go off the page.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

