### PR TITLE
Fix: add radio role for donation amount level buttons

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import {__} from '@wordpress/i18n';
 
 /**
  * @since 3.0.0
@@ -44,7 +45,7 @@ export default function DonationAmountLevels({name, currency, levels, onLevelCli
                 'givewp-fields-amount__levels-container--has-descriptions': groupedLevels.labeled.length > 0,
             })}
             role="radiogroup"
-            aria-label="Donation Amount"
+            aria-label={__('Donation Amount', 'give')}
         >
             {allLevels.map((level, index) => {
                 const label = formatter.format(level.value);

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -42,6 +42,8 @@ export default function DonationAmountLevels({name, currency, levels, onLevelCli
             className={classNames('givewp-fields-amount__levels-container', {
                 'givewp-fields-amount__levels-container--has-descriptions': groupedLevels.labeled.length > 0,
             })}
+            role="radiogroup"
+            aria-label="Donation Amount"
         >
             {allLevels.map((level, index) => {
                 const label = formatter.format(level.value);
@@ -61,6 +63,8 @@ export default function DonationAmountLevels({name, currency, levels, onLevelCli
                                 'givewp-fields-amount__level--description': hasDescription,
                             })}
                             type="button"
+                            role="radio"
+                            aria-checked={selected}
                             onClick={() => {
                                 onLevelClick(level.value);
                             }}

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/DonationAmountLevels.tsx
@@ -18,6 +18,7 @@ type GroupedLevels = {
 type Level = {label: string | null; value: number};
 
 /**
+ * @unreleased Add proper roles and ARIA attributes
  * @since 3.12.0 add level descriptions.
  * @since 3.0.0
  */


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2457]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the proper `role` and `ARIA` attributes to the donation amount levels so the accessibility systems can understand it like a radio button, where the user needs to select just one option instead of a group of independent buttons.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donation amount levels block.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

![image](https://github.com/user-attachments/assets/e77ad5f8-c416-41ac-a0ae-b82201309d82)

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Make sure the donations level block container is using the `radiogroup` role.
2. Make sure each item of the donations level block is using the `radio` role.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2457]: https://stellarwp.atlassian.net/browse/GIVE-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ