### PR TITLE
Refactor: Change Campaign Donations block sort by attribute to "Recent Donations"

### DIFF
--- a/src/Campaigns/Blocks/CampaignDonations/block.json
+++ b/src/Campaigns/Blocks/CampaignDonations/block.json
@@ -28,7 +28,7 @@
         },
         "sortBy": {
             "type": "string",
-            "default": "top-donations"
+            "default": "recent-donations"
         },
         "donationsPerPage": {
             "type": "number",


### PR DESCRIPTION
Resolves [GIVE-2302]

## Description
This pull request includes a change to the `src/Campaigns/Blocks/CampaignDonations/block.json` file to update the default sorting behavior for donations.

* [`src/Campaigns/Blocks/CampaignDonations/block.json`](diffhunk://#diff-8a19380a1b72c5c85eed4af65e6f0e18e8074d1452204529853088ffc2603f10L31-R31): Changed the default value of the `sortBy` property from "top-donations" to "recent-donations".

## Affects
Campaign Donations block

## Testing Instructions
- In a campaign page, add a Campaign Donations block.
- Confirm it defaults to Recent Donations in its Sort By attribute.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2302]: https://stellarwp.atlassian.net/browse/GIVE-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ