### PR TITLE
Refactor: Improve Campaign Image upload setting to enforce aspect ratio

### DIFF
--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -41,7 +41,7 @@ div.media-modal.wp-core-ui {
         min-height: 160px;
 
         & > img {
-            aspect-ratio: 16 / 9;
+            aspect-ratio: 4 / 1;
         }
     }
 

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/styles.scss
@@ -41,7 +41,7 @@ div.media-modal.wp-core-ui {
         min-height: 160px;
 
         & > img {
-            height: 100%;
+            aspect-ratio: 16 / 9;
         }
     }
 
@@ -50,7 +50,6 @@ div.media-modal.wp-core-ui {
         position: relative;
         display: flex;
         background: transparent;
-        height: 5rem;
         width: 100%;
         padding: 0;
         color: var(--givewp-shades-white);
@@ -83,7 +82,6 @@ div.media-modal.wp-core-ui {
 
     &__image {
         width: 100%;
-        height: 5rem;
         object-fit: cover;
         object-position: center;
         transition: filter 0.3s ease;


### PR DESCRIPTION
Resolves [GIVE-2329]

## Description
This pull request includes changes such as modifying the aspect ratio of the Campaign Images setting and removing fixed height properties to allow for a more flexible and responsive design.

Styling improvements:

* Changed the aspect ratio of images within the media modal to 16:9 for better consistency and responsiveness.
* Removed fixed height properties from the media modal and its image elements to allow for more flexible layout and design. [[1]](diffhunk://#diff-9b8130e52ccd659df1924d2c78bd4270ce0e4fc9924f3f3fcde66103d71b6d61L53) [[2]](diffhunk://#diff-9b8130e52ccd659df1924d2c78bd4270ce0e4fc9924f3f3fcde66103d71b6d61L86)

## Affects
Campaign Settings

## Visuals
![CleanShot 2025-03-28 at 15 04 52](https://github.com/user-attachments/assets/10b24921-fd7d-4c53-9bbc-8c9144928b86)

## Testing Instructions
1.	Go to a campaign’s settings page.
2.	Try adding images of different sizes to the campaign.
3.	Confirm they all respect the 16:9 aspect ratio.
4.	Confirm that everything else related to the uploader still looks good.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2329]: https://stellarwp.atlassian.net/browse/GIVE-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ