### PR TITLE
Feature: add SecurityChallenge Field to Fields API 

### DIFF
--- a/src/DonationForms/DataTransferObjects/ValidationRouteData.php
+++ b/src/DonationForms/DataTransferObjects/ValidationRouteData.php
@@ -7,6 +7,7 @@ use Give\DonationForms\Exceptions\DonationFormForbidden;
 use Give\DonationForms\Models\DonationForm;
 use Give\Framework\FieldsAPI\Actions\CreateValidatorFromFormFields;
 use Give\Framework\FieldsAPI\Exceptions\NameCollisionException;
+use Give\Framework\FieldsAPI\SecurityChallenge;
 use Give\Framework\Http\Response\Types\JsonResponse;
 use Give\Framework\Support\Contracts\Arrayable;
 use WP_Error;
@@ -44,6 +45,7 @@ class ValidationRouteData implements Arrayable
      * compares the request against the individual fields,
      * their types and validation rules.
      *
+     * @unreleased updated to exclude security challenge fields during pre-validation
      * @since 3.22.0 added additional validation for form validity, added givewp_donation_form_fields_validated action
      * @since 3.0.0
      *
@@ -61,7 +63,7 @@ class ValidationRouteData implements Arrayable
         }
 
         $formFields = array_filter($form->schema()->getFields(), static function ($field) use ($request) {
-            return array_key_exists($field->getName(), $request);
+            return array_key_exists($field->getName(), $request) && !is_subclass_of($field, SecurityChallenge::class);
         });
 
         $validator = (new CreateValidatorFromFormFields())($formFields, $request);

--- a/src/Framework/FieldsAPI/SecurityChallenge.php
+++ b/src/Framework/FieldsAPI/SecurityChallenge.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Give\Framework\FieldsAPI;
+
+
+/**
+ * Security challenge fields are a special snowflake.
+ * They can typically only be validated once on the server.
+ * Using this field type will ensure that the field is not validated on the server
+ * before the form is fully submitted, avoiding pre-validation endpoints.
+ *
+ * @unreleased
+ */
+abstract class SecurityChallenge extends Field
+{
+    /**
+     * @unreleased
+     */
+    protected int $serverValidationLimit = 1;
+
+    /**
+     * @unreleased
+     */
+    public function serverValidationLimit(int $limit): SecurityChallenge
+    {
+        $this->serverValidationLimit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getServerValidationLimit(): int
+    {
+        return $this->serverValidationLimit;
+    }
+}


### PR DESCRIPTION
…n endpoint

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Security challenge fields are a special snowflake. They can typically only be validated once on the server. Extending this new abstract field will ensure that the field is not validated on the server before the form is fully submitted, avoiding our current pre-validation endpoint.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- Will currently only affect CloudFlare Turnstile

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

TBD

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

