### PR TITLE
Fix: Add argument type check

### DIFF
--- a/src/Helpers/ArrayDataSet.php
+++ b/src/Helpers/ArrayDataSet.php
@@ -11,6 +11,7 @@ class ArrayDataSet
      * You can pass a multi dimensional array but only zero level array keys will be renamed.
      *
      * @since 2.7.0
+     * @unreleased Add is_array check
      *
      * @param array $renameTo Pass array of existing key name as key and new key name as value.
      *
@@ -20,6 +21,10 @@ class ArrayDataSet
      */
     public static function renameKeys($array, $renameTo)
     {
+        if ( ! is_array($array)) {
+            return [];
+        }
+
         // Rename key if property name exist for them.
         foreach ($renameTo as $oldKey => $newKey) {
             if (array_key_exists($oldKey, $array)) {


### PR DESCRIPTION
## Description
This pull request includes an update to the `ArrayDataSet` class in the `src/Helpers/ArrayDataSet.php` file. The main change introduces a check to ensure that the input is an array before attempting to rename its keys.

## Affects

ArrayDataSet helper class


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

