### PR TITLE
Fix: include `aria-required` in all required fields

### DIFF
--- a/src/DonationForms/resources/app/utilities/registerFieldAndBuildProps.tsx
+++ b/src/DonationForms/resources/app/utilities/registerFieldAndBuildProps.tsx
@@ -8,18 +8,29 @@ const formTemplates = window.givewp.form.templates;
 const LabelTemplate = formTemplates.layouts.fieldLabel;
 const ErrorMessageTemplate = formTemplates.layouts.fieldError;
 
+/**
+ * @unreleased include aria-required attribute in all required fields.
+ */
 export default function registerFieldAndBuildProps(
     field: Field,
     register: UseFormReturn['register'],
     errors
 ): FieldProps {
     const fieldError = getErrorByFieldName(errors, field.name);
+    const validationOptions = buildRegisterValidationOptions(field.validationRules);
+
+    const baseInputProps = register(field.name, validationOptions);
+
+    const inputProps = {
+        ...baseInputProps,
+        'aria-required': !!field.validationRules?.required ? 'true' : undefined,
+    };
 
     return {
         ...field,
-        inputProps: register(field.name, buildRegisterValidationOptions(field.validationRules)),
+        inputProps: inputProps,
         fieldError,
-        Label: () => <LabelTemplate label={field.label} required={field.validationRules.required} />,
+        Label: () => <LabelTemplate label={field.label} required={field.validationRules?.required} />,
         ErrorMessage: () => <ErrorMessageTemplate error={fieldError} name={field.name} />,
     };
 }

--- a/src/DonationForms/resources/registrars/templates/fields/Date.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Date.tsx
@@ -5,6 +5,9 @@ import {DateProps} from '@givewp/forms/propTypes';
 import 'react-datepicker/dist/react-datepicker.css';
 import styles from '../styles.module.scss';
 
+/**
+ * @unreleased add aria-required attribute.
+ */
 export default function Date({
     Label,
     ErrorMessage,
@@ -30,6 +33,7 @@ export default function Date({
                 dateFormat={dateFormat}
                 selected={value ? parse(value, dateFormat, new window.Date()) : null}
                 onChange={(date) => setValue(inputProps.name, date ? format(date, dateFormat) : '')}
+                ariaRequired={inputProps['aria-required']}
             />
 
             <ErrorMessage />

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,5 +1,8 @@
 import {FileProps} from '@givewp/forms/propTypes';
 
+/**
+ * @unreleased add aria-required attribute.
+ */
 export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError, description, inputProps}: FileProps) {
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
     const {setValue} = window.givewp.form.hooks.useFormContext();
@@ -20,6 +23,7 @@ export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError,
                 onChange={(e) => {
                     setValue(name, e.target.files[0]);
                 }}
+                aria-required={inputProps['aria-required']}
             />
 
             <input type="hidden" {...inputProps} />

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -142,6 +142,7 @@ function StateFieldContainer({
                         onChange={updateStateValue}
                         disabled={statesLoading}
                         aria-invalid={fieldError ? 'true' : 'false'}
+                        aria-required={stateRequired ? 'true' : 'false'}
                     >
                         {statesLoading ? (
                             <>
@@ -187,6 +188,7 @@ function StateFieldContainer({
                     aria-invalid={fieldError ? 'true' : 'false'}
                     placeholder={statesLoading ? __('Loading...', 'give') : ''}
                     disabled={statesLoading}
+                    aria-required={stateRequired ? 'true' : 'false'}
                 />
 
                 <HiddenStateField />


### PR DESCRIPTION
Resolves [GIVE-2461]

## Description
This PR adds the `aria-required="true"` attribute to all required form fields. This ensures that assistive technologies can programmatically identify which fields are mandatory, improving accessibility compliance.

The` aria-required` attribute has been added in the inputProps returned by `registerFieldAndBuildProps`, so it is automatically applied to each visible input field based on its validation rules.

Exceptions & Special Cases:

- Fields like `Date` and `File` inputs, which use hidden elements to manage the actual submitted value, had the aria-required attribute manually applied to their visible counterparts to ensure correct accessibility behavior.

- Some fields, such as those used for honeypot, hidden, password or authentication, are intentionally excluded since they are not visible or interactive and should not be exposed to assistive technologies. The same goes for MultiSelect as the `react-select` component does not accept `aria-required` as a prop.

## Affects
All input fields & corresponding blocks.

## Visuals
### All Fields Made Required
https://www.loom.com/share/677ccec038784f7aad1e5b15399b9ab6?sid=f3ddd3e0-1fcc-4ce3-83e4-d59960dbf99c

### All Fields Made Optional
https://github.com/user-attachments/assets/7ad1c1e7-0076-4323-be0b-7c23d0c2e662



## Testing Instructions
- Add various blocks that allow you to make them required.
- Inspect these input elements in the browser & verify they contain the `aria-required` attribute.
- Remove the required setting & verify the `aria-required` attribute is no longer visible.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2461]: https://stellarwp.atlassian.net/browse/GIVE-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ