### PR TITLE
Fix: campaigns missing translations

### DIFF
--- a/src/Campaigns/Actions/EnqueueCampaignPageEditorAssets.php
+++ b/src/Campaigns/Actions/EnqueueCampaignPageEditorAssets.php
@@ -5,8 +5,10 @@ namespace Give\Campaigns\Actions;
 use Give\Campaigns\Models\CampaignPage;
 use Give\Campaigns\ValueObjects\CampaignPageMetaKeys;
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
 
 /**
+ * @unreleased set script translations
  * @since 4.0.0
  */
 class EnqueueCampaignPageEditorAssets
@@ -36,9 +38,9 @@ class EnqueueCampaignPageEditorAssets
             'id' => $campaignPage->campaignId,
         ], admin_url('edit.php'));
 
-
+        $handleName = 'givewp-campaign-page-post-type-editor';
         wp_enqueue_script(
-            'givewp-campaign-page-post-type-editor',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignPagePostTypeEditor.js',
             $scriptAsset['dependencies'],
             $scriptAsset['version'],
@@ -46,11 +48,13 @@ class EnqueueCampaignPageEditorAssets
         );
 
         wp_localize_script(
-            'givewp-campaign-page-post-type-editor',
+            $handleName,
             'giveCampaignPage',
             [
                 'campaignDetailsURL' => $campaignDetailsURL,
             ]
         );
+
+        Language::setScriptTranslations($handleName);
     }
 }

--- a/src/Campaigns/Actions/EnqueueCampaignPageEditorAssets.php
+++ b/src/Campaigns/Actions/EnqueueCampaignPageEditorAssets.php
@@ -14,6 +14,7 @@ use Give\Helpers\Language;
 class EnqueueCampaignPageEditorAssets
 {
     /**
+     * @unreleased set script translations
      * @since 4.0.0
      */
     public function __invoke()
@@ -30,6 +31,7 @@ class EnqueueCampaignPageEditorAssets
             return;
         }
 
+        $handleName = 'givewp-campaign-page-post-type-editor';
         $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignPagePostTypeEditor.asset.php');
 
         $campaignDetailsURL = add_query_arg([
@@ -38,7 +40,6 @@ class EnqueueCampaignPageEditorAssets
             'id' => $campaignPage->campaignId,
         ], admin_url('edit.php'));
 
-        $handleName = 'givewp-campaign-page-post-type-editor';
         wp_enqueue_script(
             $handleName,
             GIVE_PLUGIN_URL . 'build/campaignPagePostTypeEditor.js',

--- a/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
@@ -28,6 +28,7 @@ class LoadCampaignDetailsAssets
         );
 
         wp_enqueue_script($handleName);
+        wp_set_script_translations($handleName, 'give');
         wp_enqueue_style('givewp-design-system-foundation');
         wp_enqueue_style(
             $handleName,

--- a/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignDetailsAssets.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
 
 /**
  * @since 4.0.0
@@ -10,6 +11,7 @@ use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 class LoadCampaignDetailsAssets
 {
     /**
+     * @unreleased set script translations
      * @since 4.0.0
      */
     public function __invoke()
@@ -28,7 +30,9 @@ class LoadCampaignDetailsAssets
         );
 
         wp_enqueue_script($handleName);
-        wp_set_script_translations($handleName, 'give');
+
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style('givewp-design-system-foundation');
         wp_enqueue_style(
             $handleName,

--- a/src/Campaigns/Actions/LoadCampaignsListTableAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignsListTableAssets.php
@@ -5,6 +5,7 @@ namespace Give\Campaigns\Actions;
 use Give\API\REST\V3\Routes\Campaigns\ValueObjects\CampaignRoute;
 use Give\Campaigns\ListTable\CampaignsListTable;
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
 
 /**
  * @since 4.0.0
@@ -12,6 +13,7 @@ use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 class LoadCampaignsListTableAssets
 {
     /**
+     * @unreleased set script translations
      * @since 4.0.0
      */
     public function __invoke()
@@ -27,8 +29,6 @@ class LoadCampaignsListTableAssets
             true
         );
 
-        wp_set_script_translations($handleName, 'give');
-        
         wp_localize_script($handleName, 'GiveCampaignsListTable',
             [
                 'apiRoot' => esc_url_raw(rest_url(CampaignRoute::NAMESPACE . '/campaigns/list-table')),
@@ -43,6 +43,9 @@ class LoadCampaignsListTableAssets
         );
 
         wp_enqueue_script($handleName);
+
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style('givewp-design-system-foundation');
         wp_enqueue_style(
             $handleName,

--- a/src/Campaigns/Actions/LoadCampaignsListTableAssets.php
+++ b/src/Campaigns/Actions/LoadCampaignsListTableAssets.php
@@ -27,6 +27,8 @@ class LoadCampaignsListTableAssets
             true
         );
 
+        wp_set_script_translations($handleName, 'give');
+        
         wp_localize_script($handleName, 'GiveCampaignsListTable',
             [
                 'apiRoot' => esc_url_raw(rest_url(CampaignRoute::NAMESPACE . '/campaigns/list-table')),

--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
 
 /**
  * @since 4.0.0
@@ -22,43 +23,48 @@ class RegisterCampaignBlocks
     }
 
     /**
+     * @unreleased set script translations
      * @since 4.0.0
      */
     public function loadBlockEditorAssets(): void
     {
+        $handleName = 'givewp-campaign-blocks';
         $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignBlocks.asset.php');
 
         wp_register_script(
-            'givewp-campaign-blocks',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlocks.js',
             $scriptAsset['dependencies'],
             $scriptAsset['version'],
             true
         );
+        wp_enqueue_script($handleName);
 
-        wp_enqueue_script('givewp-campaign-blocks');
-        wp_set_script_translations('givewp-campaign-blocks', 'give');
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style(
-            'givewp-campaign-blocks',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlocks.css',
             ['wp-components'],
             $scriptAsset['version']
         );
 
+        $handleName = 'givewp-campaign-landing-page-blocks';
         $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignBlocksLandingPage.asset.php');
 
         wp_register_script(
-            'givewp-campaign-landing-page-blocks',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlocksLandingPage.js',
             $scriptAsset['dependencies'],
             $scriptAsset['version'],
             true
         );
+        wp_enqueue_script($handleName);
 
-        wp_enqueue_script('givewp-campaign-landing-page-blocks');
-        wp_set_script_translations('givewp-campaign-landing-page-blocks', 'give');
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style(
-            'givewp-campaign-landing-page-blocks',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlocksLandingPage.css',
             ['wp-components'],
             $scriptAsset['version']

--- a/src/Campaigns/Actions/RegisterCampaignBlocks.php
+++ b/src/Campaigns/Actions/RegisterCampaignBlocks.php
@@ -37,6 +37,7 @@ class RegisterCampaignBlocks
         );
 
         wp_enqueue_script('givewp-campaign-blocks');
+        wp_set_script_translations('givewp-campaign-blocks', 'give');
         wp_enqueue_style(
             'givewp-campaign-blocks',
             GIVE_PLUGIN_URL . 'build/campaignBlocks.css',
@@ -55,6 +56,7 @@ class RegisterCampaignBlocks
         );
 
         wp_enqueue_script('givewp-campaign-landing-page-blocks');
+        wp_set_script_translations('givewp-campaign-landing-page-blocks', 'give');
         wp_enqueue_style(
             'givewp-campaign-landing-page-blocks',
             GIVE_PLUGIN_URL . 'build/campaignBlocksLandingPage.css',

--- a/src/Campaigns/Actions/RegisterCampaignEntity.php
+++ b/src/Campaigns/Actions/RegisterCampaignEntity.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
 
 /**
  * @since 4.0.0
@@ -10,6 +11,7 @@ use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 class RegisterCampaignEntity
 {
     /**
+     * @unreleased set script translations
      * @since 4.0.0
      */
     public function __invoke()
@@ -26,5 +28,7 @@ class RegisterCampaignEntity
         );
 
         wp_enqueue_script($handleName);
+
+        Language::setScriptTranslations($handleName);
     }
 }

--- a/src/Campaigns/Blocks/Campaign/CampaignShortcode.php
+++ b/src/Campaigns/Blocks/Campaign/CampaignShortcode.php
@@ -2,6 +2,9 @@
 
 namespace Give\Campaigns\Blocks\Campaign;
 
+use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
+
 /**
  * @since 4.2.0
  */
@@ -27,23 +30,29 @@ class CampaignShortcode
     }
 
     /**
+     * @unreleased Use info from asset.php file and set script translations
      * @since 4.2.0
      */
     public function loadAssets()
     {
+        $handleName = 'givewp-campaign-block-app';
+        $asset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignBlockApp.asset.php');
+
         wp_enqueue_script(
-            'givewp-campaign-block-app',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlockApp.js',
-            [],
-            null,
+            $asset['dependencies'],
+            $asset['version'],
             true
         );
 
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style(
-            'givewp-campaign-block-style',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignBlockApp.css',
             [],
-            null
+            $asset['version']
         );
 
         wp_enqueue_style('givewp-design-system-foundation');

--- a/src/Campaigns/Blocks/CampaignForm/CampaignFormShortcode.php
+++ b/src/Campaigns/Blocks/CampaignForm/CampaignFormShortcode.php
@@ -2,6 +2,9 @@
 
 namespace Give\Campaigns\Blocks\CampaignForm;
 
+use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
+
 /**
  * @unreleased
  */
@@ -31,19 +34,24 @@ class CampaignFormShortcode
      */
     public function loadAssets()
     {
+        $handleName = 'givewp-campaign-form-app';
+        $asset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignListTable.asset.php');
+
         wp_enqueue_script(
-            'givewp-campaign-form-app',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignFormBlockApp.js',
-            [],
-            null,
+            $asset['dependencies'],
+            $asset['version'],
             true
         );
 
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style(
-            'givewp-campaign-form-style',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignFormBlockApp.css',
             [],
-            null
+            $asset['version']
         );
 
         wp_enqueue_style('givewp-design-system-foundation');

--- a/src/Campaigns/Blocks/CampaignForm/CampaignFormShortcode.php
+++ b/src/Campaigns/Blocks/CampaignForm/CampaignFormShortcode.php
@@ -35,7 +35,7 @@ class CampaignFormShortcode
     public function loadAssets()
     {
         $handleName = 'givewp-campaign-form-app';
-        $asset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignListTable.asset.php');
+        $asset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignFormBlockApp.asset.php');
 
         wp_enqueue_script(
             $handleName,

--- a/src/Campaigns/Blocks/CampaignGrid/CampaignGridShortcode.php
+++ b/src/Campaigns/Blocks/CampaignGrid/CampaignGridShortcode.php
@@ -2,6 +2,9 @@
 
 namespace Give\Campaigns\Blocks\CampaignGrid;
 
+use Give\Framework\Support\Facades\Scripts\ScriptAsset;
+use Give\Helpers\Language;
+
 /**
  * @since 4.2.0
  */
@@ -27,23 +30,29 @@ class CampaignGridShortcode
     }
 
     /**
+     * @unreleased Use info from asset.php file and set script translations
      * @since 4.2.0
      */
     public function loadAssets()
     {
+        $handleName = 'givewp-campaign-grid-app';
+        $asset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/campaignGridApp.asset.php');
+
         wp_enqueue_script(
-            'givewp-campaign-grid-app',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignGridApp.js',
-            [],
-            null,
+            $asset['dependencies'],
+            $asset['version'],
             true
         );
 
+        Language::setScriptTranslations($handleName);
+
         wp_enqueue_style(
-            'givewp-campaign-grid-style',
+            $handleName,
             GIVE_PLUGIN_URL . 'build/campaignGridApp.css',
             [],
-            null
+            $asset['version']
         );
 
         wp_enqueue_style('givewp-design-system-foundation');

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -3,6 +3,7 @@ import Chart from 'react-apexcharts';
 import apiFetch from '@wordpress/api-fetch';
 import {addQueryArgs} from '@wordpress/url';
 import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';
+import {__} from '@wordpress/i18n';
 
 const campaignId = new URLSearchParams(window.location.search).get('id');
 
@@ -22,7 +23,7 @@ const RevenueChart = () => {
     const {currency} = getCampaignOptionsWindowData();
     const currencyFormatter = amountFormatter(currency);
     const [max, setMax] = useState(100);
-    const [series, setSeries] = useState([{name: 'Revenue', data: getDefaultData()}]);
+    const [series, setSeries] = useState([{name: __('Revenue', 'give'), data: getDefaultData()}]);
 
     useEffect(() => {
         apiFetch({path: addQueryArgs('/givewp/v3/campaigns/' + campaignId + '/revenue')}).then(
@@ -33,7 +34,7 @@ const RevenueChart = () => {
                     setMax(undefined);
                     setSeries([
                         {
-                            name: 'Revenue',
+                            name: __('Revenue', 'give'),
                             data: data.map((item) => {
                                 return {
                                     x: item.date,

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -204,7 +204,7 @@ $borderColor: #9A9A9A;
             background-color: var(--givewp-primary-color);
             border: none;
             color: #fff;
-            
+
             &:focus{
                 outline: none;
             }
@@ -283,6 +283,7 @@ $borderColor: #9A9A9A;
         input[type="radio"] {
             position: absolute;
             z-index: -999;
+            border: none;
         }
     }
 }

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -204,7 +204,7 @@ $borderColor: #9A9A9A;
             background-color: var(--givewp-primary-color);
             border: none;
             color: #fff;
-
+            
             &:focus{
                 outline: none;
             }

--- a/src/DonationForms/resources/styles/components/_amount.scss
+++ b/src/DonationForms/resources/styles/components/_amount.scss
@@ -283,7 +283,6 @@ $borderColor: #9A9A9A;
         input[type="radio"] {
             position: absolute;
             z-index: -999;
-            border: none;
         }
     }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2430]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR makes sure all strings for campaigns are available to be translated.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign strings.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Demo video:** https://www.loom.com/share/9697385ca9a8415d87086e6fb5470821?sid=cb3d8451-43d6-432c-894a-783683540e08

![image](https://github.com/user-attachments/assets/05a4fa77-92e7-4b80-82f5-c65efb8107b9)

![image](https://github.com/user-attachments/assets/4fc81512-4956-401f-8170-f171ae9f914e)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Go to the plugin root folder and run this command: `wp i18n make-pot . languages/give.pot` (**ignore this step if you are testing it using a zip file**)
2. Install [Loco Translate](https://br.wordpress.org/plugins/loco-translate/) and start a translation for a new target language
3. Copy a string from the campaigns overview page like `This chart shows your campaign goal progress` and paste it in the Loco Translate search box
4. Add some random thing to the translated string
5. Change the WP settings to use the target language (from step 2) and make sure the new string gets applied

**Important:** for more context, check the [demo video](https://www.loom.com/share/9697385ca9a8415d87086e6fb5470821?sid=cb3d8451-43d6-432c-894a-783683540e08) demonstrating the steps above.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2430]: https://stellarwp.atlassian.net/browse/GIVE-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ