### PR TITLE
feature: add text color and width to donate button blockl

### DIFF
--- a/src/Campaigns/Blocks/DonateButton/block.json
+++ b/src/Campaigns/Blocks/DonateButton/block.json
@@ -10,7 +10,11 @@
         "align": [
             "wide",
             "full"
-        ]
+        ],
+        "color": {
+            "text": true,
+            "background": false
+        }
     },
     "attributes": {
         "campaignId": {
@@ -24,6 +28,13 @@
             "type": "string"
         },
         "buttonText": {
+            "type": "string"
+        },
+        "width": {
+            "type": "string",
+            "default": "100%"
+        },
+        "textColor": {
             "type": "string"
         }
     },

--- a/src/Campaigns/Blocks/DonateButton/edit.tsx
+++ b/src/Campaigns/Blocks/DonateButton/edit.tsx
@@ -5,20 +5,24 @@ import apiFetch from '@wordpress/api-fetch';
 import useSWR from 'swr';
 import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
 import {BlockEditProps} from '@wordpress/blocks';
-import {PanelBody, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
+import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import useCampaign from '../shared/hooks/useCampaign';
 import CampaignSelector from '../shared/components/CampaignSelector';
 
-
 /**
  * @since 4.0.0
  */
-export default function Edit({attributes, setAttributes}: BlockEditProps<{
+export default function Edit({
+    attributes,
+    setAttributes,
+}: BlockEditProps<{
     campaignId: number;
     buttonText: string;
     useDefaultForm: boolean;
     selectedForm: string;
+    width: string;
+    justification: string;
 }>) {
     const blockProps = useBlockProps();
     const {buttonText = __('Donate', 'give')} = attributes;
@@ -31,24 +35,21 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<{
     );
 
     const campaignForms = (() => {
-        const {data, isLoading}: { data: { items: [] }, isLoading: boolean } = useSWR(
+        const {data, isLoading}: {data: {items: []}; isLoading: boolean} = useSWR(
             addQueryArgs('/give-api/v2/admin/forms', {campaignId: attributes.campaignId, status: 'publish'}),
-            path => apiFetch({path})
-        )
+            (path) => apiFetch({path})
+        );
 
         if (isLoading) {
-            return [{label: __('Loading...', 'give'), value: ''}]
+            return [{label: __('Loading...', 'give'), value: ''}];
         }
 
-        const options = data?.items.map((form: { name: string, id: string }) => ({
+        const options = data?.items.map((form: {name: string; id: string}) => ({
             label: form.name,
-            value: form.id
-        }))
+            value: form.id,
+        }));
 
-        return [
-            {label: __('Select form', 'give'), value: ''},
-            ...options
-        ];
+        return [{label: __('Select form', 'give'), value: ''}, ...options];
     })();
 
     return (
@@ -61,43 +62,82 @@ export default function Edit({attributes, setAttributes}: BlockEditProps<{
             </CampaignSelector>
 
             {hasResolved && campaign?.id && (
-                <InspectorControls>
-                    <PanelBody title="Settings" initialOpen={true}>
-                        <TextControl
-                            label={__('Donate button', 'give')}
-                            value={buttonText}
-                            onChange={(buttonText: string) => setAttributes({buttonText})}
-                        />
-                        <ToggleControl
-                            label={__('Use default form', 'give')}
-                            checked={attributes.useDefaultForm}
-                            onChange={(useDefaultForm: boolean) => setAttributes({useDefaultForm})}
-                            help={
-                                <>
-                                    {__('Uses the campaign’s default form.', 'give')}
-                                    {` `}
-                                    <a
-                                        href={`${adminBaseUrl}&id=${attributes.campaignId}&tab=forms`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        aria-label={__('Change campaign default form', 'give')}
-                                    >
-                                        {__('Change default form', 'give')}
-                                    </a>
-                                </>
-                            }
-                        />
-                        {!attributes.useDefaultForm && (
-                            <SelectControl
-                                label={__('Form', 'give')}
-                                onChange={(selectedForm: string) => setAttributes({selectedForm})}
-                                options={campaignForms}
-                                value={attributes.selectedForm}
-                                help={__('Donations are collected through this form.', 'give')}
+                <>
+                    <InspectorControls group="settings">
+                        <PanelBody title="Settings" initialOpen={true}>
+                            <TextControl
+                                label={__('Donate button', 'give')}
+                                value={buttonText}
+                                onChange={(buttonText: string) => setAttributes({buttonText})}
                             />
-                        )}
-                    </PanelBody>
-                </InspectorControls>
+                            <ToggleControl
+                                label={__('Use default form', 'give')}
+                                checked={attributes.useDefaultForm}
+                                onChange={(useDefaultForm: boolean) => setAttributes({useDefaultForm})}
+                                help={
+                                    <>
+                                        {__('Uses the campaign’s default form.', 'give')}
+                                        {` `}
+                                        <a
+                                            href={`${adminBaseUrl}&id=${attributes.campaignId}&tab=forms`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            aria-label={__('Change campaign default form', 'give')}
+                                        >
+                                            {__('Change default form', 'give')}
+                                        </a>
+                                    </>
+                                }
+                            />
+                            {!attributes.useDefaultForm && (
+                                <SelectControl
+                                    label={__('Form', 'give')}
+                                    onChange={(selectedForm: string) => setAttributes({selectedForm})}
+                                    options={campaignForms}
+                                    value={attributes.selectedForm}
+                                    help={__('Donations are collected through this form.', 'give')}
+                                />
+                            )}
+                        </PanelBody>
+                    </InspectorControls>
+
+                    <InspectorControls group={'styles'} initialOpen={true}>
+                        <PanelBody title={__('Width', 'give')} initialOpen={true}>
+                            <PanelRow>
+                                <div role="group" className="components-button-group" aria-label="Button width">
+                                    <button
+                                        type="button"
+                                        className="components-button is-small"
+                                        onClick={() => setAttributes({width: '25%'})}
+                                    >
+                                        25%
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="components-button is-small"
+                                        onClick={() => setAttributes({width: '50%'})}
+                                    >
+                                        50%
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="components-button is-small"
+                                        onClick={() => setAttributes({width: '75%'})}
+                                    >
+                                        75%
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="components-button is-small"
+                                        onClick={() => setAttributes({width: '100%'})}
+                                    >
+                                        100%
+                                    </button>
+                                </div>
+                            </PanelRow>
+                        </PanelBody>
+                    </InspectorControls>
+                </>
             )}
         </div>
     );

--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -10,29 +10,28 @@ use Give\Campaigns\Repositories\CampaignRepository;
  */
 
 if (
-    ! isset($attributes['campaignId']) ||
-    ! ($campaign = give(CampaignRepository::class)->getById($attributes['campaignId']))
+    !isset($attributes['campaignId']) ||
+    !($campaign = give(CampaignRepository::class)->getById($attributes['campaignId']))
 ) {
     return;
 }
 
 $blockInlineStyles = sprintf(
-    '--givewp-primary-color: %s;',
-    esc_attr($campaign->primaryColor ?? '#0b72d9')
+    '--givewp-primary-color: %s; width: %s;',
+    esc_attr($attributes['backgroundColor'] ?? $campaign->primaryColor ?? '#0b72d9'),
+    esc_attr($attributes['width'] ?? '100%')
 );
+
 ?>
 
 <div
-    <?php
-    echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block'])); ?>
-    style="<?php
-    echo esc_attr($blockInlineStyles); ?>">
-    <?php
-    echo give(RenderDonateButton::class)(
-        ($attributes['useDefaultForm'] || ! isset($attributes['selectedForm']))
+    <?php echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block'])); ?>
+    style="<?php echo esc_attr($blockInlineStyles); ?>">
+    <?php echo give(RenderDonateButton::class)(
+        ($attributes['useDefaultForm'] || !isset($attributes['selectedForm']))
             ? $campaign->defaultFormId
             : $attributes['selectedForm'],
-        $attributes['buttonText'] ?? __('Donate', 'give'),
+        $attributes['buttonText'] ?? __('Donate', 'give')
     );
     ?>
 </div>

--- a/src/Campaigns/Blocks/DonateButton/styles.scss
+++ b/src/Campaigns/Blocks/DonateButton/styles.scss
@@ -3,6 +3,7 @@
         line-height: 1.5;
         transition: all 0.2s ease;
         width: 100%;
+        color: inherit;
 
         &:hover {
             background-color: color-mix(in srgb, var(--givewp-primary-color), black 20%);

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/styles/index.scss
@@ -54,7 +54,7 @@
 
 .givewp-donation-form-link,
 .givewp-donation-form-modal__open {
-    color: var(--givewp-secondary-color, #ffffff) !important;
+    color: var(--givewp-secondary-color, #ffffff);
     background: var(--givewp-primary-color, #2271b1);
     padding: 0.75rem 1.25rem !important;
     cursor: pointer;


### PR DESCRIPTION
Resolves [GIVE-2364]

## Description
This is intended to be the first iteration of including additional style options to the campaign donate button block.
These changes allow the block width and text color to change.

## Affects
Campaign Donate Button Block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions
- Create a campaign and landing page.
- Select the styles tab and update the block text color & width.
- Verify changes in both the block editor and the frontend page.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2364]: https://stellarwp.atlassian.net/browse/GIVE-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ