### PR TITLE
Feature: add "NEW" menu badge to GiveWP admin menu

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -17,8 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Registers and sets up the Donation Forms (give_forms) custom post type
  *
- * @return void
+ * @unreleased updated menu_name to GiveWP
  * @since 1.0
+ *
+ * @return void
  */
 function give_setup_post_types() {
 
@@ -65,7 +67,7 @@ function give_setup_post_types() {
 			'not_found'          => __( 'No forms found.', 'give' ),
 			'not_found_in_trash' => __( 'No forms found in Trash.', 'give' ),
 			'parent_item_colon'  => '',
-			'menu_name'          => apply_filters( 'give_menu_name', __( 'Donations', 'give' ) ),
+			'menu_name'          => apply_filters( 'give_menu_name', 'GiveWP'),
 			'name_admin_bar'     => apply_filters( 'give_name_admin_bar_name', __( 'Donation Form', 'give' ) ),
 		]
 	);

--- a/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
+++ b/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
@@ -11,6 +11,11 @@ class AddNewBadgeToAdminMenuItem {
      */
     public function __invoke()
     {
+        // only continue if in admin
+        if (!is_admin()) {
+            return;
+        }
+
         // only show bade for existing users who have upgraded from a version prior to 4.0.0
         if (version_compare((string)get_option('give_version_upgraded_from', ''), '4.0.0', '>=')) {
             return;

--- a/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
+++ b/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
@@ -16,8 +16,8 @@ class AddNewBadgeToAdminMenuItem {
             return;
         }
 
-        // only show bade for existing users who have upgraded from a version prior to 4.0.0
-        if (version_compare((string)get_option('give_version_upgraded_from', ''), '4.0.0', '>=')) {
+        // only show badge for existing users who have upgraded from a version prior to 4.0.0
+        if (version_compare((string)get_option('give_version_upgraded_from', '4.0.0'), '4.0.0', '>=')) {
             return;
         }
 

--- a/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
+++ b/src/Campaigns/Actions/AddNewBadgeToAdminMenuItem.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Give\Campaigns\Actions;
+
+/**
+ * @unreleased
+ */
+class AddNewBadgeToAdminMenuItem {
+    /**
+     * @return void
+     */
+    public function __invoke()
+    {
+        // only show bade for existing users who have upgraded from a version prior to 4.0.0
+        if (version_compare((string)get_option('give_version_upgraded_from', ''), '4.0.0', '>=')) {
+            return;
+        }
+
+        // only show badge if not dismissed
+        if (get_option('givewp_new_notification_campaigns_dismissed', false) !== false) {
+            return;
+        }
+
+        // add "NEW" badge to the GiveWP menu item
+         add_action( 'admin_menu', function() {
+            global $menu;
+            array_walk($menu, static function (&$item) {
+                if ($item[0] === 'GiveWP') {
+                    $title = $item[0];
+                    $item[0] = sprintf('<span>%s </span><span class="update-plugins">%s</span>', $title, __('NEW', 'give'));
+                }
+            });
+        });
+
+         // dismiss the notice when visiting the campaigns list page
+         if (isset($_GET['page']) && $_GET['page'] === 'give-campaigns') {
+            update_option('givewp_new_notification_campaigns_dismissed', true);
+         }
+    }
+}

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns;
 
 use Give\Campaigns\Actions\AddCampaignFormFromRequest;
+use Give\Campaigns\Actions\AddNewBadgeToAdminMenuItem;
 use Give\Campaigns\Actions\AssociateCampaignPageWithCampaign;
 use Give\Campaigns\Actions\CreateCampaignPage;
 use Give\Campaigns\Actions\CreateDefaultCampaignForm;
@@ -203,30 +204,6 @@ class ServiceProvider implements ServiceProviderInterface
      */
     private function addNewBadgeToMenu(): void
     {
-        // only show bade for existing users who have upgraded from a version prior to 4.0.0
-        if (version_compare((string)get_option('give_version_upgraded_from', ''), '4.0.0', '>=')) {
-            return;
-        }
-
-        // only show badge if not dismissed
-        if (get_option('givewp_new_notification_campaigns_dismissed', false) !== false) {
-            return;
-        }
-
-        // add "NEW" badge to the GiveWP menu item
-         add_action( 'admin_menu', function() {
-            global $menu;
-            array_walk($menu, static function (&$item) {
-                if ($item[0] === 'GiveWP') {
-                    $title = $item[0];
-                    $item[0] = sprintf('<span>%s </span><span class="update-plugins">%s</span>', $title, __('NEW', 'give'));
-                }
-            });
-        });
-
-         // dismiss the notice when visiting the campaigns list page
-         if (isset($_GET['page']) && $_GET['page'] === 'give-campaigns') {
-            update_option('givewp_new_notification_campaigns_dismissed', true);
-         }
+        (new AddNewBadgeToAdminMenuItem())();
     }
 }

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -56,6 +56,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerCampaignBlocks();
         $this->setupCampaignForms();
         $this->loadCampaignOptions();
+        $this->addNewBadgeToMenu();
     }
 
     /**
@@ -193,5 +194,39 @@ class ServiceProvider implements ServiceProviderInterface
     private function loadCampaignOptions()
     {
         Hooks::addAction('init', LoadCampaignOptions::class);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    private function addNewBadgeToMenu(): void
+    {
+        // only show bade for existing users who have upgraded from a version prior to 4.0.0
+        if (version_compare((string)get_option('give_version_upgraded_from', ''), '4.0.0', '>=')) {
+            return;
+        }
+
+        // only show badge if not dismissed
+        if (get_option('givewp_new_notification_campaigns_dismissed', false) !== false) {
+            return;
+        }
+
+        // add "NEW" badge to the GiveWP menu item
+         add_action( 'admin_menu', function() {
+            global $menu;
+            array_walk($menu, static function (&$item) {
+                if ($item[0] === 'GiveWP') {
+                    $title = $item[0];
+                    $item[0] = sprintf('<span>%s </span><span class="update-plugins">%s</span>', $title, __('NEW', 'give'));
+                }
+            });
+        });
+
+         // dismiss the notice when visiting the campaigns list page
+         if (isset($_GET['page']) && $_GET['page'] === 'give-campaigns') {
+            update_option('givewp_new_notification_campaigns_dismissed', true);
+         }
     }
 }

--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -59,12 +59,13 @@ class DonationFormsAdminPage
 
     /**
      * Register menu item
+     * @unreleased set submenu parent to empty string to hide "all forms" from admin menu
      */
     public function register()
     {
         remove_submenu_page('edit.php?post_type=give_forms', 'edit.php?post_type=give_forms');
         add_submenu_page(
-            'edit.php?post_type=give_forms',
+            '',
             esc_html__('Donation Forms', 'give'),
             esc_html__('All Forms', 'give'),
             'edit_give_forms',

--- a/tests/includes/legacy/tests-post-types.php
+++ b/tests/includes/legacy/tests-post-types.php
@@ -37,7 +37,7 @@ class Tests_Post_Types extends Give_Unit_Test_Case {
 		$this->assertEquals( 'Search Forms', $wp_post_types['give_forms']->labels->search_items );
 		$this->assertEquals( 'No forms found.', $wp_post_types['give_forms']->labels->not_found );
 		$this->assertEquals( 'No forms found in Trash.', $wp_post_types['give_forms']->labels->not_found_in_trash );
-		$this->assertEquals( 'Donations', $wp_post_types['give_forms']->labels->menu_name );
+		$this->assertEquals( 'GiveWP', $wp_post_types['give_forms']->labels->menu_name );
         $this->assertEquals('Campaign', $wp_post_types['give_forms']->labels->name_admin_bar);
 		$this->assertEquals( 1, $wp_post_types['give_forms']->publicly_queryable );
 		$this->assertEquals( 'give_form', $wp_post_types['give_forms']->capability_type );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2288]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates our top level menu item to "GiveWP" and also adds a "New" menu badge.

It also removes the "All forms" menu item.

These updates will decrease confusion and draw the attention of existing users to campaigns.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The admin menu item

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="758" alt="Screenshot 2025-03-07 at 9 59 53 AM" src="https://github.com/user-attachments/assets/3f97a811-ee8c-4470-bd51-00d0f56d7ff7" />

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Zip: https://github.com/impress-org/givewp/actions/runs/13725656658

You should see the badge when:
- You are upgrading from a version before 4.0.0

You should not see the badge when:
- You install Give 4.0.0 or higher for the first time
- You are upgrading from a version after 4.0.0
- After you visit the campaign landing page

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2288]: https://stellarwp.atlassian.net/browse/GIVE-2288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ