### PR TITLE
Fix: campaign revenue graph height

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -83,7 +83,7 @@ const RevenueChart = () => {
                 series={series}
                 type="area"
                 width="100%"
-                height="300"
+                height="100%"
             />
         </>
     )


### PR DESCRIPTION
Resolves #
This PR fixes the revenue graph height.

## Description
Currently our revenue graph is set to a fix height which leaves a lot of whitespace beneath the parent container. I changed the height of the revenue graph from fix to fill(100%) where it takes up the space of the parent container.

## Affects
Changes the height of the revenue graph

## Visuals

Before
<img width="1329" alt="Screenshot 2025-03-07 at 8 44 57 PM" src="https://github.com/user-attachments/assets/3cc54241-d5b2-4798-adcb-b196a0427f9c" />

After
<img width="1326" alt="Screenshot 2025-03-07 at 8 45 21 PM" src="https://github.com/user-attachments/assets/b47817bc-10ae-4884-9397-30f27e677799" />


## Testing Instructions
Check the revenue graph of a campaign to make sure if it fills the height of the parent container.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

