### PR TITLE
Fix: hide donate button from campaign page if form is not published

### DIFF
--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -3,15 +3,17 @@
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
+use Give\DonationForms\V2\Models\DonationForm;
+use Give\Log\Log;
 
 /**
  * @var array    $attributes
  * @var Campaign $campaign
  */
 
-if (
-    ! isset($attributes['campaignId'])
-    || ! $campaign = give(CampaignRepository::class)->getById($attributes['campaignId'])
+if (!isset($attributes['campaignId']) ||
+    !($campaign = give(CampaignRepository::class)->getById($attributes['campaignId'])) ||
+    !DonationForm::find($campaign->defaultFormId)->status->isPublished()
 ) {
     return;
 }

--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -4,7 +4,6 @@ use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
 use Give\DonationForms\V2\Models\DonationForm;
-use Give\Log\Log;
 
 /**
  * @var array    $attributes

--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -12,7 +12,8 @@ use Give\DonationForms\V2\Models\DonationForm;
 
 if (!isset($attributes['campaignId']) ||
     !($campaign = give(CampaignRepository::class)->getById($attributes['campaignId'])) ||
-    !DonationForm::find($campaign->defaultFormId)->status->isPublished()
+    !$campaign->defaultForm() ||
+    !$campaign->defaultForm()->status->isPublished()
 ) {
     return;
 }


### PR DESCRIPTION
Resolves: [GIVE-2305]

## Description
This fix ensures that the "Donate" button on the campaign page is hidden when the associated donation form is not published. Previously, the button would render even while the donation form was in draft.

## Affects
Campaign page
Donate button block

## Visuals


## Testing Instructions
- Publish a campaign.
- Ensure the default form is in draft mode.
- View the campaign page -> the donate button should NOT render.
- Publish the default form.
- View the campaign page -> the donate button should render.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2305]: https://stellarwp.atlassian.net/browse/GIVE-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ