### PR TITLE
Feature: Donations list table - show campaign title instead of the form title 

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -405,6 +405,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 	 *
 	 * @access public
 	 * @since  1.0
+     * @unreleased change donation form to campaign
 	 *
 	 * @return array $columns Array of all the list table columns
 	 */
@@ -465,6 +466,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 	 *
 	 * @access public
 	 * @since  1.0
+     * @unreleased show campaign name instead of the form name
 	 *
 	 * @return string Column Name
 	 */

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -10,6 +10,8 @@
  */
 
 // Exit if accessed directly.
+use Give\Donations\Models\Donation;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -410,7 +412,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 		$columns = [
 			'cb'            => '<input type="checkbox" />', // Render a checkbox instead of text.
 			'donation'      => __( 'Donation', 'give' ),
-			'donation_form' => __( 'Donation Form', 'give' ),
+			'campaign' => __( 'Campaign', 'give' ),
 			'status'        => __( 'Status', 'give' ),
 			'date'          => __( 'Date', 'give' ),
 			'amount'        => __( 'Amount', 'give' ),
@@ -434,7 +436,7 @@ class Give_Payment_History_Table extends WP_List_Table {
 	public function get_sortable_columns() {
 		$columns = [
 			'donation'      => [ 'ID', true ],
-			'donation_form' => [ 'donation_form', false ],
+			'campaign '     => [ 'campaign', false ],
 			'status'        => [ 'status', false ],
 			'amount'        => [ 'amount', false ],
 			'date'          => [ 'date', false ],
@@ -502,19 +504,11 @@ class Give_Payment_History_Table extends WP_List_Table {
 				$value .= sprintf( '<br><small>%1$s %2$s</small>', __( 'via', 'give' ), give_get_gateway_admin_label( $payment->gateway ) );
 				break;
 
-			case 'donation_form':
-				$form_title = empty( $payment->form_title ) ? sprintf( __( 'Untitled (#%s)', 'give' ), $payment->form_id ) : $payment->form_title;
-				$value      = '<a href="' . admin_url( 'post.php?post=' . $payment->form_id . '&action=edit' ) . '">' . $form_title . '</a>';
-				$level      = give_get_donation_form_title(
-					$payment,
-					[
-						'only_level' => true,
-					]
-				);
+			case 'campaign':
 
-				if ( ! empty( $level ) ) {
-					$value .= $level;
-				}
+                $donation = Donation::find($payment->ID);
+
+				$value = '<a href="' . admin_url( 'edit.php?post_type=give_forms&page=give-campaigns&id=' . $donation->campaign->id . '&tab=overview&action=edit' ) . '">' . $donation->campaign->title . '</a>';
 
 				break;
 

--- a/src/Donations/ListTable/Columns/CampaignColumn.php
+++ b/src/Donations/ListTable/Columns/CampaignColumn.php
@@ -8,37 +8,34 @@ use Give\Donations\Models\Donation;
 use Give\Framework\ListTable\ModelColumn;
 
 /**
- * @since 2.24.0
+ * @unreleased
  *
  * @extends ModelColumn<Donation>
  */
-class FormColumn extends ModelColumn
+class CampaignColumn extends ModelColumn
 {
-
-    protected $sortColumn = 'formTitle';
-
     /**
-     * @since 2.24.0
+     * @unreleased
      *
      * @inheritDoc
      */
     public static function getId(): string
     {
-        return 'form';
+        return 'campaign';
     }
 
     /**
-     * @since 2.24.0
+     * @unreleased
      *
      * @inheritDoc
      */
     public function getLabel(): string
     {
-        return __('Donation Form', 'give');
+        return __('Campaign', 'give');
     }
 
     /**
-     * @since 2.24.0
+     * @unreleased
      *
      * @inheritDoc
      *
@@ -48,9 +45,9 @@ class FormColumn extends ModelColumn
     {
         return sprintf(
             '<a href="%s" aria-label="%s">%s</a>',
-            admin_url("post.php?post={$model->formId}&action=edit"),
-            __('Visit donation form page', 'give'),
-            $model->formTitle
+            admin_url("post.php?post={$model->campaign->id}&action=edit"),
+            __('Visit campaign page', 'give'),
+            $model->campaign->title
         );
     }
 }

--- a/src/Donations/ListTable/Columns/CampaignColumn.php
+++ b/src/Donations/ListTable/Columns/CampaignColumn.php
@@ -45,7 +45,7 @@ class CampaignColumn extends ModelColumn
     {
         return sprintf(
             '<a href="%s" aria-label="%s">%s</a>',
-            admin_url("post.php?post={$model->campaign->id}&action=edit"),
+            admin_url("edit.php?post_type=give_forms&page=give-campaigns&id={$model->campaign->id}&tab=overview&action=edit"),
             __('Visit campaign page', 'give'),
             $model->campaign->title
         );

--- a/src/Donations/ListTable/DonationsListTable.php
+++ b/src/Donations/ListTable/DonationsListTable.php
@@ -5,7 +5,7 @@ namespace Give\Donations\ListTable;
 use Give\Donations\ListTable\Columns\AmountColumn;
 use Give\Donations\ListTable\Columns\CreatedAtColumn;
 use Give\Donations\ListTable\Columns\DonorColumn;
-use Give\Donations\ListTable\Columns\FormColumn;
+use Give\Donations\ListTable\Columns\CampaignColumn;
 use Give\Donations\ListTable\Columns\GatewayColumn;
 use Give\Donations\ListTable\Columns\IdColumn;
 use Give\Donations\ListTable\Columns\PaymentTypeColumn;
@@ -13,6 +13,7 @@ use Give\Donations\ListTable\Columns\StatusColumn;
 use Give\Framework\ListTable\ListTable;
 
 /**
+ * @unreleased show campaign title instead of form title
  * @since 2.24.0
  */
 class DonationsListTable extends ListTable
@@ -40,7 +41,7 @@ class DonationsListTable extends ListTable
             new PaymentTypeColumn(),
             new CreatedAtColumn(),
             new DonorColumn(),
-            new FormColumn(),
+            new CampaignColumn(),
             new GatewayColumn(),
             new StatusColumn(),
         ];
@@ -59,7 +60,7 @@ class DonationsListTable extends ListTable
             PaymentTypeColumn::getId(),
             CreatedAtColumn::getId(),
             DonorColumn::getId(),
-            FormColumn::getId(),
+            CampaignColumn::getId(),
             StatusColumn::getId(),
         ];
     }

--- a/tests/Unit/Donations/Endpoints/TestListDonations.php
+++ b/tests/Unit/Donations/Endpoints/TestListDonations.php
@@ -3,6 +3,7 @@
 namespace Give\Tests\Unit\Donations\Endpoints;
 
 use Exception;
+use Give\Campaigns\Models\Campaign;
 use Give\Donations\Endpoints\ListDonations;
 use Give\Donations\ListTable\DonationsListTable;
 use Give\Donations\Models\Donation;
@@ -23,7 +24,10 @@ class TestListDonations extends TestCase
      */
     public function testShouldReturnListWithSameSize()
     {
-        $donations = Donation::factory()->count(5)->create();
+        $campaign = Campaign::factory()->create();
+        $donations = Donation::factory()->count(5)->create([
+            'campaignId' => $campaign->id
+        ]);
 
         $mockRequest = $this->getMockRequest();
         // set_params
@@ -47,7 +51,10 @@ class TestListDonations extends TestCase
      */
     public function testShouldReturnListWithSameData()
     {
-        $donations = Donation::factory()->count(5)->create();
+        $campaign = Campaign::factory()->create();
+        $donations = Donation::factory()->count(5)->create([
+            'campaignId' => $campaign->id
+        ]);
         $sortDirection = ['asc', 'desc'][round(rand(0, 1))];
         $mockRequest = $this->getMockRequest();
         // set_params


### PR DESCRIPTION

## Description

This PR updates the donations list table to show the campaign title instead of the form title. 

## Affects

Donations list table


## Testing Instructions

Make a donation to a campaign
Visit donations list table and check the campaign column

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

