### PR TITLE
Feature: add support for 3d secure to PayPal Commerce Gateway 

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -202,7 +202,15 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
      * @unreleased
      */
     const cardFieldsOnApproveHandler: PayPalCardFieldsComponentBasics['onApprove'] = async (data) => {
-        payPalOrderId = data.orderID;
+        // @ts-ignore
+        const {orderID, liabilityShift} = data;
+        payPalOrderId = orderID
+
+        if (liabilityShift && !['POSSIBLE', 'YES'].includes(liabilityShift)) {
+            console.log('Liability shift not possible or not accepted.');
+            throw new Error(__('Card type and issuing bank are not ready to complete a 3D Secure authentication.', 'give'));
+        }
+
         return;
     };
 

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -78,6 +78,7 @@ class PayPalCommerce extends PaymentGateway
     }
 
     /**
+     * @unreleased updated to include 3D Secure validation
      * @since 4.0.0 updated to update and capture payment
      * @since 2.19.0
      *

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -98,7 +98,9 @@ class PayPalCommerce extends PaymentGateway
 
             $transactionId = $payPalOrder->purchase_units[0]->payments->captures[0]->id;
 
-        } elseif ($payPalOrder->status === 'APPROVED') {
+        } elseif ($payPalOrder->status === 'APPROVED' || $payPalOrder->status === 'CREATED') {
+            $this->validate3dSecure($payPalOrder);
+
             if ($this->shouldUpdateOrder($donation, $payPalOrder)){
                 $payPalOrderRepository->updateApprovedOrder($payPalOrderId, $donation->amount);
             }
@@ -110,7 +112,7 @@ class PayPalCommerce extends PaymentGateway
 
             $transactionId  = $response->purchase_units[0]->payments->captures[0]->id;
         } else {
-            throw new PaymentGatewayException('PayPal Order status is not approved or completed.');
+            throw new PaymentGatewayException('PayPal Order status is not found.');
         }
 
         give()->payment_meta->update_meta(
@@ -331,6 +333,21 @@ class PayPalCommerce extends PaymentGateway
             );
 
             throw new PaymentGatewayException($errorMessage);
+        }
+
+        $this->validate3dSecure($payPalOrder);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws PaymentGatewayException
+     */
+    private function validate3dSecure(object $payPalOrder): void
+    {
+        // Check if the order is not ready for 3D Secure authentication
+        if (isset($payPalOrder->payment_source->card->authentication_result->liability_shift) && !in_array($payPalOrder->payment_source->card->authentication_result->liability_shift, ['POSSIBLE', 'YES'])) {
+            throw new PaymentGatewayException('Card type and issuing bank are not ready to complete a 3D Secure authentication.');
         }
     }
 }

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -99,6 +99,7 @@ class PayPalOrder
      *
      * @see https://developer.paypal.com/docs/api/orders/v2
      *
+     * @unreleased updated to include 3d secure params for card payments
      * @since 3.4.2 Extract the amount parameters to a separate method
      * @since 3.1.0 "payer" argument is deprecated, using payment_source/paypal.
      * @since 2.9.0

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -142,6 +142,13 @@ class PayPalOrder
                     ],
                     "email_address" => $array['payer']['email'],
                 ],
+                'card' => [
+                    'attributes' => [
+                        'verification' => [
+                            'method' => 'SCA_WHEN_REQUIRED'
+                        ]
+                    ]
+                ]
             ],
             'purchase_units' => [
                 $purchaseUnits

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -17,8 +17,6 @@ use PayPalCheckoutSdk\Payments\CapturesRefundRequest;
 use PayPalHttp\HttpException;
 use PayPalHttp\IOException;
 
-use stdClass;
-
 use function give_record_gateway_error as logError;
 
 /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2397]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds minimal support for 3d secure to the PayPal commerce gateway card fields api.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- PayPal Commerce using card fields

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- In order to properly test will want to set the PayPal Order createOrder request param to `SCA_ALWAYS`
- Then use the test scenarios https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2397]: https://stellarwp.atlassian.net/browse/GIVE-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ