### PR TITLE
Feature: add default form indicator to list table

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -46,7 +46,7 @@ export default function CampaignsDetailsPage({campaignId}) {
     const [isCreatingPage, setIsCreatingPage] = useState<boolean>(false);
     const [show, _setShowValue] = useState<Show>({
         contextMenu: false,
-        confirmationModal: false
+        confirmationModal: false,
     });
 
     const dispatch = useDispatch('givewp/campaign-notifications');
@@ -81,16 +81,34 @@ export default function CampaignsDetailsPage({campaignId}) {
 
     const {formState, handleSubmit, reset, setValue} = methods;
 
+    // Close context menu when clicked outside
+    useEffect(() => {
+        document.addEventListener('click', (e) => {
+            if (show.contextMenu) {
+                return;
+            }
+
+            if (
+                e.target instanceof HTMLElement &&
+                !e.target.closest(`.${styles.campaignButtonDots}`) &&
+                !e.target.closest(`.${styles.contextMenu}`)
+            ) {
+                setShow({contextMenu: false});
+                (document.querySelector(`.${styles.campaignButtonDots}`) as HTMLElement)?.blur();
+            }
+        });
+    }, []);
+
     // Set default values when campaign is loaded
     useEffect(() => {
         if (hasResolved) {
             const {pageId, ...rest} = campaign;
             // exclude pageId from default values if null
-             if (pageId > 0) {
+            if (pageId > 0) {
                 reset({...campaign, pageId});
             } else {
                 reset({...rest});
-             }
+            }
         }
     }, [hasResolved]);
 
@@ -242,7 +260,9 @@ export default function CampaignsDetailsPage({campaignId}) {
                                         onClick={handleCampaignPageCreation}
                                         disabled={isCreatingPage}
                                     >
-                                        {isCreatingPage ? __('Creating Campaign Page', 'give') : __('Create Campaign Page', 'give')}
+                                        {isCreatingPage
+                                            ? __('Creating Campaign Page', 'give')
+                                            : __('Create Campaign Page', 'give')}
                                     </button>
                                 )}
 

--- a/src/DonationForms/V2/ListTable/Columns/TitleColumn.php
+++ b/src/DonationForms/V2/ListTable/Columns/TitleColumn.php
@@ -50,8 +50,9 @@ class TitleColumn extends ModelColumn
     public function getCellValue($model): string
     {
         return sprintf(
-            '<a href="%s" rel="noopener noreferrer" class="giveDonationFormsLink">%s</a>',
+            '<a href="%s" rel="noopener noreferrer" class="giveDonationFormsLink" title="%s">%s</a>',
             add_query_arg(['locale' => Language::getLocale()], get_edit_post_link($model->id)),
+            esc_attr($model->title),
             wp_strip_all_tags($model->title)
         );
     }

--- a/src/DonationForms/V2/ListTable/DonationFormsListTable.php
+++ b/src/DonationForms/V2/ListTable/DonationFormsListTable.php
@@ -7,7 +7,6 @@ use Give\DonationForms\V2\ListTable\Columns\DonationCountColumn;
 use Give\DonationForms\V2\ListTable\Columns\DonationRevenueColumn;
 use Give\DonationForms\V2\ListTable\Columns\GoalColumn;
 use Give\DonationForms\V2\ListTable\Columns\IdColumn;
-use Give\DonationForms\V2\ListTable\Columns\ShortcodeColumn;
 use Give\DonationForms\V2\ListTable\Columns\StatusColumn;
 use Give\DonationForms\V2\ListTable\Columns\TitleColumn;
 use Give\Framework\ListTable\ListTable;
@@ -40,7 +39,6 @@ class DonationFormsListTable extends ListTable
             new GoalColumn(),
             new DonationCountColumn(),
             new DonationRevenueColumn(),
-            new ShortcodeColumn(),
             new DateCreatedColumn(),
             new StatusColumn(),
         ];
@@ -59,7 +57,6 @@ class DonationFormsListTable extends ListTable
             GoalColumn::getId(),
             DonationCountColumn::getId(),
             DonationRevenueColumn::getId(),
-            ShortcodeColumn::getId(),
             DateCreatedColumn::getId(),
             StatusColumn::getId(),
         ];

--- a/src/DonationForms/V2/ListTable/DonationFormsListTable.php
+++ b/src/DonationForms/V2/ListTable/DonationFormsListTable.php
@@ -7,7 +7,6 @@ use Give\DonationForms\V2\ListTable\Columns\DonationCountColumn;
 use Give\DonationForms\V2\ListTable\Columns\DonationRevenueColumn;
 use Give\DonationForms\V2\ListTable\Columns\GoalColumn;
 use Give\DonationForms\V2\ListTable\Columns\IdColumn;
-use Give\DonationForms\V2\ListTable\Columns\LevelsColumn;
 use Give\DonationForms\V2\ListTable\Columns\ShortcodeColumn;
 use Give\DonationForms\V2\ListTable\Columns\StatusColumn;
 use Give\DonationForms\V2\ListTable\Columns\TitleColumn;
@@ -38,7 +37,6 @@ class DonationFormsListTable extends ListTable
         return [
             new IdColumn(),
             new TitleColumn(),
-            new LevelsColumn(),
             new GoalColumn(),
             new DonationCountColumn(),
             new DonationRevenueColumn(),
@@ -58,7 +56,6 @@ class DonationFormsListTable extends ListTable
         return [
             IdColumn::getId(),
             TitleColumn::getId(),
-            LevelsColumn::getId(),
             GoalColumn::getId(),
             DonationCountColumn::getId(),
             DonationRevenueColumn::getId(),

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -112,33 +112,24 @@ const columnFilters: Array<ColumnFilterConfig> = [
     {
         column: 'title',
         filter: (item) => {
+            const CubeTooltip = () => (
+                <div className={styles.tooltipContainer}>
+                    <CubeIcon />
+                    <div className={styles.tooltip}>{__('Uses the Visual Form Builder', 'give')}</div>
+                </div>
+            );
+
             return (
                 <>
-                    {item?.v3form ? (
-                        <div className={styles.titleContainer}>
-                            <div className={styles.migratedForm}>
-                                <div className={styles.tooltipContainer}>
-                                    <CubeIcon />
-                                    <div className={styles.tooltip}>{__('Uses the Visual Form Builder', 'give')}</div>
-                                </div>
-                                <Interweave attributes={{className: 'interweave'}} content={item?.title} />
-                            </div>
-                            {item?.isDefaultCampaignForm && (
-                                <div className={`${styles.defaultFormPill} givewp-default-form-pill`}>
-                                    {__('Default')}
-                                </div>
-                            )}
-                        </div>
-                    ) : (
-                        <div className={styles.titleContainer}>
+                    <div className={styles.titleContainer}>
+                        <div className={styles.migratedForm}>
+                            {item?.v3Form && <CubeTooltip />}
                             <Interweave attributes={{className: 'interweave'}} content={item?.title} />
-                            {item?.isDefaultCampaignForm && (
-                                <div className={`${styles.defaultFormPill} givewp-default-form-pill`}>
-                                    {__('Default')}
-                                </div>
-                            )}
                         </div>
-                    )}
+                        {item?.isDefaultCampaignForm && (
+                            <div className={`${styles.defaultFormPill} givewp-default-form-pill`}>{__('Default')}</div>
+                        )}
+                    </div>
                 </>
             );
         },

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -115,15 +115,29 @@ const columnFilters: Array<ColumnFilterConfig> = [
             return (
                 <>
                     {item?.v3form ? (
-                        <div className={styles.migratedForm}>
-                            <div className={styles.tooltipContainer}>
-                                <CubeIcon />
-                                <div className={styles.tooltip}>{__('Uses the Visual Form Builder', 'give')}</div>
+                        <div className={styles.titleContainer}>
+                            <div className={styles.migratedForm}>
+                                <div className={styles.tooltipContainer}>
+                                    <CubeIcon />
+                                    <div className={styles.tooltip}>{__('Uses the Visual Form Builder', 'give')}</div>
+                                </div>
+                                <Interweave attributes={{className: 'interweave'}} content={item?.title} />
                             </div>
-                            <Interweave attributes={{className: 'interweave'}} content={item?.title} />
+                            {item?.isDefaultCampaignForm && (
+                                <div className={`${styles.defaultFormPill} givewp-default-form-pill`}>
+                                    {__('Default')}
+                                </div>
+                            )}
                         </div>
                     ) : (
-                        <Interweave attributes={{className: 'interweave'}} content={item?.title} />
+                        <div className={styles.titleContainer}>
+                            <Interweave attributes={{className: 'interweave'}} content={item?.title} />
+                            {item?.isDefaultCampaignForm && (
+                                <div className={`${styles.defaultFormPill} givewp-default-form-pill`}>
+                                    {__('Default')}
+                                </div>
+                            )}
+                        </div>
                     )}
                 </>
             );

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -123,7 +123,7 @@ const columnFilters: Array<ColumnFilterConfig> = [
                 <>
                     <div className={styles.titleContainer}>
                         <div className={styles.migratedForm}>
-                            {item?.v3Form && <CubeTooltip />}
+                            {item?.v3form && <CubeTooltip />}
                             <Interweave attributes={{className: 'interweave'}} content={item?.title} />
                         </div>
                         {item?.isDefaultCampaignForm && (

--- a/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
@@ -1,4 +1,4 @@
-import {__} from '@wordpress/i18n';
+import {__, sprintf} from '@wordpress/i18n';
 import {useSWRConfig} from 'swr';
 import RowAction from '@givewp/components/ListTable/RowAction';
 import ListTableApi from '@givewp/components/ListTable/api';
@@ -7,7 +7,6 @@ import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePag
 import {Interweave} from 'interweave';
 import {UpgradeModalContent} from './Migration';
 import {createInterpolateElement} from '@wordpress/element';
-
 
 const donationFormsApi = new ListTableApi(window.GiveDonationForms);
 
@@ -87,6 +86,11 @@ export function DonationFormsRowActions({data, item, removeRow, addRow, setUpdat
         );
     };
 
+    const copyShortcode = (event) => {
+        navigator.clipboard.writeText(`[give_form id="${item.id}"]`);
+        alert(sprintf(__('The shortcode for Donation Form #%d has been copied to your clipboard!', 'give'), item.id));
+    };
+
     return (
         <>
             {parameters.status === 'trash' ? (
@@ -134,6 +138,12 @@ export function DonationFormsRowActions({data, item, removeRow, addRow, setUpdat
                             hiddenText={item?.name}
                         />
                     )}
+                    <RowAction
+                        onClick={copyShortcode}
+                        actionId={item.id}
+                        displayText={__('Copy shortcode', 'give')}
+                        hiddenText={item?.name}
+                    />
                     {isCampaignDetailsPage && !item.isDefaultCampaignForm && (
                         <RowAction
                             onClick={confirmDefaultCampaignFormModal}

--- a/src/Views/Components/ListTable/InterweaveSSR/styles.scss
+++ b/src/Views/Components/ListTable/InterweaveSSR/styles.scss
@@ -292,10 +292,16 @@
     }
 
     .giveDonationFormsLink {
-        font-size: 1.125rem;
-        font-weight: 700;
-        text-decoration: none;
         color: #2271b1;
+        display: block;
+        font-size: 1rem;
+        font-weight: 700;
+        max-width: 16ch;
+        overflow: hidden;
+        position: relative;
+        text-decoration: none;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .shortcode {

--- a/src/Views/Components/ListTable/InterweaveSSR/styles.scss
+++ b/src/Views/Components/ListTable/InterweaveSSR/styles.scss
@@ -296,7 +296,7 @@
         display: block;
         font-size: 1rem;
         font-weight: 700;
-        max-width: 16ch;
+        max-width: 32ch;
         overflow: hidden;
         position: relative;
         text-decoration: none;

--- a/src/Views/Components/ListTable/ListTable/ListTable.module.scss
+++ b/src/Views/Components/ListTable/ListTable/ListTable.module.scss
@@ -29,7 +29,6 @@
     border-spacing: 0;
     inline-size: 100%;
     font-size: 1em;
-    table-layout: fixed;
 }
 
 /* Visually hidden class omitting position: absolute since that breaks the table

--- a/src/Views/Components/ListTable/ListTable/ListTable.module.scss
+++ b/src/Views/Components/ListTable/ListTable/ListTable.module.scss
@@ -76,7 +76,12 @@
 }
 
 .selectAll {
-    width: 2rem;
+    inline-size: 1rem;
+    padding-right: 0;
+
+    input[type="checkbox"] {
+        transform: translateX(-2px);
+    }
 }
 
 #updateError {
@@ -166,11 +171,7 @@
 }
 
 .id {
-    inline-size: 3.25rem;
-}
-
-.donationForms .levels {
-    inline-size: 8rem;
+    inline-size: 2.5rem;
 }
 
 .donationForms .goal {

--- a/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
@@ -256,7 +256,7 @@ ul[role='document'] + .flexRow {
 
 .defaultFormPill {
     position: absolute;
-    bottom: -.8735rem;
+    bottom: -.75rem;
     left: 0;
     background: var(--givewp-neutral-200);
     width: fit-content;
@@ -266,9 +266,10 @@ ul[role='document'] + .flexRow {
     align-items: center;
     gap: 8px;
     margin: 1px 0 26px 16.7px;
-    padding: 2px 16px;
+    padding: 2px 10px;
     border-radius: 12px;
     transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+    font-size: 0.75rem;
 }
 
 .migratedForm {

--- a/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
@@ -254,17 +254,34 @@ ul[role='document'] + .flexRow {
     transform: translate(-50%, 0);
 }
 
+.defaultFormPill {
+    position: absolute;
+    bottom: -.8735rem;
+    left: 0;
+    background: var(--givewp-neutral-200);
+    width: fit-content;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin: 1px 0 26px 16.7px;
+    padding: 2px 16px;
+    border-radius: 12px;
+    transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+}
+
 .migratedForm {
     display: flex;
     align-items: center;
 
     .tooltipContainer {
-        position: relative;
+        position: absolute;
+        left: -.55rem;
         display: flex;
         align-items: center;
 
         svg {
-            margin-right: 5px;
             fill: #3A21D9;
         }
     }
@@ -399,7 +416,8 @@ ul[role='document'] + .flexRow {
     padding: var(--givewp-spacing-4) var(--givewp-spacing-6);
     border-top-left-radius: var(--givewp-rounded-8);
     border-top-right-radius: var(--givewp-rounded-8);
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);}
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
 
 .dialog {
     margin: auto;

--- a/src/Views/Components/ListTable/ListTableRows/ListTableRows.module.scss
+++ b/src/Views/Components/ListTable/ListTableRows/ListTableRows.module.scss
@@ -24,7 +24,6 @@ tr.duplicated {
 .tableRowActions {
     position: absolute;
     inset-block-end: 1rem;
-
     display: flex;
     align-items: center;
     column-gap: 1.25rem;
@@ -133,3 +132,13 @@ div.abandoned {
         opacity: 0;
     }
 }
+
+.tableRow:hover {
+    :global {
+        .givewp-default-form-pill {
+            opacity: 0;
+        }
+    }
+}
+
+

--- a/src/Views/Components/ListTable/TableCell/TableCell.module.scss
+++ b/src/Views/Components/ListTable/TableCell/TableCell.module.scss
@@ -1,7 +1,7 @@
 .tableCell {
     position: relative;
     padding-block-start: 1em;
-    padding-block-end: 2.5em;
+    padding-block-end: 2.75em;
     padding-inline: 1em;
     vertical-align: middle;
     font-size: 0.875em;

--- a/src/Views/Components/ListTable/TableCell/TableCell.module.scss
+++ b/src/Views/Components/ListTable/TableCell/TableCell.module.scss
@@ -16,6 +16,12 @@
             transition: all 0.05s ease-in-out;
         }
     }
+
+    input[type="checkbox"] {
+        margin: 0;
+        padding: 0;
+        transform: translateY(-1px);
+    }
 }
 
 .tableRowHeader {


### PR DESCRIPTION
Resolves [GIVE-2327]

## Description
This PR removes the donation levels column and introduces a default form pill to help indicate which form is marked as the default.

Additionally replaces the  shortcode column with a row action to copy the shortcode.

## Affects
Donation form list table

## Visuals
https://github.com/user-attachments/assets/15901119-48d9-4177-b090-54d1ce04fb21

## Testing Instructions

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2327]: https://stellarwp.atlassian.net/browse/GIVE-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ