### PR TITLE
Fix: resolve PayPal commerce update order amount and fee recovery opt-in

### DIFF
--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -32,7 +32,6 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
      * a component, so it cannot use hooks to access the form field values.
      */
     let amount;
-    let feeRecovery;
     let firstName;
     let lastName;
     let email;
@@ -264,11 +263,9 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
     };
 
     const FormFieldsProvider = ({children}) => {
-        const {useWatch} = window.givewp.form.hooks;
         const formData = window.givewp.form.hooks.useFormData();
 
         amount = formData.amount;
-        feeRecovery = useWatch({name: 'feeRecovery'});
         firstName = formData.firstName;
         lastName = formData.lastName;
         email = formData.email;
@@ -298,7 +295,6 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
             getFieldState,
             setFocus,
             getValues,
-            formState: {errors},
             trigger,
             setError,
         } = useFormContext();
@@ -307,7 +303,7 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         const props: PayPalButtonsComponentProps = {
             style: buttonsStyle,
             disabled: isSubmitting || isSubmitSuccessful,
-            forceReRender: [donationType, amount, feeRecovery, firstName, lastName, email, currency],
+            forceReRender: [donationType, amount, firstName, lastName, email, currency],
             onClick: async (data, actions) => {
                 // Validate whether payment gateway support subscriptions.
                 if (donationType === 'subscription' && !gateway.supportsSubscriptions) {

--- a/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
+++ b/src/PaymentGateways/PayPalCommerce/AjaxRequestHandler.php
@@ -10,6 +10,7 @@ use Give\PaymentGateways\PayPalCommerce\Repositories\PayPalAuth;
 use Give\PaymentGateways\PayPalCommerce\Repositories\PayPalOrder;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Settings;
 use Give\PaymentGateways\PayPalCommerce\Repositories\Webhooks;
+use Give\Helpers\Form\Utils as FormUtils;
 
 /**
  * Class AjaxRequestHandler
@@ -257,6 +258,7 @@ class AjaxRequestHandler
     }
 
     /**
+     * @unreleased only filter amount for v2 forms
      * @since 3.4.2
      */
     private function getOrderData(): array
@@ -264,11 +266,13 @@ class AjaxRequestHandler
         $postData = give_clean($_POST);
         $formId = absint($postData['give-form-id']);
         $donorAddress = $this->getDonorAddressFromPostedDataForPaypalOrder($postData);
+        $isV3Form = FormUtils::isV3Form($formId);
 
-        return [
-            'formId' => $formId,
-            'formTitle' => give_payment_gateway_item_title(['post_data' => $postData], 127),
-            'donationAmount' => isset($postData['give-amount']) ?
+        if ($isV3Form) {
+            // if coming from v3 forms, fee recovery is already included in the amount and should not be filtered.
+            $amount = isset($postData['give-amount']) ? give_clean($postData['give-amount']) : '0.00';
+        } else {
+            $amount = isset($postData['give-amount']) ?
                 (float)apply_filters(
                     'give_donation_total',
                     give_maybe_sanitize_amount(
@@ -276,7 +280,13 @@ class AjaxRequestHandler
                         ['currency' => give_get_currency($formId)]
                     )
                 ) :
-                '0.00',
+                '0.00';
+        }
+
+        return [
+            'formId' => $formId,
+            'formTitle' => give_payment_gateway_item_title(['post_data' => $postData], 127),
+            'donationAmount' => $amount,
             'payer' => [
                 'firstName' => $postData['give_first'],
                 'lastName' => $postData['give_last'],

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -78,6 +78,7 @@ class PayPalCommerce extends PaymentGateway
     }
 
     /**
+     * @unreleased updated to use updateOrderFromDonation
      * @since 4.1.0 updated to include 3D Secure validation
      * @since 4.0.0 updated to update and capture payment
      * @since 2.19.0

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -103,7 +103,7 @@ class PayPalCommerce extends PaymentGateway
             $this->validate3dSecure($payPalOrder);
 
             if ($this->shouldUpdateOrder($donation, $payPalOrder)){
-                $payPalOrderRepository->updateApprovedOrder($payPalOrderId, $donation->amount);
+                $payPalOrderRepository->updateApprovedOrder($payPalOrderId, $donation->amount, $donation->formTitle);
             }
 
             // ready to capture order, response is the updated PayPal order.

--- a/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
+++ b/src/PaymentGateways/PayPalCommerce/PayPalCommerce.php
@@ -103,7 +103,7 @@ class PayPalCommerce extends PaymentGateway
             $this->validate3dSecure($payPalOrder);
 
             if ($this->shouldUpdateOrder($donation, $payPalOrder)){
-                $payPalOrderRepository->updateApprovedOrder($payPalOrderId, $donation->amount, $donation->formTitle);
+                $payPalOrderRepository->updateOrderFromDonation($payPalOrderId, $donation);
             }
 
             // ready to capture order, response is the updated PayPal order.

--- a/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
+++ b/src/PaymentGateways/PayPalCommerce/Repositories/PayPalOrder.php
@@ -280,6 +280,7 @@ class PayPalOrder
     }
 
     /**
+     * @unreleased updated to support donation category
      * @since 4.1.0 Add PayPal-Partner-Attribution-Id header
      * @since 4.0.0
      *


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2559](https://stellarwp.atlassian.net/browse/GIVE-2559)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR resolves the following 2 bugs:
1. The global setting "Fee Opt-in" when set to "Forced Opt-in" is causing fee recovered amount to be added to the donation total twice for v3 forms. [[Ref 1](https://github.com/impress-org/give-fee-recovery/blob/4ebbb9b6a64a7d769fb15308083f88429919af17/src/ServiceProvider.php#L42), [Ref 2](https://github.com/impress-org/give-fee-recovery/blob/08dbad91f1ed7f30787063fec3b6747fe2b7be64/src/Service/AddFeeToDonationAmount.php#L60)]
2. When using Donation category and amount is being updated, the api request needs to include amount breakdown for v3 forms.

This ensures we are sending the correct request format to PayPal when updating an order that is expecting the DONATION category type. 

This also ensures fee recovery does not modify the amount for v3 forms.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- PayPal commerce on v3 forms

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

PR ZIP: https://github.com/impress-org/givewp/actions/runs/14885048727


**Test 1: Fee recovery global settings**

- Setup PayPal commerce, set to donation transaction
- Install Fee Recovery
- Set global settings to force opt-in
- Click the smart buttons and make sure the amount matches the intended donation amount from the form
- Make sure the payment goes through.

<img width="1333" alt="Screenshot 2025-05-06 at 3 15 07 PM" src="https://github.com/user-attachments/assets/eaa4d74c-ca8f-497c-89ea-dfa9641637eb" />

**Test 2: PayPal update order amount**

This will only be triggered if something after the form processing affects the total amount.  To simulate this you can use an action that adds $2 to the donation after the form is submitted.

Add the following snippet:

```php
add_action('givewp_donation_created', function ($donation) {
  $donation->amount = $donation->amount->add(\Give\Framework\Support\ValueObjects\Money::fromDecimal('2.00', $donation->amount->getCurrency()->getCode()));
  $donation->save();
});
```

Now make a donation using smart buttons in a v3 form, make sure the payment goes through.

**Test 3: Regression tests**

- Test PayPal commerce on v3 forms
- Test PayPal commerce on v2 forms

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2559]: https://stellarwp.atlassian.net/browse/GIVE-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ