### PR TITLE
Fix: style links in the header description

### DIFF
--- a/src/DonationForms/resources/styles/elements/_header.scss
+++ b/src/DonationForms/resources/styles/elements/_header.scss
@@ -26,5 +26,14 @@
             color: inherit;
             margin: 0;
         }
+
+        a {
+            text-decoration: underline;
+            cursor: pointer;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves [GIVE-2465]

## Description
Previously, links added in the form header description lacked distinctive styling, making them appear as plain text. This could confuse users or prevent them from discovering important linked content.

This PR updates the styles for anchor (<a>) tags within the form header description to ensure they are visually recognizable as clickable links. These changes improve usability by helping sighted users identify interactive elements more easily.

## Affects
Form Header Description 

## Visuals
https://github.com/user-attachments/assets/bd74fae3-3105-41fb-bb3e-09cb9128b1c7

## Testing Instructions
- Create a form with an enabled header.
- Add a link in the header description.
- Verify it looks like a clickable link (text underline, hover styles etc)
- View in the editor & the frontend.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2465]: https://stellarwp.atlassian.net/browse/GIVE-2465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ