### PR TITLE
Fix: Update legacy form URLs containing both UTM tags and anchors

### DIFF
--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -58,7 +58,7 @@ class Utils
                 $queryString,
                 wp_parse_args(substr($url, $index + 1))
             );
-            $url = substr($url, 0, $index); // Remove query part from URL
+            $url = substr($url, 0, $index);
         }
 
         $url = add_query_arg($queryString, $url);
@@ -71,12 +71,8 @@ class Utils
             $url = add_query_arg([$name => $value], $url);
         }
 
-        if (!empty($urlAnchor)) {
-            $urlParts = explode('?', $url, 2);
-            $url = $urlParts[0] . '#' . $urlAnchor;
-            if (isset($urlParts[1])) {
-                $url .= '?' . $urlParts[1];
-            }
+        if ($urlAnchor) {
+            $url = add_query_arg('request_anchor', $urlAnchor, $url);
         }
 
         return esc_url_raw($url);

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -72,7 +72,7 @@ class Utils
             $url = add_query_arg([$name => $value], $url);
         }
 
-        if ($urlAnchor) {
+        if (!empty($urlAnchor)) {
             $url = add_query_arg('request_anchor', $urlAnchor, $url);
         }
 

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -41,30 +41,41 @@ class Utils
      */
     public static function switchRequestedURL($location, $url, $addArgs = [], $removeArgs = [])
     {
+        $urlAnchor = '';
+
+        if (strpos($url, '#') !== false) {
+            [$url, $urlAnchor] = explode('#', $url, 2);
+        }
+
         $queryString = [];
 
-        if ($index = strpos($location, '?')) {
-            $queryString = wp_parse_args(substr($location, strpos($location, '?') + 1));
+        if (($index = strpos($location, '?')) !== false) {
+            $queryString = wp_parse_args(substr($location, $index + 1));
         }
 
-        if ($index = strpos($url, '?')) {
-            $queryString = array_merge($queryString, wp_parse_args(substr($url, strpos($url, '?') + 1)));
+        if (($index = strpos($url, '?')) !== false) {
+            $queryString = array_merge(
+                $queryString,
+                wp_parse_args(substr($url, $index + 1))
+            );
+            $url = substr($url, 0, $index); // Remove query part from URL
         }
 
-        $url = add_query_arg(
-            $queryString,
-            $url
-        );
+        $url = add_query_arg($queryString, $url);
 
-        if ($removeArgs) {
-            foreach ($removeArgs as $name) {
-                $url = add_query_arg([$name => false], $url);
-            }
+        foreach ((array) $removeArgs as $name) {
+            $url = add_query_arg([$name => false], $url);
         }
 
-        if ($addArgs) {
-            foreach ($addArgs as $name => $value) {
-                $url = add_query_arg([$name => $value], $url);
+        foreach ((array) $addArgs as $name => $value) {
+            $url = add_query_arg([$name => $value], $url);
+        }
+
+        if (!empty($urlAnchor)) {
+            $urlParts = explode('?', $url, 2);
+            $url = $urlParts[0] . '#' . $urlAnchor;
+            if (isset($urlParts[1])) {
+                $url .= '?' . $urlParts[1];
             }
         }
 

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -30,6 +30,7 @@ class Utils
     /**
      * This function will change request url with other url.
      *
+     * @unreleased Replace URL anchor with request_anchor argument
      * @since 2.7.0
      *
      * @param string $location Requested URL.


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-932]

## Description
In legacy forms, setting up a success or failure URL that contains both UTM tags and an anchor breaks Stripe payments. This pull request fixes the issue by removing the anchor and then re-adding it as a `request_anchor` argument in the URL. This way, we make sure the URLs never contain both tags and anchors at the same time.

## Affects
Legacy Forms

## Testing Instructions
1. Add the following sample hook to a functions file. It'll append sample UTM tags and an anchor to the current page URL that is used in success and failure URLs:
```php
<?php
/**
 * Add sample UTM tags and an anchor to the current GiveWP page URL.
 *
 * @param string $url The original URL.
 * @return string Modified URL with UTM tags and anchor.
 */
function add_utm_tags_and_anchor_to_give_url( $url ) {
    // Add UTM parameters using add_query_arg
    $url_with_utm = add_query_arg( array(
        'utm_source'   => 'newsletter',
        'utm_medium'   => 'email',
        'utm_campaign' => 'spring_sale',
    ), $url );

    // Append anchor
    $url_with_anchor = $url_with_utm . '#video';

    return $url_with_anchor;
}
add_filter( 'give_get_current_page_url', 'add_utm_tags_and_anchor_to_give_url' );
```
2. Using a legacy form, donate using Stripe payment
3. Everything must be processed as expected. Opcionally, confirm the success URL contains the `request_anchor` argument on it.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-932]: https://stellarwp.atlassian.net/browse/GIVE-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ