### PR TITLE
Fix: improve contrast on default form colors

### DIFF
--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -319,7 +319,7 @@ class FormSettings implements Arrayable, Jsonable
         $self->goalEndDate = $array['goalEndDate'] ?? '';
         $self->designId = $array['designId'] ?? null;
         $self->inheritCampaignColors = $array['inheritCampaignColors'] ?? false;
-        $self->primaryColor = $array['primaryColor'] ?? '#69b86b';
+        $self->primaryColor = $array['primaryColor'] ?? '#2d802f';
         $self->secondaryColor = $array['secondaryColor'] ?? '#f49420';
         $self->goalAmount = $array['goalAmount'] ?? 0;
         $self->registrationNotification = $array['registrationNotification'] ?? false;

--- a/src/DonationForms/Properties/FormSettings.php
+++ b/src/DonationForms/Properties/FormSettings.php
@@ -14,6 +14,7 @@ use Give\Framework\Support\Contracts\Arrayable;
 use Give\Framework\Support\Contracts\Jsonable;
 
 /**
+ * @unreleased Update default value for Primary color to improve accessibility color contrast.
  * @since 3.16.0 Added $enableReceiptConfirmationPage property
  * @since 3.12.0 Add goalProgressType
  * @since 3.2.0 Remove addSlashesRecursive method

--- a/src/DonationForms/resources/styles/components/_goal.scss
+++ b/src/DonationForms/resources/styles/components/_goal.scss
@@ -39,7 +39,7 @@
         }
 
         &__stat-label {
-            color: var(--givewp-grey-400);
+            color: var(--givewp-grey-500);
             font-size: var(--givewp-font-size-paragraph-lg);
             font-weight: 600;
             line-height: 1.5;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
@@ -15,7 +15,7 @@ export default function Color({dispatch}) {
     const defaultColors = [
         {name: 'Black', slug: 'black', color: '#000000'},
         {name: 'Dark Blue', slug: 'dark-blue', color: '#1E1AE2'},
-        {name: 'Give Primary Default', slug: 'give-primary-default', color: '#69b86b'},
+        {name: 'Give Primary Default', slug: 'give-primary-default', color: '#2d802f'},
         {name: 'Red', slug: 'red', color: '#BD3D36'},
         {name: 'Orange', slug: 'orange', color: '#EB712E'},
         {name: 'Gray', slug: 'gray', color: '#5F7385'},

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
@@ -5,6 +5,9 @@ import {PanelColorSettings} from '@wordpress/block-editor';
 import {PanelBody} from '@wordpress/components';
 import ColorInheritanceToggle from '@givewp/form-builder/settings/design/style-controls/color-inheritance-toggle';
 
+/**
+ * @unreleased Update the value of the default colors Primary color to improve accessibility color contrast.
+ */
 export default function Color({dispatch}) {
     const {
         settings: {primaryColor, secondaryColor},


### PR DESCRIPTION
Resolves [GIVE-2503]   [GIVE-2459]   [GIVE-2491] 

## Description
This PR aims to improve the color contrast in the forms text by updating the forms default primary color choice & updating the goal stats text color.

- Goal Stat Labels Contrast
Issue: Labels such as “Raised,” “Donations,” and “Goal” did not meet the minimum 4.5:1 contrast ratio against their background.
Fix: Updated text color from `Grey-400` to `Grey-500` to ensure sufficient contrast.

- Payment Gateway Focus Outline
Issue: The green focus outline on the payment gateway selector with the form's default green background failed to meet the required 3:1 contrast ratio.
Fix: Resolved by updating the form’s default primary color, which affects both the background and focus outline color.

-  White Text on Green Background
Issue: White text used on the form’s default green background did not meet the required 4.5:1 contrast ratio.
Fix: Resolved by updating the form’s default primary color, which affects both the background and focus outline color.

## Affects
Forms default primary color
Goal stats color

## Visuals
### Contrast Errors
<img width="1639" alt="contrast-errors" src="https://github.com/user-attachments/assets/49641de0-bf54-4f14-86da-d23b60a421eb" />

### Fixed
<img width="1639" alt="no-errors" src="https://github.com/user-attachments/assets/099f4b82-a133-4536-a779-676c79ea244e" />

## Testing Instructions
- Create a campaign.
- Edit the campaign form and choose the classic template.
- Enable the progress goal & stats.
- From the design tab switch to the style settings in the right sidebar.
- Toggle the inherit campaign color off this should enable the default color selector and default primary color choice.
- There are two ways to test the contrast, I used arc-toolkit to view the accessibility errors but you can also take the colors and input them in a website like https://webaim.org/resources/contrastchecker/ to view the contrast numbers. We are only verifying the default green & the color of the goal stats. You can see examples in the photos Ive added to the pr.

### Testing default primary color contrast
https://github.com/user-attachments/assets/62040935-c484-4233-b753-22ffb5815485

### Testing goal stats contrast
https://github.com/user-attachments/assets/2fca476e-5536-4bbc-970e-2dbfa7f32459


## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2503]: https://stellarwp.atlassian.net/browse/GIVE-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-2459]: https://stellarwp.atlassian.net/browse/GIVE-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-2491]: https://stellarwp.atlassian.net/browse/GIVE-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ