### PR TITLE
Fix: only hide donate button from PayPal if hosted fields are not present

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -10,7 +10,7 @@ import type {Gateway} from '@givewp/forms/types';
 import {__, sprintf} from '@wordpress/i18n';
 import {debounce} from 'react-ace/lib/editorOptions';
 import {Flex, TextControl} from '@wordpress/components';
-import {CSSProperties, useEffect, useState} from 'react';
+import {CSSProperties, useEffect, useRef, useState} from 'react';
 import {PayPalSubscriber} from './types';
 import handleValidationRequest from '@givewp/forms/app/utilities/handleValidationRequest';
 
@@ -568,7 +568,7 @@ import handleValidationRequest from '@givewp/forms/app/utilities/handleValidatio
             }
 
             if (!validateHostedFields()) {
-                throw new Error('Invalid hosted fields');
+                throw new Error('Invalid PayPal card fields');
             }
 
             const approveOrderCallback = async (data) => {
@@ -636,7 +636,7 @@ import handleValidationRequest from '@givewp/forms/app/utilities/handleValidatio
                     'form#give-next-gen button[type="submit"]'
                 );
 
-                if (submitButton) {
+                if (submitButton && !hostedField) {
                     submitButton.style.display = 'none';
                 }
 

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -10,7 +10,7 @@ import type {Gateway} from '@givewp/forms/types';
 import {__, sprintf} from '@wordpress/i18n';
 import {debounce} from 'react-ace/lib/editorOptions';
 import {Flex, TextControl} from '@wordpress/components';
-import {CSSProperties, useEffect, useRef, useState} from 'react';
+import {CSSProperties, useEffect, useState} from 'react';
 import {PayPalSubscriber} from './types';
 import handleValidationRequest from '@givewp/forms/app/utilities/handleValidationRequest';
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2265]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This ensures our donate button is not hidden when PayPal hosted fields are present. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- PayPal donations

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

Notice the donate buttons (showing validation by default when hosted fields and smart buttons are present)

<img width="699" alt="Screenshot 2025-03-17 at 5 37 35 PM" src="https://github.com/user-attachments/assets/ca576ab3-a020-4bcb-a28f-5b0493b0f9af" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/13910574470

- Connect to PayPal using [advanced card processing]( https://givewp.com/documentation/core/payment-gateways/paypal-donations/#standard-card-processing-vs-advanced-card-processing)
- Create a v3 form with PayPal donations enabled
- Make sure the donate button is present when hosted fields are being displayed.  Note: this is when it says "or pay with card" - not the button that shows Debit / Credit option.
- Make sure the donation goes through properly
- Make sure the donate button is hidden when smart buttons only is enabled.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2265]: https://stellarwp.atlassian.net/browse/GIVE-2265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ