### PR TITLE
Feature: add metadata to stripe recurring donations

### DIFF
--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/UpdateStripeInvoiceMetaData.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Actions/UpdateStripeInvoiceMetaData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Actions;
+
+use Give\Donations\Models\Donation;
+use Stripe\Invoice;
+
+/**
+ * @unreleased
+ */
+class UpdateStripeInvoiceMetaData
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(Invoice $invoice, Donation $donation)
+    {
+        $invoice->updateAttributes(['metadata' => give_stripe_prepare_metadata($donation->id)]);
+        $invoice->save();
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Decorators/SubscriptionModelDecorator.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Decorators/SubscriptionModelDecorator.php
@@ -4,7 +4,6 @@ namespace Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webho
 use Exception;
 use Give\Framework\Support\Facades\DateTime\Temporal;
 use Give\Framework\Support\ValueObjects\Money;
-use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Actions\UpdateStripeInvoiceMetaData;
 use Give\Subscriptions\Models\Subscription;
 use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 use Stripe\Invoice;
@@ -42,7 +41,6 @@ class SubscriptionModelDecorator {
     }
 
     /**
-     * @unreleased Update Stripe Invoice metadata
      * @since 3.22.0 updated to use model method
      * @since 3.0.0
      *
@@ -50,7 +48,7 @@ class SubscriptionModelDecorator {
      */
     public function handleRenewal(Invoice $invoice): SubscriptionModelDecorator
     {
-        $renewalDonation = $this->subscription->createRenewal([
+        $this->subscription->createRenewal([
             'amount' => Money::fromDecimal(
                 give_stripe_cents_to_dollars($invoice->total),
                 strtoupper($invoice->currency)
@@ -58,8 +56,6 @@ class SubscriptionModelDecorator {
             'createdAt' => Temporal::toDateTime(date_i18n('Y-m-d H:i:s', $invoice->created)),
             'gatewayTransactionId' => $invoice->payment_intent,
         ]);
-
-        give(UpdateStripeInvoiceMetaData::class)($invoice, $renewalDonation);
 
         // refresh the subscription model
         $subscription = Subscription::find($this->subscription->id);

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentSucceeded.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentSucceeded.php
@@ -6,6 +6,7 @@ use Give\Donations\Models\Donation;
 use Give\Donations\Models\DonationNote;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\Exceptions\Primitives\Exception;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Actions\UpdateStripeInvoiceMetaData;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Decorators\SubscriptionModelDecorator;
 use Give\Subscriptions\Models\Subscription;
 use Stripe\Event;
@@ -42,6 +43,7 @@ class InvoicePaymentSucceeded
     }
 
     /**
+     * @unreleased Update Stripe Invoice metadata
      * @since 3.0.4 Return a bool value.
      * @since 3.0.0
      * @throws \Exception
@@ -60,6 +62,7 @@ class InvoicePaymentSucceeded
 
         if ($initialDonation = give()->donations->getByGatewayTransactionId($invoice->payment_intent)) {
             $this->handleInitialDonation($initialDonation);
+            give(UpdateStripeInvoiceMetaData::class)($invoice, $initialDonation);
         } else {
             $subscriptionModel = $this->getSubscriptionModelDecorator($subscription);
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentSucceeded.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/InvoicePaymentSucceeded.php
@@ -62,12 +62,14 @@ class InvoicePaymentSucceeded
 
         if ($initialDonation = give()->donations->getByGatewayTransactionId($invoice->payment_intent)) {
             $this->handleInitialDonation($initialDonation);
-            give(UpdateStripeInvoiceMetaData::class)($invoice, $initialDonation);
+            $this->updateStripeInvoiceMetaData($invoice, $initialDonation);
         } else {
             $subscriptionModel = $this->getSubscriptionModelDecorator($subscription);
 
             if ($subscriptionModel->shouldCreateRenewal()) {
                 $subscriptionModel = $subscriptionModel->handleRenewal($invoice);
+                $renewalDonation = $subscriptionModel->subscription->donations[0];
+                $this->updateStripeInvoiceMetaData($invoice, $renewalDonation);
             }
 
             if ($subscriptionModel->shouldEndSubscription()) {
@@ -115,5 +117,13 @@ class InvoicePaymentSucceeded
     protected function cancelSubscription(SubscriptionModelDecorator $subscriptionModel)
     {
         $subscriptionModel->cancelSubscription();
+    }
+
+    /**
+     * @unreleased
+     */
+    protected function updateStripeInvoiceMetaData(Invoice $invoice, Donation $donation)
+    {
+        give(UpdateStripeInvoiceMetaData::class)($invoice, $donation);
     }
 }

--- a/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php
+++ b/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/InvoicePaymentSucceededTest.php
@@ -25,6 +25,7 @@ class InvoicePaymentSucceededTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @unreleased Update Stripe Invoice metadata
      * @since 3.0.0
      *
      * @throws Exception
@@ -55,7 +56,19 @@ class InvoicePaymentSucceededTest extends TestCase
             ]
         ]);
 
-        $listener = new InvoicePaymentSucceeded();
+        $listener = $this->createMockWithCallback(
+            InvoicePaymentSucceeded::class,
+            function (MockBuilder $mockBuilder) {
+                // partial mock gateway by setting methods on the mock builder
+                $mockBuilder->setMethods(['updateStripeInvoiceMetaData']);
+
+                return $mockBuilder->getMock();
+            }
+        );
+
+        /** @var MockObject $listener */
+        $listener->expects($this->once())
+            ->method('updateStripeInvoiceMetaData');
 
         $listener->processEvent($mockEvent);
 
@@ -67,6 +80,7 @@ class InvoicePaymentSucceededTest extends TestCase
     }
 
     /**
+     * @unreleased Update Stripe Invoice metadata
      * @since 3.0.0
      *
      * @throws Exception
@@ -104,7 +118,21 @@ class InvoicePaymentSucceededTest extends TestCase
             ]
         ]);
 
-        $listener = new InvoicePaymentSucceeded();
+        //$listener = new InvoicePaymentSucceeded();
+
+        $listener = $this->createMockWithCallback(
+            InvoicePaymentSucceeded::class,
+            function (MockBuilder $mockBuilder) {
+                // partial mock gateway by setting methods on the mock builder
+                $mockBuilder->setMethods(['updateStripeInvoiceMetaData']);
+
+                return $mockBuilder->getMock();
+            }
+        );
+
+        /** @var MockObject $listener */
+        $listener->expects($this->once())
+            ->method('updateStripeInvoiceMetaData');
 
         $listener->processEvent($mockEvent);
 
@@ -182,6 +210,7 @@ class InvoicePaymentSucceededTest extends TestCase
     }
 
     /**
+     * @unreleased Update Stripe Invoice metadata
      * @since 3.0.0
      *
      * @throws Exception
@@ -226,7 +255,7 @@ class InvoicePaymentSucceededTest extends TestCase
             InvoicePaymentSucceeded::class,
             function (MockBuilder $mockBuilder) {
                 // partial mock gateway by setting methods on the mock builder
-                $mockBuilder->setMethods(['cancelSubscription']);
+                $mockBuilder->setMethods(['cancelSubscription', 'updateStripeInvoiceMetaData']);
 
                 return $mockBuilder->getMock();
             }
@@ -235,6 +264,10 @@ class InvoicePaymentSucceededTest extends TestCase
         /** @var MockObject $listener */
         $listener->expects($this->once())
             ->method('cancelSubscription');
+
+        /** @var MockObject $listener */
+        $listener->expects($this->once())
+            ->method('updateStripeInvoiceMetaData');
 
         $listener->processEvent($mockEvent);
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-318]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds metadata to Stripe transactions that belong to a Stripe subscription, so now users can have the same metadata info that they already have on the one-time donations.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe recurring donations

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/ab38e7af-3406-4a92-9d4c-287d5b7c84d2)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Make sure your test site can receive webhook events from Stripe
2. Set up a VB form with the Stripe Element gateway enabled
3. Create a subscription with the Stripe Element gateway
4. Go to the Stripe dashboard and trigger a renewal
5. Make sure both the initial donation and the renewal donation have metadata added

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-318]: https://stellarwp.atlassian.net/browse/GIVE-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ