### PR TITLE
Feature: Support Multiple Goal Types in Campaign Goal Progress Chart

### DIFF
--- a/src/Campaigns/CampaignDonationQuery.php
+++ b/src/Campaigns/CampaignDonationQuery.php
@@ -38,14 +38,14 @@ class CampaignDonationQuery extends QueryBuilder
      */
     public function between(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
-        $query = clone $this;
-        $query->joinDonationMeta('_give_completed_date', 'completed');
-        $query->whereBetween(
+        $this->joinDonationMeta('_give_completed_date', 'completed');
+        $this->whereBetween(
             'completed.meta_value',
             $startDate->format('Y-m-d H:i:s'),
             $endDate->format('Y-m-d H:i:s')
         );
-        return $query;
+
+        return $this;
     }
 
     /**
@@ -57,10 +57,10 @@ class CampaignDonationQuery extends QueryBuilder
      */
     public function sumIntendedAmount()
     {
-        $query = clone $this;
-        $query->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
-        $query->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
-        return $query->sum(
+        $this->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
+        $this->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
+
+        return $this->sum(
             /**
              * The intended amount meta and the amount meta could either be 0 or NULL.
              * So we need to use the NULLIF function to treat the 0 values as NULL.
@@ -76,8 +76,7 @@ class CampaignDonationQuery extends QueryBuilder
      */
     public function countDonations(): int
     {
-        $query = clone $this;
-        return $query->count('donation.ID');
+        return $this->count('donation.ID');
     }
 
     /**
@@ -85,9 +84,9 @@ class CampaignDonationQuery extends QueryBuilder
      */
     public function countDonors(): int
     {
-        $query = clone $this;
-        $query->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
-        return $query->count('DISTINCT donorId.meta_value');
+        $this->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+
+        return $this->count('DISTINCT donorId.meta_value');
     }
 
     /**
@@ -95,19 +94,17 @@ class CampaignDonationQuery extends QueryBuilder
      */
     public function getDonationsByDay(): array
     {
-        $query = clone $this;
-
-        $query->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
-        $query->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
-        $query->select(
+        $this->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
+        $this->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
+        $this->select(
             'SUM(COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)) as amount'
         );
 
-        $query->joinDonationMeta('_give_completed_date', 'completed');
-        $query->select('DATE(completed.meta_value) as date');
-        $query->groupBy('date');
+        $this->joinDonationMeta('_give_completed_date', 'completed');
+        $this->select('DATE(completed.meta_value) as date');
+        $this->groupBy('date');
 
-        return $query->getAll();
+        return $this->getAll();
     }
 
     /**

--- a/src/Campaigns/CampaignSubscriptionQuery.php
+++ b/src/Campaigns/CampaignSubscriptionQuery.php
@@ -30,6 +30,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
         // Include only forms associated with the Campaign.
         $this->joinDonationMeta(DonationMetaKeys::CAMPAIGN_ID, 'campaignId');
         $this->where('campaignId.meta_value', $campaign->id);
+
     }
 
     /**
@@ -37,13 +38,13 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function between(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
-        $this->whereBetween(
+        $query = clone $this;
+        $query->whereBetween(
             'created',
             $startDate->format('Y-m-d H:i:s'),
             $endDate->format('Y-m-d H:i:s')
         );
-
-        return $this;
+        return $query;
     }
 
     /**
@@ -55,7 +56,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function sumInitialAmount()
     {
-        return $this->sum('initial_amount');
+        return (clone $this)->sum('initial_amount');
     }
 
     /**
@@ -63,7 +64,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function countDonations(): int
     {
-        return $this->count('donation.ID');
+        return (clone $this)->count('donation.ID');
     }
 
     /**
@@ -71,9 +72,9 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function countDonors(): int
     {
-        $this->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
-
-        return $this->count('DISTINCT donorId.meta_value');
+        $query = clone $this;
+        $query->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+        return $query->count('DISTINCT donorId.meta_value');
     }
 
     /**
@@ -103,7 +104,6 @@ class CampaignSubscriptionQuery extends QueryBuilder
                 ->on('subscription.parent_payment_id', $alias . '.donation_id')
                 ->andOn($alias . '.meta_key', $key, true);
         });
-
         return $this;
     }
 }

--- a/src/Campaigns/CampaignSubscriptionQuery.php
+++ b/src/Campaigns/CampaignSubscriptionQuery.php
@@ -30,7 +30,6 @@ class CampaignSubscriptionQuery extends QueryBuilder
         // Include only forms associated with the Campaign.
         $this->joinDonationMeta(DonationMetaKeys::CAMPAIGN_ID, 'campaignId');
         $this->where('campaignId.meta_value', $campaign->id);
-
     }
 
     /**
@@ -38,13 +37,13 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function between(DateTimeInterface $startDate, DateTimeInterface $endDate): self
     {
-        $query = clone $this;
-        $query->whereBetween(
+        $this->whereBetween(
             'created',
             $startDate->format('Y-m-d H:i:s'),
             $endDate->format('Y-m-d H:i:s')
         );
-        return $query;
+
+        return $this;
     }
 
     /**
@@ -56,7 +55,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function sumInitialAmount()
     {
-        return (clone $this)->sum('initial_amount');
+        return $this->sum('initial_amount');
     }
 
     /**
@@ -64,7 +63,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function countDonations(): int
     {
-        return (clone $this)->count('donation.ID');
+        return $this->count('donation.ID');
     }
 
     /**
@@ -72,9 +71,9 @@ class CampaignSubscriptionQuery extends QueryBuilder
      */
     public function countDonors(): int
     {
-        $query = clone $this;
-        $query->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
-        return $query->count('DISTINCT donorId.meta_value');
+        $this->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+
+        return $this->count('DISTINCT donorId.meta_value');
     }
 
     /**
@@ -104,6 +103,7 @@ class CampaignSubscriptionQuery extends QueryBuilder
                 ->on('subscription.parent_payment_id', $alias . '.donation_id')
                 ->andOn($alias . '.meta_key', $key, true);
         });
+
         return $this;
     }
 }

--- a/src/Campaigns/CampaignSubscriptionQuery.php
+++ b/src/Campaigns/CampaignSubscriptionQuery.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Give\Campaigns;
+
+use DateTimeInterface;
+use Give\Campaigns\Models\Campaign;
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Framework\QueryBuilder\JoinQueryBuilder;
+use Give\Framework\QueryBuilder\QueryBuilder;
+
+/**
+ * @unreleased
+ */
+class CampaignSubscriptionQuery extends QueryBuilder
+{
+    /**
+     * @unreleased
+     */
+    public function __construct(Campaign $campaign)
+    {
+        $this->from('give_subscriptions', 'subscription');
+
+        // Include only current payment "mode"
+        $this->where('payment_mode', give_is_test_mode() ? 'test' : 'live');
+
+        // Include only valid statuses
+        $this->joinDonation('donation');
+        $this->whereIn('donation.post_status', ['publish', 'give_subscription']);
+
+        // Include only forms associated with the Campaign.
+        $this->joinDonationMeta(DonationMetaKeys::CAMPAIGN_ID, 'campaignId');
+        $this->where('campaignId.meta_value', $campaign->id);
+
+    }
+
+    /**
+     * @unreleased
+     */
+    public function between(DateTimeInterface $startDate, DateTimeInterface $endDate): self
+    {
+        $query = clone $this;
+        $query->whereBetween(
+            'created',
+            $startDate->format('Y-m-d H:i:s'),
+            $endDate->format('Y-m-d H:i:s')
+        );
+        return $query;
+    }
+
+    /**
+     * Returns a calculated sum of the intended amounts (without recovered fees) for the donations.
+     *
+     * @unreleased
+     *
+     * @return int|float
+     */
+    public function sumInitialAmount()
+    {
+        return (clone $this)->sum('initial_amount');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function countDonations(): int
+    {
+        return (clone $this)->count('donation.ID');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function countDonors(): int
+    {
+        $query = clone $this;
+        $query->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorId');
+        return $query->count('DISTINCT donorId.meta_value');
+    }
+
+    /**
+     * @unreleased
+     */
+    public function joinDonation($alias): self
+    {
+        $this->join(function (JoinQueryBuilder $builder) use ($alias) {
+            $builder
+                ->leftJoin('posts', $alias)
+                ->on('subscription.parent_payment_id', $alias . '.ID');
+        });
+        $this->where($alias . '.post_type', 'give_payment');
+
+        return $this;
+    }
+
+    /**
+     * An opinionated join method for the donation meta table.
+     * @unreleased
+     */
+    public function joinDonationMeta($key, $alias): self
+    {
+        $this->join(function (JoinQueryBuilder $builder) use ($key, $alias) {
+            $builder
+                ->leftJoin('give_donationmeta', $alias)
+                ->on('subscription.parent_payment_id', $alias . '.donation_id')
+                ->andOn($alias . '.meta_key', $key, true);
+        });
+        return $this;
+    }
+}

--- a/src/Campaigns/DataTransferObjects/CampaignGoalData.php
+++ b/src/Campaigns/DataTransferObjects/CampaignGoalData.php
@@ -3,8 +3,9 @@
 namespace Give\Campaigns\DataTransferObjects;
 
 use Give\Campaigns\CampaignDonationQuery;
+use Give\Campaigns\CampaignSubscriptionQuery;
 use Give\Campaigns\Models\Campaign;
-use Give\DonationForms\ValueObjects\GoalType;
+use Give\Campaigns\ValueObjects\CampaignGoalType;
 use Give\Framework\Support\Contracts\Arrayable;
 
 /**
@@ -60,16 +61,27 @@ class CampaignGoalData implements Arrayable
      */
     private function getActual(): int
     {
-        $query = new CampaignDonationQuery($this->campaign);
+        $query = $this->campaign->goalType->isOneOf(
+            CampaignGoalType::SUBSCRIPTIONS(),
+            CampaignGoalType::AMOUNT_FROM_SUBSCRIPTIONS(),
+            CampaignGoalType::DONORS_FROM_SUBSCRIPTIONS()
+        )
+            ? new CampaignSubscriptionQuery($this->campaign)
+            : new CampaignDonationQuery($this->campaign);
 
         switch ($this->campaign->goalType->getValue()) {
-            case GoalType::DONATIONS():
+            case CampaignGoalType::DONATIONS():
+            case CampaignGoalType::SUBSCRIPTIONS():
                 return $query->countDonations();
 
-            case GoalType::DONORS():
+            case CampaignGoalType::DONORS():
+            case CampaignGoalType::DONORS_FROM_SUBSCRIPTIONS():
                 return $query->countDonors();
 
-            case GoalType::AMOUNT():
+            case CampaignGoalType::AMOUNT_FROM_SUBSCRIPTIONS():
+                return $query->sumInitialAmount();
+
+            case CampaignGoalType::AMOUNT():
             default:
                 return $query->sumIntendedAmount();
         }
@@ -91,7 +103,7 @@ class CampaignGoalData implements Arrayable
      */
     private function getActualFormatted(): string
     {
-        if ($this->campaign->goalType == GoalType::AMOUNT) {
+        if ($this->campaign->goalType == CampaignGoalType::AMOUNT) {
             return give_currency_filter(give_format_amount($this->actual));
         }
 
@@ -103,7 +115,7 @@ class CampaignGoalData implements Arrayable
      */
     private function getGoalFormatted(): string
     {
-        if ($this->campaign->goalType == GoalType::AMOUNT) {
+        if ($this->campaign->goalType == CampaignGoalType::AMOUNT) {
             return give_currency_filter(give_format_amount($this->goal));
         }
 

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -149,9 +149,9 @@ const GoalProgressWidget = () => {
                 <HeaderText>{__('Goal progress', 'give')}</HeaderText>
                 <HeaderSubText>{__('Show your campaign performance', 'give')}</HeaderSubText>
             </header>
-            <GoalProgressChart value={campaign.goalStats.actual} goal={campaign.goal} />
+            <GoalProgressChart value={campaign.goalStats.actual} goal={campaign.goal} goalType={campaign.goalType} />
         </div>
-    )
+    );
 }
 
 const DateRangeFilters = ({options, onSelect, selected}) => {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
@@ -4,22 +4,15 @@ import React from 'react';
 
 import styles from './styles.module.scss';
 import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
+import type {Campaign} from '@givewp/campaigns/admin/components/types';
 
 const {currency} = getCampaignOptionsWindowData();
 const currencyFormatter = amountFormatter(currency);
 
-type GoalType =
-    | 'amount'
-    | 'donations'
-    | 'donors'
-    | 'amountFromSubscriptions'
-    | 'subscriptions'
-    | 'donorsFromSubscriptions';
-
 type GoalProgressChartProps = {
     value: number;
     goal: number;
-    goalType: GoalType;
+    goalType: Partial<Campaign>['goalType'];
 };
 
 const goalTypeLabels = {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
@@ -1,73 +1,95 @@
 import {__} from '@wordpress/i18n';
-import Chart from "react-apexcharts";
-import React from "react";
+import Chart from 'react-apexcharts';
+import React from 'react';
 
-import styles from "./styles.module.scss"
-import {getCampaignOptionsWindowData, amountFormatter} from '@givewp/campaigns/utils';
+import styles from './styles.module.scss';
+import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
 
 const {currency} = getCampaignOptionsWindowData();
 const currencyFormatter = amountFormatter(currency);
 
+type GoalType =
+    | 'amount'
+    | 'donations'
+    | 'donors'
+    | 'amountFromSubscriptions'
+    | 'subscriptions'
+    | 'donorsFromSubscriptions';
+
 type GoalProgressChartProps = {
     value: number;
     goal: number;
-}
+    goalType: GoalType;
+};
 
-const GoalProgressChart = ({ value, goal }: GoalProgressChartProps) => {
+const goalTypeLabels = {
+    amount: __('Amount raised', 'give'),
+    donations: __('Number of donations', 'give'),
+    donors: __('Number of donors', 'give'),
+    amountFromSubscriptions: __('Recurring amount raised', 'give'),
+    subscriptions: __('Number of recurring donations', 'give'),
+    donorsFromSubscriptions: __('Number of recurring donors', 'give'),
+};
+
+const GoalProgressChart = ({value, goal, goalType}: GoalProgressChartProps) => {
     const progress = Math.ceil((value / goal) * 100);
     const percentage = Math.min(progress, 100);
 
+    const isCurrencyGoal = ['amount', 'amountFromSubscriptions'].includes(goalType);
+    const formattedValue = isCurrencyGoal ? currencyFormatter.format(value) : value.toString();
+    const formattedGoal = isCurrencyGoal ? currencyFormatter.format(goal) : goal.toString();
+
     return (
-            <div className={styles.goalProgressChart}>
-                <div className={styles.chartContainer}>
-                    <Chart
-                        options={{
-                            chart: {
-                                height: 1024,
-                                type: 'radialBar',
-                            },
-                            plotOptions: {
-                                radialBar: {
-                                    hollow: {
-                                        margin: 15,
-                                        size: "60%",
+        <div className={styles.goalProgressChart}>
+            <div className={styles.chartContainer}>
+                <Chart
+                    options={{
+                        chart: {
+                            height: 1024,
+                            type: 'radialBar',
+                        },
+                        plotOptions: {
+                            radialBar: {
+                                hollow: {
+                                    margin: 15,
+                                    size: '60%',
+                                },
+                                dataLabels: {
+                                    /**
+                                     * The "name" is the top label, here it is the value/amount
+                                     * The "value" is the percent progress
+                                     *
+                                     * Note: These are visually inverted (using offsetY) to match the design
+                                     */
+                                    name: {
+                                        offsetY: 20,
+                                        show: true,
+                                        color: '#4B5563',
+                                        fontSize: '12px',
                                     },
-                                    dataLabels: {
-                                        /**
-                                         * The "name" is the top label, here it is the value/amount
-                                         * The "value" is the percent progress
-                                         *
-                                         * Note: These are visually inverted (using offsetY) to match the design
-                                         */
-                                        name: {
-                                            offsetY: 20,
-                                            show: true,
-                                            color: "#4B5563",
-                                            fontSize: "12px"
-                                        },
-                                        value: {
-                                            offsetY: -20,
-                                            color: "#060C1A",
-                                            fontSize: "24px",
-                                            show: true
-                                        }
-                                    }
-                                }
+                                    value: {
+                                        offsetY: -20,
+                                        color: '#060C1A',
+                                        fontSize: '24px',
+                                        show: true,
+                                    },
+                                },
                             },
-                            colors: ['#459948'],
-                            labels: [currencyFormatter.format(value)],
-                        }}
-                        series={[percentage]}
-                        type="radialBar"
-                    />
-                </div>
-                <div className={styles.goalDetails}>
-                    <div className={styles.goal}>{__('Goal', 'give')}</div>
-                    <div className={styles.amount}>{currencyFormatter.format(goal)}</div>
-                    <div className={styles.goalType}>{__('Amount raised', 'give')}</div>
-                </div>
+                        },
+                        colors: ['#459948'],
+                        labels: [formattedValue],
+                    }}
+                    series={[percentage]}
+                    type="radialBar"
+                />
             </div>
-    )
-}
+            <div className={styles.goalDetails}>
+                <div className={styles.goal}>{__('Goal', 'give')}</div>
+                <div className={styles.amount}>{formattedGoal}</div>
+                <div className={styles.goalType}>{goalTypeLabels[goalType]}</div>
+            </div>
+        </div>
+    );
+};
 
 export default GoalProgressChart;

--- a/src/Campaigns/resources/admin/components/types.ts
+++ b/src/Campaigns/resources/admin/components/types.ts
@@ -10,12 +10,18 @@ export type Campaign = {
     image: string;
     primaryColor: string;
     secondaryColor: string;
-    goalType: string;
+    goalType:
+        | 'amount'
+        | 'donations'
+        | 'donors'
+        | 'amountFromSubscriptions'
+        | 'subscriptions'
+        | 'donorsFromSubscriptions';
     goal: number;
     goalStats: {
-        actual: number,
-        percentage: number,
-        goal: number,
+        actual: number;
+        percentage: number;
+        goal: number;
     };
     status: string;
     startDateTime: {

--- a/src/Subscriptions/Factories/SubscriptionFactory.php
+++ b/src/Subscriptions/Factories/SubscriptionFactory.php
@@ -46,27 +46,32 @@ class SubscriptionFactory extends ModelFactory
     }
 
     /**
+     * @unreleased Add $donationAttributes parameter and merge it with the default attributes when creating a donation
      * @since 2.23.0
      *
      * @return Subscription|Subscription[]
      * @throws Exception
      */
-    public function createWithDonation(array $attributes = [])
+    public function createWithDonation(array $subscriptionAttributes = [], array $donationAttributes = [])
     {
-        $subscriptions = $this->create($attributes);
+        $subscriptions = $this->create($subscriptionAttributes);
 
-        if ( $this->count === 1 ) {
+        if ($this->count === 1) {
             $subscriptions = [$subscriptions];
         }
 
         foreach ($subscriptions as $subscription) {
-            $donation = Donation::factory()->create([
+            $defaultDonationAttributes = [
                 'amount' => $subscription->amount,
                 'type' => DonationType::SUBSCRIPTION(),
                 'status' => DonationStatus::COMPLETE(),
                 'gatewayId' => $subscription->gatewayId,
                 'subscriptionId' => $subscription->id,
-            ]);
+            ];
+
+            $donation = Donation::factory()->create(
+                array_merge($defaultDonationAttributes, $donationAttributes)
+            );
 
             give()->subscriptions->updateLegacyParentPaymentId($subscription->id, $donation->id);
         }

--- a/tests/Unit/Campaigns/CampaignSubscriptionQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignSubscriptionQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Unit\Campaigns;
+
+use Give\Campaigns\CampaignSubscriptionQuery;
+use Give\Campaigns\Models\Campaign;
+use Give\DonationForms\Models\DonationForm;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Subscriptions\Models\Subscription;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ */
+class CampaignSubscriptionQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testCountCampaignDonations()
+    {
+        /** @var Campaign $campaign */
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::find($campaign->defaultFormId);
+
+        for ($count = 0; $count < 2; $count++) {
+            Subscription::factory()->createWithDonation(
+                ['amount' => new Money(1000, 'USD')],
+                ['formId' => $form->id]
+            );
+        }
+
+        $query = new CampaignSubscriptionQuery($campaign);
+
+        $this->assertEquals(2, $query->countDonations());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testSumCampaignDonations()
+    {
+        /** @var Campaign $campaign */
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::find($campaign->defaultFormId);
+
+        for ($count = 0; $count < 2; $count++) {
+            Subscription::factory()
+                ->createWithDonation(
+                    ['amount' => new Money(1000, 'USD')],
+                    ['formId' => $form->id]
+                )->createRenewal();
+        }
+
+        $query = new CampaignSubscriptionQuery($campaign);
+
+        $this->assertEquals(20.00, $query->sumInitialAmount());
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCountCampaignDonors()
+    {
+        /** @var Campaign $campaign */
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::find($campaign->defaultFormId);
+
+        for ($count = 0; $count < 2; $count++) {
+            Subscription::factory()
+                ->createWithDonation(
+                    ['amount' => new Money(1000, 'USD')],
+                    ['formId' => $form->id]
+                )->createRenewal();
+        }
+
+        $query = new CampaignSubscriptionQuery($campaign);
+
+        $this->assertEquals(2, $query->countDonors());
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-2290]

## Description
This Pull Request enhances the Campaign Goal Progress Chart component by adding support for multiple goal types. Previously, the chart always displayed progress as “Amount Raised”, regardless of the selected goal type.

With this update:
- The widget correctly displays progress based on the selected goal type.
- Currency formatting is now applied only for `amount` and `amountFromSubscriptions` goal types.

Under the hood:
- Added a new `CampaignSubscriptionQuery` class.
- Replaced all instances of the `GoalType` enum from `DonationForms` in the `CampaignGoalData` class with the `CampaignGoalType` enum from `Campaigns`.
- Updated the `getActual` method in the `CampaignGoalData` class to implement distinct query builders depending on the selected campaign goal type (`CampaignDonationQuery` or `CampaignSubscriptionQuery`). Goal types related to subscriptions have been incorporated into the case conditional.

This improves accuracy and clarity in representing different campaign goal types in the Campaign Overview tab.

## Affects
Initially, the Campaign Overview tab, but as a side effect, any other Campaign Goal widget as well.

## Visuals
https://github.com/user-attachments/assets/d7375346-c7bf-4131-b8a9-4241f028639a

## Testing Instructions
To test this PR, you’ll need a campaign with some donations and subscriptions. Then, go to the Settings tab of the campaign, switch between the Goal Type options, and verify that they are correctly reflected in the Campaign Goal widget in the Overview tab.

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2290]: https://stellarwp.atlassian.net/browse/GIVE-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ