### PR TITLE
Fix: ensure donation form view stats always shows revenue amount

### DIFF
--- a/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
@@ -109,7 +109,7 @@ class DonationFormGoalData implements Arrayable
      *
      * @since 4.1.0
      */
-    private function isSubscription(): bool
+    public function isSubscription(): bool
     {
         return in_array(
             $this->getGoalType()->getValue(), [

--- a/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
+++ b/src/DonationForms/DataTransferObjects/DonationFormGoalData.php
@@ -255,4 +255,25 @@ class DonationFormGoalData implements Arrayable
             'isAchieved' => $this->isEnabled && $this->formSettings->enableAutoClose && $progressPercentage >= 100,
         ];
     }
+
+    /**
+     * Get total donation revenue, the exception is for subscription amount goal, it will return the sum of initial amount
+     *
+     * @unreleased
+     */
+    public function getTotalDonationRevenue()
+    {
+        if ($this->getGoalType()->getValue() === 'amountFromSubscriptions') {
+            $query = $this->getQuery();
+
+            return $query->sumInitialAmount();
+        }
+
+
+        $query = $this->goalSource->isCampaign()
+            ? new CampaignDonationQuery($this->campaign)
+            : (new DonationQuery())->form($this->formId);
+
+        return $query->sumIntendedAmount();
+    }
 }

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -214,7 +214,7 @@ class DonationFormViewModel
         }
 
         return [
-            'totalRevenue' => $this->donationFormGoalData->isSubscription()  ? $query->sumInitialAmount() : $query->sumIntendedAmount(),
+            'totalRevenue' => $this->donationFormGoalData->getTotalDonationRevenue(),
             'totalCountValue' => $this->goalType()->isDonations() || $this->goalType()->isAmount()
                 ? $query->count()
                 : $this->getTotalCountValue(),

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -200,9 +200,9 @@ class DonationFormViewModel
     }
 
     /**
+     * @unreleased ensure totalRevenue always reflects revenue
      * @since 4.1.0  use DonationFormGoalData instead of repository
-     *
-     * @since       3.0.0
+     * @since 3.0.0
      */
     private function formStatsData(): array
     {
@@ -216,7 +216,7 @@ class DonationFormViewModel
         }
 
         return [
-            'totalRevenue' => $this->donationFormGoalData->getCurrentAmount(),
+            'totalRevenue' => $this->goalType()->isAmountFromSubscriptions()  ? $query->sumInitialAmount() : $query->sumIntendedAmount(),
             'totalCountValue' => $this->goalType()->isDonations() || $this->goalType()->isAmount()
                 ? $query->count()
                 : $this->getTotalCountValue(),

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -201,7 +201,7 @@ class DonationFormViewModel
 
     /**
      * @unreleased ensure totalRevenue always reflects revenue
-     * @since 4.1.0  use DonationFormGoalData instead of repository
+     * @since 4.1.0 use DonationFormGoalData instead of repository
      * @since 3.0.0
      */
     private function formStatsData(): array
@@ -209,14 +209,12 @@ class DonationFormViewModel
         $query = $this->donationFormGoalData->getQuery();
 
         // Only form goal has range
-        if ($this->formSettings->goalSource->isForm()) {
-            if ($this->formSettings->goalProgressType->isCustom()) {
-                $query->between($this->formSettings->goalStartDate, $this->formSettings->goalEndDate);
-            }
+        if ($this->formSettings->goalSource->isForm() && $this->formSettings->goalProgressType->isCustom()) {
+            $query->between($this->formSettings->goalStartDate, $this->formSettings->goalEndDate);
         }
 
         return [
-            'totalRevenue' => $this->goalType()->isAmountFromSubscriptions()  ? $query->sumInitialAmount() : $query->sumIntendedAmount(),
+            'totalRevenue' => $this->donationFormGoalData->isSubscription()  ? $query->sumInitialAmount() : $query->sumIntendedAmount(),
             'totalCountValue' => $this->goalType()->isDonations() || $this->goalType()->isAmount()
                 ? $query->count()
                 : $this->getTotalCountValue(),


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2573]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

I noticed the donation form header stats were not displaying the revenue correctly.  That specific amount is meant to always show "amount raised" regardless of if the goal type is count.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Donation form view

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

**Before**

<img width="627" alt="Screenshot 2025-05-12 at 2 45 58 PM" src="https://github.com/user-attachments/assets/2eadfe81-c7e7-4e70-ae69-aa9b69541b9b" />

**After**

<img width="687" alt="Screenshot 2025-05-12 at 2 46 16 PM" src="https://github.com/user-attachments/assets/9aa860fd-7dfa-44c1-aa9c-c6d96c58cea1" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

https://github.com/impress-org/givewp/actions/runs/15047590083

- Set a form goal, switching between options
- Make sure the "raised" amount is always in revenue

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2573]: https://stellarwp.atlassian.net/browse/GIVE-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ