### PR TITLE
Fix: campaign migration dates

### DIFF
--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -146,8 +146,8 @@ class MigrateFormsToCampaignForms extends Migration
                 'secondary_color' => $formSettings->secondaryColor,
                 'campaign_goal' => $formSettings->goalAmount,
                 'goal_type' => $formSettings->goalType,
-                'start_date' => $formSettings->goalStartDate,
-                'end_date' => $formSettings->goalEndDate,
+                'start_date' => $formCreatedAt,
+                'end_date' => null,
                 'date_created' => $formCreatedAt,
             ]);
 

--- a/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
+++ b/src/Campaigns/Migrations/MigrateFormsToCampaignForms.php
@@ -98,7 +98,13 @@ class MigrateFormsToCampaignForms extends Migration
         // Ensure campaigns will be displayed in the same order on the list table
         $query->orderBy('forms.ID');
 
-        return $query->getAll();
+        $results = $query->getAll();
+
+        if (!$results) {
+            return [];
+        }
+
+        return $results;
     }
 
     /**
@@ -107,7 +113,7 @@ class MigrateFormsToCampaignForms extends Migration
      */
     protected function getUpgradedV2FormsData(): array
     {
-        return DB::table('posts', 'forms')
+        $results = DB::table('posts', 'forms')
             ->select(['forms.ID', 'formId'], ['campaign_forms.campaign_id', 'campaignId'])
             ->attachMeta('give_formmeta', 'ID', 'form_id', 'migratedFormId')
             ->join(function (JoinQueryBuilder $builder) {
@@ -118,6 +124,12 @@ class MigrateFormsToCampaignForms extends Migration
             ->where('forms.post_type', 'give_forms')
             ->whereIsNotNull('give_formmeta_attach_meta_migratedFormId.meta_value')
             ->getAll();
+
+        if (!$results) {
+            return [];
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
+++ b/tests/Unit/Campaigns/Migrations/MigrateFormsToCampaignFormsTest.php
@@ -148,4 +148,22 @@ final class MigrateFormsToCampaignFormsTest extends TestCase
 
         $this->assertNotEquals($form1->id, $campaign->defaultFormId);
     }
+
+    /**
+     * @unreleased
+     * @throws Exception
+     */
+    public function testFormDatesMatchCampaignDates(): void
+    {
+        /** @var DonationForm $form */
+        $form = DonationForm::factory()->create();
+        $migration = new MigrateFormsToCampaignForms();
+        $migration->run();
+
+        /** @var Campaign $campaign */
+        $campaign = Campaign::findByFormId($form->id);
+        $this->assertEquals($form->createdAt, $campaign->createdAt);
+        $this->assertEquals($form->createdAt, $campaign->startDate);
+        $this->assertNull($campaign->endDate);
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The current form to campaign migration is settings the start and end dates as the form goal dates.  This is not correct as these are separate concepts.  The start date of a campaign should be when the form was created and there should be no end date (end date is not a concept yet).

This will ensure the lifespan of a form is migrated to a campaign and the revenue tracking will be accurate because it uses the same dates.

This also protects against potential type errors using arrap_map as results can return null.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The Form to Campaign migration

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Migrate forms to campaigns and make sure the dates are correct.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

