### PR TITLE
Fix: remove target attribute from form title anchor tag

### DIFF
--- a/src/DonationForms/V2/ListTable/Columns/TitleColumn.php
+++ b/src/DonationForms/V2/ListTable/Columns/TitleColumn.php
@@ -50,7 +50,7 @@ class TitleColumn extends ModelColumn
     public function getCellValue($model): string
     {
         return sprintf(
-            '<a href="%s" target="_blank" rel="noopener noreferrer" class="giveDonationFormsLink">%s</a>',
+            '<a href="%s" rel="noopener noreferrer" class="giveDonationFormsLink">%s</a>',
             add_query_arg(['locale' => Language::getLocale()], get_edit_post_link($model->id)),
             wp_strip_all_tags($model->title)
         );


### PR DESCRIPTION
Resolves [GIVE-2321]

## Description
This ensures the donation form title anchor tag opens in the same window to achieve parity with the edit anchor tag.

## Affects
Donation Forms list table

## Visuals
https://github.com/user-attachments/assets/bd2c2732-a93c-4ed0-ae0e-751c3ff7e31c

## Testing Instructions
- Visit the donation forms  list table. 
- Click on the title of the form.
- Verify the link opens in the same page as opposed to a new page.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2321]: https://stellarwp.atlassian.net/browse/GIVE-2321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ