### PR TITLE
Refactor: tweak gateway fields padding on mobile screens

### DIFF
--- a/src/DonationForms/resources/styles/components/_gateways.scss
+++ b/src/DonationForms/resources/styles/components/_gateways.scss
@@ -1,3 +1,5 @@
+@use '../variables';
+
 .givewp-fields-gateways {
     &__list {
         display: flex;
@@ -62,6 +64,10 @@
 
         &--active &__fields {
             display: block;
+
+            @media screen and (max-width: variables.$givewp-breakpoint-sm) {
+                padding: var(--givewp-spacing-4);
+            }
         }
 
         &--empty {

--- a/src/DonationForms/resources/styles/elements/_fields.scss
+++ b/src/DonationForms/resources/styles/elements/_fields.scss
@@ -120,6 +120,7 @@ input[type="checkbox"], input[type="radio"] {
     font-size: inherit;
     vertical-align: middle;
     cursor: pointer;
+    flex-shrink: 0;
 
     &:checked::before {
         transform: scale(1);


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2105]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds a CSS media query to adjust the padding for payment gateway fields on smaller screens - check the attached demo video for more context.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Payment Gateways list on VFB forms

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/0a1c8c83b6bf4619abc787d425fb3d62?sid=e8029878-8892-465e-abee-4b3e79c4f466

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Follow the test instructions from this other related PR: https://github.com/impress-org/give-authorize-gateway/pull/127

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2105]: https://stellarwp.atlassian.net/browse/GIVE-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ