### PR TITLE
Refactor: display v3 custom fields in donor dashboard and legacy receipts

### DIFF
--- a/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -5,13 +5,11 @@ namespace Give\DonationForms\ViewModels;
 use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\FormDesigns\ClassicFormDesign\ClassicFormDesign;
 use Give\DonationForms\Models\DonationForm;
-use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\Repositories\DonationFormRepository;
 use Give\Donations\Models\Donation;
 use Give\Framework\DesignSystem\Actions\RegisterDesignSystemStyles;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\Receipts\DonationReceipt;
-use Give\Framework\Receipts\DonationReceiptBuilder;
 use Give\Framework\Support\Scripts\Concerns\HasScriptAssetFile;
 use Give\Helpers\Language;
 
@@ -48,9 +46,7 @@ class DonationConfirmationReceiptViewModel
      */
     public function getReceipt(): DonationReceipt
     {
-        $receipt = new DonationReceipt($this->donation);
-
-        return (new DonationReceiptBuilder($receipt))->toConfirmationPage();
+        return $this->donation->confirmationPageReceipt();
     }
 
     /**

--- a/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
+++ b/src/DonationForms/ViewModels/DonationConfirmationReceiptViewModel.php
@@ -46,7 +46,7 @@ class DonationConfirmationReceiptViewModel
      */
     public function getReceipt(): DonationReceipt
     {
-        return $this->donation->confirmationPageReceipt();
+        return $this->donation->receipt();
     }
 
     /**

--- a/src/Donations/Models/Donation.php
+++ b/src/Donations/Models/Donation.php
@@ -266,7 +266,7 @@ class Donation extends Model implements ModelCrud, ModelHasFactory
     /**
      * @unreleased
      */
-    public function confirmationPageReceipt(): DonationReceipt
+    public function receipt(): DonationReceipt
     {
         return give()->donations->getConfirmationPageReceipt($this);
     }

--- a/src/Donations/Models/Donation.php
+++ b/src/Donations/Models/Donation.php
@@ -19,6 +19,7 @@ use Give\Framework\Models\Model;
 use Give\Framework\Models\ModelQueryBuilder;
 use Give\Framework\Models\ValueObjects\Relationship;
 use Give\Framework\PaymentGateways\PaymentGateway;
+use Give\Framework\Receipts\DonationReceipt;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\Subscriptions\Models\Subscription;
 
@@ -260,6 +261,14 @@ class Donation extends Model implements ModelCrud, ModelHasFactory
     public function gateway(): PaymentGateway
     {
         return give()->gateways->getPaymentGateway($this->gatewayId);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function confirmationPageReceipt(): DonationReceipt
+    {
+        return give()->donations->getConfirmationPageReceipt($this);
     }
 
     /**

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -611,7 +611,7 @@ class DonationRepository
     /**
      * @unreleased
      */
-    public function getConfirmationPageReceipt(Donation $donation)
+    public function getConfirmationPageReceipt(Donation $donation): DonationReceipt
     {
         $receipt = new DonationReceipt($donation);
 

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -617,20 +617,4 @@ class DonationRepository
 
         return (new DonationReceiptBuilder($receipt))->toConfirmationPage();
     }
-
-    /**
-     * @unreleased
-     */
-    public function getCustomFields(Donation $donation)
-    {
-        $form = DonationForm::find($donation->formId);
-
-        if (!$form) {
-            return [];
-        }
-
-        return array_filter($form->schema()->getFields(), static function (Field $field) {
-            return $field->shouldShowInReceipt();
-        });
-    }
 }

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -50,7 +50,6 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerDonationsAdminPage();
         $this->addCustomFieldsToDonationDetails();
 
-
         give(MigrationsRegister::class)->addMigrations([
             AddMissingDonorIdToDonationComments::class,
             SetAutomaticFormattingOption::class,

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -50,6 +50,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->registerDonationsAdminPage();
         $this->addCustomFieldsToDonationDetails();
 
+
         give(MigrationsRegister::class)->addMigrations([
             AddMissingDonorIdToDonationComments::class,
             SetAutomaticFormattingOption::class,

--- a/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
+++ b/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
@@ -2,7 +2,9 @@
 
 namespace Give\Form\LegacyConsumer\Actions;
 
+use Give\DonationForms\Models\DonationForm;
 use Give\Donations\Models\Donation;
+use Give\Helpers\Form\Utils;
 use Give\Receipt\DonationReceipt;
 
 /**
@@ -18,12 +20,12 @@ class AddCustomFieldsToLegacyReceipt
 
         $donation = Donation::find($receipt->donationId);
 
+        // make sure we have a valid donation
         if (!$donation) {
             return;
         }
 
-        $confirmationPageReceipt = $donation->receipt();
-        $details = $confirmationPageReceipt->additionalDetails->getDetails();
+        $details = $donation->receipt()->additionalDetails->getDetails();
 
         if (empty($details)) {
             return;

--- a/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
+++ b/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Give\Form\LegacyConsumer\Actions;
+
+use Give\Receipt\DonationReceipt;
+
+/**
+ * @unreleased
+ */
+class AddCustomFieldsToLegacyReceipt
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(DonationReceipt $receipt)
+    {
+
+        $donation = \Give\Donations\Models\Donation::find($receipt->donationId);
+
+        if (!$donation) {
+            return;
+        }
+
+        $confirmationPageReceipt = $donation->confirmationPageReceipt();
+        $details = $confirmationPageReceipt->additionalDetails->getDetails();
+
+        if (empty($details)) {
+            return;
+        }
+
+        $index = 0;
+        $section = $receipt->getSections()[DonationReceipt::ADDITIONALINFORMATIONSECTIONID];
+
+        foreach ($details as $detail) {
+            $index++;
+            // line item will fail if the value is null/empty so we need to check for it and add an empty space instead
+            $section->addLineItem(
+                [
+                    'id' => "givewp-custom-field-{$index}",
+                    'label' => !empty($detail->label) ? $detail->label : ' ',
+                    'value' => !empty($detail->value) ? $detail->value : ' ',
+                ]
+            );
+        }
+    }
+}

--- a/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
+++ b/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
@@ -21,7 +21,7 @@ class AddCustomFieldsToLegacyReceipt
             return;
         }
 
-        $confirmationPageReceipt = $donation->confirmationPageReceipt();
+        $confirmationPageReceipt = $donation->receipt();
         $details = $confirmationPageReceipt->additionalDetails->getDetails();
 
         if (empty($details)) {

--- a/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
+++ b/src/Form/LegacyConsumer/Actions/AddCustomFieldsToLegacyReceipt.php
@@ -2,6 +2,7 @@
 
 namespace Give\Form\LegacyConsumer\Actions;
 
+use Give\Donations\Models\Donation;
 use Give\Receipt\DonationReceipt;
 
 /**
@@ -15,7 +16,7 @@ class AddCustomFieldsToLegacyReceipt
     public function __invoke(DonationReceipt $receipt)
     {
 
-        $donation = \Give\Donations\Models\Donation::find($receipt->donationId);
+        $donation = Donation::find($receipt->donationId);
 
         if (!$donation) {
             return;

--- a/src/Form/LegacyConsumer/ServiceProvider.php
+++ b/src/Form/LegacyConsumer/ServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Give\Form\LegacyConsumer;
 
+use Give\Form\LegacyConsumer\Actions\AddCustomFieldsToLegacyReceipt;
 use Give\Form\LegacyConsumer\Commands\DeprecateOldTemplateHook;
+use Give\Helpers\Hooks;
 use Give\Receipt\DonationReceipt;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
 use Give_Donate_Form;
@@ -97,5 +99,7 @@ class ServiceProvider implements ServiceProviderInterface
                 give(TemplateHooks::class)->walk(new Commands\SetupFieldEmailTag);
             }
         );
+
+        Hooks::addAction('give_new_receipt', AddCustomFieldsToLegacyReceipt::class);
     }
 }

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -39,16 +39,11 @@ class GenerateConfirmationPageReceipt
      */
     protected function getCustomFields(Donation $donation): array
     {
-        if (give(DonationFormRepository::class)->isLegacyForm($donation->formId)) {
+        $customFields = give()->donations->getCustomFields($donation);
+
+        if (empty($customFields)) {
             return [];
         }
-
-        /** @var DonationForm $form */
-        $form = DonationForm::find($donation->formId);
-
-        $customFields = array_filter($form->schema()->getFields(), static function (Field $field) {
-            return $field->shouldShowInReceipt();
-        });
 
         $receiptDetails = [];
         foreach ($customFields as $field) {

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -39,7 +39,15 @@ class GenerateConfirmationPageReceipt
      */
     protected function getCustomFields(Donation $donation): array
     {
-        $customFields = give()->donations->getCustomFields($donation);
+        $form = DonationForm::find($donation->formId);
+
+        if (!$form) {
+            return [];
+        }
+
+        return array_filter($form->schema()->getFields(), static function (Field $field) {
+            return $field->shouldShowInReceipt();
+        });
 
         if (empty($customFields)) {
             return [];

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -39,19 +39,16 @@ class GenerateConfirmationPageReceipt
      */
     protected function getCustomFields(Donation $donation): array
     {
+        if (give(DonationFormRepository::class)->isLegacyForm($donation->formId)) {
+            return [];
+        }
+
+        /** @var DonationForm $form */
         $form = DonationForm::find($donation->formId);
 
-        if (!$form) {
-            return [];
-        }
-
-        return array_filter($form->schema()->getFields(), static function (Field $field) {
+        $customFields = array_filter($form->schema()->getFields(), static function (Field $field) {
             return $field->shouldShowInReceipt();
         });
-
-        if (empty($customFields)) {
-            return [];
-        }
 
         $receiptDetails = [];
         foreach ($customFields as $field) {

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -33,18 +33,19 @@ class GenerateConfirmationPageReceipt
     }
 
     /**
+     * @unreleased return early if the form model is not found
      * @since 3.4.0 updated to check for metaKey first and then fallback to name
      * @since 3.3.0 updated conditional to check for scopes and added support for retrieving values programmatically with Fields API
      * @since 3.0.0
      */
     protected function getCustomFields(Donation $donation): array
     {
-        if (give(DonationFormRepository::class)->isLegacyForm($donation->formId)) {
-            return [];
-        }
-
         /** @var DonationForm $form */
         $form = DonationForm::find($donation->formId);
+
+        if (!$form) {
+            return [];
+        }
 
         $customFields = array_filter($form->schema()->getFields(), static function (Field $field) {
             return $field->shouldShowInReceipt();


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves: [GIVE-2444]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

There is a difference between how v2 and v3 forms reference custom fields like the ones in FFM.  In some areas like the donor dashboard, the custom fields were not displaying because the logic for v3 forms was not in place.  This ensures we are displaying custom fields coming form v3 forms in the legacy receipt.  This was accomplished by running through the old `give_new_receipt` using the new receipt schema.

To make our lives easier, I added a simple method on the Donation model to generate the `DonationReceipt` instance.

```php
$donation->receipt();
```

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The confirmation page logic was updates slightly
- Legacy receipt in donor dashboard should show custom fields from v3 forms now

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


https://github.com/user-attachments/assets/54006577-2834-4fb6-85b8-c57e404e6a77


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/14670422589

- Create a v3 form with a bunch of different custom fields
- View the donor dashboard and donation receipt
- You should now see custom fields show up

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2444]: https://stellarwp.atlassian.net/browse/GIVE-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ