### PR TITLE
Refactor: update sum queries to use donation fee amount instead of fee recovery intended amount

### DIFF
--- a/src/Campaigns/Blocks/CampaignDonations/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/render.php
@@ -29,13 +29,14 @@ $query = (new CampaignDonationQuery($campaign))
     ->select(
         'donation.ID as id',
         'donorIdMeta.meta_value as donorId',
-        'amountMeta.meta_value as amount',
+        'amountMeta.meta_value - IFNULL(feeAmountRecovered.meta_value, 0) as amount',
         'donorName.meta_value as donorName',
         'donation.post_date as date'
     )
     ->joinDonationMeta(DonationMetaKeys::DONOR_ID, 'donorIdMeta')
     ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
     ->joinDonationMeta(DonationMetaKeys::FIRST_NAME, 'donorName')
+    ->joinDonationMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered')
     ->leftJoin('give_donors', 'donorIdMeta.meta_value', 'donors.id', 'donors')
     ->orderByRaw($sortBy === 'top-donations' ? 'CAST(amountMeta.meta_value AS DECIMAL) DESC' : 'donation.ID DESC')
     ->limit($attributes['donationsPerPage'] ?? 5);

--- a/src/Campaigns/Blocks/CampaignStats/render.php
+++ b/src/Campaigns/Blocks/CampaignStats/render.php
@@ -23,10 +23,11 @@ if (
 $query = (new CampaignDonationQuery($campaign))
     ->select(
         $attributes['statistic'] === 'top-donation'
-            ? 'MAX(amountMeta.meta_value) as amount'
-            : 'AVG(amountMeta.meta_value) as amount'
+        ? 'MAX(amountMeta.meta_value - IFNULL(feeAmountRecovered.meta_value, 0)) as amount'
+        : 'AVG(amountMeta.meta_value - IFNULL(feeAmountRecovered.meta_value, 0)) as amount'
     )
-    ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta');
+    ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amountMeta')
+    ->joinDonationMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered');
 
 $donationStat = $query->get();
 

--- a/src/Campaigns/CampaignDonationQuery.php
+++ b/src/Campaigns/CampaignDonationQuery.php
@@ -58,7 +58,7 @@ class CampaignDonationQuery extends QueryBuilder
     {
         $query = clone $this;
         $query->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
-        $query->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
+        $query->joinDonationMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered');
         return $query->sum(
             /**
              * The intended amount meta and the amount meta could either be 0 or NULL.
@@ -66,7 +66,7 @@ class CampaignDonationQuery extends QueryBuilder
              * Then we coalesce the values to select the first non-NULL value.
              * @link https://github.com/impress-org/givewp/pull/7411
              */
-            'COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)'
+            'IFNULL(amount.meta_value, 0) - IFNULL(feeAmountRecovered.meta_value, 0)'
         );
     }
 
@@ -115,9 +115,9 @@ class CampaignDonationQuery extends QueryBuilder
         $query = clone $this;
 
         $query->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount');
-        $query->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount');
+        $query->joinDonationMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered');
         $query->select(
-            'SUM(COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)) as amount'
+            'SUM(IFNULL(amount.meta_value, 0) - IFNULL(feeAmountRecovered.meta_value, 0)) as amount'
         );
 
         $query->select('YEAR(donation.post_date) as year');

--- a/src/Campaigns/CampaignsDataQuery.php
+++ b/src/Campaigns/CampaignsDataQuery.php
@@ -75,9 +75,9 @@ class CampaignsDataQuery extends QueryBuilder
     public function collectIntendedAmounts()
     {
         return (clone $this)
-            ->select('SUM(COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0))) as sum')
+            ->select('SUM(IFNULL(amount.meta_value, 0) - IFNULL(feeAmountRecovered.meta_value, 0)) as sum')
             ->joinDonationMeta(DonationMetaKeys::AMOUNT, 'amount')
-            ->joinDonationMeta('_give_fee_donation_amount', 'intendedAmount')
+            ->joinDonationMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered')
             ->getAll(ARRAY_A);
     }
 

--- a/src/DonationForms/DonationQuery.php
+++ b/src/DonationForms/DonationQuery.php
@@ -120,10 +120,10 @@ class DonationQuery extends QueryBuilder
             $this->includeOnlyCurrentMode();
         }
 
-        $this->joinMeta('_give_payment_total', 'amount');
-        $this->joinMeta('_give_fee_donation_amount', 'intendedAmount');
+        $this->joinMeta(DonationMetaKeys::AMOUNT, 'amount');
+        $this->joinMeta(DonationMetaKeys::FEE_AMOUNT_RECOVERED, 'feeAmountRecovered');
         return $this->sum(
-            'COALESCE(NULLIF(intendedAmount.meta_value,0), NULLIF(amount.meta_value,0), 0)'
+            'IFNULL(amount.meta_value, 0) - IFNULL(feeAmountRecovered.meta_value, 0)'
         );
     }
 

--- a/src/DonationForms/resources/app/form/Header.tsx
+++ b/src/DonationForms/resources/app/form/Header.tsx
@@ -19,9 +19,7 @@ const HeaderImageTemplate = withTemplateWrapper(formTemplates.layouts.headerImag
  */
 export default function Header({form}: {form: DonationForm}) {
     const formatGoalAmount = useCallback((amount: number) => {
-        return amountFormatter(form.currency, {
-            maximumFractionDigits: 0,
-        }).format(amount);
+        return amountFormatter(form.currency).format(amount);
     }, []);
 
     return (

--- a/tests/Unit/Campaigns/CampaignDonationQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignDonationQueryTest.php
@@ -28,14 +28,13 @@ final class CampaignDonationQueryTest extends TestCase
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $db = DB::table('give_campaign_forms');
-
 
         Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1000, 'USD'),
         ]);
+
         Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -50,28 +49,24 @@ final class CampaignDonationQueryTest extends TestCase
     /**
      * @since 4.0.0
      */
-    public function testSumCampaignDonations()
+    public function testSumIntendedAmountReturnsSumOfDonationsWithoutRecoveredFees()
     {
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $donation1 = Donation::factory()->create([
+        Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1051, 'USD'),
             'feeAmountRecovered' => new Money(35, 'USD'),
         ]);
 
-        give_update_meta($donation1->id, '_give_fee_donation_amount', 10.16);
-
-        $donation2 = Donation::factory()->create([
+        Donation::factory()->create([
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1051, 'USD'),
             'feeAmountRecovered' => new Money(35, 'USD'),
         ]);
-
-        give_update_meta($donation2->id, '_give_fee_donation_amount', 10.16);
 
         $query = new CampaignDonationQuery($campaign);
 
@@ -105,7 +100,7 @@ final class CampaignDonationQueryTest extends TestCase
     /**
      * @since 4.0.0
      */
-    public function testCoalesceIntendedAmountWithoutRecoveredFees()
+    public function testSumIntendedAmountWithoutRecoveredFees()
     {
         $campaign = Campaign::factory()->create();
         $form = DonationForm::find($campaign->defaultFormId);
@@ -114,8 +109,8 @@ final class CampaignDonationQueryTest extends TestCase
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
             'amount' => new Money(1070, 'USD'),
+            'feeAmountRecovered' => new Money(70, 'USD'),
         ]);
-        give_update_meta($donation->id, '_give_fee_donation_amount', 10.00);
 
         $query = new CampaignDonationQuery($campaign);
 

--- a/tests/Unit/Campaigns/CampaignsDataQueryTest.php
+++ b/tests/Unit/Campaigns/CampaignsDataQueryTest.php
@@ -31,7 +31,7 @@ final class CampaignsDataQueryTest extends TestCase
 
         $form = DonationForm::find($campaign->defaultFormId);
 
-        $donation1 = Donation::factory()->create([
+        Donation::factory()->create([
             'campaignId' => $campaign->id,
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -39,9 +39,7 @@ final class CampaignsDataQueryTest extends TestCase
             'feeAmountRecovered' => new Money(35, 'USD'),
         ]);
 
-        give_update_meta($donation1->id, '_give_fee_donation_amount', 10.16);
-
-        $donation2 = Donation::factory()->create([
+        Donation::factory()->create([
             'campaignId' => $campaign->id,
             'formId' => $form->id,
             'status' => DonationStatus::COMPLETE(),
@@ -49,13 +47,19 @@ final class CampaignsDataQueryTest extends TestCase
             'feeAmountRecovered' => new Money(35, 'USD'),
         ]);
 
-        give_update_meta($donation2->id, '_give_fee_donation_amount', 10.16);
+
+        Donation::factory()->create([
+            'campaignId' => $campaign->id,
+            'formId' => $form->id,
+            'status' => DonationStatus::COMPLETE(),
+            'amount' => new Money(1000, 'USD'),
+        ]);
 
         $campaignsDataQuery = CampaignsDataQuery::donations([$campaign->id]);
 
         $this->assertEquals([
             [
-                'sum' => 20.32,
+                'sum' => 30.32,
                 'campaign_id' => $campaign->id,
             ]
         ], $campaignsDataQuery->collectIntendedAmounts());

--- a/tests/Unit/Campaigns/Repositories/CampaignsDataRepositoryTest.php
+++ b/tests/Unit/Campaigns/Repositories/CampaignsDataRepositoryTest.php
@@ -53,7 +53,7 @@ final class CampaignsDataRepositoryTest extends TestCase
     /**
      * @unreleased
      */
-    public function testSumCampaignDonations()
+    public function testGetRevenueReturnsSumOfDonationsWithoutRecoveredFees()
     {
         /** @var Campaign $campaign */
         $campaign = Campaign::factory()->create([
@@ -77,7 +77,7 @@ final class CampaignsDataRepositoryTest extends TestCase
 
         $campaignsData = CampaignsDataRepository::campaigns([$campaign->id]);
 
-        $this->assertEquals(21.02, $campaignsData->getRevenue($campaign));
+        $this->assertEquals(20.32, $campaignsData->getRevenue($campaign));
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The current campaign and donation queries are using the intended amount meta value from fee recovery.  This value is risky to use because it was calculated by fee recovery and is not a core concept of GiveWP.  Although it has been working (as far as we know) I don't find it reliable because it's controlled by an add-on who calculates this amount at the time of donation created.  This means, the value can get out of sync if the donation amount is changed.

The _core_ concept of GiveWP as defined in our [Donation model](https://github.com/impress-org/givewp/blob/400523ed9db4c22a84299dfbcf9a1d210aeecaa8/src/Donations/Models/Donation.php#L238) is the `amount` and `feeAmountRecovered`.   The `amount` is the total donation amount _including_  `feeAmountRecovered` and the `feeAmountRecovered` is the standalone fee amount that was recovered.  In order to derive the intended amount in GiveWP we subtract `feeAmountRecovered` from the `amount`.

This PR updates our queries to follow this standard.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

This affects our main queries used to display goal progress and revenue amounts:

- src/Campaigns/CampaignDonationQuery.php
- src/Campaigns/CampaignsDataQuery.php
- src/DonationForms/DonationQuery.php
- src/Campaigns/Blocks/CampaignDonations/render.php
- src/Campaigns/Blocks/CampaignDonors/render.php
- src/Campaigns/CampaignDonationQuery.php

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1323" alt="Screenshot 2025-04-24 at 6 16 51 PM" src="https://github.com/user-attachments/assets/af9335a0-041c-4d96-b6d1-f998c00c2ed2" />

<img width="1315" alt="Screenshot 2025-04-24 at 6 16 59 PM" src="https://github.com/user-attachments/assets/0a1f0cf3-487a-40dc-87dd-757bef0f9131" />

<img width="1234" alt="Screenshot 2025-04-24 at 6 17 08 PM" src="https://github.com/user-attachments/assets/e9861536-b0fa-4011-9e7b-b5459022036e" />

<img width="683" alt="Screenshot 2025-04-24 at 6 24 58 PM" src="https://github.com/user-attachments/assets/76bc8240-4b43-4c53-abcc-6c0f59bf95b0" />



## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a campaign and install fee recovery
- Make a bunch of donations with fee amount recovered
- Make sure the goal progress does not included fees recovered
- Make sure the list of donations, donors and stats on the campaign page exclude fees

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

