### PR TITLE
Feature: Add migration to recalculate exchange rates

### DIFF
--- a/src/Donations/Migrations/RecalculateExchangeRate.php
+++ b/src/Donations/Migrations/RecalculateExchangeRate.php
@@ -51,18 +51,18 @@ class RecalculateExchangeRate extends BatchMigration
         // and either the exchange rate does not exist or is equal to 1
 
         return DB::table('posts', 'posts')
-            ->leftJoin('give_donationmeta as meta1', 'posts.ID', 'meta1.donation_id')
-            ->leftJoin('give_donationmeta as meta2', 'posts.ID', 'meta2.donation_id')
-            ->leftJoin('give_donationmeta as meta3', 'posts.ID', 'meta3.donation_id')
+            ->leftJoin('give_donationmeta as baseCurrencyMeta', 'posts.ID', 'baseCurrencyMeta.donation_id')
+            ->leftJoin('give_donationmeta as paymentCurrencyMeta', 'posts.ID', 'paymentCurrencyMeta.donation_id')
+            ->leftJoin('give_donationmeta as exchangeRateMeta', 'posts.ID', 'exchangeRateMeta.donation_id')
             ->where('posts.post_type', 'give_payment')
-            ->where('meta1.meta_key', '_give_cs_base_currency')
-            ->whereIsNotNull('meta1.meta_value')
-            ->where('meta2.meta_key', DonationMetaKeys::CURRENCY)
-            ->whereRaw('AND meta1.meta_value != meta2.meta_value')
-            ->where('meta3.meta_key', DonationMetaKeys::EXCHANGE_RATE)
+            ->where('baseCurrencyMeta.meta_key', '_give_cs_base_currency')
+            ->whereIsNotNull('baseCurrencyMeta.meta_value')
+            ->where('paymentCurrencyMeta.meta_key', DonationMetaKeys::CURRENCY)
+            ->whereRaw('AND baseCurrencyMeta.meta_value != paymentCurrencyMeta.meta_value')
+            ->where('exchangeRateMeta.meta_key', DonationMetaKeys::EXCHANGE_RATE)
             ->where(function($query) {
-                $query->where('meta3.meta_value', '1')
-                    ->orWhereIsNull('meta3.meta_value')
+                $query->where('exchangeRateMeta.meta_value', '1')
+                    ->orWhereIsNull('exchangeRateMeta.meta_value');
             });
     }
 

--- a/src/Donations/Migrations/RecalculateExchangeRate.php
+++ b/src/Donations/Migrations/RecalculateExchangeRate.php
@@ -125,7 +125,7 @@ class RecalculateExchangeRate extends BatchMigration
      */
     public function getBatchItemsAfter($lastId): ?array
     {
-        $item = clone $this->query()
+        $item = $this->query()
             ->select('MIN(ID) AS first_id, MAX(ID) AS last_id')
             ->where('ID', $lastId, '>')
             ->limit($this->getBatchSize())

--- a/src/Donations/Migrations/RecalculateExchangeRate.php
+++ b/src/Donations/Migrations/RecalculateExchangeRate.php
@@ -125,11 +125,12 @@ class RecalculateExchangeRate extends BatchMigration
      */
     public function getBatchItemsAfter($lastId): ?array
     {
-        $item = $this->query()
-            ->select('MIN(ID) AS first_id, MAX(ID) AS last_id')
+        $subquerySQL = $this->query()
             ->where('ID', $lastId, '>')
             ->limit($this->getBatchSize())
-            ->get();
+            ->getSQL();
+
+        $item = DB::get_row("SELECT MIN(ID) AS first_id, MAX(ID) AS last_id FROM ($subquerySQL) as batch");
 
         if (!$item) {
             return null;

--- a/src/Donations/Migrations/RecalculateExchangeRate.php
+++ b/src/Donations/Migrations/RecalculateExchangeRate.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Give\Donations\Migrations;
+
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Framework\Database\DB;
+use Give\Framework\Database\Exceptions\DatabaseQueryException;
+use Give\Framework\Migrations\Contracts\BatchMigration;
+use Give\Framework\Migrations\Exceptions\DatabaseMigrationException;
+use Give\Framework\QueryBuilder\QueryBuilder;
+use Give\Framework\Support\ValueObjects\Money;
+
+/**
+ * @unreleased
+ */
+class RecalculateExchangeRate extends BatchMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'recalculate_exchange_rate';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function title(): string
+    {
+        return 'Recalculate exchange rate';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp(): string
+    {
+        return strtotime('2025-04-24 00:00:00');
+    }
+
+    /**
+     * Base query
+     *
+     * @unreleased
+     */
+    protected function query(): QueryBuilder
+    {
+        // Select donations where base currency is not empty,
+        // base currency is different from payment currency,
+        // and either the exchange rate does not exist or is equal to 1
+
+        return DB::table('posts', 'posts')
+            ->leftJoin('give_donationmeta as meta1', 'posts.ID', 'meta1.donation_id')
+            ->leftJoin('give_donationmeta as meta2', 'posts.ID', 'meta2.donation_id')
+            ->leftJoin('give_donationmeta as meta3', 'posts.ID', 'meta3.donation_id')
+            ->where('posts.post_type', 'give_payment')
+            ->where('meta1.meta_key', '_give_cs_base_currency')
+            ->whereIsNotNull('meta1.meta_value')
+            ->where('meta2.meta_key', DonationMetaKeys::CURRENCY)
+            ->whereRaw('AND meta1.meta_value != meta2.meta_value')
+            ->where('meta3.meta_key', DonationMetaKeys::EXCHANGE_RATE)
+            ->where(function($query) {
+                $query->where('meta3.meta_value', '1')
+                    ->orWhereIsNull('meta3.meta_value')
+            });
+    }
+
+    /**
+     * @inheritDoc
+     * @throws DatabaseMigrationException
+     */
+    public function runBatch($firstId, $lastId)
+    {
+        try {
+            $query = $this->query()
+                ->select('posts.ID')
+                ->attachMeta(
+                    'give_donationmeta',
+                    'ID',
+                    'donation_id',
+                    [DonationMetaKeys::AMOUNT, 'amount']
+                )
+                ->attachMeta(
+                    'give_donationmeta',
+                    'ID',
+                    'donation_id',
+                    [DonationMetaKeys::CURRENCY, 'currency']
+                )
+                ->attachMeta(
+                    'give_donationmeta',
+                    'ID',
+                    'donation_id',
+                    [DonationMetaKeys::BASE_AMOUNT, 'baseAmount']
+                )
+                ->attachMeta(
+                    'give_donationmeta',
+                    'ID',
+                    'donation_id',
+                    ['_give_cs_base_currency', 'baseCurrency']
+                )
+                ->orderBy('posts.ID', 'ASC');
+
+            // Migration Runner will pass null for lastId in the last step
+            if (is_null($lastId)) {
+                $query->where('posts.ID', $firstId, '>');
+            } else {
+                $query->whereBetween('posts.ID', $firstId, $lastId);
+            }
+
+            $donations = $query->getAll();
+
+            foreach ($donations as $donation) {
+                $amount = Money::fromDecimal($donation->amount, $donation->currency);
+                $baseAmount = Money::fromDecimal($donation->baseAmount, $donation->baseCurrency);
+
+                /** @var Money $exchangeRate */
+                $exchangeRate = $amount->divide($baseAmount->formatToDecimal());
+
+                give()->payment_meta->update_meta($donation->ID, DonationMetaKeys::EXCHANGE_RATE, $exchangeRate->formatToDecimal());
+            }
+        } catch (DatabaseQueryException $exception) {
+            throw new DatabaseMigrationException("An error occurred while updating donation exchange rates to the donation meta table",
+                0, $exception);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItemsCount(): int
+    {
+        return $this->query()->count();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBatchItemsAfter($lastId): ?array
+    {
+        $item = clone $this->query()
+            ->select('MIN(posts.ID) AS first_id, MAX(posts.ID) AS last_id')
+            ->where('posts.ID', $lastId, '>')
+            ->orderBy('posts.ID', 'ASC')
+            ->limit($this->getBatchSize())
+            ->get();
+
+        if ( ! $item) {
+            return null;
+        }
+
+        return [
+            $item->first_id,
+            $item->last_id,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBatchSize(): int
+    {
+        return 100;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasMoreItemsToBatch($lastProcessedId): ?bool
+    {
+        return $this->query()
+            ->where('posts.ID', $lastProcessedId, '>')
+            ->limit(1)
+            ->count();
+    }
+}

--- a/src/Donations/ServiceProvider.php
+++ b/src/Donations/ServiceProvider.php
@@ -15,6 +15,7 @@ use Give\Donations\LegacyListeners\UpdateDonorPaymentIds;
 use Give\Donations\ListTable\DonationsListTable;
 use Give\Donations\Migrations\AddMissingDonorIdToDonationComments;
 use Give\Donations\Migrations\MoveDonationCommentToDonationMetaTable;
+use Give\Donations\Migrations\RecalculateExchangeRate;
 use Give\Donations\Migrations\SetAutomaticFormattingOption;
 use Give\Donations\Migrations\UnserializeTitlePrefix;
 use Give\Donations\Models\Donation;
@@ -55,6 +56,7 @@ class ServiceProvider implements ServiceProviderInterface
             SetAutomaticFormattingOption::class,
             MoveDonationCommentToDonationMetaTable::class,
             UnserializeTitlePrefix::class,
+            RecalculateExchangeRate::class,
         ]);
     }
 

--- a/src/Donations/ValueObjects/DonationMetaKeys.php
+++ b/src/Donations/ValueObjects/DonationMetaKeys.php
@@ -13,6 +13,7 @@ use Give\Framework\Support\ValueObjects\EnumInteractsWithQueryBuilder;
  *
  * @method static DonationMetaKeys AMOUNT()
  * @method static DonationMetaKeys CAMPAIGN_ID()
+ * @method static DonationMetaKeys BASE_AMOUNT()
  * @method static DonationMetaKeys CURRENCY()
  * @method static DonationMetaKeys GATEWAY()
  * @method static DonationMetaKeys DONOR_ID()

--- a/tests/Unit/Donations/Migrations/RecalculateExchangeRateTest.php
+++ b/tests/Unit/Donations/Migrations/RecalculateExchangeRateTest.php
@@ -8,6 +8,9 @@ use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 
+/**
+ * @unreleased
+ */
 class RecalculateExchangeRateTest extends TestCase
 {
     use RefreshDatabase;
@@ -17,27 +20,30 @@ class RecalculateExchangeRateTest extends TestCase
      */
     private $migration;
 
+    /**
+     * @unreleased
+     */
     public function setUp(): void
     {
         parent::setUp();
         $this->migration = new RecalculateExchangeRate();
     }
 
+    /**
+     * @unreleased
+     */
     public function testGetBatchSizeReturnsCorrectValue()
     {
         $this->assertEquals(100, $this->migration->getBatchSize());
     }
 
+    /**
+     * @unreleased
+     */
     public function testRunBatchUpdatesExchangeRates()
     {
         // Create test data
-        $donationId = $this->createDonationWithMeta([
-            DonationMetaKeys::AMOUNT => '100.00',
-            DonationMetaKeys::BASE_AMOUNT => '80.00',
-            DonationMetaKeys::CURRENCY => 'USD',
-            '_give_cs_base_currency' => 'EUR',
-            DonationMetaKeys::EXCHANGE_RATE => '1'
-        ]);
+        $donationId = $this->createDonationWithMeta($this->getDefaultDonationMeta());
 
         // Run the migration
         $this->migration->runBatch(0, $donationId + 1);
@@ -49,34 +55,31 @@ class RecalculateExchangeRateTest extends TestCase
         $this->assertEquals('1.25', $updatedExchangeRate);
     }
 
+    /**
+     * @unreleased
+     */
     public function testGetItemsCountReturnsCorrectCount()
     {
-        $this->createDonationWithMeta([
-            DonationMetaKeys::AMOUNT => '100.00',
-            DonationMetaKeys::BASE_AMOUNT => '80.00',
-            DonationMetaKeys::CURRENCY => 'USD',
-            '_give_cs_base_currency' => 'EUR',
-            DonationMetaKeys::EXCHANGE_RATE => '1'
-        ]);
+        $this->createDonationWithMeta($this->getDefaultDonationMeta());
 
         $count = $this->migration->getItemsCount();
         $this->assertEquals(1, $count);
     }
 
+    /**
+     * @unreleased
+     */
     public function testHasMoreItemsToBatchReturnsCorrectValue()
     {
-        $donationId = $this->createDonationWithMeta([
-            DonationMetaKeys::AMOUNT => '100.00',
-            DonationMetaKeys::BASE_AMOUNT => '80.00',
-            DonationMetaKeys::CURRENCY => 'USD',
-            '_give_cs_base_currency' => 'EUR',
-            DonationMetaKeys::EXCHANGE_RATE => '1'
-        ]);
+        $donationId = $this->createDonationWithMeta($this->getDefaultDonationMeta());
 
         $this->assertTrue($this->migration->hasMoreItemsToBatch(0));
         $this->assertFalse($this->migration->hasMoreItemsToBatch($donationId + 1));
     }
 
+    /**
+     * @unreleased
+     */
     private function createDonationWithMeta(array $meta): int
     {
         $donationId = Donation::factory()->create()->id;
@@ -86,5 +89,19 @@ class RecalculateExchangeRateTest extends TestCase
         }
 
         return $donationId;
+    }
+
+    /**
+     * @unreleased
+     */
+    private function getDefaultDonationMeta(): array
+    {
+        return [
+            DonationMetaKeys::AMOUNT => '100.00',
+            DonationMetaKeys::BASE_AMOUNT => '80.00',
+            DonationMetaKeys::CURRENCY => 'USD',
+            '_give_cs_base_currency' => 'EUR',
+            DonationMetaKeys::EXCHANGE_RATE => '1'
+        ];
     }
 }

--- a/tests/Unit/Donations/Migrations/RecalculateExchangeRateTest.php
+++ b/tests/Unit/Donations/Migrations/RecalculateExchangeRateTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Give\Tests\Unit\Donations\Migrations;
+
+use Give\Donations\Migrations\RecalculateExchangeRate;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+class RecalculateExchangeRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var RecalculateExchangeRate
+     */
+    private $migration;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->migration = new RecalculateExchangeRate();
+    }
+
+    public function testGetBatchSizeReturnsCorrectValue()
+    {
+        $this->assertEquals(100, $this->migration->getBatchSize());
+    }
+
+    public function testRunBatchUpdatesExchangeRates()
+    {
+        // Create test data
+        $donationId = $this->createDonationWithMeta([
+            DonationMetaKeys::AMOUNT => '100.00',
+            DonationMetaKeys::BASE_AMOUNT => '80.00',
+            DonationMetaKeys::CURRENCY => 'USD',
+            '_give_cs_base_currency' => 'EUR',
+            DonationMetaKeys::EXCHANGE_RATE => '1'
+        ]);
+
+        // Run the migration
+        $this->migration->runBatch(0, $donationId + 1);
+
+        // Verify the exchange rate was updated
+        $updatedExchangeRate = give()->payment_meta->get_meta($donationId, DonationMetaKeys::EXCHANGE_RATE, true);
+
+        $this->assertNotEmpty($updatedExchangeRate);
+        $this->assertEquals('1.25', $updatedExchangeRate);
+    }
+
+    public function testGetItemsCountReturnsCorrectCount()
+    {
+        $this->createDonationWithMeta([
+            DonationMetaKeys::AMOUNT => '100.00',
+            DonationMetaKeys::BASE_AMOUNT => '80.00',
+            DonationMetaKeys::CURRENCY => 'USD',
+            '_give_cs_base_currency' => 'EUR',
+            DonationMetaKeys::EXCHANGE_RATE => '1'
+        ]);
+
+        $count = $this->migration->getItemsCount();
+        $this->assertEquals(1, $count);
+    }
+
+    public function testHasMoreItemsToBatchReturnsCorrectValue()
+    {
+        $donationId = $this->createDonationWithMeta([
+            DonationMetaKeys::AMOUNT => '100.00',
+            DonationMetaKeys::BASE_AMOUNT => '80.00',
+            DonationMetaKeys::CURRENCY => 'USD',
+            '_give_cs_base_currency' => 'EUR',
+            DonationMetaKeys::EXCHANGE_RATE => '1'
+        ]);
+
+        $this->assertTrue($this->migration->hasMoreItemsToBatch(0));
+        $this->assertFalse($this->migration->hasMoreItemsToBatch($donationId + 1));
+    }
+
+    private function createDonationWithMeta(array $meta): int
+    {
+        $donationId = Donation::factory()->create()->id;
+
+        foreach ($meta as $metaKey => $metaValue) {
+            give()->payment_meta->update_meta($donationId, $metaKey, $metaValue);
+        }
+
+        return $donationId;
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-2516]

## Description
This PR implements a migration to update exchange rates for existing donations where the exchange rate was not properly stored. This is a follow-up to the fix implemented in #7888, which addressed the issue of exchange rates not being stored properly in donations made through legacy forms.

## Affects
Donations' Exchange Rate

## Testing Instructions
1. Using a previous version of GiveWP, create donations using legacy forms with Currency Switcher enabled and a different currency selected.
2. In the admin area, navigate to the Donation Details page and verify that the Exchange Rate is displayed as "1".
3. Update GiveWP to this version.
4. In GiveWP > Tools > Data > Database upgrades, confirm that the migration completed successfully without any errors.
5. Return to the Donation Details page and verify that the Exchange Rate has been updated to reflect the approximate exchange rate from the time of the donation.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2516]: https://stellarwp.atlassian.net/browse/GIVE-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ