### PR TITLE
Refactor: Enable GiftAid Form download immediately in V3 Confirmation Page

### DIFF
--- a/src/DonationForms/Actions/ValidateReceiptViewPermission.php
+++ b/src/DonationForms/Actions/ValidateReceiptViewPermission.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Give\DonationForms\Actions;
+
+/**
+ * @unreleased
+ */
+class ValidateReceiptViewPermission
+{
+    /**
+     * The GET parameter name for the receipt ID.
+     *
+     * @var string
+     */
+    private const RECEIPT_ID = 'receipt_id';
+
+    /**
+     * @unreleased
+     */
+    public function __invoke(bool $canViewReceipt, int $donationId): bool
+    {
+        if (!isset($_GET[self::RECEIPT_ID])) {
+            return $canViewReceipt;
+        }
+
+        $receiptId = give_clean($_GET[self::RECEIPT_ID]);
+
+        if (empty($receiptId)) {
+            return $canViewReceipt;
+        }
+
+        $donation = give()->donations->getByReceiptId($receiptId);
+
+        if (!$donation || $donation->id !== $donationId) {
+            return $canViewReceipt;
+        }
+
+        return true;
+    }
+}

--- a/src/DonationForms/Controllers/DonationConfirmationReceiptViewController.php
+++ b/src/DonationForms/Controllers/DonationConfirmationReceiptViewController.php
@@ -5,8 +5,6 @@ namespace Give\DonationForms\Controllers;
 use Give\DonationForms\DataTransferObjects\DonationConfirmationReceiptViewRouteData;
 use Give\DonationForms\ViewModels\DonationConfirmationReceiptViewModel;
 use Give\Donations\Models\Donation;
-use Give\Donations\ValueObjects\DonationMetaKeys;
-use Give\Framework\QueryBuilder\QueryBuilder;
 
 class DonationConfirmationReceiptViewController
 {
@@ -21,7 +19,7 @@ class DonationConfirmationReceiptViewController
             return '';
         }
 
-        $donation = $this->getDonationByReceiptId($data->receiptId);
+        $donation = give()->donations->getByReceiptId($data->receiptId);
 
         if (!$donation) {
             return '';
@@ -38,23 +36,5 @@ class DonationConfirmationReceiptViewController
 
         ob_clean();
         return (new DonationConfirmationReceiptViewModel($donation))->render();
-    }
-
-    /**
-     * @since 3.0.0
-     *
-     * @return Donation|null
-     */
-    private function getDonationByReceiptId(string $receiptId)
-    {
-        return give()->donations->prepareQuery()
-            ->where('post_type', 'give_payment')
-            ->where('ID', function (QueryBuilder $builder) use ($receiptId) {
-                $builder
-                    ->select('donation_id')
-                    ->from('give_donationmeta')
-                    ->where('meta_key', DonationMetaKeys::PURCHASE_KEY()->getValue())
-                    ->where('meta_value', $receiptId);
-            })->get();
     }
 }

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -10,6 +10,7 @@ use Give\DonationForms\Actions\PrintFormMetaTags;
 use Give\DonationForms\Actions\ReplaceGiveReceiptShortcodeViewWithDonationConfirmationIframe;
 use Give\DonationForms\Actions\SanitizeDonationFormPreviewRequest;
 use Give\DonationForms\Actions\StoreBackwardsCompatibleFormMeta;
+use Give\DonationForms\Actions\ValidateReceiptViewPermission;
 use Give\DonationForms\AsyncData\Actions\GetAsyncFormDataForListView;
 use Give\DonationForms\AsyncData\Actions\GiveGoalProgressStats;
 use Give\DonationForms\AsyncData\Actions\LoadAsyncDataAssets;
@@ -85,6 +86,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerPostStatus();
         $this->registerAddFormSubmenuLink();
         $this->registerHoneyPotField();
+        $this->registerReceiptViewPermission();
 
         Hooks::addAction('givewp_donation_form_created', StoreBackwardsCompatibleFormMeta::class);
         Hooks::addAction('givewp_donation_form_updated', StoreBackwardsCompatibleFormMeta::class);
@@ -399,5 +401,13 @@ class ServiceProvider implements ServiceProviderInterface
                 (new AddHoneyPotFieldToDonationForms())($form, $honeypotFieldName);
             }
         }, 10, 2);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerReceiptViewPermission()
+    {
+        Hooks::addFilter('give_can_view_receipt', ValidateReceiptViewPermission::class, '__invoke', 10, 2);
     }
 }

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -166,6 +166,30 @@ class DonationRepository
     }
 
     /**
+     * @unreleased
+     */
+    public function getByReceiptId(string $receiptId): ?Donation
+    {
+        return $this->queryByReceiptId($receiptId)->get();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function queryByReceiptId(string $receiptId): ModelQueryBuilder
+    {
+        return $this->prepareQuery()
+            ->where('post_type', 'give_payment')
+            ->whereIn('ID', function (QueryBuilder $builder) use ($receiptId) {
+                $builder
+                    ->select('donation_id')
+                    ->from('give_donationmeta')
+                    ->where('meta_key', DonationMetaKeys::PURCHASE_KEY)
+                    ->where('meta_value', $receiptId);
+            });
+    }
+
+    /**
      * @since 3.20.0 store meta using native WP functions
      * @since 2.23.0 retrieve the post_parent instead of relying on parentId property
      * @since 2.21.0 replace actions with givewp_donation_creating and givewp_donation_created

--- a/tests/Unit/Actions/ValidateReceiptViewPermissionTest.php
+++ b/tests/Unit/Actions/ValidateReceiptViewPermissionTest.php
@@ -78,6 +78,7 @@ class ValidateReceiptViewPermissionTest extends TestCase
      */
     public function testReturnsOriginalPermissionWhenDonationIdDoesNotMatch(): void
     {
+        /** @var Donation $donation */
         $donation = Donation::factory()->create();
         $_GET['receipt_id'] = $donation->purchaseKey;
 
@@ -92,6 +93,7 @@ class ValidateReceiptViewPermissionTest extends TestCase
      */
     public function testReturnsTrueWhenDonationIdMatches(): void
     {
+        /** @var Donation $donation */
         $donation = Donation::factory()->create();
         $_GET['receipt_id'] = $donation->purchaseKey;
 

--- a/tests/Unit/Actions/ValidateReceiptViewPermissionTest.php
+++ b/tests/Unit/Actions/ValidateReceiptViewPermissionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Give\Tests\Unit\Actions;
+
+use Give\DonationForms\Actions\ValidateReceiptViewPermission;
+use Give\Donations\Models\Donation;
+use Give\Tests\TestCase;
+
+/**
+ * @unreleased
+ */
+class ValidateReceiptViewPermissionTest extends TestCase
+{
+    /**
+     * @unreleased
+     */
+    private ValidateReceiptViewPermission $action;
+
+    /**
+     * @unreleased
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->action = new ValidateReceiptViewPermission();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        unset($_GET['receipt_id']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsOriginalPermissionWhenReceiptIdIsNotSet(): void
+    {
+        $result = ($this->action)(false, 123);
+        $this->assertFalse($result);
+
+        $result = ($this->action)(true, 123);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsOriginalPermissionWhenReceiptIdIsEmpty(): void
+    {
+        $_GET['receipt_id'] = '';
+
+        $result = ($this->action)(false, 123);
+        $this->assertFalse($result);
+
+        $result = ($this->action)(true, 123);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsOriginalPermissionWhenDonationNotFound(): void
+    {
+        $_GET['receipt_id'] = 'ABC123';
+
+        $result = ($this->action)(false, 123);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws \Exception
+     */
+    public function testReturnsOriginalPermissionWhenDonationIdDoesNotMatch(): void
+    {
+        $donation = Donation::factory()->create();
+        $_GET['receipt_id'] = $donation->purchaseKey;
+
+        $result = ($this->action)(false, 123);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws \Exception
+     */
+    public function testReturnsTrueWhenDonationIdMatches(): void
+    {
+        $donation = Donation::factory()->create();
+        $_GET['receipt_id'] = $donation->purchaseKey;
+
+        $result = ($this->action)(false, $donation->id);
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2324]
Depends on https://github.com/impress-org/give-gift-aid/pull/192

## Description
This pull request addresses an issue where the GiftAid Declaration Form download link fails validation permissions right after a donation is made using a V3 form. This happens because, in V3, the donation is not set in the user session as in Legacy Donation Forms, which prevents the form from being downloaded immediately.

To fix this, the pull request hooks into the `give_can_view_receipt` filter and attempts to validate the current view for V3 forms. If it’s not a V3 form, it simply returns the original value provided by the filter.

### New Feature: Validate Receipt View Permissions

* [`src/DonationForms/Actions/ValidateReceiptViewPermission.php`](diffhunk://#diff-50af02626f127e283e1ca6231318dbce7c63e2184a4f8ab8ca1e01881b230381R1-R40): Added a new action class `ValidateReceiptViewPermission` to handle the validation of receipt view permissions.
* [`src/DonationForms/ServiceProvider.php`](diffhunk://#diff-852cce29f02c66e4baa6b9aa95caf8ee92576669565057a4f5f7ad1201400aceR13): Registered the new action class in the service provider. [[1]](diffhunk://#diff-852cce29f02c66e4baa6b9aa95caf8ee92576669565057a4f5f7ad1201400aceR13) [[2]](diffhunk://#diff-852cce29f02c66e4baa6b9aa95caf8ee92576669565057a4f5f7ad1201400aceR89) [[3]](diffhunk://#diff-852cce29f02c66e4baa6b9aa95caf8ee92576669565057a4f5f7ad1201400aceR405-R412)

### Refactoring

* [`src/DonationForms/Controllers/DonationConfirmationReceiptViewController.php`](diffhunk://#diff-be517cad0b555948b39749482c7a0f6934bd38fdfeba4ddf2fd8dbafd940ed03L24-R22): Updated the controller to use the new `getByReceiptId` method from the `DonationRepository` instead of a custom query. [[1]](diffhunk://#diff-be517cad0b555948b39749482c7a0f6934bd38fdfeba4ddf2fd8dbafd940ed03L24-R22) [[2]](diffhunk://#diff-be517cad0b555948b39749482c7a0f6934bd38fdfeba4ddf2fd8dbafd940ed03L42-L59)
* [`src/Donations/Repositories/DonationRepository.php`](diffhunk://#diff-3f82b85c8ae7136fa03f994a58461956262ab368aa6de4bfe1402950540f5776R168-R191): Added `getByReceiptId` and `queryByReceiptId` methods to the `DonationRepository` for retrieving donations by receipt ID.

### Testing

* [`tests/Unit/Actions/ValidateReceiptViewPermissionTest.php`](diffhunk://#diff-0de42e2620e024da3d524d734aa7d2dad748af8770d220c9571f1108a9750025R1-R101): Added unit tests for the `ValidateReceiptViewPermission` action to ensure it works as expected.

## Affects
Gift Aid Download Form link in Receipts

## Testing Instructions
1.	Go to a donation form using the V3 Form Template.
2.	Fill out the form and enable the Gift Aid option.
3.	Complete the donation.
4.	On the confirmation page, find and click the GiftAid Declaration Form download link.
5.	Make sure the form downloads successfully without any validation or permission errors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2324]: https://stellarwp.atlassian.net/browse/GIVE-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ