### PR TITLE
fix: prevent parent page scroll on initial step of multi-step forms

### DIFF
--- a/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
@@ -18,11 +18,14 @@ export default function Steps({steps}: { steps: StepObject[] }) {
     const previousStep = usePrevious(currentStep);
 
     /**
+     * @unreleased prevent scroll on initial step.
      * @since 3.16.0 Scroll to the top of the iframe when the step changes.
      */
     useEffect(() => {
-        /* @ts-ignore */
-        window.parent.document.getElementById(window.parentIFrame?.getId())?.scrollIntoView()
+        if (currentStep !== 0) {
+            /* @ts-ignore */
+            window.parent.document.getElementById(window.parentIFrame?.getId())?.scrollIntoView()
+        }
     }, [currentStep]);
 
     const stepElements = steps?.map(({id, element}) => {

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
@@ -22,7 +22,7 @@ export default function Steps({steps}: { steps: StepObject[] }) {
      * @since 3.16.0 Scroll to the top of the iframe when the step changes.
      */
     useEffect(() => {
-        if (currentStep !== 0) {
+        if (currentStep > 0) {
             /* @ts-ignore */
             window.parent.document.getElementById(window.parentIFrame?.getId())?.scrollIntoView()
         }


### PR DESCRIPTION
Resolves [GIVE-1300]

## Description
This PR prevents the iframe from scrolling into view on the initial step of MultiStep & Two-panel forms.

## Affects

## Visuals

## Testing Instructions
- Create a v3 Multi-Step form.
- Use the DonationForm block to render it on a page. Make sure to add content to the page so the form is pushed down far enough that you'd have to scroll down to view.
- View the page in safari & other common browsers to confirm that the form is not scrolled into view when visiting the page.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-1300]: https://stellarwp.atlassian.net/browse/GIVE-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ