### PR TITLE
Refactor: Replace campaign blocks icons with Give icon

### DIFF
--- a/src/Campaigns/Blocks/CampaignDonations/index.tsx
+++ b/src/Campaigns/Blocks/CampaignDonations/index.tsx
@@ -1,13 +1,14 @@
-import {paragraph as icon} from '@wordpress/icons';
 import schema from './block.json';
 import Edit from './edit';
+import GiveIcon from '@givewp/components/GiveIcon';
 
 /**
  * @unreleased
  */
 const settings = {
-    icon,
+    icon: <GiveIcon color="grey" />,
     edit: Edit,
+    save: () => null,
 };
 
 export default {

--- a/src/Campaigns/Blocks/CampaignDonors/index.tsx
+++ b/src/Campaigns/Blocks/CampaignDonors/index.tsx
@@ -1,13 +1,14 @@
-import {paragraph as icon} from '@wordpress/icons';
 import schema from './block.json';
 import Edit from './edit';
+import GiveIcon from '@givewp/components/GiveIcon';
 
 /**
  * @unreleased
  */
 const settings = {
-    icon,
+    icon: <GiveIcon color="grey" />,
     edit: Edit,
+    save: () => null,
 };
 
 export default {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2308]

## Description
This pull request updates the icon displayed in the Campaign Donations and the Campaign Donors blocks.

### File renaming and icon update:

* [`src/Campaigns/Blocks/CampaignDonations/index.tsx`](diffhunk://#diff-29e916fdf58e1636bef0b4d787d6ac40675aebf445a1399904712192467fec56L1-R11): Renamed from `index.ts` and updated the icon to use `GiveIcon` with a grey color. Added a `save` function that returns `null`.
* [`src/Campaigns/Blocks/CampaignDonors/index.tsx`](diffhunk://#diff-29e916fdf58e1636bef0b4d787d6ac40675aebf445a1399904712192467fec56L1-R11): Renamed from `index.ts` and updated the icon to use `GiveIcon` with a grey color. Added a `save` function that returns `null`.

## Affects
Campaign Donations and the Campaign Donors blocks

## Visuals
![CleanShot 2025-03-18 at 16 31 30](https://github.com/user-attachments/assets/cd2a95df-e9bc-4dc8-a73e-d989822dcb5c)

## Testing Instructions
Confirm the icon has been replaced in the blocks and that nothing else has changed.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2308]: https://stellarwp.atlassian.net/browse/GIVE-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ