### PR TITLE
Fix: content of Button should be contained in a span for z-index setting

### DIFF
--- a/src/DonorDashboards/resources/js/app/components/button/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/button/index.tsx
@@ -28,8 +28,10 @@ const Button = ({icon, children, onClick, href, type, variant,classnames, ...res
                 href={href}
                 {...rest}
             >
-                {children}
-                {icon && <FontAwesomeIcon icon={icon} />}
+                <span>
+                    {children}
+                    {icon && <FontAwesomeIcon icon={icon} />}
+                </span>
             </a>
         );
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #7794

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->
The issue mentioned that the text wasn't displaying in the "Download Receipt" button on the Donor Dashboard.

After some investigation, I determined that this was caused by the background generated via :before overlapping the button's content and obscuring it.  

I wanted to modify the CSS to assign a stronger z-index to the content than to the background.  
The problem: Pure text nodes can't be styled with CSS.

So, I had to wrap the button's content in an HTML tag to give it a z-index that would make it visible.

I wanted to use a \<div\> tag that would match the behavior of a \<button\>.

But I realized that the CSS was already written for content encapsulated in a \<span\>, and I followed the apparent intent of the code by using this tag, which is therefore already styled to appear correctly.

**This could cause unintended behavior when trying to include block type content in a \<Button\>**

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Donor Dashboard > Donation History > receipt page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://github.com/user-attachments/assets/1a9a9782-ce11-4a6d-859b-b12b71a336d9)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

