### PR TITLE
Fix: Prevent the “More” button from triggering form submission

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -231,7 +231,10 @@ export default function CampaignsDetailsPage({campaignId}) {
 
                                 <button
                                     className={`button button-secondary ${styles.campaignButtonDots}`}
-                                    onClick={() => setShow({contextMenu: !show.contextMenu})}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        setShow({contextMenu: !show.contextMenu});
+                                    }}
                                 >
                                     <DotsIcons />
                                 </button>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2297]

## Description
This pull request includes a minor change to the CampaignDetailsPage component. It prevents the default action when clicking the button to toggle the context menu, ensuring that the Settings form is not submitted.

* [`src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx`](diffhunk://#diff-461710b1cb6206c00012b28588b98d4b62b17ee4e12e3795909d58826cb0f860L234-R237): Added `e.preventDefault()` to the button click event handler to prevent the default action.

## Affects
Campaign Settings page

## Visuals
![CleanShot 2025-03-19 at 10 01 54](https://github.com/user-attachments/assets/7318e208-5c5e-490d-8fcd-b3c3c65567f3)

## Testing Instructions
Confirm that clicking the “More” button to open the context menu on the Campaign Settings page does not trigger the Update Campaign action.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2297]: https://stellarwp.atlassian.net/browse/GIVE-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ