### PR TITLE
Feature: Add global CSS editor for donation forms via “Custom Styles” setting

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -646,6 +646,71 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 					<?php
 					break;
 
+                // Code Editor.
+                case 'code_editor':
+                    $option_value = self::get_option($option_name, $value['id'], $value['default']);
+                    $editor_attributes = isset($value['editor_attributes']) ? $value['editor_attributes'] : [];
+
+                    wp_enqueue_code_editor([
+                        'type' => $editor_attributes['mode'] ?? 'text/html',
+                    ]);
+                    ?>
+                    <tr valign="top" <?php
+                    echo ! empty($value['wrapper_class']) ? 'class="' . $value['wrapper_class'] . '"' : ''; ?>>
+                        <th scope="row" class="titledesc">
+                            <label
+                                for="<?php
+                                echo esc_attr($value['id']); ?>"><?php
+                                echo self::get_field_title($value); ?></label>
+                        </th>
+                        <td class="give-forminp give-forminp-<?php
+                        echo sanitize_title($value['type']); ?>">
+                            <textarea
+                                name="<?php
+                                echo esc_attr($value['id']); ?>"
+                                id="<?php
+                                echo esc_attr($value['id']); ?>"
+                                style="<?php
+                                echo esc_attr($value['css']); ?>"
+                                class="<?php
+                                echo esc_attr($value['class']); ?>"
+                            ><?php
+                                echo esc_textarea($option_value); ?></textarea>
+                            <?php
+                            echo $description; ?>
+
+                            <script>
+                                window.addEventListener('DOMContentLoaded', function() {
+                                    if (typeof wp.codeEditor === 'undefined') {
+                                        return;
+                                    }
+
+                                    wp.codeEditor.initialize(<?php echo esc_attr($value['id']); ?>, {
+                                        codeEditor: {
+                                            mode: '<?php echo esc_attr($editor_attributes['mode'] ?? 'text/html'); ?>',
+                                            lineNumbers: <?php echo esc_attr(
+                                                $editor_attributes['lineNumbers'] ?? true
+                                            ); ?>,
+                                            lineWrapping: <?php echo esc_attr(
+                                                $editor_attributes['lineWrapping'] ?? true
+                                            ); ?>,
+                                            autoCloseBrackets:  <?php echo esc_attr(
+                                                $editor_attributes['autoCloseBrackets'] ?? true
+                                            ); ?>,
+                                            matchBrackets:  <?php echo esc_attr(
+                                                $editor_attributes['matchBrackets'] ?? true
+                                            ); ?>,
+                                            indentUnit: <?php echo esc_attr($editor_attributes['indentUnit'] ?? 4); ?>,
+                                            tabSize: <?php echo esc_attr($editor_attributes['tabSize'] ?? 4); ?>,
+                                        },
+                                    });
+                                });
+                            </script>
+                        </td>
+                    </tr>
+                    <?php
+                    break;
+
 				// Select boxes.
 				case 'select':
 				case 'multiselect':
@@ -1141,6 +1206,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 						break;
 					case 'wysiwyg':
 					case 'textarea':
+                    case 'code_editor':
 						$value = wp_kses_post( trim( $raw_value ) );
 						break;
 					case 'multiselect':

--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -446,8 +446,8 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 		/**
 		 * This function will help you prepare the admin settings field.
 		 *
+         * @unreleased Added support for code editor field.
 		 * @since  2.5.5
-		 * @access public
 		 *
 		 * @param array  $value       Settings Field Array.
 		 * @param string $option_name Option Name.
@@ -1138,6 +1138,7 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 		 *
 		 * Loops though the give options array and outputs each field.
 		 *
+         * @unreleased Added validation for code editor field.
 		 * @since  1.8
 		 *
 		 * @param  array  $options     Options array to output

--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -229,6 +229,32 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
                     ];
                     break;
 
+                case 'donation-forms':
+                    $settings = [
+                        [
+                            'id' => 'give_setting_advanced_section_donation_forms',
+                            'type' => 'title',
+                        ],
+                        [
+                            'name' => __('Custom Styles', 'give'),
+                            'desc' => __(
+                                'Add your own custom CSS styles here to customize the appearance of all donation forms across your site. These styles will be applied globally, allowing you to maintain consistent design without editing each form individually.',
+                                'give'
+                            ),
+                            'id' => 'custom_form_styles',
+                            'type' => 'code_editor',
+                            'css' => 'width: 100%;',
+                            'editor_attributes' => [
+                                'mode' => 'css',
+                            ],
+                        ],
+                        [
+                            'id' => 'give_setting_advanced_section_donation_forms',
+                            'type' => 'sectionend',
+                        ],
+                    ];
+                    break;
+
                 case 'akismet-spam-protection':
                     $settings = [
                         [
@@ -332,6 +358,7 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
         {
             $sections = [
                 'advanced-options' => __('Advanced Options', 'give'),
+                'donation-forms' => __('Donation Forms', 'give'),
                 'akismet-spam-protection' => __('Akismet SPAM Protection', 'give'),
             ];
 

--- a/includes/admin/settings/class-settings-advanced.php
+++ b/includes/admin/settings/class-settings-advanced.php
@@ -58,6 +58,7 @@ if ( ! class_exists( 'Give_Settings_Advanced' ) ) :
         /**
          * Get settings array.
          *
+         * @unreleased Added Donation Forms section
          * @since  1.8
          * @return array
          */

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -111,7 +111,7 @@ class DonationFormViewModel
 
         wp_add_inline_style(
             'givewp-base-form-styles',
-            give_get_option('custom_form_styles', '')
+            wp_strip_all_tags(give_get_option('custom_form_styles', ''))
         );
 
         wp_enqueue_style('givewp-base-form-styles');

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -88,6 +88,7 @@ class DonationFormViewModel
     }
 
     /**
+     * @unreleased Added custom form styles
      * @since 3.0.0
      */
     public function enqueueGlobalStyles()

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -108,6 +108,11 @@ class DonationFormViewModel
             }"
         );
 
+        wp_add_inline_style(
+            'givewp-base-form-styles',
+            give_get_option('custom_form_styles', '')
+        );
+
         wp_enqueue_style('givewp-base-form-styles');
     }
 

--- a/src/Views/Form/Templates/Classic/Classic.php
+++ b/src/Views/Form/Templates/Classic/Classic.php
@@ -180,6 +180,12 @@ class Classic extends Template implements Hookable, Scriptable
             ])
         );
 
+        // Custom styles
+        wp_add_inline_style(
+            'give-classic-template',
+            give_get_option('custom_form_styles', '')
+        );
+
         // JS
         wp_enqueue_script(
             'give-classic-template-js',

--- a/src/Views/Form/Templates/Classic/Classic.php
+++ b/src/Views/Form/Templates/Classic/Classic.php
@@ -185,7 +185,7 @@ class Classic extends Template implements Hookable, Scriptable
         // Custom styles
         wp_add_inline_style(
             'give-classic-template',
-            give_get_option('custom_form_styles', '')
+            wp_strip_all_tags(give_get_option('custom_form_styles', ''))
         );
 
         // JS

--- a/src/Views/Form/Templates/Classic/Classic.php
+++ b/src/Views/Form/Templates/Classic/Classic.php
@@ -130,6 +130,8 @@ class Classic extends Template implements Hookable, Scriptable
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Added custom form styles
      */
     public function loadScripts()
     {

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -348,6 +348,12 @@ class Sequoia extends Template implements Hookable, Scriptable
 
         wp_add_inline_style('give-sequoia-template-css', $dynamicCss);
 
+        // Custom styles
+        wp_add_inline_style(
+            'give-sequoia-template-css',
+            give_get_option('custom_form_styles', '')
+        );
+
         wp_enqueue_script(
             'give-sequoia-template-js',
             GIVE_PLUGIN_URL . 'build/assets/dist/js/give-sequoia-template.js',

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -81,6 +81,8 @@ class Sequoia extends Template implements Hookable, Scriptable
 
     /**
      * @inheritDoc
+     *
+     * @unreleased Added custom form styles
      * @since 2.16.0 Load google fonts if "enabled".
      */
     public function loadScripts()

--- a/src/Views/Form/Templates/Sequoia/Sequoia.php
+++ b/src/Views/Form/Templates/Sequoia/Sequoia.php
@@ -353,7 +353,7 @@ class Sequoia extends Template implements Hookable, Scriptable
         // Custom styles
         wp_add_inline_style(
             'give-sequoia-template-css',
-            give_get_option('custom_form_styles', '')
+            wp_strip_all_tags(give_get_option('custom_form_styles', ''))
         );
 
         wp_enqueue_script(


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2362]

## Description
This pull request adds a new global setting called “Custom Styles”, allowing admin users to define CSS rules that will be applied to all Donation Forms across the website.

To support this feature, we introduced a new admin setting type called `code_editor`, which renders a CodeMirror-powered editor. The `custom_form_styles` option is then enqueued as inline styles on the front end, with support for both legacy and VFB forms.

## Affects
Admin Settings and Form styles

## Visuals
https://github.com/user-attachments/assets/217e3120-1674-4a6a-9f02-56432b54b792

## Testing Instructions
1. Go to Settings > Advanced > Donation Forms
2. Add custom CSS to the editor and save it
3. Confirm those CSS rules are being applied to all your forms.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2362]: https://stellarwp.atlassian.net/browse/GIVE-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ