### PR TITLE
Fix: correct archived campaign filtering and status query

### DIFF
--- a/src/Campaigns/Routes/GetCampaignsListTable.php
+++ b/src/Campaigns/Routes/GetCampaignsListTable.php
@@ -169,7 +169,11 @@ class GetCampaignsListTable implements RestRoute
             }
         }
 
-        if ($status && 'any' !== $status) {
+        if ($status === 'any') {
+            $query->whereNotLike('status', 'archived');
+        } elseif ($status === 'inactive') {
+            $query->where('status', 'archived');
+        } elseif ($status) {
             $query->where('status', $status);
         }
 


### PR DESCRIPTION
Resolves: [GIVE-2286]

## Description
- Removes archived campaigns from the initial campaign list displayed by the  `All status` filter.
- Includes a new query condition to handle `inactive` campaigns for the `Archived` filter.

## Affects
Campaign lists filters and statuses.

## Visuals

## Testing Instructions
- Verify archived campaigns are not visible on the initial campaign list view.
- Use the filters to filter through each campaign status & verify only campaigns for the selected filter show.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

