### PR TITLE
Refactor: enable async load for campaign forms list table

### DIFF
--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -168,18 +168,6 @@ class ServiceProvider implements ServiceProviderInterface
             Hooks::addAction('admin_enqueue_scripts', DonationFormsAdminPage::class, 'loadScripts');
         }
 
-        /**
-         * We implemented a feature to load the stats columns ("Goal", "Donations" and "Revenue") using an async approach,
-         * so we could prevent a long page load on websites with lots of forms. However, the campaign details page's current
-         * "Forms" tab still doesn't support it. Still, it's using the same Form List Table that active the async approach by
-         * default, so the line below is necessary to disable it while we still don't have support for async loading on this screen.
-         *
-         * @see https://github.com/impress-org/givewp/pull/7483
-         */
-        if (!defined('GIVE_IS_ALL_STATS_COLUMNS_ASYNC_ON_ADMIN_FORM_LIST_VIEWS')) {
-            define('GIVE_IS_ALL_STATS_COLUMNS_ASYNC_ON_ADMIN_FORM_LIST_VIEWS', false);
-        }
-
         Hooks::addAction('admin_init', RedirectLegacyCreateFormToCreateCampaign::class);
 
         Hooks::addAction('save_post_give_forms', AddCampaignFormFromRequest::class, 'optionBasedFormEditor', 10, 3);

--- a/src/DonationForms/AsyncData/resources/loadAsyncData.js
+++ b/src/DonationForms/AsyncData/resources/loadAsyncData.js
@@ -7,7 +7,7 @@
  * 2) When the user adds a block in the WP block editor
  * 3) When the user scrolls the mouse
  * 4) When the user resizes the screen
- * 5) the "Forms" tab of the campaign details page gets updated
+ * 5) When the "Forms" tab of the campaign details page gets updated
  *
  * @since 3.16.0
  */

--- a/src/DonationForms/AsyncData/resources/loadAsyncData.js
+++ b/src/DonationForms/AsyncData/resources/loadAsyncData.js
@@ -9,6 +9,7 @@
  * 4) When the user resizes the screen
  * 5) When the "Forms" tab of the campaign details page gets updated
  *
+ * @unreleased Add support to campaign details page (the "Forms" tab)
  * @since 3.16.0
  */
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/DonationForms/AsyncData/resources/loadAsyncData.js
+++ b/src/DonationForms/AsyncData/resources/loadAsyncData.js
@@ -353,21 +353,24 @@ document.addEventListener('DOMContentLoaded', () => {
     // Trigger the async logic every time the "Forms" tab of the campaign details page gets updated
     window.onload = function () {
         const campaignsPage = document.querySelector('#give-admin-campaigns-root');
-        if (!!campaignsPage) {
-            // create an Observer instance
-            const resizeObserver = new ResizeObserver((entries) => {
-                const queryString = window.location.search;
-                const params = new URLSearchParams(queryString);
-                const isCampaignFormsTab = params.has('tab') && 'forms' === params.get('tab');
-                if (isCampaignFormsTab) {
-                    window.GiveDonationFormsAsyncData.scriptDebug &&
-                        console.log('Campaigns Page height changed:', entries[0].target.clientHeight);
-                    maybeLoadAsyncData();
-                }
-            });
 
-            // start observing a DOM node
-            resizeObserver.observe(campaignsPage);
+        if (!campaignsPage) {
+            return;
         }
+
+        const observer = new MutationObserver(() => {
+            const params = new URLSearchParams(window.location.search);
+            const isCampaignFormsTab = params.get('tab') === 'forms';
+
+            if (isCampaignFormsTab) {
+                window.GiveDonationFormsAsyncData.scriptDebug && console.log('Campaigns Page mutated on Forms Tab');
+                maybeLoadAsyncData();
+            }
+        });
+
+        observer.observe(campaignsPage, {
+            childList: true,
+            subtree: true,
+        });
     };
 });

--- a/src/DonationForms/AsyncData/resources/loadAsyncData.js
+++ b/src/DonationForms/AsyncData/resources/loadAsyncData.js
@@ -7,6 +7,7 @@
  * 2) When the user adds a block in the WP block editor
  * 3) When the user scrolls the mouse
  * 4) When the user resizes the screen
+ * 5) the "Forms" tab of the campaign details page gets updated
  *
  * @since 3.16.0
  */
@@ -345,6 +346,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // start observing a DOM node
             resizeObserver.observe(wpBlockEditorContent);
+        }
+    };
+
+    // Trigger the async logic every time the "Forms" tab of the campaign details page gets updated
+    window.onload = function () {
+        const campaignsPage = document.querySelector('#give-admin-campaigns-root');
+        if (!!campaignsPage) {
+            // create an Observer instance
+            const resizeObserver = new ResizeObserver((entries) => {
+                const queryString = window.location.search;
+                const params = new URLSearchParams(queryString);
+                const isCampaignFormsTab = params.has('tab') && 'forms' === params.get('tab');
+                if (isCampaignFormsTab) {
+                    window.GiveDonationFormsAsyncData.scriptDebug &&
+                        console.log('Campaigns Page height changed:', entries[0].target.clientHeight);
+                    maybeLoadAsyncData();
+                }
+            });
+
+            // start observing a DOM node
+            resizeObserver.observe(campaignsPage);
         }
     };
 });

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -123,7 +123,8 @@ class ServiceProvider implements ServiceProviderInterface
         // Load assets on the admin form list pages
         $isLegacyAdminFormListPage = isset($_GET['post_type']) && 'give_forms' === $_GET['post_type'] && ! isset($_GET['page']);
         $isAdminFormListPage = isset($_GET['page']) && 'give-forms' === $_GET['page'];
-        if ($isLegacyAdminFormListPage || $isAdminFormListPage) {
+        $isAdminCampaignDetailsPage = isset($_GET['page'], $_GET['id']) && 'give-campaigns' === $_GET['page'];
+        if ($isLegacyAdminFormListPage || $isAdminFormListPage || $isAdminCampaignDetailsPage) {
             Hooks::addAction('admin_enqueue_scripts', LoadAsyncDataAssets::class);
         }
 

--- a/src/DonationForms/ServiceProvider.php
+++ b/src/DonationForms/ServiceProvider.php
@@ -107,6 +107,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased Add support to campaign details page (the "Forms" tab)
      * @since 3.15.0
      */
     private function registerAsyncData()


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2356]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Previously, we implemented the async load feature for the `Goal`, `Donations`, and `Revenue` columns of the _"All Forms"_ list table on this PR: https://github.com/impress-org/givewp/pull/7483

Since the campaigns forms tab is using this same list table, this PR aims to enable this same feature on the campaign details page as well so we can prevent slow page loads in cases where a website has multiple forms/donations associated with a single campaign.

Right now, this feature is enabled by default, but after the campaigns release, we can work to optimize the queries like we did here: https://github.com/impress-org/givewp/pull/7819

So, this feature should soon be disabled by default.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign forms list table

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/05cf7b19-c3c2-4ef1-9b3e-65334f10cedf)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Go to the _"Forms"_ tab of a campaign and make sure the `Goal`, `Donations`, and `Revenue` columns are loading the data asynchronously.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2356]: https://stellarwp.atlassian.net/browse/GIVE-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ