### PR TITLE
Fix: Render mocked button in Campaign blocks only in the editor

### DIFF
--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -30,15 +30,16 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donations)) : ?>
             <div class="givewp-campaign-donations-block__donate-button">
                 <?php
-                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
-                }
-
-                echo (new BlockRenderController())->render([
+                $blockRender = (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
                     'formFormat' => 'modal',
                 ]);
+
+                echo $blockRender ?? sprintf(
+                    '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                    $donateButtonText
+                );
                 ?>
             </div>
         <?php
@@ -67,16 +68,17 @@ $blockInlineStyles = sprintf(
                 <div class="givewp-campaign-donations-block__empty-button">
                     <?php
                     $firstDonationButtonText = __('Be the first', 'give');
-                    
-                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
-                    }
 
-                    echo (new BlockRenderController())->render([
+                    $blockRender = (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
                         'openFormButton' => $firstDonationButtonText,
                         'formFormat' => 'modal',
                     ]);
+
+                    echo $blockRender ?? sprintf(
+                        '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                        $firstDonationButtonText
+                    );
                     ?>
                 </div>
             <?php

--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -30,10 +30,6 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donations)) : ?>
             <div class="givewp-campaign-donations-block__donate-button">
                 <?php
-                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
-                }
-
                 echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
@@ -66,15 +62,9 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donations-block__empty-button">
                     <?php
-                    $firstDonationButtonText = __('Be the first', 'give');
-                    
-                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
-                    }
-
                     echo (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
-                        'openFormButton' => $firstDonationButtonText,
+                        'openFormButton' => __('Be the first', 'give'),
                         'formFormat' => 'modal',
                     ]);
                     ?>

--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -30,11 +30,16 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donations)) : ?>
             <div class="givewp-campaign-donations-block__donate-button">
                 <?php
+                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
+                }
+
                 echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
-                    'openFormButton' => $attributes['donateButtonText'],
+                    'openFormButton' => $donateButtonText,
                     'formFormat' => 'modal',
-                ]); ?>
+                ]);
+                ?>
             </div>
         <?php
         endif; ?>
@@ -61,9 +66,15 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donations-block__empty-button">
                     <?php
+                    $firstDonationButtonText = __('Be the first', 'give');
+                    
+                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
+                    }
+
                     echo (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
-                        'openFormButton' => __('Be the first', 'give'),
+                        'openFormButton' => $firstDonationButtonText,
                         'formFormat' => 'modal',
                     ]);
                     ?>

--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -30,6 +30,10 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donations)) : ?>
             <div class="givewp-campaign-donations-block__donate-button">
                 <?php
+                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
+                }
+
                 echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
@@ -62,9 +66,15 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donations-block__empty-button">
                     <?php
+                    $firstDonationButtonText = __('Be the first', 'give');
+                    
+                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
+                    }
+
                     echo (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
-                        'openFormButton' => __('Be the first', 'give'),
+                        'openFormButton' => $firstDonationButtonText,
                         'formFormat' => 'modal',
                     ]);
                     ?>

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -32,6 +32,10 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donors)) : ?>
             <div class="givewp-campaign-donors-block__donate-button">
                 <?php
+                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
+                }
+
                 echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
@@ -68,9 +72,15 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donors-block__empty-button">
                     <?php
+                    $firstDonationButtonText = __('Be the first donor', 'give');
+
+                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
+                    }
+
                     echo (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
-                        'openFormButton' => __('Be the first donor', 'give'),
+                        'openFormButton' => $firstDonationButtonText,
                         'formFormat' => 'modal',
                     ]);
                     ?>

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -32,10 +32,6 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donors)) : ?>
             <div class="givewp-campaign-donors-block__donate-button">
                 <?php
-                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
-                }
-
                 echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
@@ -72,15 +68,9 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donors-block__empty-button">
                     <?php
-                    $firstDonationButtonText = __('Be the first donor', 'give');
-
-                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
-                    }
-
                     echo (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
-                        'openFormButton' => $firstDonationButtonText,
+                        'openFormButton' => __('Be the first donor', 'give'),
                         'formFormat' => 'modal',
                     ]);
                     ?>

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -32,15 +32,16 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donors)) : ?>
             <div class="givewp-campaign-donors-block__donate-button">
                 <?php
-                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
-                }
-
-                echo (new BlockRenderController())->render([
+                $blockRender = (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
                     'formFormat' => 'modal',
                 ]);
+
+                echo $blockRender ?? sprintf(
+                    '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                    $donateButtonText
+                );
                 ?>
             </div>
         <?php
@@ -74,15 +75,16 @@ $blockInlineStyles = sprintf(
                     <?php
                     $firstDonationButtonText = __('Be the first donor', 'give');
 
-                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
-                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
-                    }
-
-                    echo (new BlockRenderController())->render([
+                    $blockRender = (new BlockRenderController())->render([
                         'formId' => $campaign->defaultFormId,
                         'openFormButton' => $firstDonationButtonText,
                         'formFormat' => 'modal',
                     ]);
+
+                    echo $blockRender ?? sprintf(
+                        '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                        $firstDonationButtonText
+                    );
                     ?>
                 </div>
             <?php

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -32,13 +32,15 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donors)) : ?>
             <div class="givewp-campaign-donors-block__donate-button">
                 <?php
-                $params = [
+                if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                    echo "<button type='button' class='givewp-donation-form-modal__open'>$donateButtonText</button>";
+                }
+
+                echo (new BlockRenderController())->render([
                     'formId' => $campaign->defaultFormId,
                     'openFormButton' => $donateButtonText,
                     'formFormat' => 'modal',
-                ];
-
-                echo (new BlockRenderController())->render($params);
+                ]);
                 ?>
             </div>
         <?php
@@ -70,13 +72,17 @@ $blockInlineStyles = sprintf(
             if ($attributes['showButton']) : ?>
                 <div class="givewp-campaign-donors-block__empty-button">
                     <?php
-                    $params = [
-                        'formId' => $campaign->defaultFormId,
-                        'openFormButton' => __('Be the first donor', 'give'),
-                        'formFormat' => 'modal',
-                    ];
+                    $firstDonationButtonText = __('Be the first donor', 'give');
 
-                    echo (new BlockRenderController())->render($params);
+                    if ( ! empty($_REQUEST['post']) || ! empty($_REQUEST['action']) || ! empty($_REQUEST['_locale'])) {
+                        echo "<button type='button' class='givewp-donation-form-modal__open'>{$firstDonationButtonText}</button>";
+                    }
+
+                    echo (new BlockRenderController())->render([
+                        'formId' => $campaign->defaultFormId,
+                        'openFormButton' => $firstDonationButtonText,
+                        'formFormat' => 'modal',
+                    ]);
                     ?>
                 </div>
             <?php

--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -14,6 +14,7 @@ use Give\Helpers\Language;
 class BlockRenderController
 {
     /**
+     * @unreleased Return a mocked button when inside the editor.
      * @since 3.22.0 Add locale support
      * @since 3.2.0 include form url for new tab format.
      * @since 3.0.0
@@ -22,9 +23,12 @@ class BlockRenderController
      */
     public function render(array $attributes)
     {
-        // return early if we're still inside the editor to avoid server side effects
+        // return early with a mocked button if we're still inside the editor to avoid server side effects
         if (!empty($_REQUEST['post']) || !empty($_REQUEST['action']) || !empty($_REQUEST['_locale'])) {
-            return null;
+            return sprintf(
+                '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                $attributes['openFormButton']
+            );
         }
 
         $blockAttributes = BlockAttributes::fromArray($attributes);

--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -14,7 +14,6 @@ use Give\Helpers\Language;
 class BlockRenderController
 {
     /**
-     * @unreleased Return a mocked button when inside the editor.
      * @since 3.22.0 Add locale support
      * @since 3.2.0 include form url for new tab format.
      * @since 3.0.0
@@ -23,12 +22,9 @@ class BlockRenderController
      */
     public function render(array $attributes)
     {
-        // return early with a mocked button if we're still inside the editor to avoid server side effects
+        // return early if we're still inside the editor to avoid server side effects
         if (!empty($_REQUEST['post']) || !empty($_REQUEST['action']) || !empty($_REQUEST['_locale'])) {
-            return sprintf(
-                '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
-                $attributes['openFormButton']
-            );
+            return null;
         }
 
         $blockAttributes = BlockAttributes::fromArray($attributes);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2303]

## Description
This pull request includes several changes to improve the rendering logic and documentation in the `CampaignDonations` and `CampaignDonors` blocks and the `BlockRenderController` class. The most important changes include updating the `BlockRenderController` `render` method to return a mocked button when inside the editor.

Improvements to rendering logic:

* [`src/Campaigns/Blocks/CampaignDonations/resources/views/render.php`](diffhunk://#diff-576c57f1c9320d16476eeffb43f71d3b96b8416eb64502be47d386a8a6b24db6L35-R38): Updated the `BlockRenderController` call to directly pass the parameters instead of using an array.
* [`src/Campaigns/Blocks/CampaignDonors/resources/views/render.php`](diffhunk://#diff-b081880b048cae2c325b6cdbb7d649e95ca56872c896bc18392c3ae98338df82L35-R39): Simplified the `BlockRenderController` call by directly passing parameters in two instances. [[1]](diffhunk://#diff-b081880b048cae2c325b6cdbb7d649e95ca56872c896bc18392c3ae98338df82L35-R39) [[2]](diffhunk://#diff-b081880b048cae2c325b6cdbb7d649e95ca56872c896bc18392c3ae98338df82L73-R75)

Enhancements to `BlockRenderController`:

* [`src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php`](diffhunk://#diff-6afdb6343e85db42452a2debf534303d64d06709fd43e3119b0670f89a2fabaeR17): Added a new comment to indicate a mocked button return when inside the editor.
* [`src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php`](diffhunk://#diff-6afdb6343e85db42452a2debf534303d64d06709fd43e3119b0670f89a2fabaeL25-R31): Modified the `render` method to return a mocked button with the `openFormButton` text when inside the editor.


## Affects
Donate buttons in the Campaign Donations and Campaign Donors blocks.

## Visuals
![CleanShot 2025-03-18 at 16 56 18](https://github.com/user-attachments/assets/b0120368-166c-4b1e-8529-95deec1786f6)
![CleanShot 2025-03-18 at 17 05 38](https://github.com/user-attachments/assets/c2286394-4f2b-45a8-8a73-e088921213ef)

## Testing Instructions
Confirm that donate buttons are being rendered on the blocks in the editor

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2303]: https://stellarwp.atlassian.net/browse/GIVE-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ