### PR TITLE
Fix: Edit Donation Form should not open campaign creation modal

### DIFF
--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -14,49 +14,17 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     public function __invoke()
     {
-        if ( ! $this->isAddingNewForm()) {
-            return;
+        if (
+            $GLOBALS['pagenow'] === 'post-new.php'
+            && isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms'
+        ) {
+            if (
+                ! isset($_GET['campaignId'])
+                || ! (Campaign::find(absint($_GET['campaignId'])))
+            ) {
+                wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=give-campaigns&new=campaign'));
+                exit;
+            }
         }
-
-        if ($this->isEditingCampaignForm()) {
-            return;
-        }
-
-        if ( ! isset($_GET['campaignId']) || ! (Campaign::find(absint($_GET['campaignId'])))) {
-            wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=give-campaigns&new=campaign'));
-            exit;
-        }
-    }
-
-    /**
-     * @unreleased
-     */
-    private function isAddingNewForm(): bool
-    {
-        global $pagenow;
-
-        $isOptionBasedFormEditorPage = $pagenow === 'post-new.php';
-        $isVisualFormBuilderPage = $pagenow === 'edit.php' && isset($_GET['page']) && 'givewp-form-builder' === $_GET['page'];
-        $isGiveFormsCpt = isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms';
-
-        return ($isOptionBasedFormEditorPage || $isVisualFormBuilderPage) && $isGiveFormsCpt;
-    }
-
-    /**
-     * @unreleased
-     */
-    private function isEditingCampaignForm(): bool
-    {
-        global $pagenow;
-
-        $formId = $pagenow === 'post.php' && isset($_GET['post']) ? absint($_GET['post']) : 0;
-        $formId = $pagenow === 'edit.php' && isset($_GET['donationFormID'], $_GET['page']) && 'givewp-form-builder' === $_GET['page'] ? absint($_GET['donationFormID']) : $formId;
-        $isGiveFormsCpt = (isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms') || (get_post_type($formId) === 'give_forms');
-
-        if ($formId && $isGiveFormsCpt) {
-            return (bool)Campaign::findByFormId($formId);
-        }
-
-        return false;
     }
 }

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -3,7 +3,6 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\Models\Campaign;
-use GiveP2P\P2P\Repositories\CampaignRepository;
 
 /**
  * @unreleased
@@ -35,10 +34,10 @@ class RedirectLegacyCreateFormToCreateCampaign
             && isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms'
             && isset($_GET['page']) && $_GET['page'] === 'givewp-form-builder'
         ) {
-            if (isset($_GET['p2p'])) {
+            if (defined('GIVE_P2P_VERSION') && isset($_GET['p2p'])) {
                 if (
                     ! isset($_GET['donationFormID'])
-                    || ! give(CampaignRepository::class)->getByFormId($_GET['donationFormID'])
+                    || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID'])
                 ) {
                     wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=p2p-add-campaign'));
                     exit;

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -27,6 +27,8 @@ class RedirectLegacyCreateFormToCreateCampaign
                 wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=give-campaigns&new=campaign'));
                 exit;
             }
+
+            return;
         }
 
         if (

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -59,7 +59,7 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     private function isP2P(): bool
     {
-        return class_exists(\GiveP2P\P2P\Repositories\CampaignRepository::class) && isset($_GET['p2p']);
+        return isset($_GET['p2p']);
     }
 
     /**
@@ -93,7 +93,11 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     private function isP2PCampaignFormIdInvalidOrMissing(): bool
     {
-        return ! isset($_GET['donationFormID']) || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID']);
+        if (class_exists(\GiveP2P\P2P\Repositories\CampaignRepository::class)) {
+            return ! isset($_GET['donationFormID']) || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID']);
+        }
+
+        return true;
     }
 
     /**

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -3,7 +3,6 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\Models\Campaign;
-use GiveP2P\P2P\Repositories\CampaignRepository;
 
 /**
  * @unreleased
@@ -94,7 +93,7 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     private function isP2PCampaignFormIdInvalidOrMissing(): bool
     {
-        return ! isset($_GET['donationFormID']) || ! give(CampaignRepository::class)->getByFormId($_GET['donationFormID']);
+        return ! isset($_GET['donationFormID']) || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID']);
     }
 
     /**

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -3,6 +3,8 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\ValueObjects\CampaignType;
+use Give\Framework\Database\DB;
 
 /**
  * @unreleased
@@ -93,11 +95,12 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     private function isP2PCampaignFormIdInvalidOrMissing(): bool
     {
-        if (class_exists(\GiveP2P\P2P\Repositories\CampaignRepository::class)) {
-            return ! isset($_GET['donationFormID']) || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID']);
-        }
+        $form = DB::table('give_campaigns')
+            ->where('form_id', $_GET['donationFormID'])
+            ->where('campaign_type', CampaignType::CORE, '!=')
+            ->get();
 
-        return true;
+        return ! isset($_GET['donationFormID']) || ! $form;
     }
 
     /**

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\Models\Campaign;
+use GiveP2P\P2P\Repositories\CampaignRepository;
 
 /**
  * @unreleased
@@ -14,8 +15,10 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     public function __invoke()
     {
+        global $pagenow;
+
         if (
-            $GLOBALS['pagenow'] === 'post-new.php'
+            $pagenow === 'post-new.php'
             && isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms'
         ) {
             if (
@@ -24,6 +27,30 @@ class RedirectLegacyCreateFormToCreateCampaign
             ) {
                 wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=give-campaigns&new=campaign'));
                 exit;
+            }
+        }
+
+        if (
+            $pagenow === 'edit.php'
+            && isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms'
+            && isset($_GET['page']) && $_GET['page'] === 'givewp-form-builder'
+        ) {
+            if (isset($_GET['p2p'])) {
+                if (
+                    ! isset($_GET['donationFormID'])
+                    || ! give(CampaignRepository::class)->getByFormId($_GET['donationFormID'])
+                ) {
+                    wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=p2p-add-campaign'));
+                    exit;
+                }
+            } else {
+                if (
+                    ! isset($_GET['donationFormID'])
+                    || ! Campaign::findByFormId(absint($_GET['donationFormID']))
+                ) {
+                    wp_safe_redirect(admin_url('edit.php?post_type=give_forms&page=give-campaigns&new=campaign'));
+                    exit;
+                }
             }
         }
     }

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -59,7 +59,7 @@ class RedirectLegacyCreateFormToCreateCampaign
      */
     private function isP2P(): bool
     {
-        return class_exists(CampaignRepository::class) && isset($_GET['p2p']);
+        return class_exists(\GiveP2P\P2P\Repositories\CampaignRepository::class) && isset($_GET['p2p']);
     }
 
     /**

--- a/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
+++ b/src/Campaigns/Actions/RedirectLegacyCreateFormToCreateCampaign.php
@@ -34,7 +34,11 @@ class RedirectLegacyCreateFormToCreateCampaign
             && isset($_GET['post_type']) && $_GET['post_type'] === 'give_forms'
             && isset($_GET['page']) && $_GET['page'] === 'givewp-form-builder'
         ) {
-            if (defined('GIVE_P2P_VERSION') && isset($_GET['p2p'])) {
+            // p2p
+            if (
+                class_exists(\GiveP2P\P2P\Repositories\CampaignRepository::class)
+                && isset($_GET['p2p'])
+            ) {
                 if (
                     ! isset($_GET['donationFormID'])
                     || ! give(\GiveP2P\P2P\Repositories\CampaignRepository::class)->getByFormId($_GET['donationFormID'])

--- a/src/DonationForms/V2/Endpoints/ListDonationForms.php
+++ b/src/DonationForms/V2/Endpoints/ListDonationForms.php
@@ -3,6 +3,7 @@
 namespace Give\DonationForms\V2\Endpoints;
 
 use Give\Campaigns\Models\Campaign;
+use Give\Campaigns\ValueObjects\CampaignType;
 use Give\DonationForms\V2\ListTable\DonationFormsListTable;
 use Give\Framework\Database\DB;
 use Give\Framework\QueryBuilder\JoinQueryBuilder;
@@ -142,6 +143,12 @@ class ListDonationForms extends Endpoint
         $totalForms = $this->getTotalFormsCount();
         $totalPages = (int)ceil($totalForms / $this->request->get_param('perPage'));
 
+        // get p2p forms
+        $p2pForms = DB::table('give_campaigns')
+            ->select('form_id')
+            ->where('campaign_type', CampaignType::CORE, '!=')
+            ->getAll(ARRAY_A);
+
         if ('model' === $this->request->get_param('return')) {
             $items = $forms;
         } else {
@@ -149,9 +156,19 @@ class ListDonationForms extends Endpoint
             $items = $this->listTable->getItems();
 
             foreach ($items as $i => &$item) {
+                $queryArgs = [
+                    'locale' => Language::getLocale(),
+                ];
+
+                foreach($p2pForms as $form) {
+                    if ($item['id'] == $form['form_id']) {
+                        $queryArgs['p2p'] = true;
+                        break;
+                    }
+                }
+
                 $item['name'] = get_the_title($item['id']);
-                $item['edit'] = add_query_arg(['locale' => Language::getLocale()],
-                    get_edit_post_link($item['id'], 'edit'));
+                $item['edit'] = add_query_arg($queryArgs, get_edit_post_link($item['id'], 'edit'));
                 $item['permalink'] = get_permalink($item['id']);
                 $item['v3form'] = (bool)give_get_meta($item['id'], 'formBuilderSettings');
                 $item['status_raw'] = $forms[$i]->status->getValue();
@@ -165,7 +182,7 @@ class ListDonationForms extends Endpoint
                 'totalItems' => $totalForms,
                 'totalPages' => $totalPages,
                 'trash' => defined('EMPTY_TRASH_DAYS') && EMPTY_TRASH_DAYS > 0,
-                'defaultForm' => $this->defaultForm
+                'defaultForm' => $this->defaultForm,
             ]
         );
     }
@@ -221,7 +238,7 @@ class ListDonationForms extends Endpoint
 
     /**
      * @unreleased Add "campaignId" support
-     * @since 2.24.0
+     * @since      2.24.0
      *
      * @param QueryBuilder $query
      *

--- a/src/FormBuilder/FormBuilderRouteBuilder.php
+++ b/src/FormBuilder/FormBuilderRouteBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Give\FormBuilder;
 
+use Give\Campaigns\ValueObjects\CampaignType;
+use Give\Framework\Database\DB;
 use Give\Helpers\Language;
 
 class FormBuilderRouteBuilder
@@ -75,8 +77,13 @@ class FormBuilderRouteBuilder
             $queryArgs['campaignId'] = $_GET['campaignId'];
         }
 
-        // P2P
-        if (isset($_GET['p2p'])) {
+        // Check if it's P2P form
+        $form = DB::table('give_campaigns')
+            ->where('form_id', $this->donationFormID)
+            ->where('campaign_type', CampaignType::CORE, '!=')
+            ->get();
+
+        if ($form) {
             $queryArgs['p2p'] = true;
         }
 

--- a/src/FormBuilder/FormBuilderRouteBuilder.php
+++ b/src/FormBuilder/FormBuilderRouteBuilder.php
@@ -58,6 +58,7 @@ class FormBuilderRouteBuilder
     }
 
     /**
+     * @unreleased add p2p param
      * @since 3.22.0 Add locale support
      * @since 3.0.0
      */
@@ -72,6 +73,11 @@ class FormBuilderRouteBuilder
 
         if (isset($_GET['campaignId'])) {
             $queryArgs['campaignId'] = $_GET['campaignId'];
+        }
+
+        // P2P
+        if (isset($_GET['p2p'])) {
+            $queryArgs['p2p'] = true;
         }
 
         return add_query_arg(


### PR DESCRIPTION
## Description
This PR resolves the issue with the redirect logic for campaign forms. The issue was that the `RedirectLegacyCreateFormToCreateCampaign` class was not accounting for the p2p campaign forms.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

