### PR TITLE
Fix: campaign list table when empty

### DIFF
--- a/src/Campaigns/CampaignsDataQuery.php
+++ b/src/Campaigns/CampaignsDataQuery.php
@@ -22,8 +22,11 @@ class CampaignsDataQuery extends QueryBuilder
     {
         $this->select('campaignId.meta_value as campaign_id');
         $this->whereIn('donation.post_status', ['publish', 'give_subscription']);
-        $this->whereIn('campaignId.meta_value', $campaignIds);
         $this->groupBy('campaign_id');
+
+        if (!empty($campaignIds)) {
+            $this->whereIn('campaignId.meta_value', $campaignIds);
+        }
     }
 
 

--- a/src/Campaigns/CampaignsDataQuery.php
+++ b/src/Campaigns/CampaignsDataQuery.php
@@ -22,11 +22,8 @@ class CampaignsDataQuery extends QueryBuilder
     {
         $this->select('campaignId.meta_value as campaign_id');
         $this->whereIn('donation.post_status', ['publish', 'give_subscription']);
+        $this->whereIn('campaignId.meta_value', $campaignIds);
         $this->groupBy('campaign_id');
-
-        if (!empty($campaignIds)) {
-            $this->whereIn('campaignId.meta_value', $campaignIds);
-        }
     }
 
 

--- a/src/Campaigns/Controllers/CampaignRequestController.php
+++ b/src/Campaigns/Controllers/CampaignRequestController.php
@@ -71,7 +71,7 @@ class CampaignRequestController
 
         $campaigns = $query->getAll() ?? [];
         $totalCampaigns = empty($campaigns) ? 0 : $totalQuery->count();
-        $totalPages = (int)ceil($totalCampaigns / $perPage);
+        $totalPages = $totalCampaigns === 0 ? 0 : (int)ceil($totalCampaigns / $perPage);
 
         $ids = array_map(function ($campaign) {
             return $campaign->id;

--- a/src/Campaigns/Routes/GetCampaignsListTable.php
+++ b/src/Campaigns/Routes/GetCampaignsListTable.php
@@ -97,8 +97,19 @@ class GetCampaignsListTable implements RestRoute
         $this->request = $request;
         $this->listTable = give(CampaignsListTable::class);
 
-        $campaigns = $this->getCampaigns();
         $campaignsCount = $this->getTotalCampaignsCount();
+
+        if ($campaignsCount === 0) {
+            return new WP_REST_Response(
+                [
+                    'items' => [],
+                    'totalItems' => 0,
+                    'totalPages' => 0,
+                ]
+            );
+        }
+
+        $campaigns = $this->getCampaigns();
         $pageCount = (int)ceil($campaignsCount / $request->get_param('perPage'));
 
         $ids = array_map(function (Campaign $campaign) {

--- a/tests/Feature/Controllers/CampaignsRequestControllerTest.php
+++ b/tests/Feature/Controllers/CampaignsRequestControllerTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Give\Campaigns\Controllers\CampaignRequestController;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\ValueObjects\CampaignRoute;
+use Give\Campaigns\ValueObjects\CampaignStatus;
 use Give\Campaigns\ViewModels\CampaignViewModel;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
@@ -41,6 +42,50 @@ class CampaignsRequestControllerTest extends TestCase
             $response->data,
             $campaignViewModel->exports()
         );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShowShouldReturnCampaignsData()
+    {
+        $campaign = Campaign::factory()->create();
+        $campaign2 = Campaign::factory()->create();
+        $campaignViewModel = new CampaignViewModel($campaign);
+        $campaignViewModel2 = new CampaignViewModel($campaign2);
+
+        $request = $this->getMockRequest(WP_REST_Server::READABLE);
+        $request->set_param('status', [CampaignStatus::ACTIVE]);
+        $request->set_param('per_page', 30);
+        $request->set_param('page', 1);
+
+        $response = (new CampaignRequestController())->getCampaigns($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertSame(
+            $response->data,
+            [$campaignViewModel->exports(), $campaignViewModel2->exports()]
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShowShouldNotReturnCampaignsDataWhenEmpty()
+    {
+        $request = $this->getMockRequest(WP_REST_Server::READABLE);
+        $request->set_param('status', [CampaignStatus::ACTIVE]);
+        $request->set_param('per_page', 30);
+        $request->set_param('page', 1);
+
+        $response = (new CampaignRequestController())->getCampaigns($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertEmpty($response->data);
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2372]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes an error on the the campaign list table when it's empty by adding an empty conditional to the campaign data query when there are no ids to be used in a WHER IN clause.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign list able.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a fresh install, dismiss onboarding and view campaign list table. There should be no errors

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2372]: https://stellarwp.atlassian.net/browse/GIVE-2372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ