### PR TITLE
Feature: add draft campaign page notice

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/DraftCampaignPageNotice.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/Notices/DraftCampaignPageNotice.tsx
@@ -1,0 +1,16 @@
+import {WarningIcon} from '@givewp/campaigns/admin/components/Icons';
+import {__} from '@wordpress/i18n';
+
+export default function DraftCampaignPageNotice() {
+    return (
+        <>
+            <WarningIcon />
+            <span>
+                {__(
+                    "Your campaign page won't be visible until it's published. Use the 'Edit Campaign Page' button to open the page editor and publish it.",
+                    'give'
+                )}
+            </span>
+        </>
+    );
+}

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -153,6 +153,7 @@ export default function CampaignsDetailsPage({campaignId}) {
         } else {
             dispatch.dismissNotification('update-campaign-draft-page-notice');
         }
+        // @ts-ignore
     }, [record?.status, campaign?.status]);
 
     const onSubmit: SubmitHandler<Campaign> = async (data) => {

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -125,7 +125,7 @@ export default function CampaignsDetailsPage({campaignId}) {
         }
 
         // @ts-ignore
-        if (record && record?.status !== 'publish') {
+        if (record && record?.status !== 'publish' && campaign?.status !== 'archived') {
             dispatch.addNotice({
                 id: 'update-campaign-draft-page-notice',
                 type: 'info',
@@ -135,7 +135,7 @@ export default function CampaignsDetailsPage({campaignId}) {
         } else {
             dispatch.dismissNotification('update-campaign-draft-page-notice');
         }
-    }, [record]);
+    }, [record, campaign?.status]);
 
     const onSubmit: SubmitHandler<Campaign> = async (data) => {
         const shouldSave =
@@ -340,7 +340,10 @@ export default function CampaignsDetailsPage({campaignId}) {
                         title={__('Archive Campaign', 'give')}
                         isOpen={show.confirmationModal}
                         handleClose={() => setShow({confirmationModal: false, contextMenu: false})}
-                        handleConfirm={() => updateStatus('archived')}
+                        handleConfirm={() => {
+                            updateStatus('archived');
+                            dispatch.dismissNotification('update-campaign-draft-page-notice');
+                        }}
                     />
                 </article>
             </form>

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -153,7 +153,7 @@ export default function CampaignsDetailsPage({campaignId}) {
         } else {
             dispatch.dismissNotification('update-campaign-draft-page-notice');
         }
-    }, [record, campaign?.status]);
+    }, [record?.status, campaign?.status]);
 
     const onSubmit: SubmitHandler<Campaign> = async (data) => {
         const shouldSave =

--- a/src/Campaigns/resources/admin/components/Notifications/Notices.module.scss
+++ b/src/Campaigns/resources/admin/components/Notifications/Notices.module.scss
@@ -84,6 +84,15 @@
         }
     }
 
+    .type-info {
+        border-color: #0c7ff2;
+        background-color: #f2f9ff;
+
+        svg > path {
+            fill: #0c7ff2;
+        }
+    }
+
     // Note: other notification types styles are not defined. You can define them below
 }
 


### PR DESCRIPTION
Resolves [GIVE-2366]

## Description
This includes a notice for users directing them to Publish their campaign landing page. The notice disappears once the page has been published and remains closed on all published pages. This notice will also be hidden when a campaign is archived.

## Affects
Campaign Overview Page
## Visuals

https://github.com/user-attachments/assets/60660c33-c56d-4624-b890-98e0d5ad4f4a


## Testing Instructions
- Create a new campaign - view the notice.
- Move the campaign to archived status - it should disappear.
- Move the campaign status back to draft - it should reappear
- Follow the directions on the notice.
- View the campaign overview page - verify the notice has been removed.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2366]: https://stellarwp.atlassian.net/browse/GIVE-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ