### PR TITLE
Refactor: hide PayPal Standard admin options by default

### DIFF
--- a/includes/admin/class-admin-settings.php
+++ b/includes/admin/class-admin-settings.php
@@ -316,16 +316,17 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 		 * Output admin fields.
 		 *
 		 * Loops though the give options array and outputs each field.
-		 *
-		 * @todo Refactor this function
-		 *
+         *
+         * @unreleased Display tabs only when there is more than one group available
 		 * @since  1.8
 		 * @access public
-		 *
-		 * @param array  $sections     Opens array to output.
-		 * @param string $option_name Opens array to output.
+         *
+         * @param array  $sections    Opens array to output.
+         * @param string $option_name Opens array to output.
 		 *
 		 * @return void
+         * @todo       Refactor this function
+         *
 		 */
 		public static function output_fields( $sections, $option_name = '' ) {
 
@@ -338,25 +339,29 @@ if ( ! class_exists( 'Give_Admin_Settings' ) ) :
 				$defaultGroup = current( array_keys( $groups ) );
 				?>
 				<div class="give-settings-section-content">
-					<div class="give-settings-section-group-menu">
-						<ul>
-							<?php
-							foreach ( $groups as $slug => $group ) {
-								$current_group = ! empty( $_GET['group'] ) ? give_clean( $_GET['group'] ) : $defaultGroup;
-								$active_class  = ( $slug === $current_group ) ? 'active' : '';
+                    <?php
+                    if (count($groups) > 1) : ?>
+                        <div class="give-settings-section-group-menu">
+                            <ul>
+                                <?php
+                                foreach ($groups as $slug => $group) {
+                                    $current_group = ! empty($_GET['group']) ? give_clean($_GET['group']) : $defaultGroup;
+                                    $active_class = ($slug === $current_group) ? 'active' : '';
 
-								echo sprintf(
-									'<li><a class="%1$s" href="%2$s" data-group="%3$s">%4$s</a></li>',
-									esc_html( $active_class ),
-									esc_url( admin_url( "edit.php?post_type=give_forms&page={$current_page}&tab={$current_tab}&section={$current_section}&group={$slug}" ) ),
-									esc_html( $slug ),
-									esc_html( $group )
-								);
-							}
-							?>
-						</ul>
-					</div>
-					<div class="give-settings-section-group-content">
+                                    echo sprintf(
+                                        '<li><a class="%1$s" href="%2$s" data-group="%3$s">%4$s</a></li>',
+                                        esc_html($active_class),
+                                        esc_url(admin_url("edit.php?post_type=give_forms&page={$current_page}&tab={$current_tab}&section={$current_section}&group={$slug}")),
+                                        esc_html($slug),
+                                        esc_html($group)
+                                    );
+                                }
+                                ?>
+                            </ul>
+                        </div>
+                    <?php
+                    endif; ?>
+                    <div class="give-settings-section-group-content">
 						<?php
 						foreach ( $sections as $group => $fields ) {
 							$current_group = ! empty( $_GET['group'] ) ? give_clean( $_GET['group'] ) : $defaultGroup;

--- a/src/PaymentGateways/ServiceProvider.php
+++ b/src/PaymentGateways/ServiceProvider.php
@@ -104,6 +104,10 @@ class ServiceProvider implements ServiceProviderInterface
      */
     private function maybeHidePayPalStandard()
     {
+        if ( ! is_admin()) {
+            return;
+        }
+
         $isPayPalStandardConnected = is_email(give_get_option('paypal_email', false));
         $alwaysShowPayPalStandardAdminOptions = defined('GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS') && GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS;
 

--- a/src/PaymentGateways/ServiceProvider.php
+++ b/src/PaymentGateways/ServiceProvider.php
@@ -63,6 +63,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('give_embed_footer', CheckoutGateway::class, 'maybeHandleRedirect', 99999);
 
         $this->registerPayPalDonationsMigrationBanners();
+        $this->maybeHidePayPalStandard();
     }
 
     /**
@@ -96,5 +97,49 @@ class ServiceProvider implements ServiceProviderInterface
         // Banner for the migration from PayPal Standard to PayPal Donations.
         give(GatewaySettingPageBanner::class)->setupHook();
         give(PayPalStandardToDonationsMigrationGlobalBanner::class)->setHook();
+    }
+
+    /**
+     * @unreleased
+     */
+    private function maybeHidePayPalStandard()
+    {
+        $isPayPalStandardConnected = is_email(give_get_option('paypal_email', false));
+        $alwaysShowPayPalStandardAdminOptions = defined('GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS') && GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS;
+
+
+        add_filter('give_settings_payment_gateways_menu_groups',
+            function ($groups) use ($isPayPalStandardConnected, $alwaysShowPayPalStandardAdminOptions) {
+                if ($isPayPalStandardConnected || $alwaysShowPayPalStandardAdminOptions) {
+                    return $groups;
+                }
+
+                if (isset($groups['v2']['gateways']['paypal'])) {
+                    unset($groups['v2']['gateways']['paypal']);
+                }
+
+                if (isset($groups['v3']['gateways']['paypal'])) {
+                    unset($groups['v3']['gateways']['paypal']);
+                }
+
+                return $groups;
+            },
+            999
+        );
+
+        add_filter('give_get_groups_paypal',
+            function ($groups) use ($isPayPalStandardConnected, $alwaysShowPayPalStandardAdminOptions) {
+                if ($isPayPalStandardConnected || $alwaysShowPayPalStandardAdminOptions) {
+                    return $groups;
+                }
+
+                if (isset($groups['paypal'])) {
+                    unset($groups['paypal']);
+                }
+
+                return $groups;
+            },
+            999
+        );
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2325]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR hides the PayPal Standard admin option by default when the  `GiveWP > Settings > Payment Gateways > PayPal > PayPal Standard > PayPal Email` is not filled out.

If someone needs to force these options to be visible in the UI, they can add the `define('GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS', true);` to the `wp-config.php` file.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- GiveWP > Settings > Payment Gateways > Gateways
- GiveWP > Settings > Payment Gateways > PayPal

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/045729f4-8b1d-4c78-bc26-56c6d95e90f6)

![image](https://github.com/user-attachments/assets/d0866b0f-715b-4ebd-b700-2f6183eb0314)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

**Important:** Before starting, check if you had the `GiveWP > Settings > Payment Gateways > PayPal > PayPal Standard > PayPal Email` filled out; If yes, make sure to remove it and save the settings.  

Then, pull the change from this branch and make sure that there are no PayPal Standard options available on these pages:

- GiveWP > Settings > Payment Gateways > Gateways
- GiveWP > Settings > Payment Gateways > PayPal
- Add the `define('GIVE_ALWAYS_SHOW_PAYPAL_STANDARD_ADMIN_OPTIONS', true);` in your `wp-config.php` file and make sure the options related to PayPal Standard are now available in the previous pages

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2325]: https://stellarwp.atlassian.net/browse/GIVE-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ