### PR TITLE
Refactor: improve Campaign overview stats styling and loading

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/DateRangeFilters.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/DateRangeFilters.tsx
@@ -1,0 +1,25 @@
+import {filterOptions} from '../CampaignStats';
+import styles from './styles.module.scss';
+
+type DateRangeFiltersProps = {
+    options: typeof filterOptions;
+    onSelect: (value: number) => void;
+    selected: number;
+}
+
+const DateRangeFilters = ({options, onSelect, selected}: DateRangeFiltersProps) => {
+    return (
+        <div className={styles.dateRangeFilter}>
+            {options.map((option, index) => (
+                <button
+                    className={selected === option.value && styles.selectedDateRange}
+                    key={index}
+                    onClick={() => onSelect(option.value)}
+                >
+                    {option.label}
+                </button>
+            ))}
+        </div>
+    );
+};
+export default DateRangeFilters;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
@@ -5,7 +5,6 @@ import type {PercentChangePillProps} from './types';
  * @unreleased
  */
 const getPercentageChange = (previousValue: number, currentValue: number) => {
-    console.log({previousValue, currentValue});
     if (previousValue === 0) {
         return currentValue === 0 ? 0 : 100;
     }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
@@ -5,11 +5,17 @@ import type {PercentChangePillProps} from './types';
  * @unreleased
  */
 const getPercentageChange = (previousValue: number, currentValue: number) => {
+    console.log({previousValue, currentValue});
     if (previousValue === 0) {
-        return 0;
+        return currentValue === 0 ? 0 : 100;
     }
 
-    return Math.ceil(100 * ((currentValue - previousValue) / Math.abs(previousValue)));
+    const value = currentValue - previousValue / Math.abs(previousValue) * 100;
+    if (value !== 100) {
+        return value.toFixed(1);
+    }
+
+    return value;
 }
 
 const IconArrowUp = () => (

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/PercentChangePill.tsx
@@ -1,0 +1,53 @@
+import styles from './styles.module.scss';
+import type {PercentChangePillProps} from './types';
+
+/**
+ * @unreleased
+ */
+const getPercentageChange = (previousValue: number, currentValue: number) => {
+    if (previousValue === 0) {
+        return 0;
+    }
+
+    return Math.ceil(100 * ((currentValue - previousValue) / Math.abs(previousValue)));
+}
+
+const IconArrowUp = () => (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5.833 11.667 10 7.5l4.167 4.167H5.833z" fill="#2D802F"/>
+    </svg>
+);
+
+const IconArrowDown = () => (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M10 12.5 5.833 8.335h8.334L10 12.501z" fill="#D92D0B"/>
+    </svg>
+)
+
+const IconArrowRight = () => (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8.334 14.167V5.834l4.166 4.167-4.166 4.166z" fill="#060C1A"/>
+    </svg>
+)
+
+/**
+ * @unreleased
+ */
+const PercentChangePill = ({value, comparison}: PercentChangePillProps) => {
+    const change = getPercentageChange(comparison, value);
+
+    const [color, backgroundColor, symbol] =
+        change === 0
+            ? ['#060c1a', '#f2f2f2', <IconArrowRight />]
+            : change > 0
+            ? ['#2d802f', '#f2fff3', <IconArrowUp />]
+            : ['#e35f45', '#fff4f2', <IconArrowDown />];
+
+    return (
+        <div className={styles.percentChangePill} style={{backgroundColor: backgroundColor, color: color}}>
+            {symbol} <span>{change}%</span>
+        </div>
+    );
+};
+
+export default PercentChangePill;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/StatWidget.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/StatWidget.tsx
@@ -1,0 +1,29 @@
+import styles from './styles.module.scss';
+import PercentChangePill from './PercentChangePill';
+import HeaderText from '../HeaderText';
+import type {StatWidgetProps} from './types';
+import {Spinner} from '@givewp/components';
+
+/**
+ * @unreleased
+ */
+const StatWidget = ({label, value, previousValue, description, formatter = null, loading = false}: StatWidgetProps) => {
+    return (
+        <div className={styles.statWidget}>
+            <header>
+                <HeaderText>{label}</HeaderText>
+            </header>
+            <div className={styles.statWidgetAmount}>
+                <div className={styles.statWidgetDisplay}>
+                    {!loading ? formatter?.format(value) ?? value : <span>{<Spinner />}</span>}
+                </div>
+                {previousValue !== null && <PercentChangePill value={value} comparison={previousValue} />}
+            </div>
+            <footer>
+                <div>{description}</div>
+            </footer>
+        </div>
+    );
+};
+
+export default StatWidget;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -62,8 +62,8 @@ const CampaignStats = () => {
 
     const widgetDescription = filterOptions.find((option) => option.value === dayRange)?.description;
 
-    const amountRaised = stats.length > 0 ? Number(stats[0].amountRaised) : 0;
-    const previousAmountRaised = stats.length > 1 ? Number(stats[1].amountRaised) : null;
+    const amountRaised = stats.length > 0 ? stats[0].amountRaised : 0;
+    const previousAmountRaised = stats.length > 1 ? stats[1].amountRaised : null;
     const donationCount = stats.length > 0 ? stats[0].donationCount : 0;
     const previousDonationCount = stats.length > 1 ? stats[1].donationCount : null;
     const donorCount  = stats.length > 0 ? stats[0].donorCount : 0;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -26,6 +26,22 @@ export const filterOptions = [
     {label: __('All-time', 'give'), value: 0, description: __('total for all-time', 'give')},
 ];
 
+const fetchCampaignOverviewStats = async (days: number, setLoading: Function, setStats: Function) => {
+        setLoading(true);
+
+        try {
+            const response = await apiFetch({
+                path: addQueryArgs(`/give-api/v2/campaigns/${campaignId}/statistics`, {rangeInDays: days}),
+            });
+
+            setStats(response as CampaignOverViewStat[]);
+            setLoading(false);
+        } catch (error) {
+            console.error('Error fetching campaign stats:', error);
+            setLoading(false);
+        }
+    };
+
 const CampaignStats = () => {
     const [dayRange, setDayRange] = useState<number>(0);
     /**
@@ -39,26 +55,8 @@ const CampaignStats = () => {
     const [loading, setLoading] = useState<boolean>(false);
 
     useEffect(() => {
-        if (stats.length === 0) {
-            onDayRangeChange(0);
-        }
-    }, []);
-
-    const onDayRangeChange = async (days: number) => {
-        setDayRange(days);
-        setLoading(true);
-
-        try {
-            const response = await apiFetch({
-                path: addQueryArgs(`/give-api/v2/campaigns/${campaignId}/statistics`, {rangeInDays: days}),
-            });
-
-            setStats(response as CampaignOverViewStat[]);
-            setLoading(false);
-        } catch (error) {
-            console.error('Error fetching campaign stats:', error);
-        }
-    };
+        fetchCampaignOverviewStats(dayRange, setLoading, setStats);
+    }, [dayRange]);
 
     const widgetDescription = filterOptions.find((option) => option.value === dayRange)?.description;
 
@@ -71,7 +69,7 @@ const CampaignStats = () => {
 
     return (
         <>
-            <DateRangeFilters selected={dayRange} options={filterOptions} onSelect={onDayRangeChange} />
+            <DateRangeFilters selected={dayRange} options={filterOptions} onSelect={(value) => setDayRange(value)} />
             <div className={styles.mainGrid}>
                 <StatWidget
                     label={__('Amount raised', 'give')}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -1,174 +1,122 @@
 import {__} from '@wordpress/i18n';
-import {useEffect, useState} from "react";
-import RevenueChart from "../RevenueChart";
-import GoalProgressChart from "../GoalProgressChart";
+import {useEffect, useState} from 'react';
+import RevenueChart from '../RevenueChart';
+import GoalProgressChart from '../GoalProgressChart';
 import apiFetch from '@wordpress/api-fetch';
 import {addQueryArgs} from '@wordpress/url';
 import HeaderText from '../HeaderText';
 import HeaderSubText from '../HeaderSubText';
-import DefaultFormWidget from "../DefaultForm";
-import {useCampaignEntityRecord, amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
-
-import styles from "./styles.module.scss"
+import DefaultFormWidget from '../DefaultForm';
+import StatWidget from './StatWidget';
+import DateRangeFilters from './DateRangeFilters';
+import {amountFormatter, getCampaignOptionsWindowData, useCampaignEntityRecord} from '@givewp/campaigns/utils';
+import type {CampaignOverViewStat} from './types';
+import styles from './styles.module.scss';
 
 const campaignId = new URLSearchParams(window.location.search).get('id');
 
 const {currency} = getCampaignOptionsWindowData();
 const currencyFormatter = amountFormatter(currency);
 
-const pluck = (array: any[], property: string) => array.map(element => element[property])
-
-const filterOptions = [
+export const filterOptions = [
     {label: __('Today', 'give'), value: 1, description: __('from today', 'give')},
     {label: __('Last 7 days', 'give'), value: 7, description: __('from the last 7 days', 'give')},
     {label: __('Last 30 days', 'give'), value: 30, description: __('from the last 30 days', 'give')},
     {label: __('Last 90 days', 'give'), value: 90, description: __('from the last 90 days', 'give')},
     {label: __('All-time', 'give'), value: 0, description: __('total for all-time', 'give')},
-]
+];
 
 const CampaignStats = () => {
-
-    const [dayRange, setDayRange] = useState(null);
-    const [stats, setStats] = useState([]);
+    const [dayRange, setDayRange] = useState<number>(0);
+    /**
+     * The stats array is currently either an array size of 1 or 2
+     * if the array size is 1 it means all-time stats
+     * if the array size is 2 it means the stats for the day range was selected
+     * the second element in the array is the query for the previous day range
+     */
+    const [stats, setStats] = useState<CampaignOverViewStat[]>([]);
     const {campaign} = useCampaignEntityRecord();
+    const [loading, setLoading] = useState<boolean>(false);
 
     useEffect(() => {
-        onDayRangeChange(0)
-    }, [])
+        if (stats.length === 0) {
+            onDayRangeChange(0);
+        }
+    }, []);
 
     const onDayRangeChange = async (days: number) => {
-        setDayRange(days)
+        setDayRange(days);
+        setLoading(true);
 
-        apiFetch({path: addQueryArgs('/give-api/v2/campaigns/' + campaignId + '/statistics', {rangeInDays: days})})
-            .then(setStats);
-    }
+        try {
+            const response = await apiFetch({
+                path: addQueryArgs(`/give-api/v2/campaigns/${campaignId}/statistics`, {rangeInDays: days}),
+            });
 
-    const widgetDescription = filterOptions.find(option => option.value === dayRange)?.description
+            setStats(response as CampaignOverViewStat[]);
+            setLoading(false);
+        } catch (error) {
+            console.error('Error fetching campaign stats:', error);
+        }
+    };
+
+    const widgetDescription = filterOptions.find((option) => option.value === dayRange)?.description;
+
+    const amountRaised = stats.length > 0 ? Number(stats[0].amountRaised) : 0;
+    const previousAmountRaised = stats.length > 1 ? Number(stats[1].amountRaised) : null;
+    const donationCount = stats.length > 0 ? stats[0].donationCount : 0;
+    const previousDonationCount = stats.length > 1 ? stats[1].donationCount : null;
+    const donorCount  = stats.length > 0 ? stats[0].donorCount : 0;
+    const previousDonorCount = stats.length > 1 ? stats[1].donorCount : null;
 
     return (
         <>
             <DateRangeFilters selected={dayRange} options={filterOptions} onSelect={onDayRangeChange} />
             <div className={styles.mainGrid}>
-                <StatWidget label={__('Amount raised', 'give')} values={pluck(stats, 'amountRaised')}
-                            description={widgetDescription} formatter={currencyFormatter} />
-                <StatWidget label={__('Number of donations', 'give')} values={pluck(stats, 'donationCount')}
-                            description={widgetDescription} />
-                <StatWidget label={__('Number of donors', 'give')} values={pluck(stats, 'donorCount')}
-                            description={widgetDescription} />
-                <RevenueWidget />
+                <StatWidget
+                    label={__('Amount raised', 'give')}
+                    value={amountRaised}
+                    previousValue={previousAmountRaised}
+                    description={widgetDescription}
+                    formatter={currencyFormatter}
+                    loading={loading}
+                />
+                <StatWidget
+                    label={__('Number of donations', 'give')}
+                    value={donationCount}
+                    previousValue={previousDonationCount}
+                    description={widgetDescription}
+                    loading={loading}
+                />
+                <StatWidget
+                    label={__('Number of donors', 'give')}
+                    value={donorCount}
+                    previousValue={previousDonorCount}
+                    description={widgetDescription}
+                    loading={loading}
+                />
+                <div className={styles.revenueWidget}>
+                    <header className={styles.headerSpacing}>
+                        <HeaderText>{__('Revenue', 'give')}</HeaderText>
+                        <HeaderSubText>
+                            {__('This graph shows revenue for the campaign over its lifetime.', 'give')}
+                        </HeaderSubText>
+                    </header>
+                    <RevenueChart />
+                </div>
                 <div className={styles.nestedGrid}>
-                    <GoalProgressWidget />
+                    <div className={styles.progressWidget}>
+                        <header className={styles.headerSpacing}>
+                            <HeaderText>{__('Goal progress', 'give')}</HeaderText>
+                            <HeaderSubText>{__('This chart shows your campaign goal progress.', 'give')}</HeaderSubText>
+                        </header>
+                        <GoalProgressChart value={campaign.goalStats.actual} goal={campaign.goal} goalType={campaign.goalType} />
+                    </div>
                     <DefaultFormWidget defaultForm={campaign.defaultFormTitle} />
                 </div>
             </div>
         </>
-    )
-}
-
-const FooterText = ({children}) => {
-    return (
-        <div className={styles.footerText}>
-            {children}
-        </div>
-    )
-}
-
-const DisplayText = ({children}) => {
-    return (
-        <div className={styles.statWidgetDisplay}>
-            {children}
-        </div>
-    )
-}
-
-const StatWidget = ({label, values, description, formatter = null}) => {
-    return (
-        <div className={styles.statWidget}>
-            <header>
-                <HeaderText>{label}</HeaderText>
-            </header>
-            <div className={styles.statWidgetAmount}>
-                <DisplayText>
-                    {'undefined' !== typeof values[0]
-                        ? formatter?.format(values[0]) ?? values[0]
-                        : <span>&nbsp;</span>
-                    }
-                </DisplayText>
-                {!!values[1] && (
-                    <PercentChangePill value={values[0]} comparison={values[1]} />
-                )}
-            </div>
-            <footer>
-                <FooterText>{description}</FooterText>
-            </footer>
-        </div>
-    )
-}
-
-const PercentChangePill = ({value, comparison}) => {
-
-    const change = Math.round(100 * ((value - comparison) / comparison)) ?? 0
-
-    const [color, backgroundColor, symbol] = change == 0
-        ? ['#060c1a', '#f2f2f2', '⯈']
-        : change > 0
-            ? ['#2d802f', '#f2fff3', '⯅']
-            : ['#e35f45', '#fff4f2', '⯆']
-
-    return (
-        <span
-            className={styles.percentChangePill}
-            style={{backgroundColor: backgroundColor, color: color,}}
-        >
-            <small>{symbol}</small> {Math.abs(change)}%
-        </span>
-    )
-
-}
-
-
-const RevenueWidget = () => {
-    return (
-        <div className={styles.revenueWidget}>
-            <header className={styles.headerSpacing}>
-                <HeaderText>{__('Revenue', 'give')}</HeaderText>
-                <HeaderSubText>{__('Show your revenue over time', 'give')}</HeaderSubText>
-            </header>
-            <RevenueChart />
-        </div>
     );
-}
-
-const GoalProgressWidget = () => {
-
-    const {campaign} = useCampaignEntityRecord();
-
-    return (
-        <div className={styles.progressWidget}>
-            <header className={styles.headerSpacing}>
-                <HeaderText>{__('Goal progress', 'give')}</HeaderText>
-                <HeaderSubText>{__('Show your campaign performance', 'give')}</HeaderSubText>
-            </header>
-            <GoalProgressChart value={campaign.goalStats.actual} goal={campaign.goal} goalType={campaign.goalType} />
-        </div>
-    );
-}
-
-const DateRangeFilters = ({options, onSelect, selected}) => {
-    return (
-        <div className={styles.dateRangeFilter}>
-            {options.map((option, index) => (
-                <button
-                    className={selected === option.value && styles.selectedDateRange}
-                    key={index}
-                    onClick={() => onSelect(option.value)}
-                >
-                    {option.label}
-                </button>
-            ))}
-        </div>
-    )
-}
-
+};
 
 export default CampaignStats;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/styles.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/styles.module.scss
@@ -89,9 +89,15 @@
 }
 
 .percentChangePill {
-    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 12px 2px 4px;
     font-size: .8rem;
     border-radius: var(--givewp-rounded-16);
+    min-width: 71px;
+    height: 24px;
+    gap: 2px;
 }
 
 .progressWidget {
@@ -125,7 +131,7 @@
       grid-template-columns: 1fr;
       gap: var(--givewp-spacing-3);
     }
-  
+
     .revenueWidget {
       grid-column: span 1;
     }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/types.ts
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/types.ts
@@ -1,0 +1,28 @@
+/**
+ * @unreleased
+ */
+export type StatWidgetProps = {
+    label: string;
+    value: number;
+    previousValue?: number;
+    description: string;
+    formatter?: Intl.NumberFormat;
+    loading?: boolean;
+};
+
+/**
+ * @unreleased
+ */
+export type CampaignOverViewStat = {
+    amountRaised: number;
+    donationCount: number;
+    donorCount: number;
+};
+
+/**
+ * @unreleased
+ */
+export type PercentChangePillProps = {
+    value: number;
+    comparison: number;
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Overview.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Overview.tsx
@@ -1,11 +1,9 @@
-import CampaignStats from "../Components/CampaignStats";
+import CampaignStats from '../Components/CampaignStats';
 
 /**
  * @unreleased
  */
 export default () => {
-
-
     return (
         <div>
             <div>
@@ -13,4 +11,4 @@ export default () => {
             </div>
         </div>
     );
-}
+};

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -4,7 +4,6 @@ import {useDispatch} from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import {JSONSchemaType} from 'ajv';
 import {ajvResolver} from '@hookform/resolvers/ajv';
-import {GiveCampaignOptions} from '@givewp/campaigns/types';
 import {Campaign} from '../types';
 import {FormProvider, SubmitHandler, useForm} from 'react-hook-form';
 import {Spinner as GiveSpinner} from '@givewp/components';


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->


## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The campaign overview was getting hard to manage and needed some UI improvements.  This PR cleans up the overview components for better maintainability and improves the widget data loading (with loading spinner), percentage calculations and some styling.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign overview stat widgets.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1317" alt="Screenshot 2025-03-13 at 3 35 19 PM" src="https://github.com/user-attachments/assets/d5d06297-3555-4626-ab8f-11267bb0d89e" />

<img width="1312" alt="Screenshot 2025-03-13 at 3 35 37 PM" src="https://github.com/user-attachments/assets/2aa80acf-31f6-45ba-ab5d-bad493d4080d" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a campaign with donations over a period of time
- View the campaign overview page
- You should now see a loading spinner on the stat widgets
- The stat widget percentage styling is also improved

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

