### PR TITLE
Refactor: replace donations table form filter with campaigns

### DIFF
--- a/src/Donations/DonationsAdminPage.php
+++ b/src/Donations/DonationsAdminPage.php
@@ -68,7 +68,7 @@ class DonationsAdminPage
         $data = [
             'apiRoot' => $this->apiRoot,
             'apiNonce' => $this->apiNonce,
-            'forms' => $this->getForms(),
+            'campaigns' => $this->getCampaigns(),
             'table' => give(DonationsListTable::class)->toArray(),
             'adminUrl' => $this->adminUrl,
             'paymentMode' => give_is_test_mode(),
@@ -120,26 +120,28 @@ class DonationsAdminPage
     /**
      * Retrieve a list of donation forms to populate the form filter dropdown
      *
+     * @unreleased replace formselect with campaigns.
      * @since 2.20.0
      * @return array
      */
-    private function getForms()
+    private function getCampaigns()
     {
-        $options = DB::table('posts')
+        $options = DB::table('give_campaigns')
             ->select(
-                ['ID', 'value'],
-                ['post_title', 'text']
+                ['id', 'value'],
+                ['campaign_title', 'text']
             )
-            ->where('post_type', 'give_forms')
-            ->whereIn('post_status', ['publish', 'draft', 'pending', 'private'])
             ->getAll(ARRAY_A);
 
-        return array_merge([
+        return array_merge(
             [
-                'value' => '0',
-                'text' => __('Any', 'give'),
+                [
+                    'value' => '0',
+                    'text' => __('Any', 'give'),
+                ]
             ],
-        ], $options);
+            $options
+        );
     }
 
     /**

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -73,6 +73,11 @@ class ListDonations extends Endpoint
                         'required' => false,
                         'default' => 0
                     ],
+                    'campaignId' => [
+                        'type' => 'integer',
+                        'required' => false,
+                        'default' => 0
+                    ],
                     'search' => [
                         'type' => 'string',
                         'required' => false,
@@ -234,9 +239,9 @@ class ListDonations extends Endpoint
         $search = $this->request->get_param('search');
         $start = $this->request->get_param('start');
         $end = $this->request->get_param('end');
-        $form = $this->request->get_param('form');
         $donor = $this->request->get_param('donor');
         $testMode = $this->request->get_param('testMode');
+        $campaignId = $this->request->get_param('campaignId');
 
         $dependencies = [
             DonationMetaKeys::MODE(),
@@ -274,10 +279,10 @@ class ListDonations extends Endpoint
             }
         }
 
-        if ($form) {
+        if ($campaignId) {
             $query
-                ->where('give_donationmeta_attach_meta_formId.meta_value', $form);
-            $dependencies[] = DonationMetaKeys::FORM_ID();
+                ->where('give_donationmeta_attach_meta_campaignId.meta_value', $campaignId);
+            $dependencies[] = DonationMetaKeys::CAMPAIGN_ID();
         }
 
         if ($start && $end) {

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -68,11 +68,6 @@ class ListDonations extends Endpoint
                         'default' => 30,
                         'minimum' => 1
                     ],
-                    'form' => [
-                        'type' => 'integer',
-                        'required' => false,
-                        'default' => 0
-                    ],
                     'campaignId' => [
                         'type' => 'integer',
                         'required' => false,

--- a/src/Donations/Endpoints/ListDonations.php
+++ b/src/Donations/Endpoints/ListDonations.php
@@ -13,6 +13,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 
 /**
+ * @unreleased replace form with campaignId.
  * @since 3.4.0 The class is extendable
  */
 class ListDonations extends Endpoint
@@ -242,7 +243,7 @@ class ListDonations extends Endpoint
             DonationMetaKeys::MODE(),
         ];
 
-        $hasWhereConditions = $search || $start || $end || $form || $donor;
+        $hasWhereConditions = $search || $start || $end || $campaignId || $donor;
 
         if ($search) {
             if (ctype_digit($search)) {

--- a/src/Donations/resources/components/DonationsListTable.tsx
+++ b/src/Donations/resources/components/DonationsListTable.tsx
@@ -17,7 +17,7 @@ declare global {
             apiNonce: string;
             apiRoot: string;
             adminUrl: string;
-            forms: Array<{value: string; text: string}>;
+            campaigns: Array<{value: string; text: string}>;
             table: {columns: Array<object>};
             paymentMode: boolean;
             manualDonations: boolean;
@@ -32,11 +32,11 @@ const API = new ListTableApi(window.GiveDonations);
 
 const filters: Array<FilterConfig> = [
     {
-        name: 'form',
+        name: 'campaignId',
         type: 'formselect',
-        text: __('Select Form', 'give'),
+        text: __('Select Campaign', 'give'),
         ariaLabel: __('filter donation forms by status', 'give'),
-        options: window.GiveDonations.forms,
+        options: window.GiveDonations.campaigns,
     },
     {
         name: 'search',

--- a/src/Donations/resources/components/DonationsListTable.tsx
+++ b/src/Donations/resources/components/DonationsListTable.tsx
@@ -35,7 +35,7 @@ const filters: Array<FilterConfig> = [
         name: 'campaignId',
         type: 'formselect',
         text: __('Select Campaign', 'give'),
-        ariaLabel: __('filter donation forms by status', 'give'),
+        ariaLabel: __('filter donations by campaign', 'give'),
         options: window.GiveDonations.campaigns,
     },
     {


### PR DESCRIPTION
Resolves [GIVE-2343]

## Description
This updates the Donations list table window and list table route to handle campaign filtering as opposed to form filtering.

## Affects
- DonationListTable window
- DonationListTable route (where-conditions &)
- DonationListTable filtering config

## Visuals
https://github.com/user-attachments/assets/1e9f0e77-438e-4aca-b342-2ec4de6bb1cc

## Testing Instructions
- Create several campaigns and publish multiple forms.
- Create several donations through these campaigns/forms.
- Visit the donation table and use the filter to filter by campaign.
- Verify only donations from the given campaign are listed.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2343]: https://stellarwp.atlassian.net/browse/GIVE-2343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ