### PR TITLE
Fix/Remove campaign page wireframe from campaign settings

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -50,7 +50,6 @@ export default function CampaignDetailsSettingsTab() {
 
                 <div className={styles.rightColumn}>
                     <div className={styles.sectionField}>
-                        <img src={campaignPageImage} alt={__('Enable campaign page for your campaign.', 'give')} />
                         <div className={styles.toggle}>
                             <ToggleControl
                                 label={__('Enable campaign page for your campaign.', 'give')}


### PR DESCRIPTION
Resolves [GIVE-2320](https://stellarwp.atlassian.net/browse/GIVE-2320)


## Description
This PR removes the campaign page wireframe from the settings page to improve campaign details visibility and eliminate confusion.

## Affects
UI change in the settings page.

## Visuals
Before
<img width="1300" alt="Screenshot 2025-03-18 at 2 44 40 PM" src="https://github.com/user-attachments/assets/10c51fc2-35b2-4f06-b0fe-73c0ee3cb6de" />


After
<img width="1273" alt="Screenshot 2025-03-18 at 2 42 10 PM" src="https://github.com/user-attachments/assets/3194687d-a4e0-48b2-be89-e17cf214f74b" />



## Testing Instructions
Go the campaign settings and check if there's no campaign page wireframe.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

