### PR TITLE
Fix: Improve Campaign Page Disabled State Styling

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -360,12 +360,13 @@ select[name="campaignId"] {
                         box-shadow: rgb(34, 113, 177) 0px 0px 0px 1px;
                     }
 
-                    &:not([type="checkbox"]) {
-                        &:disabled {
+                    &:disabled {
+                        cursor: not-allowed;
+
+                        &:not([type="checkbox"]) {
                             background-color: #f6f7f7;
                             box-shadow: none;
                             border-color: #9ca0af;
-                            cursor: default;
                             opacity: 0.7;
                             text-shadow: 0 1px 0 #fff;
                             transform: none;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -351,13 +351,26 @@ select[name="campaignId"] {
                 }
 
                 input, select {
+                    height: auto;
                     padding: var(--givewp-spacing-2) var(--givewp-spacing-4);
-                }
 
-                input:focus, select:focus {
-                    border-color: rgb(34, 113, 177);
-                    outline: none;
-                    box-shadow: rgb(34, 113, 177) 0px 0px 0px 1px;
+                    &:focus {
+                        border-color: rgb(34, 113, 177);
+                        outline: none;
+                        box-shadow: rgb(34, 113, 177) 0px 0px 0px 1px;
+                    }
+
+                    &:not([type="checkbox"]) {
+                        &:disabled {
+                            background-color: #f6f7f7;
+                            box-shadow: none;
+                            border-color: #9ca0af;
+                            cursor: default;
+                            opacity: 0.7;
+                            text-shadow: 0 1px 0 #fff;
+                            transform: none;
+                        }
+                    }
                 }
             }
 
@@ -365,23 +378,7 @@ select[name="campaignId"] {
                 margin: 0;
 
                 .sectionFieldCurrencyControl {
-                    font-size: 1rem;
-                    line-height: 2;
-                    display: block;
-                    width: 100%;
-                    border: 1px solid #9ca0af;
-                    border-radius: var(--givewp-spacing-1);
-                    padding: var(--givewp-spacing-2) var(--givewp-spacing-4);
-
                     div {
-                        margin: 0;
-                    }
-
-                    input {
-                        border: none;
-                        outline: none;
-                        box-shadow: none;
-                        padding: 0;
                         margin: 0;
                     }
                 }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -50,47 +50,45 @@ function ColorControl({name, disabled = false, className}: { name: string; disab
             name={name}
             control={control}
             render={({field}) => (
-                <div className={classnames('givewp-color-control', className)}>
+                <div className={classnames('givewp-color-control', className, {'is-disabled': disabled})}>
                     <div className="givewp-color-control__indicator">
                         <ColorIndicator colorValue={field.value} />
                         {field.value && <CheckIcon refColor={field.value} />}
                     </div>
 
-                    {!disabled && (
-                        <div className="givewp-color-control__popover">
-                            <button
-                                type="button"
-                                className={classnames('givewp-color-control__edit-button', {
-                                    'givewp-color-control__edit-button--active': popoverIsVisible,
-                                })}
-                                onClick={toggleVisible}
-                                aria-label={__('Edit color', 'give')}
+                    <div className="givewp-color-control__popover">
+                        <button
+                            type="button"
+                            className={classnames('givewp-color-control__edit-button', {
+                                'givewp-color-control__edit-button--active': popoverIsVisible,
+                            })}
+                            onClick={toggleVisible}
+                            aria-label={__('Edit color', 'give')}
+                        >
+                            <EditIcon />
+                            {__('Edit', 'give')}
+                        </button>
+                        {popoverIsVisible && (
+                            <Popover
+                                className="givewp-color-control__popover-content"
+                                offset={8}
+                                onClose={toggleVisible}
+                                placement="right"
                             >
-                                <EditIcon />
-                                {__('Edit', 'give')}
-                            </button>
-                            {popoverIsVisible && (
-                                <Popover
-                                    className="givewp-color-control__popover-content"
-                                    offset={8}
-                                    onClose={toggleVisible}
-                                    placement="right"
-                                >
-                                    <ColorPalette
-                                        clearable={false}
-                                        colors={[
-                                            {
-                                                colors: defaultColors,
-                                                name: __('Theme', 'give'),
-                                            },
-                                        ]}
-                                        value={field.value}
-                                        onChange={field.onChange}
-                                    />
-                                </Popover>
-                            )}
-                        </div>
-                    )}
+                                <ColorPalette
+                                    clearable={false}
+                                    colors={[
+                                        {
+                                            colors: defaultColors,
+                                            name: __('Theme', 'give'),
+                                        },
+                                    ]}
+                                    value={field.value}
+                                    onChange={field.onChange}
+                                />
+                            </Popover>
+                        )}
+                    </div>
                 </div>
             )}
         />

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -64,6 +64,7 @@ function ColorControl({name, disabled = false, className}: { name: string; disab
                             })}
                             onClick={toggleVisible}
                             aria-label={__('Edit color', 'give')}
+                            disabled={disabled}
                         >
                             <EditIcon />
                             {__('Edit', 'give')}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
@@ -4,8 +4,6 @@
     gap: var(--givewp-spacing-4);
 
     &.is-disabled {
-        pointer-events: none;
-
         .givewp-color-control__indicator {
             opacity: 0.7;
         }
@@ -15,7 +13,7 @@
             border-color: #dcdcde;
             box-shadow: none;
             color: #a7aaad;
-            cursor: default;
+            cursor: not-allowed;
             text-shadow: none;
         }
     }

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/styles.scss
@@ -3,6 +3,23 @@
     display: flex;
     gap: var(--givewp-spacing-4);
 
+    &.is-disabled {
+        pointer-events: none;
+
+        .givewp-color-control__indicator {
+            opacity: 0.7;
+        }
+
+        button {
+            background: #f6f7f7;
+            border-color: #dcdcde;
+            box-shadow: none;
+            color: #a7aaad;
+            cursor: default;
+            text-shadow: none;
+        }
+    }
+
     &__indicator {
         align-items: center;
         display: flex;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/styles.scss
@@ -6,6 +6,7 @@
     justify-content: space-between;
 
     &__textarea {
+        border-color: #9ca0af;
         border-radius: 0.25rem;
         color: var(--givewp-neutral-900);
         display: block;
@@ -14,6 +15,16 @@
         line-height: 1.5;
         padding: var(--givewp-spacing-3) var(--givewp-spacing-4);
         width: 100%;
+
+        &:disabled {
+            background-color: #f6f7f7;
+            box-shadow: none;
+            border-color: #9ca0af;
+            cursor: default;
+            opacity: 0.7;
+            text-shadow: 0 1px 0 #fff;
+            transform: none;
+        }
     }
 
     &__help,

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/styles.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/styles.scss
@@ -20,7 +20,7 @@
             background-color: #f6f7f7;
             box-shadow: none;
             border-color: #9ca0af;
-            cursor: default;
+            cursor: not-allowed;
             opacity: 0.7;
             text-shadow: 0 1px 0 #fff;
             transform: none;

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -58,6 +58,7 @@ export default function CampaignDetailsSettingsTab() {
                                 help={__('This will create a default campaign page for your campaign.', 'give')}
                                 name="enableCampaignPage"
                                 checked={enableCampaignPage}
+                                disabled={isDisabled}
                                 onChange={(value) => {
                                     setValue('enableCampaignPage', value, {shouldDirty: true});
                                 }}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -98,8 +98,14 @@ export default function CampaignsDetailsPage({campaignId}) {
         dispatch.addNotice({
             id: 'update-archive-notice',
             type: 'warning',
-            onDismiss: () => updateStatus('draft'),
-            content: (onDismiss: Function) => <ArchivedCampaignNotice handleClick={onDismiss} />,
+            content: (onDismiss) => (
+                <ArchivedCampaignNotice
+                    handleClick={() => {
+                        onDismiss();
+                        updateStatus('draft');
+                    }}
+                />
+            ),
         });
     }, [campaign?.status]);
 

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -73,7 +73,7 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
         <div id={id} className={classnames('givewp-media-library-control-wrapper', {'is-disabled': disabled})}>
             {value ? (
                 <div className={'givewp-media-library-control'}>
-                    <button className={'givewp-media-library-control__reset'} onClick={resetImage}>
+                    <button className={'givewp-media-library-control__reset'} onClick={resetImage} disabled={disabled}>
                         <img
                             className={'givewp-media-library-control__image'}
                             src={value}
@@ -99,6 +99,7 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
                                 'givewp-media-library-control__options givewp-media-library-control__options--remove'
                             }
                             onClick={resetImage}
+                            disabled={disabled}
                         >
                             {sprintf(__('Remove %s', 'give'), label.toLowerCase())}
                         </button>
@@ -107,13 +108,14 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
                                 'givewp-media-library-control__options givewp-media-library-control__options--update'
                             }
                             onClick={openMediaLibrary}
+                            disabled={disabled}
                         >
                             {sprintf(__('Change %s', 'give'), label.toLowerCase())}
                         </button>
                     </div>
                 </div>
             ) : (
-                <div className={'givewp-media-library-drop-area'} onDragOver={dropHandler}>
+                <div className={'givewp-media-library-drop-area'} onDragOver={!disabled && dropHandler}>
                     <svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <path
                             d="M19 13.5V14.7C19 16.3802 19 17.2202 18.673 17.862C18.3854 18.4265 17.9265 18.8854 17.362 19.173C16.7202 19.5 15.8802 19.5 14.2 19.5H5.8C4.11984 19.5 3.27976 19.5 2.63803 19.173C2.07354 18.8854 1.6146 18.4265 1.32698 17.862C1 17.2202 1 16.3802 1 14.7V13.5M15 6.5L10 1.5M10 1.5L5 6.5M10 1.5V13.5"
@@ -123,7 +125,11 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
                             strokeLinejoin="round"
                         />
                     </svg>
-                    <button className={'givewp-media-library-control__button'} onClick={openMediaLibrary}>
+                    <button
+                        className={'givewp-media-library-control__button'}
+                        onClick={openMediaLibrary}
+                        disabled={disabled}
+                    >
                         {actionLabel}
                     </button>
                     <p>{__('or drag your image here', 'give')}</p>

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import _ from 'lodash';
 import {__, sprintf} from '@wordpress/i18n';
+import classnames from 'classnames';
 import './styles.scss';
 
 type MediaLibrary = {
@@ -51,7 +52,7 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
                 frame.open();
                 return;
             }
-            
+
             onChange(attachment.url, attachment.alt);
         });
 
@@ -68,22 +69,8 @@ export default function UploadMedia({id, value, onChange, label, actionLabel, re
         openMediaLibrary(event);
     };
 
-    if (value && disabled) {
-        return (
-            <img
-                className={'givewp-media-library-control__image'}
-                src={value}
-                alt={__('uploaded image', 'give')}
-            />
-        )
-    }
-
-    if (disabled) {
-        return;
-    }
-
     return (
-        <div id={id}>
+        <div id={id} className={classnames('givewp-media-library-control-wrapper', {'is-disabled': disabled})}>
             {value ? (
                 <div className={'givewp-media-library-control'}>
                     <button className={'givewp-media-library-control__reset'} onClick={resetImage}>

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -131,6 +131,7 @@ div.media-modal.wp-core-ui {
                 background-color: var(--givewp-red-50);
                 border-color: currentColor;
                 color: var(--givewp-red-200);
+                cursor: not-allowed;
             }
         }
 
@@ -146,6 +147,7 @@ div.media-modal.wp-core-ui {
                 background-color: var(--givewp-neutral-50);
                 border-color: currentColor;
                 color: var(--givewp-neutral-300);
+                cursor: not-allowed;
             }
         }
     }

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -4,20 +4,8 @@ div.media-modal.wp-core-ui {
 
 .givewp-media-library-control-wrapper {
     &.is-disabled {
-        pointer-events: none;
-
-        .givewp-media-library-drop-area,
-        .givewp-media-library-control__image {
+        .givewp-media-library-drop-area {
             opacity: 0.7;
-        }
-
-        button {
-            background: #f6f7f7;
-            border-color: #dcdcde;
-            box-shadow: none;
-            color: #a7aaad;
-            cursor: default;
-            text-shadow: none;
         }
     }
 }
@@ -37,6 +25,10 @@ div.media-modal.wp-core-ui {
         border: initial;
         padding: var(--givewp-spacing-1) var(--givewp-spacing-2);
         border-radius: var(--givewp-rounded-4);
+
+        &:disabled {
+            cursor: not-allowed;
+        }
     }
 
     p, svg {
@@ -72,7 +64,6 @@ div.media-modal.wp-core-ui {
                 pointer-events: none;
             }
         }
-
     }
 
     svg {
@@ -134,6 +125,12 @@ div.media-modal.wp-core-ui {
             &:hover {
                 background-color: var(--givewp-red-25);
             }
+
+            &:disabled {
+                background-color: var(--givewp-red-50);
+                border-color: currentColor;
+                color: var(--givewp-red-200);
+            }
         }
 
         &--update {
@@ -142,6 +139,12 @@ div.media-modal.wp-core-ui {
 
             &:hover {
                 background-color: var(--givewp-neutral-50);
+            }
+
+            &:disabled {
+                background-color: var(--givewp-neutral-50);
+                border-color: currentColor;
+                color: var(--givewp-neutral-300);
             }
         }
     }

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -2,6 +2,26 @@ div.media-modal.wp-core-ui {
     z-index: 99999999999999;
 }
 
+.givewp-media-library-control-wrapper {
+    &.is-disabled {
+        pointer-events: none;
+
+        .givewp-media-library-drop-area,
+        .givewp-media-library-control__image {
+            opacity: 0.7;
+        }
+
+        button {
+            background: #f6f7f7;
+            border-color: #dcdcde;
+            box-shadow: none;
+            color: #a7aaad;
+            cursor: default;
+            text-shadow: none;
+        }
+    }
+}
+
 .givewp-media-library-drop-area {
     text-align: center;
     padding: var(--givewp-spacing-8) 0;

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -36,10 +36,7 @@ div.media-modal.wp-core-ui {
     }
 }
 
-
 .givewp-media-library-control {
-    cursor: pointer;
-
     & > button:not(svg + button) {
         min-height: 160px;
 
@@ -49,6 +46,7 @@ div.media-modal.wp-core-ui {
     }
 
     &__reset {
+        cursor: pointer;
         position: relative;
         display: flex;
         background: transparent;
@@ -58,11 +56,19 @@ div.media-modal.wp-core-ui {
         color: var(--givewp-shades-white);
         border: none;
 
-        &:hover {
+        &:hover:not(:disabled) {
             svg {
                 visibility: visible;
                 pointer-events: none;
             }
+
+            img {
+                filter: brightness(80%);
+            }
+        }
+
+        &:disabled {
+            cursor: not-allowed;
         }
     }
 
@@ -82,11 +88,6 @@ div.media-modal.wp-core-ui {
         object-position: center;
         transition: filter 0.3s ease;
         border-radius: var(--givewp-rounded-4);
-        cursor: pointer;
-
-        &:hover {
-            filter: brightness(80%); /* Adjust the brightness percentage for the desired tint */
-        }
     }
 
     &__button {

--- a/src/Campaigns/resources/admin/components/Notifications/Notices.module.scss
+++ b/src/Campaigns/resources/admin/components/Notifications/Notices.module.scss
@@ -49,11 +49,10 @@
 
 }
 
-
 .noticeContainer {
     display: flex;
     flex-direction: column-reverse;
-    padding: var(--givewp-spacing-6);
+    padding: var(--givewp-spacing-4) var(--givewp-spacing-6) 0;
     gap: 10px;
 
     .notice {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2292]

## Description
This pull request improves the handling of the disabled state in Campaign Settings for archived campaigns by ensuring that all fields are disabled and properly styled.

🛠 Fixes
Ensured that the `ToggleControl` for `enableCampaignPage` correctly reflects the isDisabled state.

✨ Features
Styled Campaign Setting Fields to properly display the disabled state for:
- `input` and `select` elements (background, border, cursor, opacity, text shadow, and transform properties).
- `textarea` elements with appropriate styling for the disabled state.

🔧 Code Cleanup
- Removed an unused import for `campaignPageImage` in `Settings.tsx`.

## Affects
Campaign Settings tab

## Visuals
![CleanShot 2025-03-18 at 17 26 01](https://github.com/user-attachments/assets/56db0bbb-fe07-41f8-ad82-dc60a3bd3d77)
_Enabled_

![CleanShot 2025-03-18 at 17 29 09](https://github.com/user-attachments/assets/085db8ee-1071-40f5-9d1a-1ff142cb2f08)
_Disabled_

## Testing Instructions
In a Campaign Settings page, confirm that all fields are disabled (cannot be edited) and look like disabled when the Campaign is archive, that all fields are still working when in any other status.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2292]: https://stellarwp.atlassian.net/browse/GIVE-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ