### PR TITLE
Fix: Hide continue button on multistep forms when using PayPal smart buttons

### DIFF
--- a/src/DonationForms/resources/app/hooks/useFormSubmitButton.ts
+++ b/src/DonationForms/resources/app/hooks/useFormSubmitButton.ts
@@ -1,4 +1,5 @@
 /**
+ * @unreleased updated the selector to use the next button classname
  * @since 4.0.0
  */
 export default function useFormSubmitButton(): HTMLButtonElement | null {
@@ -9,7 +10,9 @@ export default function useFormSubmitButton(): HTMLButtonElement | null {
         return submitButton;
     }
 
-    const nextButton: HTMLButtonElement = donationFormWithSubmitButton?.querySelector('[type="button"]');
+    const nextButton: HTMLButtonElement = donationFormWithSubmitButton?.querySelector(
+        '.givewp-donation-form__steps-button-next[type="button"]'
+    );
     if (nextButton) {
         return nextButton;
     }

--- a/src/DonationForms/resources/app/hooks/useFormSubmitButton.ts
+++ b/src/DonationForms/resources/app/hooks/useFormSubmitButton.ts
@@ -1,5 +1,5 @@
 /**
- * @unreleased updated the selector to use the next button classname
+ * @since 4.1.1 updated the selector to use the next button classname
  * @since 4.0.0
  */
 export default function useFormSubmitButton(): HTMLButtonElement | null {

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -528,7 +528,10 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
          */
         Fields() {
             const {isRecurring} = window.givewp.form.hooks.useFormData();
-            submitButton = window.givewp.form.hooks.useFormSubmitButton();
+
+            useEffect(() => {
+                submitButton = window.givewp.form.hooks.useFormSubmitButton();
+            }, []);
 
             return (
                 <FormFieldsProvider>

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -56,6 +56,10 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
 
     let payPalCardFieldsForm: PayPalCardFieldsComponent = null;
 
+    /**
+     * @unreleased updated to reassign the submit button when not assigned yet
+     * @since 4.1.0
+     */
     const showOrHideDonateButton = (showOrHide: 'show' | 'hide') => {
         submitButton = submitButton || window.givewp.form.hooks.useFormSubmitButton();
 
@@ -524,6 +528,8 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         },
 
         /**
+         * @unreleased updated the submit button to assign on mount
+         * @since 4.1.0 updated to use card fields api
          * @since 3.17.1 Hide submit button when PayPal Commerce is selected.
          */
         Fields() {

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -57,7 +57,7 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
     let payPalCardFieldsForm: PayPalCardFieldsComponent = null;
 
     /**
-     * @unreleased updated to reassign the submit button when not assigned yet
+     * @since 4.1.1 updated to reassign the submit button when not assigned yet
      * @since 4.1.0
      */
     const showOrHideDonateButton = (showOrHide: 'show' | 'hide') => {
@@ -528,7 +528,7 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         },
 
         /**
-         * @unreleased updated the submit button to assign on mount
+         * @since 4.1.1 updated the submit button to assign on mount
          * @since 4.1.0 updated to use card fields api
          * @since 3.17.1 Hide submit button when PayPal Commerce is selected.
          */


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This ensures the continue button is hidden on multistep forms when using PayPal smart buttons when not on the last step.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- PayPal donations (smart buttons) on multistep forms

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/e69ac21b9ea9411c9b7709f696898854?sid=747dbd1e-8359-4422-9d3b-2f67d5aaf4e5

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a multistep form where the gateway are not on the last step
- Make sure when PayPal donations is selected (set to smart button only) the continue button is hidden
- Test for regression issues

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

