### PR TITLE
Fix: update form sections with heading tags

### DIFF
--- a/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_sections.scss
+++ b/src/DonationForms/FormDesigns/MultiStepFormDesign/css/_sections.scss
@@ -5,5 +5,11 @@
         display: flex;
         flex-direction: column;
         gap: var(--givewp-spacing-6);
+
+        &__legend {
+            legend {
+                margin-block-end: 0;
+            }
+        }
     }
 }

--- a/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
+++ b/src/DonationForms/FormDesigns/TwoPanelStepsFormLayout/css/_sections.scss
@@ -12,6 +12,12 @@
         display: flex;
         flex-direction: column;
         gap: var(--givewp-spacing-6);
+
+        &__legend {
+            legend {
+                margin-block-end: 0;
+            }
+        }
     }
 }
 

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -32,7 +32,6 @@ export default function StepsWrapper({steps, children}: {steps: StepObject[]; ch
                             <h3 className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</h3>
                         </div>
                     </header>
-                    </div>
                     <ProgressBar value={currentStep}>
                         <Label className={'sr-only'}>{sprintf(__('Progress: Step %1$d of %2$d', 'give'), currentStep, totalSteps)}</Label>
                         <progress className="givewp-donation-form__steps-progress" value={currentStep} max={totalSteps} />

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -7,6 +7,7 @@ import {StepObject} from '@givewp/forms/app/form/MultiStepForm/types';
 import getCurrentStepObject from '@givewp/forms/app/form/MultiStepForm/utilities/getCurrentStepObject';
 
 /**
+ * @unreleased update step title element to h3.
  * @since 3.4.0 updated with steps props and showStepsHeader conditional
  * @since 3.0.0
  */
@@ -27,7 +28,7 @@ export default function StepsWrapper({steps, children}: {steps: StepObject[]; ch
                             <PreviousButton>{__('Previous', 'give')}</PreviousButton>
                         </div>
                         <div className="givewp-donation-form__steps-header-title">
-                            <p className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</p>
+                            <h3 className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</h3>
                         </div>
                     </div>
                     <progress className="givewp-donation-form__steps-progress" value={currentStep} max={totalSteps} />

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -23,26 +23,26 @@ export default function StepsWrapper({steps, children}: {steps: StepObject[]; ch
         <div className="givewp-donation-form__steps">
             {showStepsHeader && (
                 <>
-                    <div className="givewp-donation-form__steps-header">
+                    <header className="givewp-donation-form__steps-header">
                         <div className="givewp-donation-form__steps-header-previous">
                             <PreviousButton>{__('Previous', 'give')}</PreviousButton>
                         </div>
                         <div className="givewp-donation-form__steps-header-title">
                             <h3 className="givewp-donation-form__steps-header-title-text">{currentStepObject.title}</h3>
                         </div>
-                    </div>
+                    </header>
                     <progress className="givewp-donation-form__steps-progress" value={currentStep} max={totalSteps} />
                 </>
             )}
             <div className="givewp-donation-form__steps-body">{children}</div>
-            <div className="givewp-donation-form__steps-footer">
+            <footer className="givewp-donation-form__steps-footer">
                 <div className="givewp-donation-form__steps-footer-secure">
                     <i className="fas fa-lock givewp-donation-form__steps-footer-secure-icon"></i>
                     <span className="givewp-donation-form__steps-footer-secure-text">
                         {__('100% Secure Donation', 'give')}
                     </span>
                 </div>
-            </div>
+            </footer>
         </div>
     );
 }

--- a/src/DonationForms/resources/registrars/templates/layouts/Section.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/Section.tsx
@@ -1,16 +1,21 @@
 import type {SectionProps} from '@givewp/forms/propTypes';
 
-const SectionHeader = ({name, label, description}: {name: string; label?: string; description?: string}) => {
-    return label.length > 0 || description.length > 0 ? (
+/**
+ * @unreleased update legend to use the description prop.
+ */
+const Legend = ({name, description}: {name: string; description?: string}) => {
+    return description.length > 0 ? (
         <div className="givewp-layouts-section__fieldset__legend">
-            {label.length > 0 && <legend id={name}>{label}</legend>}
-            {description.length > 0 && <p>{description}</p>}
+            {description.length > 0 && <legend id={name}>{description}</legend>}
         </div>
     ) : (
         <></>
     );
 };
 
+/**
+ * @unreleased use h3 tag for the section label.
+ */
 export default function Section({
     section: {name, label, description},
     hideLabel,
@@ -18,13 +23,15 @@ export default function Section({
     children,
 }: SectionProps) {
     return (
-        <fieldset className="givewp-layouts-section__fieldset" aria-labelledby={name}>
-            <SectionHeader
-                name={name}
-                label={hideLabel ? '' : label}
-                description={hideDescription ? '' : description}
-            />
-            <div className="givewp-section-nodes">{children}</div>
-        </fieldset>
+        <>
+            {hideLabel ? '' : label.length > 0 && <h3 id={name} className="givewp-layouts-section__header">{label}</h3>}
+            <fieldset className="givewp-layouts-section__fieldset" aria-labelledby={name}>
+                <Legend
+                    name={name}
+                    description={hideDescription ? '' : description}
+                />
+                <div className="givewp-section-nodes">{children}</div>
+            </fieldset>
+        </>
     );
 }

--- a/src/DonationForms/resources/styles/elements/_multi-step-form.scss
+++ b/src/DonationForms/resources/styles/elements/_multi-step-form.scss
@@ -43,6 +43,9 @@
         }
 
         &-header-title-text {
+            font-size: 1rem;
+            line-height: 24px;
+            margin: 0;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/DonationForms/resources/styles/elements/_sections.scss
+++ b/src/DonationForms/resources/styles/elements/_sections.scss
@@ -3,7 +3,6 @@
     &__header {
         font-size: clamp(var(--givewp-spacing-5), 1.28205vw, var(--givewp-spacing-6));
         margin-block-end: var(--givewp-spacing-3);
-        line-height: 24px;
         color: var(--givewp-grey-900);
     }
 

--- a/src/DonationForms/resources/styles/elements/_sections.scss
+++ b/src/DonationForms/resources/styles/elements/_sections.scss
@@ -1,21 +1,24 @@
 // add a little styling to section legends
 .givewp-layouts-section {
+    &__header {
+        font-size: clamp(var(--givewp-spacing-5), 1.28205vw, var(--givewp-spacing-6));
+        margin-block-end: var(--givewp-spacing-3);
+        line-height: 24px;
+        color: var(--givewp-grey-900);
+    }
+
     &__fieldset {
         gap: var(--givewp-spacing-6);
 
         &__legend {
             legend {
-                font-size: clamp(var(--givewp-spacing-5), 1.28205vw, var(--givewp-spacing-6));
-                font-weight: bold;
-                color: var(--givewp-grey-900);
-                line-height: 1.6;
-                margin-block-end: var(--givewp-spacing-3);
-            }
-
-            p {
+                font-size: 1rem;
+                font-weight: 400;
+                width: 100%;
                 margin: 0;
                 color: var(--givewp-grey-700);
                 line-height: 1.5;
+                margin-block-end: var(--givewp-spacing-3);
             }
         }
     }


### PR DESCRIPTION
Resolves [GIVE-2455]

## Description
This PR ensures that each step title in the donation form is properly marked up using semantic HTML heading tags 
`<h3>` Previously, these titles were not tagged as headings, but rather nested in each `<fieldset>` -> `<legend>` element in classic forms. In multi-step forms they were represented as `<p>` elements.

## Affects
- v3 forms all templates

## Visuals
https://github.com/user-attachments/assets/f95701ce-14a5-4b04-b1bc-22f3e53ab325
https://github.com/user-attachments/assets/b8e3b604-1561-4030-bea2-24e3ac8685da


## Testing Instructions
- Create a form using each template.
- With Classic templates verify each form section has a proper heading tag.
- With Multistep templates verify each step title has a proper heading tag.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2455]: https://stellarwp.atlassian.net/browse/GIVE-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ