### PR TITLE
fix: update add campaign form styles

### DIFF
--- a/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
@@ -167,18 +167,15 @@ ul[role='document'] + .flexRow {
     $depth: 0px 1px 0px rgba(0, 0, 0, 0.25);
 
     background-color: var(--givewp-neutral-100);
-    border: 1px solid #ddd;
-    border-radius: 0.1875rem;
-    box-shadow: $depth;
-    color: #060C1A;
-    font-family: inherit;
+    border-radius: 0.25rem;
+    color: var(--givewp-neutral-900);
+    font-family: 'Inter';
     font-size: 0.875rem;
     font-weight: 500;
     display: flex;
     align-items: center;
     block-size: 2.5rem;
-    padding-inline: 0.8rem;
-    height: 2.25rem;
+    padding: 0.5rem 1rem;
     transition-property: filter, color, outline;
     transition-duration: 180ms;
     transition-timing-function: ease-in;
@@ -192,6 +189,7 @@ ul[role='document'] + .flexRow {
 
     &:is(:hover, :active, :focus) {
         background-color: var(--givewp-neutral-200);
+        color: var(--givewp-neutral-900);
     }
 
     &:active {
@@ -200,7 +198,7 @@ ul[role='document'] + .flexRow {
 
     &:focus {
         box-shadow: $depth;
-        outline: 0.125rem solid var(--give-primary-color);
+        outline: 0.125rem solid #2271B1;
         outline-offset: 0.25em;
     }
 }


### PR DESCRIPTION
## Description
This PR updates the default, hover and focus states for the add campaign form button.

## Affects
Add campaign form button.


## Visuals
Before
<img width="186" alt="Screenshot 2025-03-28 at 6 23 08 PM" src="https://github.com/user-attachments/assets/f311be27-5548-4559-8e4d-e5932086c4d4" />

After
<img width="186" alt="Screenshot 2025-03-28 at 6 20 03 PM" src="https://github.com/user-attachments/assets/6703d5fe-3228-47be-91cd-6041865baebd" />


## Testing Instructions
Click on any campaign, go to the forms list page, check the add campaign form button.


## Pre-review Checklist

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

