### PR TITLE
Fix: Prevent Enter key from triggering Previous instead of Continue in Create Campaign modal

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -425,7 +425,7 @@ export default function CampaignFormModal({isOpen, handleClose, apiSettings, tit
                             style={{marginBottom: 0}}
                         >
                             <button
-                                type="submit"
+                                type="button"
                                 onClick={() => setStep(1)}
                                 className={`button button-secondary ${styles.button} ${styles.previousButton}`}
                             >

--- a/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
+++ b/src/Campaigns/resources/admin/components/FormModal/FormModal.module.scss
@@ -52,19 +52,24 @@
                     }
                 }
 
-                button[type="submit"].button {
-                    display: block;
-                    font-size: 1rem;
-                    font-weight: 500;
-                    line-height: 1.5;
-                    padding: var(--givewp-spacing-3) var(--givewp-spacing-5);
-                    width: 100%;
-                    border-radius: 8px;
+                button {
+                    &.button {
+                        &[type="button"],
+                        &[type="submit"] {
+                            display: block;
+                            font-size: 1rem;
+                            font-weight: 500;
+                            line-height: 1.5;
+                            padding: var(--givewp-spacing-3) var(--givewp-spacing-5);
+                            width: 100%;
+                            border-radius: 8px;
 
-                    &.button-secondary {
-                        color: #060c1a;
-                        border-color: #9ca0af;
-                        background-color: white;
+                            &.button-secondary {
+                                color: #060c1a;
+                                border-color: #9ca0af;
+                                background-color: white;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2326]

## Description
In the Create Campaign modal, pressing the `Enter` key during the second step was unintentionally triggering the `Previous` button instead of `Continue`. This happened because the `Previous` button had `type="submit"`, which caused the browser to treat it as the default form submission trigger when pressing `Enter`.

This pull request updates the `Previous` button’s type to "button" to prevent unintended form submissions. Additionally, the CSS has been adjusted to maintain the same styles for the updated button type.

## Affects
Create Campaign modal

## Testing Instructions
1.	Navigate to the Campaigns list table.
2.	Click the Create Campaign button.
3.	Complete the first step and proceed to the second step.
4.	In the second step, while editing the value for any of the selected goals, press the `Enter` key.
5.	The form should be submitted successfully without triggering the `Previous` button.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

