### PR TITLE
Fix: add visible focus to User Login block buttons

### DIFF
--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -153,17 +153,19 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
             {!!errorMessage && <FieldError error={errorMessage} name={nodeName} />}
 
             <div className={styles['authentication__login-form__buttons-wrapper']}>
-                <button
-                    className={styles['authentication__login-form__reset-button']}
-                    onClick={(event) => {
-                        event.preventDefault();
-                        const passwordResetUrl = getRedirectUrl(new URL(lostPasswordUrl));
-
-                        window.top.location.assign(passwordResetUrl);
-                    }}
-                >
-                    {__('Forgot your password?', 'give')} <span>{__('Reset', 'give')}</span>
-                </button>
+                <div className={styles['authentication__login-form__reset-wrapper']}>
+                    {__('Forgot your password?', 'give')}
+                    <button
+                        className={styles['authentication__login-form__reset-button']}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            const passwordResetUrl = getRedirectUrl(new URL(lostPasswordUrl));
+                            window.top.location.assign(passwordResetUrl);
+                        }}
+                    >
+                        <span>{__('Reset', 'give')}</span>
+                    </button>
+                </div>
                 <button className={styles['authentication__login-form__login-button']} onClick={tryLogin}>
                     {__('Log In', 'give')}
                 </button>

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -153,9 +153,6 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
             {!!errorMessage && <FieldError error={errorMessage} name={nodeName} />}
 
             <div className={styles['authentication__login-form__buttons-wrapper']}>
-                <button className={styles['authentication__login-form__login-button']} onClick={tryLogin}>
-                    {__('Log In', 'give')}
-                </button>
                 <button
                     className={styles['authentication__login-form__reset-button']}
                     onClick={(event) => {
@@ -166,6 +163,9 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
                     }}
                 >
                     {__('Forgot your password?', 'give')} <span>{__('Reset', 'give')}</span>
+                </button>
+                <button className={styles['authentication__login-form__login-button']} onClick={tryLogin}>
+                    {__('Log In', 'give')}
                 </button>
             </div>
         </div>

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -145,8 +145,7 @@
             }
 
             &:focus {
-                border-color: transparent;
-                box-shadow: 0 0 0 0.125rem var(--givewp-primary-color);
+                outline: thick double var(--givewp-primary-color);
             }
         }
 

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -150,6 +150,11 @@
             }
         }
 
+        &__reset-wrapper {
+            display: flex;
+            gap: 5px;
+        }
+
         &__reset-button {
             background: none;
             border: none;
@@ -158,6 +163,7 @@
             cursor: pointer;
             font-size: 14px;
             line-height: 1.43;
+            padding: 2px;
 
             span {
                 color: var(--primary);

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -102,6 +102,11 @@
         margin: 0;
         padding: 0;
         width: auto;
+
+        &:focus {
+            border-color: transparent;
+            box-shadow: 0 0 0 0.125rem var(--givewp-primary-color);
+        }
     }
 
     &__login-form {
@@ -117,7 +122,6 @@
 
         &__buttons-wrapper {
             display: flex;
-            flex-direction: row-reverse;
             gap: 15px;
             justify-content: space-between;
             align-items: baseline;
@@ -139,6 +143,11 @@
                     background-color: color-mix(in lab, var(--givewp-primary-color) 90%, black);
                 }
             }
+
+            &:focus {
+                border-color: transparent;
+                box-shadow: 0 0 0 0.125rem var(--givewp-primary-color);
+            }
         }
 
         &__reset-button {
@@ -153,6 +162,11 @@
             span {
                 color: var(--primary);
                 font-weight: 500;
+            }
+
+            &:focus {
+                border-color: transparent;
+                box-shadow: 0 0 0 0.125rem var(--givewp-primary-color);
             }
         }
     }


### PR DESCRIPTION
Resolves [GIVE-2440]

## Description
This PR ensures visible focus styles are applied to interactive elements within the User Login block — specifically addressing buttons like “Already have an account? Log in.”, "Reset", "Login". These updates improve keyboard navigation and accessibility by making it clear when elements are focused.

## Affects
User Login block

## Visuals
https://github.com/user-attachments/assets/bdee2ae1-c954-489c-a8ff-a71791816cc9

## Testing Instructions
- Create a form.
- Add the User Login block.
- View the form in incognito mode.
- Using keyboard navigation - navigate to the User Login block & verify there is a visible focus border.
- Press enter.
- Keyboard navigate to the "Forgot password" button  & Login to verify there is a visible focus border..

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2440]: https://stellarwp.atlassian.net/browse/GIVE-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ