### PR TITLE
Refactor: Improve ModalDialog component to be scrollable

### DIFF
--- a/src/Views/Components/AdminUI/ModalDialog/index.tsx
+++ b/src/Views/Components/AdminUI/ModalDialog/index.tsx
@@ -42,41 +42,55 @@ export default function Modal({
         };
     }, []);
 
+    useEffect(() => {
+        if (isOpen) {
+            document.body.classList.add('modalDialog-open');
+        } else {
+            document.body.classList.remove('modalDialog-open');
+        }
+
+        return () => {
+            document.body.classList.remove('modalDialog-open');
+        };
+    }, [isOpen]);
+
     if (!isOpen) return null;
 
     return createPortal(
         <div className={`givewp-modal-wrapper ${wrapperClassName}`}>
             <div role="dialog" aria-label={title} className="givewp-modal-dialog">
-                {showHeader ? (
-                    <div className="givewp-modal-header">
-                        {icon && <div className="givewp-modal-icon-header">{icon}</div>}
-                        {title}
-                        {showCloseIcon && handleClose && (
-                            <button
-                                aria-label={__('Close dialog', 'give')}
-                                className="givewp-modal-close"
-                                onClick={handleClose}
-                            >
-                                <ExitIcon aria-label={__('Close dialog icon', 'give')} />
-                            </button>
-                        )}
-                    </div>
-                ) : (
-                    <>
-                        {showCloseIcon && handleClose && (
-                            <button
-                                aria-label={__('Close dialog', 'give')}
-                                className="givewp-modal-close-headless"
-                                onClick={handleClose}
-                            >
-                                <ExitIcon aria-label={__('Close dialog icon', 'give')} />
-                            </button>
-                        )}
-                        {icon && <div className="givewp-modal-icon-center">{icon}</div>}
-                    </>
-                )}
+                <div className={`givewp-modal-dialog-content`}>
+                    {showHeader ? (
+                        <div className="givewp-modal-header">
+                            {icon && <div className="givewp-modal-icon-header">{icon}</div>}
+                            {title}
+                            {showCloseIcon && handleClose && (
+                                <button
+                                    aria-label={__('Close dialog', 'give')}
+                                    className="givewp-modal-close"
+                                    onClick={handleClose}
+                                >
+                                    <ExitIcon aria-label={__('Close dialog icon', 'give')} />
+                                </button>
+                            )}
+                        </div>
+                    ) : (
+                        <>
+                            {showCloseIcon && handleClose && (
+                                <button
+                                    aria-label={__('Close dialog', 'give')}
+                                    className="givewp-modal-close-headless"
+                                    onClick={handleClose}
+                                >
+                                    <ExitIcon aria-label={__('Close dialog icon', 'give')} />
+                                </button>
+                            )}
+                            {icon && <div className="givewp-modal-icon-center">{icon}</div>}
+                        </>
+                    )}
 
-                <div className="givewp-modal-content">{children}</div>
+                    <div className="givewp-modal-content">{children}</div>
+                </div>
             </div>
         </div>,
         insertInto ? document.querySelector(insertInto) : document.body

--- a/src/Views/Components/AdminUI/ModalDialog/style.scss
+++ b/src/Views/Components/AdminUI/ModalDialog/style.scss
@@ -24,6 +24,8 @@
         box-shadow: 0 0.25rem 0.5rem 0 rgba(14, 14, 14, 0.15);
         animation: appear 112ms ease-in 0s;
         color: var(--givewp-grey-700);
+        max-height: 70%;
+        overflow-y: auto;
 
         .givewp-modal-header {
             display: flex;
@@ -90,6 +92,13 @@
             padding: var(--givewp-spacing-6);
         }
     }
+}
+
+body.modalDialog-open {
+    height: 100%;
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
 }
 
 @keyframes appear {


### PR DESCRIPTION
…closing modal<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2365]

## Description
This PR fixes an issue where using the modal with long content could cause it to be cut off by the screen. We’ve added support for the modal component to be scrollable while maintaining a maximum height of 70% of the screen height. Although this component is used in many places, the main motivation for this change is the Create Campaign modal, which is the only one likely to reach the full screen height.

## Affects
DialogModal component

## Visuals
https://github.com/user-attachments/assets/e2df99e2-72c8-4fdc-b3d8-3c267daabdd9

## Testing Instructions
1. Go to campaigns and open the Create Campaign modal while in a small screen size
2. Ensure you can complete all the steps

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

