### PR TITLE
Fix: displays missing switch buttons and hides "All Forms" menu item when using the legacy list table

### DIFF
--- a/assets/src/css/admin/_components.admin-header.scss
+++ b/assets/src/css/admin/_components.admin-header.scss
@@ -5,10 +5,6 @@
 .post-type-give_forms,
 .give_forms_page_give-subscriptions {
 
-    .page-title-action:not(.switch-new-view) {
-        display: none;
-    }
-
 	.wp-header-end + .notice {
 		margin-top: 11px;
 	}

--- a/src/DonationForms/V2/DonationFormsAdminPage.php
+++ b/src/DonationForms/V2/DonationFormsAdminPage.php
@@ -262,6 +262,11 @@ class DonationFormsAdminPage
     public function renderReactSwitch()
     {
         ?>
+        <style>
+            .page-title-action:not(.switch-new-view) {
+                display: none;
+            }
+        </style>
         <script type="text/javascript">
             function showReactTable() {
                 fetch('<?php echo esc_url_raw(rest_url('give-api/v2/admin/forms/view?isLegacy=0')) ?>', {

--- a/src/DonationForms/V2/ServiceProvider.php
+++ b/src/DonationForms/V2/ServiceProvider.php
@@ -33,11 +33,10 @@ class ServiceProvider implements ServiceProviderInterface
     {
         $userId = get_current_user_id();
         $showLegacy = get_user_meta($userId, '_give_donation_forms_archive_show_legacy', true);
-        // only register new admin page if user hasn't chosen to use the old one
-        if (empty($showLegacy)) {
-            Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'register', 0);
-            Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'highlightAllFormsMenuItem');
 
+        Hooks::addAction('admin_menu', DonationFormsAdminPage::class, 'register', 0);
+
+        if (empty($showLegacy)) {
             if (DonationFormsAdminPage::isShowing()) {
                 Hooks::addAction('admin_enqueue_scripts', DonationFormsAdminPage::class, 'loadScripts');
             }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2357]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes two problems:

1. It adds back the `Switch to New View` button on the legacy list tables for the _"Donors"_, _"Donations"_, and _"Subscriptions"_ pages.
2. Hides the `All Forms` menu item when using the legacy list table on the _"All Forms"_ page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The "Donors", "Donations", and "Subscriptions" legacy list tables
- The GiveWP sidebar menu

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/70605483-2b87-437d-ac71-ea46936e1031)

![image](https://github.com/user-attachments/assets/d46ea730-ec30-4c57-ab5c-145d6cd807f7)

![image](https://github.com/user-attachments/assets/4f8f259f-7ba6-4d15-8f1b-47cbc89e2309)

![image](https://github.com/user-attachments/assets/b906c578-0fb3-4824-951d-1804af954975)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**Problem 1:**

1. Go to the _"Donors"_, _"Donations"_, and _"Subscriptions"_ pages and click on the `Switch to Legacy View` button for each one of them.
2. On the legacy views accessed on the previous step, make sure you can see the `Switch to New View` button.

**Problem 2:**

1. Access the "All Forms" page using a URL like this: `https://givewp.local/wp-admin/edit.php?post_type=give_forms&page=give-forms`
2. Click on the `Switch to Legacy View` button
3. Make sure the `All Forms` menu item isn't displayed on the GiveWP sidebar menu


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2357]: https://stellarwp.atlassian.net/browse/GIVE-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ