### PR TITLE
Refactor: replace useWatch with useFormData to show the Fee Recovery amount on the modal for Apple/Google Pay (Stripe)

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -14,26 +14,6 @@ let stripePromise = null;
 let stripePaymentMethod = null;
 let stripePaymentMethodIsCreditCard = false;
 
-// @see https://stripe.com/docs/currencies#zero-decimal
-const zeroDecimalCurrencies = [
-    'BIF',
-    'CLP',
-    'DJF',
-    'GNF',
-    'JPY',
-    'KMF',
-    'KRW',
-    'MGA',
-    'PYG',
-    'RWF',
-    'UGX',
-    'VND',
-    'VUV',
-    'XAF',
-    'XOF',
-    'XPF',
-];
-
 const StripeFields = ({gateway}) => {
     const stripe = useStripe();
     const elements = useElements();

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -91,6 +91,7 @@ interface StripeGateway extends Gateway {
 }
 
 /**
+ * @unreleased Replace useWatch with useFormData
  * @since 3.18.0 added fields conditional when donation amount is zero
  * @since 3.13.0 Use only stripeKey to load the Stripe script (when stripeConnectedAccountId is missing) to prevent errors when the account is connected through API keys
  * @since 3.12.1 updated afterCreatePayment response type to include billing details address
@@ -200,20 +201,17 @@ const stripePaymentElementGateway: StripeGateway = {
             throw new Error('Stripe library was not able to load.  Check your Stripe settings.');
         }
 
-        const {useWatch} = window.givewp.form.hooks;
-        const donationType = useWatch({name: 'donationType'});
-        const donationCurrency = useWatch({name: 'currency'});
-        const donationAmount = useWatch({name: 'amount'});
-        const stripeAmount = dollarsToCents(donationAmount, donationCurrency.toString().toUpperCase());
+        const {isRecurring, currency, amount} = window.givewp.form.hooks.useFormData();
+        const stripeAmount = dollarsToCents(amount.toString(), currency.toUpperCase());
 
         const stripeElementOptions: StripeElementsOptionsMode = {
-            mode: donationType === 'subscription' ? 'subscription' : 'payment',
+            mode: isRecurring ? 'subscription' : 'payment',
             amount: stripeAmount,
-            currency: donationCurrency.toLowerCase(),
+            currency: currency.toLowerCase(),
             appearance: appearanceOptions,
         };
 
-        if (donationAmount <= 0) {
+        if (amount <= 0) {
             return <>{__('Donation amount must be greater than zero to proceed.', 'give')}</>;
         }
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/stripePaymentElementGateway.tsx
@@ -34,19 +34,6 @@ const zeroDecimalCurrencies = [
     'XPF',
 ];
 
-/**
- * Takes in an amount value in dollar units and returns the calculated cents amount
- *
- * @since 3.0.0
- */
-const dollarsToCents = (amount: string, currency: string) => {
-    if (zeroDecimalCurrencies.includes(currency)) {
-        return Math.round(parseFloat(amount));
-    }
-
-    return Math.round(parseFloat(amount) * 100);
-};
-
 const StripeFields = ({gateway}) => {
     const stripe = useStripe();
     const elements = useElements();
@@ -201,8 +188,7 @@ const stripePaymentElementGateway: StripeGateway = {
             throw new Error('Stripe library was not able to load.  Check your Stripe settings.');
         }
 
-        const {isRecurring, currency, amount} = window.givewp.form.hooks.useFormData();
-        const stripeAmount = dollarsToCents(amount.toString(), currency.toUpperCase());
+        const {isRecurring, currency, amountInMinorUnits: stripeAmount} = window.givewp.form.hooks.useFormData();
 
         const stripeElementOptions: StripeElementsOptionsMode = {
             mode: isRecurring ? 'subscription' : 'payment',
@@ -211,7 +197,7 @@ const stripePaymentElementGateway: StripeGateway = {
             appearance: appearanceOptions,
         };
 
-        if (amount <= 0) {
+        if (stripeAmount <= 0) {
             return <>{__('Donation amount must be greater than zero to proceed.', 'give')}</>;
         }
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2318]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR replaces the `useWatch` hook with the `useFormData` hook so we can retrieve the amount of the donation with the Fee Recovery already included. This way, we can prevent showing the donation amount without the fee recovery included in the model for Apple/Google Pay (Stripe).

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Stipe Element gateway

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![google-pay-fee-recovery](https://github.com/user-attachments/assets/1caafa11-6e21-4807-90e8-6463759a8748)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Create a VFB form
2. Add the Fee Recovery block with a fee
3. Enable the Stripe Payment Gateway
4. Ensure Apple/Google Pay is showing
5. Go through the donation process and click to add a fee
6. Select Apple or Google Pay
7. When submitting, there will be a modal with the **Donation Total** (including the fee recovery amount)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2318]: https://stellarwp.atlassian.net/browse/GIVE-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ