### PR TITLE
Fix: campaigns list table links

### DIFF
--- a/src/Campaigns/ListTable/Columns/DonationsCountColumn.php
+++ b/src/Campaigns/ListTable/Columns/DonationsCountColumn.php
@@ -55,11 +55,6 @@ class DonationsCountColumn extends ModelColumn
             ) : __('No donations', 'give');
 
 
-        return sprintf(
-            '<a class="column-donations-count-value" href="%s" aria-label="%s">%s</a>',
-            admin_url("edit.php?post_type=give_forms&page=give-payment-history&form_id=$model->id"),
-            __('Visit donations page', 'give'),
-            apply_filters("givewp_list_table_cell_value_{$this::getId()}_content", $label, $model, $this)
-        );
+        return apply_filters("givewp_list_table_cell_value_{$this::getId()}_content", $label, $model, $this);
     }
 }

--- a/src/Campaigns/ListTable/Columns/RevenueColumn.php
+++ b/src/Campaigns/ListTable/Columns/RevenueColumn.php
@@ -46,7 +46,7 @@ class RevenueColumn extends ModelColumn
 
         return sprintf(
             '<a class="column-earnings-value" href="%s" aria-label="%s">%s</a>',
-            admin_url("edit.php?post_type=give_forms&page=give-reports&tab=forms&legacy=true&form-id=$model->id"),
+            admin_url("edit.php?post_type=give_forms&page=give-campaigns&id=$model->id"),
             __('Visit form reports page', 'give'),
             apply_filters(
                 "givewp_list_table_cell_value_{$this::getId()}_content",


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The links for the `Donations` and `Revenue` columns were redirecting the users to pages that don't work to filter data related to Campaigns. This PR fixes that by removing the link for the donations count and replacing the link for the revenue table with a link to the campaigns overview tab.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaigns list table.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before:**

![image](https://github.com/user-attachments/assets/865b258b-f50c-4c5c-a733-ef14d86b0cce)

**After:**

![image](https://github.com/user-attachments/assets/9286dc21-bf5d-4fad-8e80-ecf153d5118d)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the link for the Donations column doesn't exist anymore and the link for the revenue column is redirecting to the campaign overview tab.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

