### PR TITLE
fix/update create campaignPage button and tooltip styles

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/CampaignDetailsPage.module.scss
@@ -539,6 +539,14 @@ select[name="campaignId"] {
         }
     }
 
+    .createCampaignPageButton{
+        background-color: var(--givewp-shades-white);
+
+        &:hover {
+            background-color: #F0F6FC;
+        }
+    }
+
     .editCampaignPageButton {
         color: #060c1a;
         background-color: var(--givewp-neutral-100);

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/CampaignNotice.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/CampaignNotice.tsx
@@ -20,11 +20,13 @@ export default ({title, description, type, linkHref, linkText, handleDismiss}: N
                 <CloseIcon />
             </div>
         )}
+        <div>
         <h3>
             {title}
         </h3>
         <div className={styles['content']}>
             {description}
+        </div>
         </div>
         {linkText && (
             <div className={styles['content']}>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/Notices.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/Notices.module.scss
@@ -10,14 +10,15 @@
     padding: 16px 24px 24px;
     border-radius: 8px;
     box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.15);
-    border: solid 2px #6b7280;
-    background-color: #fff;
+    border: solid 2px var(--givewp-neutral-400);
+    background-color: var(--givewp-shades-white);
 
     h3 {
-        padding: 0;
+        padding-bottom: 8px;
         margin: 0;
-        font-size: 16px;
-        color: #060c1a;
+        font-size: 1rem;
+        color: var(--givewp-neutral-900);
+        line-height: 1.5rem;
     }
 }
 
@@ -49,7 +50,8 @@
 }
 
 .content {
-    font-size: 14px;
-    color: #1f2937;
+    font-size: 0.875rem;
+    color: var(--givewp-neutral-700);
     font-weight: normal;
+    line-height: 1.25rem;
 }


### PR DESCRIPTION
## Description
This changes the default and hover state for the create campaign page button and updates the spacing for the tooltip component.


## Affects
This affects the UI of the create campaign page button and tooltip.

## Visuals

Before
<img width="199" alt="Screenshot 2025-03-27 at 5 21 15 PM" src="https://github.com/user-attachments/assets/17c3f6aa-aa58-4087-8a43-16b1abf4886a" />
<img width="201" alt="Screenshot 2025-03-27 at 5 21 22 PM" src="https://github.com/user-attachments/assets/0d29746b-ecf9-4030-8309-6ca3f3efd1e4" />
<img width="384" alt="Screenshot 2025-03-27 at 5 21 31 PM" src="https://github.com/user-attachments/assets/b912c1f3-affb-4030-b697-12f4cc1937f0" />


After
<img width="205" alt="Screenshot 2025-03-27 at 5 19 53 PM" src="https://github.com/user-attachments/assets/3473787a-3ab5-4b07-8358-8550bf4cdb3c" />
<img width="207" alt="Screenshot 2025-03-27 at 5 20 00 PM" src="https://github.com/user-attachments/assets/45766020-653f-4256-a251-e28af40d4894" />
<img width="389" alt="Screenshot 2025-03-27 at 5 20 11 PM" src="https://github.com/user-attachments/assets/dedd8fa1-155c-4cc9-a949-75ca4af4031b" />



## Testing Instructions
Check the tooltip for for campaign intros, and the default and hover state for the "create campaign page" button.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

