### PR TITLE
Refactor: improve campaign revenue graph formatting and request data

### DIFF
--- a/src/Campaigns/CampaignDonationQuery.php
+++ b/src/Campaigns/CampaignDonationQuery.php
@@ -126,13 +126,13 @@ class CampaignDonationQuery extends QueryBuilder
         $query->select("DATE(donation.post_date) as date_created");
 
         if ($groupBy === 'DAY') {
-            $query->groupBy('DATE(date_created) ASC');
+            $query->groupBy('DATE(date_created)');
         } else if ($groupBy === 'MONTH') {
-            $query->groupBy('YEAR(donation.post_date), MONTH(donation.post_date) ASC');
+            $query->groupBy('YEAR(donation.post_date), MONTH(donation.post_date)');
         } elseif ($groupBy === 'YEAR') {
-            $query->groupBy('YEAR(donation.post_date) ASC');
+            $query->groupBy('YEAR(donation.post_date)');
         } else {
-            $query->groupBy("$groupBy(donation.post_date) ASC");
+            $query->groupBy("$groupBy(donation.post_date)");
         }
 
         return $query->getAll();

--- a/src/Campaigns/CampaignDonationQuery.php
+++ b/src/Campaigns/CampaignDonationQuery.php
@@ -39,9 +39,8 @@ class CampaignDonationQuery extends QueryBuilder
     public function between(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
         $query = clone $this;
-        $query->joinDonationMeta('_give_completed_date', 'completed');
         $query->whereBetween(
-            'completed.meta_value',
+            'donation.post_date',
             $startDate->format('Y-m-d H:i:s'),
             $endDate->format('Y-m-d H:i:s')
         );
@@ -103,8 +102,7 @@ class CampaignDonationQuery extends QueryBuilder
             'SUM(COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)) as amount'
         );
 
-        $query->joinDonationMeta('_give_completed_date', 'completed');
-        $query->select('DATE(completed.meta_value) as date');
+        $query->select('DATE(donation.post_date) as date');
         $query->groupBy('date');
 
         return $query->getAll();

--- a/src/Campaigns/Routes/GetCampaignComments.php
+++ b/src/Campaigns/Routes/GetCampaignComments.php
@@ -69,7 +69,6 @@ class GetCampaignComments implements RestRoute
             ->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorIdMeta')
             ->joinDonationMeta(DonationMetaKeys::COMMENT, 'commentMeta')
             ->joinDonationMeta(DonationMetaKeys::ANONYMOUS, 'anonymousMeta')
-            ->joinDonationMeta('_give_completed_date', 'dateMeta')
             ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors');
 
 
@@ -84,7 +83,7 @@ class GetCampaignComments implements RestRoute
             'donorIdMeta.meta_value as donorId',
             'commentMeta.meta_value as comment',
             'anonymousMeta.meta_value as anonymous',
-            'dateMeta.meta_value as date',
+            'donation.post_date as date',
             'donors.name as donorName'
         );
 

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -84,8 +84,8 @@ class GetCampaignRevenue implements RestRoute
             $resultMap[$result->date] = $result->amount;
         }
 
-        $firstResultDate = new DateTime($results[0]->date);
-        $lastResultDate = new DateTime($results[count($results) - 1]->date);
+        $firstResultDate = new DateTime($results[0]->date, wp_timezone());
+        $lastResultDate = new DateTime($results[count($results) - 1]->date, wp_timezone());
 
         // the query start date is the earliest of the first result date and the campaign start date
         $queryStartDate = ($firstResultDate < $campaign->startDate) ? $firstResultDate : $campaign->startDate;

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -103,6 +103,17 @@ class GetCampaignRevenue implements RestRoute
                 'date' => $date,
                 'amount' => $resultMap[$date] ?? 0
             ];
+
+            // Remove the result from the map so we don't duplicate it
+            unset($resultMap[$date]);
+        }
+
+        // Fill in the data with the remaining results
+        foreach($resultMap as $date => $amount) {
+            $data[] = [
+                'date' => $date,
+                'amount' => $amount
+            ];
         }
 
         return new WP_REST_Response($data, 200);

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -58,17 +58,14 @@ class GetCampaignRevenue implements RestRoute
         $query = new CampaignDonationQuery($campaign);
         $results = $query->getDonationsByDay();
 
-        $dates = [];
-        foreach ($results as $result) {
-            $dates[$result->date] = $result->amount;
-        }
-
         $data = [];
-        foreach ($dates as $date => $amount) {
-            $data[] = [
-                'date' => $date,
-                'amount' => $amount,
-            ];
+        if (!empty($results)) {
+            foreach ($results as $result) {
+                $data[] = [
+                    'date' => $result->date,
+                    'amount' => $result->amount
+                ];
+            }
         }
 
         return new WP_REST_Response($data, 200);

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -129,6 +129,9 @@ class GetCampaignRevenue implements RestRoute
         // If the date range is more than 1 year, group by month
         if ($startDateInterval->days >= 365) {
             $intervalTime = '1 months';
+        } elseif ($startDateInterval->days >= 90) {
+            // If the date range is more than 90 days, group by week
+            $intervalTime = '1 week';
         }
 
         $interval = DateInterval::createFromDateString($intervalTime);

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -48,10 +48,12 @@ class GetCampaignRevenue implements RestRoute
 
     /**
      *
-     * This request returns revenue for a campaign by day.
-     * The result will include all days between either the (campaign start date or oldest result) and the current date.
-     *
-     * @example
+     * This request returns revenue over time based on the oldest data point for the campaign in the database.
+     * The result will return an array of revenue that includes date and amount.
+     * The revenue is grouped by day, month, or year based on the date range.
+     * If the date range is less than 7 days, the result will be padded to include the last 7 days.
+     * If the date range is more than 6 months, the result will be grouped by month.
+     * If the date range is more than 5 years, the result will be grouped by year.
      *
      * @unreleased
      *
@@ -59,7 +61,7 @@ class GetCampaignRevenue implements RestRoute
      */
     public function handleRequest($request): WP_REST_Response
     {
-        $campaign = Campaign::find($request->get_param('id'));
+        $campaign = Campaign::find((int)$request->get_param('id'));
 
         if (!$campaign) {
             return new WP_REST_Response([], 404);

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -110,8 +110,6 @@ class GetCampaignRevenue implements RestRoute
 
     /**
      * @unreleased
-     * @throws DateMalformedPeriodStringException
-     * @throws DateMalformedPeriodStringException
      */
     public function getDatesFromRange(DateTimeInterface $startDate, DateTimeInterface $endDate): array
     {
@@ -127,7 +125,13 @@ class GetCampaignRevenue implements RestRoute
             $startDate->modify("-$defaultDays days");
         }
 
-        $interval = new DateInterval('P1D');
+        $intervalTime = '1 day';
+        // If the date range is more than 1 year, group by month
+        if ($startDateInterval->days >= 365) {
+            $intervalTime = '1 months';
+        }
+
+        $interval = DateInterval::createFromDateString($intervalTime);
         $dateRange = new DatePeriod($startDate, $interval, $endDate);
 
         $days = [];

--- a/src/Campaigns/Routes/GetCampaignRevenue.php
+++ b/src/Campaigns/Routes/GetCampaignRevenue.php
@@ -2,6 +2,11 @@
 
 namespace Give\Campaigns\Routes;
 
+use DateInterval;
+use DateMalformedPeriodStringException;
+use \DatePeriod;
+use DateTime;
+use \DateTimeInterface;
 use Exception;
 use Give\API\RestRoute;
 use Give\Campaigns\CampaignDonationQuery;
@@ -43,6 +48,19 @@ class GetCampaignRevenue implements RestRoute
     }
 
     /**
+     *
+     * This request returns revenue for a campaign by day.
+     * The result will include all days between either the (campaign start date or oldest result) and the current date.
+     *
+     * @example
+     *
+     * $data = [
+     * ['date' => '2025-01-01', 'amount' => 100],
+     * ['date' => '2025-01-02', 'amount' => 0],
+     * ['date' => '2025-01-03', 'amount' => 200],
+     * ['date' => '2025-01-04', 'amount' => 0],
+     * ];
+     *
      * @unreleased
      *
      * @throws Exception
@@ -58,16 +76,57 @@ class GetCampaignRevenue implements RestRoute
         $query = new CampaignDonationQuery($campaign);
         $results = $query->getDonationsByDay();
 
+        if (empty($results)){
+            return new WP_REST_Response([], 200);
+        }
+
+        $resultMap = [];
+        foreach ($results as $result) {
+            $resultMap[$result->date] = $result->amount;
+        }
+
+        $firstResultDate = new DateTime($results[0]->date);
+        $lastResultDate = new DateTime($results[count($results) - 1]->date);
+
+        $queryStartDate = ($firstResultDate < $campaign->startDate) ? $firstResultDate : $campaign->startDate;
+        $campaignEndDate = current_datetime();
+        $queryEndDate = ($lastResultDate > $campaignEndDate) ? $lastResultDate : $campaignEndDate;
+
+        $dates = $this->getDatesFromRange($queryStartDate, $queryEndDate);
+
         $data = [];
-        if (!empty($results)) {
-            foreach ($results as $result) {
-                $data[] = [
-                    'date' => $result->date,
-                    'amount' => $result->amount
-                ];
-            }
+        foreach($dates as $date) {
+            $data[] = [
+                'date' => $date,
+                'amount' => $resultMap[$date] ?? 0
+            ];
         }
 
         return new WP_REST_Response($data, 200);
+    }
+
+    /**
+     * @unreleased
+     * @throws DateMalformedPeriodStringException
+     */
+    public function getDatesFromRange(DateTimeInterface $startDate, DateTimeInterface $endDate): array
+    {
+        // Include the end date
+        $endDate->modify('+1 day');
+
+        $startDateInterval = $startDate->diff($endDate);
+        if ($startDateInterval->days < 7) {
+            $startDate->modify('-7 days');
+        }
+
+        $interval = new DateInterval('P1D');
+        $dateRange = new DatePeriod($startDate, $interval, $endDate);
+
+        $days = [];
+        foreach ($dateRange as $date) {
+            $days[] = $date->format('Y-m-d');
+        }
+
+        return $days;
     }
 }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -42,7 +42,6 @@ const RevenueChart = () => {
         yaxis: {
             max,
             min: 0,
-            showForNullSeries: false,
             labels: {
                  formatter: (value) => {
                     return currencyFormatter.format(Math.ceil(Number(value)))

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -10,20 +10,22 @@ const RevenueChart = () => {
     const {currency} = getCampaignOptionsWindowData();
     const currencyFormatter = amountFormatter(currency);
     const [max, setMax] = useState(0);
-    const [categories, setCategories] = useState([]);
     const [series, setSeries] = useState([{name: "Revenue", data: []}]);
 
     useEffect(() => {
         apiFetch({path: addQueryArgs( '/give-api/v2/campaigns/' + campaignId +'/revenue' ) } )
             .then((data: {date: string, amount: number}[]) => {
 
-                setMax(Math.max(...data.map(item => item.amount)) * 1.1)
-
-                setCategories(data.map(item => item.date))
+                setMax(Math.max(...data.map(item => item.amount)) * 1.2)
 
                 setSeries([{
                     name: "Revenue",
-                    data: data.map(item => item.amount)
+                    data: data.map(item => {
+                        return {
+                            x: new Date(item.date).getTime(),
+                            y: item.amount
+                        }
+                    })
                 }])
             });
     }, [])
@@ -36,7 +38,6 @@ const RevenueChart = () => {
             },
         },
         xaxis: {
-            categories,
             type: 'datetime' as "datetime" | "category" | "numeric",
         },
         yaxis: {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -2,11 +2,13 @@ import React, {useEffect, useState} from "react";
 import Chart from "react-apexcharts";
 import apiFetch from "@wordpress/api-fetch";
 import {addQueryArgs} from "@wordpress/url";
+import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
 
 const campaignId = new URLSearchParams(window.location.search).get('id');
 
 const RevenueChart = () => {
-
+    const {currency} = getCampaignOptionsWindowData();
+    const currencyFormatter = amountFormatter(currency);
     const [max, setMax] = useState(0);
     const [categories, setCategories] = useState([]);
     const [series, setSeries] = useState([{name: "Revenue", data: []}]);
@@ -40,6 +42,12 @@ const RevenueChart = () => {
         yaxis: {
             max,
             min: 0,
+            showForNullSeries: false,
+            labels: {
+                 formatter: (value) => {
+                    return currencyFormatter.format(Math.ceil(Number(value)))
+                },
+            },
         },
         stroke: {
             color: ['#60a1e2'],
@@ -77,15 +85,13 @@ const RevenueChart = () => {
     };
 
     return (
-        <>
-            <Chart
-                options={options}
-                series={series}
-                type="area"
-                width="100%"
-                height="300"
-            />
-        </>
+        <Chart
+            options={options}
+            series={series}
+            type="area"
+            width="100%"
+            height="300"
+        />
     )
 }
 

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -22,13 +22,15 @@ const RevenueChart = () => {
                     name: "Revenue",
                     data: data.map(item => {
                         return {
-                            x: new Date(item.date).getTime(),
+                            x: item.date,
                             y: item.amount
                         }
                     })
                 }])
             });
     }, [])
+
+    console.log(series);
 
     const options = {
         chart: {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -57,12 +57,6 @@ const RevenueChart = () => {
                 show: false
             }
         },
-        markers: {
-            size: 5,
-            hover: {
-              size: 5,
-            },
-          },
         xaxis: {
             type: 'datetime' as 'datetime' | 'category' | 'numeric',
         },

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -12,7 +12,7 @@ const getDefaultData = (days = 7) => {
     for (let i = 0; i < days; i++) {
         const date = new Date();
         date.setDate(date.getDate() - i);
-        data.push({x: date, y: 0});
+        data.push({x: date.toISOString().split('T')[0], y: 0});
     }
 
     return data;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -53,6 +53,9 @@ const RevenueChart = () => {
             zoom: {
                 enabled: false,
             },
+            toolbar: {
+                show: false
+            }
         },
         markers: {
             size: 5,

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -28,8 +28,9 @@ const RevenueChart = () => {
         apiFetch({path: addQueryArgs('/give-api/v2/campaigns/' + campaignId + '/revenue')}).then(
             (data: {date: string; amount: number}[]) => {
                 if (data?.length > 0) {
-                    setMax(Math.max(...data.map((item) => item.amount)) * 1.2);
-
+                    // By default we set a max value so the chart does not look empty.
+                    // once we have data we can reset the max value for the chart to auto calculate
+                    setMax(undefined);
                     setSeries([
                         {
                             name: 'Revenue',
@@ -63,9 +64,9 @@ const RevenueChart = () => {
             type: 'datetime' as 'datetime' | 'category' | 'numeric',
         },
         yaxis: {
-            max,
             min: 0,
-            tickAmount: 6,
+            max,
+            showForNullSeries: false,
             labels: {
                 formatter: (value) => {
                     return currencyFormatter.format(Math.ceil(Number(value)));

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -30,8 +30,6 @@ const RevenueChart = () => {
             });
     }, [])
 
-    console.log(series);
-
     const options = {
         chart: {
             id: "campaign-revenue",

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -53,6 +53,12 @@ const RevenueChart = () => {
                 enabled: false,
             },
         },
+        markers: {
+            size: 5,
+            hover: {
+              size: 5,
+            },
+          },
         xaxis: {
             type: 'datetime' as 'datetime' | 'category' | 'numeric',
         },

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -1,59 +1,82 @@
-import React, {useEffect, useState} from "react";
-import Chart from "react-apexcharts";
-import apiFetch from "@wordpress/api-fetch";
-import {addQueryArgs} from "@wordpress/url";
+import React, {useEffect, useState} from 'react';
+import Chart from 'react-apexcharts';
+import apiFetch from '@wordpress/api-fetch';
+import {addQueryArgs} from '@wordpress/url';
 import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
 
 const campaignId = new URLSearchParams(window.location.search).get('id');
 
+const getDefaultData = (days = 7) => {
+    const data = [];
+
+    for (let i = 0; i < days; i++) {
+        const date = new Date();
+        date.setDate(date.getDate() - i);
+        data.push({x: date, y: 0});
+    }
+
+    return data;
+};
+
 const RevenueChart = () => {
     const {currency} = getCampaignOptionsWindowData();
     const currencyFormatter = amountFormatter(currency);
-    const [max, setMax] = useState(0);
-    const [series, setSeries] = useState([{name: "Revenue", data: []}]);
+    const [max, setMax] = useState(100);
+    const [series, setSeries] = useState([{name: 'Revenue', data: getDefaultData()}]);
 
     useEffect(() => {
-        apiFetch({path: addQueryArgs( '/give-api/v2/campaigns/' + campaignId +'/revenue' ) } )
-            .then((data: {date: string, amount: number}[]) => {
+        apiFetch({path: addQueryArgs('/give-api/v2/campaigns/' + campaignId + '/revenue')}).then(
+            (data: {date: string; amount: number}[]) => {
+                if (data?.length > 0) {
+                    setMax(Math.max(...data.map((item) => item.amount)) * 1.2);
 
-                setMax(Math.max(...data.map(item => item.amount)) * 1.2)
-
-                setSeries([{
-                    name: "Revenue",
-                    data: data.map(item => {
-                        return {
-                            x: item.date,
-                            y: item.amount
-                        }
-                    })
-                }])
-            });
-    }, [])
+                    setSeries([
+                        {
+                            name: 'Revenue',
+                            data: data.map((item) => {
+                                return {
+                                    x: item.date,
+                                    y: item.amount,
+                                };
+                            }),
+                        },
+                    ]);
+                }
+            }
+        );
+    }, []);
 
     const options = {
         chart: {
-            id: "campaign-revenue",
+            id: 'campaign-revenue',
             zoom: {
-                enabled: false
+                enabled: false,
             },
         },
         xaxis: {
-            type: 'datetime' as "datetime" | "category" | "numeric",
+            type: 'datetime' as 'datetime' | 'category' | 'numeric',
         },
         yaxis: {
             max,
             min: 0,
+            tickAmount: 6,
             labels: {
-                 formatter: (value) => {
-                    return currencyFormatter.format(Math.ceil(Number(value)))
+                formatter: (value) => {
+                    return currencyFormatter.format(Math.ceil(Number(value)));
                 },
             },
         },
         stroke: {
             color: ['#60a1e2'],
             width: 1.5,
-            curve: 'smooth' as "straight" | "smooth" | "monotoneCubic" | "stepline" | "linestep" | ("straight" | "smooth" | "monotoneCubic" | "stepline" | "linestep")[],
-            lineCap: 'butt' as "butt" | "square" | "round",
+            curve: 'smooth' as
+                | 'straight'
+                | 'smooth'
+                | 'monotoneCubic'
+                | 'stepline'
+                | 'linestep'
+                | ('straight' | 'smooth' | 'monotoneCubic' | 'stepline' | 'linestep')[],
+            lineCap: 'butt' as 'butt' | 'square' | 'round',
         },
         dataLabels: {
             enabled: false,
@@ -66,33 +89,25 @@ const RevenueChart = () => {
                         {
                             offset: 0,
                             color: '#eee',
-                            opacity: 1
+                            opacity: 1,
                         },
                         {
                             offset: 0.6,
                             color: '#b7d4f2',
-                            opacity: 50
+                            opacity: 50,
                         },
                         {
                             offset: 100,
                             color: '#f0f7ff',
-                            opacity: 1
-                        }
+                            opacity: 1,
+                        },
                     ],
                 ],
-            }
-        }
+            },
+        },
     };
 
-    return (
-        <Chart
-            options={options}
-            series={series}
-            type="area"
-            width="100%"
-            height="100%"
-        />
-    )
-}
+    return <Chart options={options} series={series} type="area" width="100%" height="100%" />;
+};
 
-export default RevenueChart
+export default RevenueChart;

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -78,8 +78,7 @@ class DonationQuery extends QueryBuilder
             ? date('Y-m-d H:i:s')
             : date('Y-m-d H:i:s', strtotime($endDate));
 
-        $this->joinMeta('_give_completed_date', 'completed');
-        $this->whereBetween('completed.meta_value', $startDate, $endDate);
+        $this->whereBetween('donation.post_date', $startDate, $endDate);
         return $this;
     }
 

--- a/tests/Unit/Campaigns/CampaignDonationQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignDonationQueryTest.php
@@ -84,7 +84,7 @@ final class CampaignDonationQueryTest extends TestCase
 
         $db = DB::table('give_campaign_forms');
         $db->insert(['form_id' => $form->id, 'campaign_id' => $campaign->id]);
-        
+
         Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -155,10 +155,6 @@ final class CampaignDonationQueryTest extends TestCase
                 'createdAt' => new DateTime('2021-01-02 00:00:00'),
             ]),
         ];
-
-        foreach($donations as $donation) {
-            give_update_meta($donation->id, '_give_completed_date', $donation->createdAt->format('Y-m-d H:i:s'));
-        }
 
         $query = new CampaignDonationQuery($campaign);
 

--- a/tests/Unit/Campaigns/CampaignDonationQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignDonationQueryTest.php
@@ -2,7 +2,6 @@
 
 namespace Give\Tests\Unit\Campaigns;
 
-use DateTime;
 use Give\Campaigns\CampaignDonationQuery;
 use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Models\DonationForm;
@@ -56,9 +55,6 @@ final class CampaignDonationQueryTest extends TestCase
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $db = DB::table('give_campaign_forms');
-
-
         Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -83,8 +79,6 @@ final class CampaignDonationQueryTest extends TestCase
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $db = DB::table('give_campaign_forms');
-
         Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -108,9 +102,6 @@ final class CampaignDonationQueryTest extends TestCase
     {
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
-
-        $db = DB::table('give_campaign_forms');
-
 
         $donation = Donation::factory()->create([
             'formId' => $form->id,
@@ -226,24 +217,24 @@ final class CampaignDonationQueryTest extends TestCase
     /**
      * @unreleased
      */
-    protected function getYear($date): string
+    protected function getYear(string $date): string
     {
-        return (new DateTime($date))->format('Y');
+        return date_create($date)->format('Y');
     }
 
     /**
      * @unreleased
      */
-    protected function getMonth($date): string
+    protected function getMonth(string $date): string
     {
-        return (new DateTime($date))->format('m');
+        return date_create($date)->format('m');
     }
 
     /**
      * @unreleased
      */
-    protected function getDay($date): string
+    protected function getDay(string $date): string
     {
-        return (new DateTime($date))->format('d');
+        return date_create($date)->format('d');
     }
 }

--- a/tests/Unit/Campaigns/CampaignDonationQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignDonationQueryTest.php
@@ -127,37 +127,123 @@ final class CampaignDonationQueryTest extends TestCase
     /**
      * @unreleased
      */
-    public function testGetDonationsByDate()
+    public function testGetDonationsByDate(): void
     {
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $donations = [
+        $dates = [
+            '2024-01-01',
+            '2024-01-02',
+            '2024-01-03',
+            '2025-01-01',
+            '2025-01-02',
+            '2025-01-03',
+            '2025-02-01',
+            '2025-02-02',
+            '2025-02-03',
+            '2025-03-01',
+            '2025-03-02',
+            '2025-03-03',
+        ];
+
+        foreach ($dates as $date) {
             Donation::factory()->create([
                 'formId' => $form->id,
                 'status' => DonationStatus::COMPLETE(),
                 'amount' => new Money(1000, 'USD'),
-                'createdAt' => new DateTime('2021-01-01 00:00:00'),
-            ]),
-            Donation::factory()->create([
-                'formId' => $form->id,
-                'status' => DonationStatus::COMPLETE(),
-                'amount' => new Money(1000, 'USD'),
-                'createdAt' => new DateTime('2021-01-02 00:00:00'),
-            ]),
-            Donation::factory()->create([
-                'formId' => $form->id,
-                'status' => DonationStatus::COMPLETE(),
-                'amount' => new Money(1000, 'USD'),
-                'createdAt' => new DateTime('2021-01-02 00:00:00'),
-            ]),
+                'createdAt' => date_create($date . ' 00:00:00'),
+            ]);
+        }
+
+        $expectedDataForDayQuery = [];
+        foreach ($dates as $date) {
+            $expectedDataForDayQuery[] = (object)[
+                'date_created' => $date,
+                'amount' => 10.00,
+                'year' => $this->getYear($date),
+                'month' => $this->getMonth($date),
+                'day' => $this->getDay($date),
+            ];
+        }
+
+        $expectedDataForMonthQuery = [
+            (object)[
+                'date_created' => $dates[0],
+                'amount' => 30.00,
+                'year' => $this->getYear($dates[0]),
+                'month' => $this->getMonth($dates[0]),
+                'day' => $this->getDay($dates[0]),
+            ],
+            (object)[
+                'date_created' => $dates[3],
+                'amount' => 30.00,
+                'year' => $this->getYear($dates[3]),
+                'month' => $this->getMonth($dates[3]),
+                'day' => $this->getDay($dates[3]),
+            ],
+            (object)[
+                'date_created' => $dates[6],
+                'amount' => 30.00,
+                'year' => $this->getYear($dates[6]),
+                'month' => $this->getMonth($dates[6]),
+                'day' => $this->getDay($dates[6]),
+            ],
+            (object)[
+                'date_created' => $dates[9],
+                'amount' => 30.00,
+                'year' => $this->getYear($dates[9]),
+                'month' => $this->getMonth($dates[9]),
+                'day' => $this->getDay($dates[9]),
+            ],
+        ];
+
+        $expectedDataForYearQuery = [
+            (object)[
+                'date_created' => $dates[0],
+                'amount' => 30.00,
+                'year' => $this->getYear($dates[0]),
+                'month' => $this->getMonth($dates[0]),
+                'day' => $this->getDay($dates[0]),
+            ],
+            (object)[
+                'date_created' => $dates[3],
+                'amount' => 90.00,
+                'year' => $this->getYear($dates[3]),
+                'month' => $this->getMonth($dates[3]),
+                'day' => $this->getDay($dates[3]),
+            ],
         ];
 
         $query = new CampaignDonationQuery($campaign);
 
-        $this->assertEquals([
-            (object) ['date' => '2021-01-01', 'amount' => 10.00],
-            (object) ['date' => '2021-01-02', 'amount' => 20.00],
-        ], $query->getDonationsByDay());
+        $this->assertEquals($expectedDataForDayQuery, $query->getDonationsByDate('DAY'));
+        $this->assertEquals($expectedDataForMonthQuery, $query->getDonationsByDate('MONTH'));
+        $this->assertEquals($expectedDataForYearQuery, $query->getDonationsByDate('YEAR'));
+        $this->assertEquals($dates[0], $query->getOldestDonationDate());
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function getYear($date): string
+    {
+        return (new DateTime($date))->format('Y');
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function getMonth($date): string
+    {
+        return (new DateTime($date))->format('m');
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function getDay($date): string
+    {
+        return (new DateTime($date))->format('d');
     }
 }

--- a/tests/Unit/Campaigns/Routes/GetCampaignRevenueTest.php
+++ b/tests/Unit/Campaigns/Routes/GetCampaignRevenueTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Give\Tests\Unit\Campaigns\Routes;
+
+use Exception;
+use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\Routes\GetCampaignRevenue;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+
+class GetCampaignRevenueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testShouldReturnRevenueByDay(): void
+    {
+        $campaign = Campaign::factory()->create([
+            'endDate' => date_create('2025-03-10 00:00:00'),
+        ]);
+
+        $dates = [
+            '2025-03-01',
+            '2025-03-02',
+            '2025-03-03',
+        ];
+
+        foreach ($dates as $date) {
+            Donation::factory()->create([
+                'campaignId' => $campaign->id,
+                'status' => DonationStatus::COMPLETE(),
+                'amount' => new Money(1000, 'USD'),
+                'createdAt' => date_create($date . ' 00:00:00'),
+            ]);
+        }
+
+        $request = new WP_REST_Request('GET', "/give-api/v2/campaigns/$campaign->id/revenue");
+        $request->set_param('id', $campaign->id);
+
+        $route = new GetCampaignRevenue();
+        $response = $route->handleRequest($request);
+
+        $this->assertEquals([
+            $this->getResultData('2025-03-01', '10.00'),
+            $this->getResultData('2025-03-02', '10.00'),
+            $this->getResultData('2025-03-03', '10.00'),
+            $this->getResultData('2025-03-04'),
+            $this->getResultData('2025-03-05'),
+            $this->getResultData('2025-03-06'),
+            $this->getResultData('2025-03-07'),
+            $this->getResultData('2025-03-08'),
+            $this->getResultData('2025-03-09'),
+            $this->getResultData('2025-03-10'),
+        ], $response->data);
+    }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testShouldReturnRevenueByMonth(): void
+    {
+        $campaign = Campaign::factory()->create([
+            'endDate' => date_create('2025-03-10 00:00:00'),
+        ]);
+
+        $dates = [
+            '2024-01-01',
+            '2024-01-02',
+            '2024-01-03',
+            '2024-02-01',
+            '2025-03-01',
+            '2025-03-02',
+            '2025-03-03',
+        ];
+
+        foreach ($dates as $date) {
+            Donation::factory()->create([
+                'campaignId' => $campaign->id,
+                'status' => DonationStatus::COMPLETE(),
+                'amount' => new Money(1000, 'USD'),
+                'createdAt' => date_create($date . ' 00:00:00'),
+            ]);
+        }
+
+        $request = new WP_REST_Request('GET', "/give-api/v2/campaigns/$campaign->id/revenue");
+        $request->set_param('id', $campaign->id);
+
+        $route = new GetCampaignRevenue();
+        $response = $route->handleRequest($request);
+
+        $this->assertEquals([
+            $this->getResultData('2024-01', '30.00'),
+            $this->getResultData('2024-02', '10.00'),
+            $this->getResultData('2024-03'),
+            $this->getResultData('2024-04'),
+            $this->getResultData('2024-05'),
+            $this->getResultData('2024-06'),
+            $this->getResultData('2024-07'),
+            $this->getResultData('2024-08'),
+            $this->getResultData('2024-09'),
+            $this->getResultData('2024-10'),
+            $this->getResultData('2024-11'),
+            $this->getResultData('2024-12'),
+            $this->getResultData('2025-01'),
+            $this->getResultData('2025-02'),
+            $this->getResultData('2025-03', '30.00'),
+
+        ], $response->data);
+    }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testShouldReturnRevenueByYear(): void
+    {
+        $campaign = Campaign::factory()->create([
+            'endDate' => date_create('2025-03-10 00:00:00'),
+        ]);
+
+        $dates = [
+            '2020-01-01',
+            '2020-01-02',
+            '2021-01-01',
+            '2024-01-01',
+            '2024-01-02',
+            '2024-01-03',
+            '2024-02-01',
+            '2025-03-01',
+            '2025-03-02',
+            '2025-03-03',
+        ];
+
+        foreach ($dates as $date) {
+            Donation::factory()->create([
+                'campaignId' => $campaign->id,
+                'status' => DonationStatus::COMPLETE(),
+                'amount' => new Money(1000, 'USD'),
+                'createdAt' => date_create($date . ' 00:00:00'),
+            ]);
+        }
+
+        $request = new WP_REST_Request('GET', "/give-api/v2/campaigns/$campaign->id/revenue");
+        $request->set_param('id', $campaign->id);
+
+        $route = new GetCampaignRevenue();
+        $response = $route->handleRequest($request);
+
+        $this->assertEquals([
+            $this->getResultData('2020', '20'),
+            $this->getResultData('2021', '10'),
+            $this->getResultData('2022'),
+            $this->getResultData('2023'),
+            $this->getResultData('2024', '40'),
+            $this->getResultData('2025', '30'),
+        ], $response->data);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getResultData(string $dateCreated, $amount = 0): array
+    {
+        return [
+            'date' => $dateCreated,
+            'amount' => $amount ?? 0,
+        ];
+    }
+}

--- a/tests/Unit/Campaigns/Routes/GetCampaignStatisticsTest.php
+++ b/tests/Unit/Campaigns/Routes/GetCampaignStatisticsTest.php
@@ -38,7 +38,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-35 days'),
         ]);
-        give_update_meta($donation1->id, '_give_completed_date', $donation1->createdAt->format('Y-m-d H:i:s'));
 
         $donation2 = Donation::factory()->create([
             'formId' => $form->id,
@@ -46,7 +45,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-5 days'),
         ]);
-        give_update_meta($donation2->id, '_give_completed_date', $donation2->createdAt->format('Y-m-d H:i:s'));
 
         $donation3 = Donation::factory()->create([
             'formId' => $form->id,
@@ -54,7 +52,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('now'),
         ]);
-        give_update_meta($donation3->id, '_give_completed_date', $donation3->createdAt->format('Y-m-d H:i:s'));
 
         $request = new WP_REST_Request('GET', "/give-api/v2/campaigns/$campaign->id/statistics");
         $request->set_param('id', $campaign->id);
@@ -84,7 +81,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-35 days'),
         ]);
-        give_update_meta($donation1->id, '_give_completed_date', $donation1->createdAt->format('Y-m-d H:i:s'));
 
         $donation2 = Donation::factory()->create([
             'formId' => $form->id,
@@ -92,7 +88,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('-5 days'),
         ]);
-        give_update_meta($donation2->id, '_give_completed_date', $donation2->createdAt->format('Y-m-d H:i:s'));
 
         $donation3 = Donation::factory()->create([
             'formId' => $form->id,
@@ -100,7 +95,6 @@ final class GetCampaignStatisticsTest extends TestCase
             'amount' => new Money(1000, 'USD'),
             'createdAt' => new DateTime('now'),
         ]);
-        give_update_meta($donation3->id, '_give_completed_date', $donation3->createdAt->format('Y-m-d H:i:s'));
 
         $request = new WP_REST_Request('GET', "/give-api/v2/campaigns/$campaign->id/statistics");
         $request->set_param('id', $campaign->id);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2323]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This replaces the usage of `_give_completed_date` meta in our campaign/donations query to use the donation created date aka the `post_date`. The former meta is an older concept that is not reliable and is not the accurate date of a donation.  The donation created date is the only date we need to run our donation queries.  To test this out you can create a donation and change the date on donation details.  The campaign revenue graph should be reflected.

This also updates the campaign graph yAxis to format the values in currency/locale.

Finally, this fixes the issues where the campaign revenue request was hard-coding a date range of 7 days for the campaign revenue graph, resulting in data point skips when data exists beyond 7 days.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The campaign overview stats/graph
- Campaign comments block
- Donation query

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before (hard coded 7 days)**

<img width="867" alt="Screenshot 2025-03-07 at 2 59 32 PM" src="https://github.com/user-attachments/assets/a711c9b2-4ed5-42ed-a474-2cadfa54cd3b" />

**After (dynamic all time revenue)**

<img width="851" alt="Screenshot 2025-03-10 at 11 08 33 PM" src="https://github.com/user-attachments/assets/116e8b62-9cdd-426f-9519-48e726ae9cd2" />


<img width="869" alt="Screenshot 2025-03-10 at 11 08 24 PM" src="https://github.com/user-attachments/assets/c9a58fb1-fe4c-4281-a54e-f53f88490c77" />

<img width="849" alt="Screenshot 2025-03-10 at 11 09 28 PM" src="https://github.com/user-attachments/assets/371d91c8-0c16-4e90-99c2-cdb6d7d15deb" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/13797791966

- Make sure the yAxis of the graph is formatted using currency & locale
- Create a bunch of donations for a campaign, then go into donation details and change the dates, make sure graph is accurate and not resulting in a weird UI

**Scenarios:**
- New Campaign w/ no data: _defaults to show previous 7 days & $100 on yaxis_
- New Campaign w/ little data (less than 7 days): _defaults to show previous 7 days & current revenue__
- Existing Campaign created over 90 days ago: will count data back by week & show all revenue
- Existing Campaign created over 1 year ago: will count back by month and show all revenue

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2323]: https://stellarwp.atlassian.net/browse/GIVE-2323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ