### PR TITLE
Fix: Merged campaigns donation count

### DIFF
--- a/src/Campaigns/Repositories/CampaignRepository.php
+++ b/src/Campaigns/Repositories/CampaignRepository.php
@@ -5,6 +5,7 @@ namespace Give\Campaigns\Repositories;
 use Exception;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\ValueObjects\CampaignType;
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Framework\Database\DB;
 use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use Give\Framework\Models\ModelQueryBuilder;
@@ -325,6 +326,15 @@ class CampaignRepository
                 DB::prepare("UPDATE " . DB::prefix('give_campaign_forms') . " SET campaign_id = %d WHERE campaign_id IN ($campaignsToMergeIdsString)",
                     [
                         $destinationCampaign->id,
+                    ])
+            );
+
+            // Update donations campaign id meta value
+            DB::query(
+                DB::prepare("UPDATE " . DB::prefix('give_donationmeta') . " SET meta_value = %d WHERE meta_key = %s AND meta_value IN ($campaignsToMergeIdsString)",
+                    [
+                        $destinationCampaign->id,
+                        DonationMetaKeys::CAMPAIGN_ID
                     ])
             );
 


### PR DESCRIPTION
## Description

This PR resolves the issue with the donation count for merged campaigns.  The problem was in donation meta not being updated with the correct campaign id after merge.

## Affects

Campaign merge

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Create a minimum of two campaign
Make donations to each of them
Merge campaigns
Verify that the donation count is correct

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

