### PR TITLE
Fix: Prevent Modal backdrop lock conflict with iframe resizer

### DIFF
--- a/src/Views/Components/AdminUI/ModalDialog/style.scss
+++ b/src/Views/Components/AdminUI/ModalDialog/style.scss
@@ -95,10 +95,8 @@
 }
 
 body.modalDialog-open {
-    height: 100%;
     overflow: hidden;
-    position: fixed;
-    width: 100%;
+    position: relative;
 }
 
 @keyframes appear {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2399]

## Description
This Pull Request fixes an issue where opening the Modal Dialog inside an iframe causes the iframe to resize to 0px height. In this PR, we address the problem by updating the CSS rule that locks the background when the Modal Dialog is open. The new rule keeps the background lock effective while also working properly inside iframes.

## Affects
Modal DIalog component

## Visuals
![CleanShot2025-04-04at14 43 29-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7eda4f22-7b27-4139-bce3-3045e0136d8a)

## Testing Instructions
1. Create a recurring donation with Stripe then open the Donor Dashboard.
2. Go to that recurring donation and click to pause or cancel that subscription.
3. The modal must open as expected.
4. Also, confirm this fix does not break other places that component is used like the Create Campaign modal.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2399]: https://stellarwp.atlassian.net/browse/GIVE-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ