### PR TITLE
Fix: php 8.4 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "paypal/paypal-checkout-sdk": "^1.0",
         "kjohnson/format-object-list": "^0.1.0",
         "symfony/http-foundation": "^v5.4.46",
-        "moneyphp/money": "v3.3.1",
         "stellarwp/field-conditions": "^1.1",
         "stellarwp/validation": "^1.3",
         "symfony/polyfill-ctype": "^1.19",
@@ -20,7 +19,8 @@
         "psr/container": "1.1.1",
         "ext-json": "*",
         "stellarwp/admin-notices": "^2.0",
-        "stellarwp/arrays": "^1.3"
+        "stellarwp/arrays": "^1.3",
+        "moneyphp/money": "^3.3.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7434cdff752e188e2bb665489b6bd156",
+    "content-hash": "3355703fc1378c1f110e4a86d076143d",
     "packages": [
         {
             "name": "composer/installers",
@@ -193,16 +193,16 @@
         },
         {
             "name": "moneyphp/money",
-            "version": "v3.3.1",
+            "version": "v3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moneyphp/money.git",
-                "reference": "122664c2621a95180a13c1ac81fea1d2ef20781e"
+                "reference": "0dc40e3791c67e8793e3aa13fead8cf4661ec9cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moneyphp/money/zipball/122664c2621a95180a13c1ac81fea1d2ef20781e",
-                "reference": "122664c2621a95180a13c1ac81fea1d2ef20781e",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/0dc40e3791c67e8793e3aa13fead8cf4661ec9cd",
+                "reference": "0dc40e3791c67e8793e3aa13fead8cf4661ec9cd",
                 "shasum": ""
             },
             "require": {
@@ -273,9 +273,9 @@
             ],
             "support": {
                 "issues": "https://github.com/moneyphp/money/issues",
-                "source": "https://github.com/moneyphp/money/tree/master"
+                "source": "https://github.com/moneyphp/money/tree/v3.3.3"
             },
-            "time": "2020-03-18T17:49:59+00:00"
+            "time": "2022-09-21T07:43:36+00:00"
         },
         {
             "name": "paypal/paypal-checkout-sdk",

--- a/src/Donations/CustomFields/Controllers/DonationDetailsController.php
+++ b/src/Donations/CustomFields/Controllers/DonationDetailsController.php
@@ -8,17 +8,13 @@ use Give\Donations\CustomFields\Views\DonationDetailsView;
 use Give\Donations\Models\Donation;
 
 /**
- * TODO: move into donations domain
  * @since 3.0.0
  */
 class DonationDetailsController
 {
     /**
+     * @unreleased return early if no form is found
      * @since 3.0.0
-     *
-     * @param  int  $donationID
-     *
-     * @return string
      */
     public function show(int $donationID): string
     {
@@ -29,8 +25,11 @@ class DonationDetailsController
             return '';
         }
 
-        /** @var DonationForm $form */
         $form = DonationForm::find($donation->formId);
+
+        if (!$form) {
+            return '';
+        }
 
         $fields = array_filter($form->schema()->getFields(), static function ($field) {
             return $field->shouldShowInAdmin() && !$field->shouldStoreAsDonorMeta();

--- a/src/Donors/CustomFields/Controllers/DonorDetailsController.php
+++ b/src/Donors/CustomFields/Controllers/DonorDetailsController.php
@@ -35,6 +35,7 @@ class DonorDetailsController
     }
 
     /**
+     * @unreleased return array_filter to reduce null values
      * @since 3.2.2 added array fallback when no donations are found
      * @since 3.0.0
      *
@@ -52,9 +53,9 @@ class DonorDetailsController
             return !give(DonationFormRepository::class)->isLegacyForm($formId);
         });
 
-        return array_map(static function ($formId) {
+        return array_filter(array_map(static function ($formId) {
             return DonationForm::find($formId);
-        }, array_unique($formIds));
+        }, array_unique($formIds)));
     }
 
     /**

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -21,6 +21,7 @@ class RegisterFormBuilderPageRoute
     /**
      * Use add_submenu_page to register page within WP admin
      *
+     * @unreleased set parent slug to empty string
      * @since 3.0.0
      *
      * @return void

--- a/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
+++ b/src/FormBuilder/Routes/RegisterFormBuilderPageRoute.php
@@ -28,7 +28,7 @@ class RegisterFormBuilderPageRoute
     public function __invoke()
     {
         add_submenu_page(
-            null, // do not display in menu, just register page
+            '', // do not display in menu, just register page
             'Visual Donation Form Builder', // ignored
             'Add Form', // ignored
             'manage_options',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2279]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes various php 8.4 warning when interacting with campaigns.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Not much is affected.  The Money library was updated but only to a minor version that suppresses php warnings.


## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

These warnings will be removed:

<img width="1512" alt="Screenshot 2025-02-24 at 12 58 07 PM (1)" src="https://github.com/user-attachments/assets/a98fd57d-c308-4155-a959-359ab3059621" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Enabled `WP_DEBUG` and `WP_DEBUG_DISPLAY`
- Make sure no php warnings are showing in the admin

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2279]: https://stellarwp.atlassian.net/browse/GIVE-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ