### PR TITLE
Feature: Add support for Forms to inherit Campaign colors

### DIFF
--- a/src/Campaigns/Actions/CreateDefaultCampaignForm.php
+++ b/src/Campaigns/Actions/CreateDefaultCampaignForm.php
@@ -5,7 +5,6 @@ namespace Give\Campaigns\Actions;
 use Exception;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
-use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
 use Give\DonationForms\FormDesigns\MultiStepFormDesign\MultiStepFormDesign;
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\Properties\FormSettings;
@@ -18,6 +17,9 @@ use Give\FormBuilder\Actions\GenerateDefaultDonationFormBlockCollection;
 class CreateDefaultCampaignForm
 {
     /**
+     * @unreleased Added inheritCampaignColors property to FormSettings
+     * @since      4.0.0
+     *
      * @throws Exception
      */
     public function __invoke(Campaign $campaign)
@@ -31,6 +33,7 @@ class CreateDefaultCampaignForm
                 'goalAmount' => $campaign->goal,
                 'goalType' => $campaign->goalType->getValue(),
                 'designId' => MultiStepFormDesign::id(),
+                'inheritCampaignColors' => true,
             ]),
             'blocks' => (new GenerateDefaultDonationFormBlockCollection())(),
         ]);

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -262,6 +262,7 @@ class FormSettings implements Arrayable, Jsonable
      * @var array
      */
     public $currencySwitcherSettings;
+
     /**
      * @since 3.16.0
      * @var bool
@@ -269,6 +270,12 @@ class FormSettings implements Arrayable, Jsonable
     public $enableReceiptConfirmationPage;
 
     /**
+     * @unreleased
+     */
+    public bool $inheritCampaignColors;
+
+    /**
+     * @unreleased Added $inheritCampaignColors
      * @since 3.16.0 Added $enableReceiptConfirmationPage
      * @since 3.7.0 Added formExcerpt
      * @since 3.11.0 Sanitize customCSS property
@@ -300,6 +307,7 @@ class FormSettings implements Arrayable, Jsonable
         $self->goalStartDate = $array['goalStartDate'] ?? '';
         $self->goalEndDate = $array['goalEndDate'] ?? '';
         $self->designId = $array['designId'] ?? null;
+        $self->inheritCampaignColors = $array['inheritCampaignColors'] ?? false;
         $self->primaryColor = $array['primaryColor'] ?? '#69b86b';
         $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';
         $self->goalAmount = $array['goalAmount'] ?? 0;

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -2,6 +2,7 @@
 
 namespace Give\DonationForms\ViewModels;
 
+use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Actions\GenerateAuthUrl;
 use Give\DonationForms\Actions\GenerateDonateRouteUrl;
 use Give\DonationForms\Actions\GenerateDonationFormValidationRouteUrl;
@@ -72,18 +73,36 @@ class DonationFormViewModel
     }
 
     /**
+     * @unreleased Add support for campaign colors
      * @since 3.0.0
      */
     public function primaryColor(): string
     {
+        if ($this->formSettings->inheritCampaignColors) {
+            $campaignColors = $this->getCampaignColors($this->donationFormId);
+
+            if ($campaignColors['primaryColor']) {
+                return $campaignColors['primaryColor'];
+            }
+        }
+
         return $this->formSettings->primaryColor ?? '';
     }
 
     /**
+     * @unreleased Add support for campaign colors
      * @since 3.0.0
      */
     public function secondaryColor(): string
     {
+        if ($this->formSettings->inheritCampaignColors) {
+            $campaignColors = $this->getCampaignColors($this->donationFormId);
+
+            if ($campaignColors['secondaryColor']) {
+                return $campaignColors['secondaryColor'];
+            }
+        }
+
         return $this->formSettings->secondaryColor ?? '';
     }
 
@@ -459,5 +478,26 @@ class DonationFormViewModel
         $classNames[] = 'givewp-design-settings--section-style__' . $this->formSettings->designSettingsSectionStyle;
 
         $classNames[] = 'givewp-design-settings--textField-style__' . $this->formSettings->designSettingsTextFieldStyle;
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getCampaignColors(int $formId): array
+    {
+        /** @var Campaign $campaign */
+        $campaign = give()->campaigns->getByFormId($formId);
+
+        if ($campaign) {
+            return [
+                'primaryColor' => $campaign->primaryColor,
+                'secondaryColor' => $campaign->secondaryColor,
+            ];
+        }
+
+        return [
+            'primaryColor' => '',
+            'secondaryColor' => '',
+        ];
     }
 }

--- a/src/FormBuilder/Routes/CreateFormRoute.php
+++ b/src/FormBuilder/Routes/CreateFormRoute.php
@@ -45,6 +45,7 @@ class CreateFormRoute
                     'settings' => FormSettings::fromArray([
                         'enableDonationGoal' => true,
                         'goalAmount' => 1000,
+                        'inheritCampaignColors' => true,
                     ]),
                     'blocks' => (new GenerateDefaultDonationFormBlockCollection())(),
                 ]);

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -2,6 +2,7 @@
 
 namespace Give\FormBuilder\ViewModels;
 
+use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\ValueObjects\GoalProgressType;
@@ -86,6 +87,7 @@ class FormBuilderViewModel
             'nameTitlePrefixes' => give_get_option('title_prefixes', array_values(give_get_default_title_prefixes())),
             'isExcerptEnabled' => give_is_setting_enabled(give_get_option('forms_excerpt')),
             'intlTelInputSettings' => IntlTelInput::getSettings(),
+            'campaignColors' => $this->getCampaignColors($donationFormId),
         ];
     }
 
@@ -339,5 +341,26 @@ class FormBuilderViewModel
         );
 
         return array_values(array_unique($disallowedFieldNames));
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getCampaignColors(int $formId): array
+    {
+        /** @var Campaign $campaign */
+        $campaign = give()->campaigns->getByFormId($formId);
+
+        if ($campaign) {
+            return [
+                'primaryColor' => $campaign->primaryColor,
+                'secondaryColor' => $campaign->secondaryColor,
+            ];
+        }
+
+        return [
+            'primaryColor' => '',
+            'secondaryColor' => '',
+        ];
     }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
@@ -10,6 +10,7 @@ import type {
 
 import BlockRegistrar from '@givewp/form-builder/registrars/blocks';
 import {IntlTelInputSettings} from '@givewp/forms/propTypes';
+import {FormColors} from '@givewp/forms/types';
 
 type GoalTypeOption = {
     value: string;
@@ -66,6 +67,7 @@ interface FormBuilderWindowData {
     nameTitlePrefixes: string[];
     isExcerptEnabled: boolean;
     intlTelInputSettings: IntlTelInputSettings;
+    campaignColors: FormColors;
 }
 
 /**

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color-inheritance-toggle/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color-inheritance-toggle/index.tsx
@@ -1,0 +1,31 @@
+import {__} from '@wordpress/i18n';
+import {ToggleControl} from '@wordpress/components';
+import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-state';
+import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPubSub';
+
+export default function ColorInheritanceToggle({dispatch, children}) {
+    const {
+        settings: {inheritCampaignColors},
+    } = useFormState();
+
+    const {publishColors} = useDonationFormPubSub();
+
+    // TODO: Retrieve campaign colors from settings then pass them to the publishColors function
+
+    return (
+        <>
+            <ToggleControl
+                label={__('Inherit Campaign Colors', 'give')}
+                checked={inheritCampaignColors ?? false}
+                onChange={(inheritCampaignColors: boolean) => {
+                    console.log('inheritCampaignColors', inheritCampaignColors);
+                    dispatch(setFormSettings({inheritCampaignColors}));
+                    //publishColors(value);
+                }}
+                help={__('Inherit the colors from the campaign settings.', 'give')}
+            />
+
+            {!inheritCampaignColors && children}
+        </>
+    );
+}

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
@@ -3,6 +3,7 @@ import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-st
 import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPubSub';
 import {PanelColorSettings} from '@wordpress/block-editor';
 import {PanelBody} from '@wordpress/components';
+import ColorInheritanceToggle from '@givewp/form-builder/settings/design/style-controls/color-inheritance-toggle';
 
 export default function Color({dispatch}) {
     const {
@@ -27,30 +28,32 @@ export default function Color({dispatch}) {
 
     return (
         <PanelBody title={__('Color', 'give')}>
-            <PanelColorSettings
-                colorSettings={[
-                    {
-                        value: primaryColor,
-                        onChange: (primaryColor: string) => {
-                            dispatch(setFormSettings({primaryColor}));
-                            publishColors({primaryColor});
+            <ColorInheritanceToggle dispatch={dispatch}>
+                <PanelColorSettings
+                    colorSettings={[
+                        {
+                            value: primaryColor,
+                            onChange: (primaryColor: string) => {
+                                dispatch(setFormSettings({primaryColor}));
+                                publishColors({primaryColor});
+                            },
+                            label: __('Primary Color', 'give'),
+                            disableCustomColors: false,
+                            colors: defaultColors,
                         },
-                        label: __('Primary Color', 'give'),
-                        disableCustomColors: false,
-                        colors: defaultColors,
-                    },
-                    {
-                        value: secondaryColor,
-                        onChange: (secondaryColor: string) => {
-                            dispatch(setFormSettings({secondaryColor}));
-                            publishColors({secondaryColor});
+                        {
+                            value: secondaryColor,
+                            onChange: (secondaryColor: string) => {
+                                dispatch(setFormSettings({secondaryColor}));
+                                publishColors({secondaryColor});
+                            },
+                            label: __('Secondary Color', 'give'),
+                            disableCustomColors: false,
+                            colors: defaultColors,
                         },
-                        label: __('Secondary Color', 'give'),
-                        disableCustomColors: false,
-                        colors: defaultColors,
-                    },
-                ]}
-            />
+                    ]}
+                />
+            </ColorInheritanceToggle>
         </PanelBody>
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/types/formSettings.ts
@@ -2,6 +2,7 @@ import {FormStatus} from '@givewp/form-builder/types/formStatus';
 import {EmailTemplateOption} from '@givewp/form-builder/types/emailTemplateOption';
 
 /**
+ * @unreleased Added inheritCampaignColors
  * @since 3.16.0 Added enableReceiptConfirmationPage
  * @since 3.7.0 Added formExcerpt
  * @since 3.0.0
@@ -23,6 +24,7 @@ export type FormSettings = {
     designId: string;
     heading: string;
     description: string;
+    inheritCampaignColors: boolean;
     primaryColor: string;
     secondaryColor: string;
     customCss: string;

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -93,6 +93,10 @@ class FormBuilderViewModelTest extends TestCase
                 'nameTitlePrefixes' => give_get_option('title_prefixes', array_values(give_get_default_title_prefixes())),
                 'isExcerptEnabled' => give_is_setting_enabled(give_get_option('forms_excerpt')),
                 'intlTelInputSettings' => IntlTelInput::getSettings(),
+                'campaignColors' => [
+                    'primary' => '',
+                    'secondary' => '',
+                ],
             ],
             $viewModel->storageData($formId)
         );

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -94,8 +94,8 @@ class FormBuilderViewModelTest extends TestCase
                 'isExcerptEnabled' => give_is_setting_enabled(give_get_option('forms_excerpt')),
                 'intlTelInputSettings' => IntlTelInput::getSettings(),
                 'campaignColors' => [
-                    'primary' => '',
-                    'secondary' => '',
+                    'primaryColor' => '',
+                    'secondaryColor' => '',
                 ],
             ],
             $viewModel->storageData($formId)


### PR DESCRIPTION
Resolves [GIVE-2309]

## Description
This pull request adds the ability for users to have form colors inherited from the campaign that the donation form belongs to.

Initially, only new forms will have this setting enabled by default. Existing forms will continue using their own custom colors, but users will have the option to switch back to using the campaign’s colors if they prefer.

## Affects
Donation Forms colors

## Visuals
https://github.com/user-attachments/assets/2e64402e-262b-4a0a-a9d7-050c204a26d6

## Testing Instructions
1.	Create a new campaign
	•	Open the default form associated with the new campaign.
	•	Go to the “Styles” settings tab in the sidebar.
	•	Confirm that the “Inherit Campaign Colors” toggle is turned on by default.
2.	Create a new form under that campaign
	•	Open the form’s settings.
	•	Verify that the “Inherit Campaign Colors” toggle is also enabled by default in the “Style” settings.
3.	Check existing forms
	•	Open an existing form (created before this feature was added).
	•	Go to the “Styles” settings tab in the sidebar.
	•	Confirm that the “Inherit Campaign Colors” toggle is off by default.
	•	Ensure that the form still uses its previously saved custom colors.
4.	Verify front-end color behavior
	•	For a form with the toggle enabled, confirm the form uses the campaign’s primary and secondary colors on the front end.
	•	Disable the toggle and choose custom colors. Save and refresh the front end—ensure the form now reflects the custom color selection.
	•	Re-enable the toggle, save again, and confirm the form switches back to using the campaign’s colors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2309]: https://stellarwp.atlassian.net/browse/GIVE-2309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ