### PR TITLE
Fix: Show donate button after PayPal donations is umounted

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -57,6 +57,8 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
     let payPalCardFieldsForm: PayPalCardFieldsComponent = null;
 
     const showOrHideDonateButton = (showOrHide: 'show' | 'hide') => {
+        submitButton = submitButton || window.givewp.form.hooks.useFormSubmitButton();
+
         if (submitButton) {
             submitButton.style.display = showOrHide === 'hide' ? 'none' : '';
         }
@@ -162,11 +164,13 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
     const cardFieldsOnApproveHandler: PayPalCardFieldsComponentBasics['onApprove'] = async (data) => {
         // @ts-ignore
         const {orderID, liabilityShift} = data;
-        payPalOrderId = orderID
+        payPalOrderId = orderID;
 
         if (liabilityShift && !['POSSIBLE', 'YES'].includes(liabilityShift)) {
             console.log('Liability shift not possible or not accepted.');
-            throw new Error(__('Card type and issuing bank are not ready to complete a 3D Secure authentication.', 'give'));
+            throw new Error(
+                __('Card type and issuing bank are not ready to complete a 3D Secure authentication.', 'give')
+            );
         }
 
         return;
@@ -447,6 +451,7 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         }, [currency, isRecurring]);
 
         useEffect(() => {
+            console.log('shouldShowCardFields', shouldShowCardFields);
             // hide donate buttons if card fields are not expected to be shown
             if (!shouldShowCardFields) {
                 showOrHideDonateButton('hide');

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -451,7 +451,6 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         }, [currency, isRecurring]);
 
         useEffect(() => {
-            console.log('shouldShowCardFields', shouldShowCardFields);
             // hide donate buttons if card fields are not expected to be shown
             if (!shouldShowCardFields) {
                 showOrHideDonateButton('hide');

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -451,6 +451,10 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
             if (!shouldShowCardFields) {
                 showOrHideDonateButton('hide');
             }
+
+            return () => {
+                showOrHideDonateButton('show');
+            };
         }, [shouldShowCardFields]);
 
         return (


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2518]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This ensures the donate button displays again after selecting a different payment method when previously hidden.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- PayPal donations

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


https://github.com/user-attachments/assets/32fc6c0a-7c98-4d41-bbe0-42ffa4b063b5


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/14619508044

- Setup PayPal donations set to smart buttons only
- Setup another gateway like stripe
- Select PayPal donations and make sure the donate button is hidden
- Select another gateway and make sure the donate button is not hidden

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2518]: https://stellarwp.atlassian.net/browse/GIVE-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ