### PR TITLE
Fix: add fallback embed id to donation form block render

### DIFF
--- a/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
+++ b/src/DonationForms/Blocks/DonationFormBlock/Controllers/BlockRenderController.php
@@ -14,6 +14,12 @@ use Give\Helpers\Language;
 class BlockRenderController
 {
     /**
+     * @unreleased
+     */
+    protected static int $embedInstance = 0;
+
+    /**
+     * @unreleased updated with embed ID instance fallback when block ID is not set.
      * @since 3.22.0 Add locale support
      * @since 3.2.0 include form url for new tab format.
      * @since 3.0.0
@@ -27,6 +33,8 @@ class BlockRenderController
             return null;
         }
 
+        static::$embedInstance++;
+
         $blockAttributes = BlockAttributes::fromArray($attributes);
 
         if (!$blockAttributes->formId) {
@@ -38,7 +46,7 @@ class BlockRenderController
         /** @var DonationForm $donationForm */
         $donationForm = DonationForm::find($blockAttributes->formId);
 
-        $embedId = $blockAttributes->blockId ?? '';
+        $embedId = $blockAttributes->blockId ?? 'givewp-embed-' . static::$embedInstance;
 
         $locale = Language::getLocale();
         $viewUrl = $this->getViewUrl($donationForm, $embedId);

--- a/tests/Feature/Controllers/BlockRenderControllerTest.php
+++ b/tests/Feature/Controllers/BlockRenderControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Give\Tests\Feature\Controllers;
 
+use Exception;
 use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
 use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
 use Give\DonationForms\Models\DonationForm;
@@ -12,6 +13,24 @@ use PHPUnit\Framework\MockObject\MockBuilder;
 class BlockRenderControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testMultipleEmbedsOnSamePageGenerateUniqueEmbedIds(): void
+    {
+        $donationForm = DonationForm::factory()->create();
+
+        $render1 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
+        $render2 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
+        $render3 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
+
+        $this->assertStringContainsString("data-givewp-embed-id='givewp-embed-1'", $render1);
+        $this->assertStringContainsString("data-givewp-embed-id='givewp-embed-2'", $render2);
+        $this->assertStringContainsString("data-givewp-embed-id='givewp-embed-3'", $render3);
+    }
 
     /**
      * @since 3.0.0
@@ -25,7 +44,8 @@ class BlockRenderControllerTest extends TestCase
         $blockRenderController = $this->createMockWithCallback(
             BlockRenderController::class,
             function (MockBuilder $mockBuilder) {
-                $mockBuilder->setMethods(['loadEmbedScript']); // partial mock gateway by setting methods on the mock builder
+                $mockBuilder->setMethods(['loadEmbedScript']
+                ); // partial mock gateway by setting methods on the mock builder
                 return $mockBuilder->getMock();
             }
         );

--- a/tests/Feature/Controllers/BlockRenderControllerTest.php
+++ b/tests/Feature/Controllers/BlockRenderControllerTest.php
@@ -23,9 +23,18 @@ class BlockRenderControllerTest extends TestCase
     {
         $donationForm = DonationForm::factory()->create();
 
-        $render1 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
-        $render2 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
-        $render3 = (new BlockRenderController())->render(['formId' => $donationForm->id]);
+        $blockRenderController = $this->createMockWithCallback(
+            BlockRenderController::class,
+            function (MockBuilder $mockBuilder) {
+                $mockBuilder->setMethods(['loadEmbedScript']
+                ); // partial mock gateway by setting methods on the mock builder
+                return $mockBuilder->getMock();
+            }
+        );
+
+        $render1 = $blockRenderController->render(['formId' => $donationForm->id]);
+        $render2 = $blockRenderController->render(['formId' => $donationForm->id]);
+        $render3 = $blockRenderController->render(['formId' => $donationForm->id]);
 
         $this->assertStringContainsString("data-givewp-embed-id='givewp-embed-1'", $render1);
         $this->assertStringContainsString("data-givewp-embed-id='givewp-embed-2'", $render2);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2407]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I discovered we are missing the necessary embed-id on some of our donation form blocks like the campaign donate buttons.  Since these blocks are sharing the original form block render controller, they are missing the embed-id that was originally received from the block's attributes using blockId.

The embed-id is especially useful for offsite gateways so when they come back to the site, we know which form to display the confirmation page and open a modal.

For the purpose of using this controller in a more general purpose way, it was updated with a fallback way of generating the embed-id if not coming from block attributes.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation form block rendering

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Setup a campaign using Stripe Payment Element
- Donate using the campaign landing page donate button
- Make sure the confirmation page is displayed after completing the form

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2407]: https://stellarwp.atlassian.net/browse/GIVE-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ