### PR TITLE
Feature: add currency switcher listeners to core

### DIFF
--- a/src/Donations/LegacyListeners/UpdateDonationMetaWithLegacyFormCurrencySettings.php
+++ b/src/Donations/LegacyListeners/UpdateDonationMetaWithLegacyFormCurrencySettings.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Give\Donations\LegacyListeners;
+
+use Give\Donations\Models\Donation;
+use Give\Framework\Support\ValueObjects\Money;
+
+/**
+ * @unreleased
+ */
+class UpdateDonationMetaWithLegacyFormCurrencySettings
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(Donation $donation)
+    {
+        if (!isset($_POST['give-cs-exchange-rate'])) {
+            return;
+        }
+
+        $exchangeRate = give_clean($_POST['give-cs-exchange-rate']) ?? '1';
+
+        give_update_payment_meta($donation->id, '_give_cs_enabled', 'enabled');
+        give_update_payment_meta($donation->id, '_give_cs_base_currency', give_get_option('currency'));
+
+        /** @var Money $baseAmount */
+        $baseAmount = $donation->amount->divide($exchangeRate);
+
+        give_update_payment_meta($donation->id, '_give_cs_base_amount', $baseAmount->formatToDecimal());
+
+        $donation->exchangeRate = $exchangeRate;
+        $donation->save();
+    }
+}

--- a/src/Donations/Listeners/DonationCreated/UpdateDonationMetaWithCurrencySettings.php
+++ b/src/Donations/Listeners/DonationCreated/UpdateDonationMetaWithCurrencySettings.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Give\Donations\Listeners\DonationCreated;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Models\Donation;
+use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\FieldsAPI\Properties\DonationForm\CurrencySwitcherSetting;
+use Give\Framework\Support\ValueObjects\Money;
+
+/**
+ * @unreleased
+ */
+class UpdateDonationMetaWithCurrencySettings
+{
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function __invoke(Donation $donation)
+    {
+        if ($donation->amount->equals($donation->amountInBaseCurrency())) {
+            return;
+        }
+
+        $form = DonationForm::find($donation->formId);
+
+        if (!$form) {
+            return;
+        }
+
+        $currencySwitcherSettings = $form->schema()->getCurrencySwitcherSettings();
+
+        if (empty($currencySwitcherSettings)) {
+            return;
+        }
+
+        /** @var CurrencySwitcherSetting|null $donorCurrencySetting */
+        $donorCurrencySetting = current(
+            array_filter(
+                $currencySwitcherSettings,
+                static function (CurrencySwitcherSetting $setting) use ($donation) {
+                    return $setting->getId() === $donation->amount->getCurrency()->getCode();
+                }
+            )
+        );
+
+        if (!$donorCurrencySetting) {
+            return;
+        }
+
+        give_update_payment_meta($donation->id, '_give_cs_enabled', 'enabled');
+
+        give_update_payment_meta($donation->id, '_give_cs_base_currency', give_get_option('currency'));
+
+        $donation->exchangeRate = (string)$donorCurrencySetting->getExchangeRate();
+        $donation->save();
+
+
+        // Note: this concept of base amount that currency switcher has been using, simply derives the base currency amount using division of the current exchange rate.
+        // I believe this is different from $donation->amountInBaseCurrency();
+        // The v2 logic can be found in the function `give_cs_store_switched_currency_meta_data`
+        /** @var Money $baseAmount */
+        $baseAmount = $donation->amount->divide($donorCurrencySetting->getExchangeRate());
+
+        give_update_payment_meta($donation->id, '_give_cs_base_amount', $baseAmount->formatToDecimal());
+    }
+}

--- a/src/Donations/Listeners/DonationCreated/UpdateDonorMetaWithLastDonatedCurrency.php
+++ b/src/Donations/Listeners/DonationCreated/UpdateDonorMetaWithLastDonatedCurrency.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Give\Donations\Listeners\DonationCreated;
+
+use Give\Donations\Models\Donation;
+
+/**
+ * Ported over from v2 forms `give_cs_store_switched_currency_meta_data`
+ *
+ * @unreleased
+ */
+class UpdateDonorMetaWithLastDonatedCurrency
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(Donation $donation)
+    {
+        $donorCurrency = give()->donor_meta->get_meta($donation->donorId, '_give_cs_currency', true);
+
+        if ($donorCurrency !== $donation->amount->getCurrency()->getCode()) {
+            give()->donor_meta->update_meta(
+                $donation->donorId,
+                '_give_cs_currency',
+                $donation->amount->getCurrency()->getCode()
+            );
+        }
+    }
+}

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -12,6 +12,7 @@ use Give\Donations\LegacyListeners\DispatchGiveUpdatePaymentStatus;
 use Give\Donations\LegacyListeners\InsertSequentialId;
 use Give\Donations\LegacyListeners\RemoveSequentialId;
 use Give\Donations\LegacyListeners\UpdateDonorPaymentIds;
+use Give\Donations\LegacyListeners\UpdateDonationMetaWithLegacyFormCurrencySettings;
 use Give\Donations\Listeners\DonationCreated\UpdateDonationMetaWithCurrencySettings;
 use Give\Donations\Listeners\DonationCreated\UpdateDonorMetaWithLastDonatedCurrency;
 use Give\Donations\ListTable\DonationsListTable;
@@ -72,6 +73,7 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction('givewp_donation_creating', DispatchGivePreInsertPayment::class);
 
         add_action('givewp_donation_created', static function (Donation $donation) {
+            (new UpdateDonationMetaWithLegacyFormCurrencySettings())($donation);
             (new InsertSequentialId())($donation);
             (new DispatchGiveInsertPayment())($donation);
             (new UpdateDonorPaymentIds())($donation);

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -12,6 +12,8 @@ use Give\Donations\LegacyListeners\DispatchGiveUpdatePaymentStatus;
 use Give\Donations\LegacyListeners\InsertSequentialId;
 use Give\Donations\LegacyListeners\RemoveSequentialId;
 use Give\Donations\LegacyListeners\UpdateDonorPaymentIds;
+use Give\Donations\Listeners\DonationCreated\UpdateDonationMetaWithCurrencySettings;
+use Give\Donations\Listeners\DonationCreated\UpdateDonorMetaWithLastDonatedCurrency;
 use Give\Donations\ListTable\DonationsListTable;
 use Give\Donations\Migrations\AddMissingDonorIdToDonationComments;
 use Give\Donations\Migrations\MoveDonationCommentToDonationMetaTable;
@@ -46,6 +48,7 @@ class ServiceProvider implements ServiceProviderInterface
      */
     public function boot()
     {
+        $this->bootListeners();
         $this->bootLegacyListeners();
         $this->registerDonationsAdminPage();
         $this->addCustomFieldsToDonationDetails();
@@ -127,6 +130,18 @@ class ServiceProvider implements ServiceProviderInterface
     {
         add_action('give_view_donation_details_billing_after', static function ($donationId) {
             echo (new DonationDetailsController())->show($donationId);
+        });
+    }
+
+    /**
+     * @unreleased
+     */
+    private function bootListeners()
+    {
+        add_action('givewp_donation_created', static function (Donation $donation) {
+            (new UpdateDonationMetaWithCurrencySettings())($donation);
+
+            (new UpdateDonorMetaWithLastDonatedCurrency())($donation);
         });
     }
 }

--- a/tests/Unit/Donations/Listeners/DonationCreated/TestUpdateDonationMetaWithCurrencySettings.php
+++ b/tests/Unit/Donations/Listeners/DonationCreated/TestUpdateDonationMetaWithCurrencySettings.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\Donations\Listeners\DonationCreated;
+
+use Give\DonationForms\Models\DonationForm;
+use Give\Donations\Listeners\DonationCreated\UpdateDonationMetaWithCurrencySettings;
+use Give\Donations\Models\Donation;
+use Give\Framework\FieldsAPI\DonationForm as FieldsAPIDonationForm;
+use Give\Framework\FieldsAPI\Properties\DonationForm\CurrencySwitcherSetting;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @coversDefaultClass UpdateDonationMetaWithCurrencySettings
+ */
+class TestUpdateDonationMetaWithCurrencySettings extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testShouldUpdateDonationMetaWithCurrencySettings()
+    {
+        add_action('givewp_donation_form_schema', function (FieldsAPIDonationForm $form) {
+            $form->currencySwitcherSettings(
+                new CurrencySwitcherSetting('USD', 1, [], 2),
+                new CurrencySwitcherSetting('EUR', 2, [], 2),
+            );
+        });
+
+        /** @var DonationForm $form */
+        $form = DonationForm::factory()->create();
+
+        give_update_option('currency', 'USD');
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'amount' => new Money(100, 'EUR'),
+            'formId' => $form->id,
+        ]);
+
+        $action = new UpdateDonationMetaWithCurrencySettings();
+        $action($donation);
+
+        $this->assertEquals('EUR', $donation->amount->getCurrency()->getCode());
+        $this->assertEquals(2, $donation->exchangeRate);
+
+        $this->assertEquals('enabled', give_get_meta($donation->id, '_give_cs_enabled', true));
+        $this->assertEquals('USD', give_get_meta($donation->id, '_give_cs_base_currency', true));
+        $this->assertEquals('0.50', give_get_meta($donation->id, '_give_cs_base_amount', true));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testShouldNotUpdateDonationMetaWithCurrencySettingsIfCurrencySwitcherSettingsAreNotSet()
+    {
+        $action = new UpdateDonationMetaWithCurrencySettings();
+        $donation = Donation::factory()->create();
+
+        $action($donation);
+
+        $this->assertEmpty(give()->payment_meta->get_meta($donation->id, '_give_cs_enabled', true));
+        $this->assertEmpty(give()->payment_meta->get_meta($donation->id, '_give_cs_base_currency', true));
+        $this->assertEmpty(give()->payment_meta->get_meta($donation->id, '_give_cs_base_amount', true));
+    }
+}

--- a/tests/Unit/Donations/Listeners/DonationCreated/TestUpdateDonorMetaWithLastDonatedCurrency.php
+++ b/tests/Unit/Donations/Listeners/DonationCreated/TestUpdateDonorMetaWithLastDonatedCurrency.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\Donations\Listeners\DonationCreated;
+
+use Give\Donations\Listeners\DonationCreated\UpdateDonorMetaWithLastDonatedCurrency;
+use Give\Donations\Models\Donation;
+use Give\Donors\Models\Donor;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @coversDefaultClass UpdateDonorMetaWithLastDonatedCurrency
+ */
+class TestUpdateDonorMetaWithLastDonatedCurrency extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     */
+    public function testShouldUpdateDonorMetaWithLastDonatedCurrency()
+    {
+        $donor = Donor::factory()->create();
+
+        $donation = Donation::factory()->create([
+            'donorId' => $donor->id,
+            'amount' => new Money(100, 'EUR'),
+        ]);
+
+        $action = new UpdateDonorMetaWithLastDonatedCurrency();
+        $action($donation);
+
+        $this->assertEquals('EUR', give()->donor_meta->get_meta($donor->id, '_give_cs_currency', true));
+    }
+}


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Related: [GIVE-2516], [GIVE-859], https://github.com/impress-org/give-currency-switcher/pull/321

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This moves the actions that handle updating currency meta into core.  Previously all this logic lived in the currency switcher add-on however, as more of the currency concepts actually live in core it makes sense for this logic to live there as well.  This will ensure that core will handle associating currency data to the donation, eventually leaving the currency switcher add-on to simply supply settings like exchange rates.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- creating donations with currency settings (currency switcher)

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/01fb49c1491c483c97c559fb2c367421?sid=90566c00-457c-4422-b223-7f5c1d6f190f

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/14604325546

- create a campaign with both v2 and v3 forms
- install currency switcher and setup settings to enable currency switcher on both forms
- create donation using the currency switcher and make sure the meta for donation is accurate for exchange_rate, as well as the revenue table.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2516]: https://stellarwp.atlassian.net/browse/GIVE-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-859]: https://stellarwp.atlassian.net/browse/GIVE-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ