### PR TITLE
Fix: migrated forms to campaigns allows goal amount to be 0

### DIFF
--- a/src/Campaigns/DataTransferObjects/CampaignGoalData.php
+++ b/src/Campaigns/DataTransferObjects/CampaignGoalData.php
@@ -31,7 +31,7 @@ class CampaignGoalData implements Arrayable
     /**
      * @var int
      */
-    private $goal;
+    public $goal;
 
     /**
      * @var int|string
@@ -103,7 +103,7 @@ class CampaignGoalData implements Arrayable
      */
     private function getActualFormatted(): string
     {
-        if ($this->campaign->goalType == CampaignGoalType::AMOUNT) {
+        if ($this->campaign->goalType->isAmount()) {
             return give_currency_filter(give_format_amount($this->actual));
         }
 
@@ -115,7 +115,7 @@ class CampaignGoalData implements Arrayable
      */
     private function getGoalFormatted(): string
     {
-        if ($this->campaign->goalType == CampaignGoalType::AMOUNT) {
+        if ($this->campaign->goalType->isAmount()) {
             return give_currency_filter(give_format_amount($this->goal));
         }
 

--- a/src/Campaigns/ListTable/Columns/GoalColumn.php
+++ b/src/Campaigns/ListTable/Columns/GoalColumn.php
@@ -38,6 +38,10 @@ class GoalColumn extends ModelColumn
     {
         $goalData = new CampaignGoalData($model);
 
+        if ($goalData->goal === 0) {
+            return __('No Goal Set', 'give');
+        }
+
         $template = '
             <div
                 role="progressbar"

--- a/src/Campaigns/Routes/RegisterCampaignRoutes.php
+++ b/src/Campaigns/Routes/RegisterCampaignRoutes.php
@@ -294,7 +294,6 @@ class RegisterCampaignRoutes
                 ],
                 'goal' => [
                     'type' => 'number',
-                    'minimum' => 1,
                     'description' => esc_html__('Campaign goal', 'give'),
                     'errorMessage' => esc_html__('Must be a number', 'give'),
                 ],
@@ -336,7 +335,7 @@ class RegisterCampaignRoutes
                     'then' => [
                         'properties' => [
                             'goal' => [
-                                'minimum' => 1,
+                                //'minimum' => 1,
                                 'type' => 'number',
                             ],
                         ],

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {useFormContext} from 'react-hook-form';
+import {useFormContext, useWatch} from 'react-hook-form';
 import {Upload} from '../../Inputs';
 import styles from '../CampaignDetailsPage.module.scss';
 import {ToggleControl} from '@wordpress/components';
@@ -25,13 +25,15 @@ export default function CampaignDetailsSettingsTab() {
         formState: {errors},
     } = useFormContext();
 
-    const [goalType, image, status, shortDescription, enableCampaignPage] = watch([
+    const [goal, goalType, image, status, shortDescription, enableCampaignPage] = watch([
+        'goal',
         'goalType',
         'image',
         'status',
         'shortDescription',
         'enableCampaignPage',
     ]);
+
     const isDisabled = status === 'archived';
 
     const goalInputAttributes = new CampaignGoalInputAttributes(goalType, currency);
@@ -195,7 +197,7 @@ export default function CampaignDetailsSettingsTab() {
                                     currency={currency as CurrencyCode}
                                     disabled={isDisabled}
                                     placeholder={goalInputAttributes.getPlaceholder()}
-                                    value={watch('goal')}
+                                    value={goal}
                                     onValueChange={(value) => {
                                         setValue('goal', Number(value ?? 0), {shouldDirty: true});
                                     }}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -197,7 +197,7 @@ export default function CampaignDetailsSettingsTab() {
                                     placeholder={goalInputAttributes.getPlaceholder()}
                                     value={watch('goal')}
                                     onValueChange={(value) => {
-                                        setValue('goal', Number(value), {shouldDirty: true});
+                                        setValue('goal', Number(value ?? 0), {shouldDirty: true});
                                     }}
                                 />
                             </div>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Tabs/Settings.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {useFormContext, useWatch} from 'react-hook-form';
+import {useFormContext} from 'react-hook-form';
 import {Upload} from '../../Inputs';
 import styles from '../CampaignDetailsPage.module.scss';
 import {ToggleControl} from '@wordpress/components';

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -75,6 +75,7 @@ export default function CampaignsDetailsPage({campaignId}) {
 
     const methods = useForm<Campaign>({
         mode: 'onBlur',
+        shouldFocusError: true,
         ...resolver,
     });
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Currently, campaigns require a goal.  However, forms do not.  So when an existing form is migrated to a campaign and a goal was not enabled, the campaign goal is defaulting to amount and setting value to 0.  This is a problem because we are currently requiring a goal value so in this scenario you would not be able to update the campaign until you update the goal value.

Ideally, we should have a setting for enabling campaign goals instead of requiring one.

This PR is a quick fix that allows a goal amount to be 0, prevents the goal amount input from displaying NaN, and sets react-hook-form to focus on error inputs.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Campaign goals

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before**
<img width="1311" alt="Screenshot 2025-03-21 at 6 08 43 PM" src="https://github.com/user-attachments/assets/3697775b-91ee-450d-a8fe-68955fc642a6" />


<img width="894" alt="Screenshot 2025-03-22 at 7 12 22 AM" src="https://github.com/user-attachments/assets/dcfe73f8-b10d-4bfb-98d3-0d92b8758a1d" />


**After**

<img width="1306" alt="Screenshot 2025-03-22 at 7 36 58 AM" src="https://github.com/user-attachments/assets/2f100dd7-0aef-4638-a602-7d7da90f9121" />

<img width="1305" alt="Screenshot 2025-03-22 at 7 37 25 AM" src="https://github.com/user-attachments/assets/496a91c1-9ff1-49c1-94b7-31b1db17f11f" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Set a campaign goal amount to be 0 and make sure you can edit the campaign.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

