### PR TITLE
Fix: enable header when switching form templates

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
@@ -11,7 +11,12 @@ export default function Layout({dispatch, formDesigns, designId}) {
                 <SelectControl
                     label={__('Form layout', 'give')}
                     value={designId}
-                    onChange={(designId: string) => dispatch(setFormSettings({designId}))}
+                    onChange={(designId: string) => {
+                        dispatch(setFormSettings({designId}));
+                        if (designId !== 'multi-step') {
+                            dispatch(setFormSettings({showHeader: true}));
+                        }
+                    }}
                     options={designOptions}
                     help={__(
                         'Change the appearance of your donation form on your site. Each option has a different layout.',

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/layout/index.tsx
@@ -2,6 +2,9 @@ import {PanelBody, PanelRow, SelectControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {setFormSettings} from '@givewp/form-builder/stores/form-state';
 
+/**
+ * @unreleased enable showHeader when switching to Classic or Two-panel form templates.
+ */
 export default function Layout({dispatch, formDesigns, designId}) {
     const designOptions = Object.values(formDesigns).map(({id, name}) => ({value: id, label: name}));
 


### PR DESCRIPTION
Resolves [GIVE-2558]

## Description
By default, new campaigns utilize a multi-step form template with the header disabled. Switching to the two-panel layout results in a form that visually mirrors the multi-step template, potentially confusing new users. Additionally, the classic template benefits from a visible header for improved aesthetics.

This update ensures the header is enabled when transitioning to either the two-panel or classic templates, providing a visually appealing experience across all form layouts.

## Affects
- Form template settings

## Visuals
https://github.com/user-attachments/assets/a204dbb8-1cb2-4cc5-8136-c20e6176a6d0

## Testing Instructions
- create a campaign and view the default form in the builder.
- Switch to classic it should reenable the header.
- Remove the header switch to two panel it should reenable the header.
- Remove the header switch to multistep the header should stay removed.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2558]: https://stellarwp.atlassian.net/browse/GIVE-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ