### PR TITLE
Fix: Standardize input placeholder styles to improve color contrast

### DIFF
--- a/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
+++ b/src/DonationForms/FormDesigns/ClassicFormDesign/css/_inputs.scss
@@ -56,6 +56,7 @@ textarea {
     line-height: 1.2;
 
     &::placeholder {
+        color: var(--givewp-grey-400);
         opacity: 0.6;
     }
 

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
@@ -21,6 +21,7 @@ const groupSeparator = formatter.format(1000).replace(/[0-9]/g, '');
 const decimalSeparator = formatter.format(1.1).replace(/[0-9]/g, '');
 
 /**
+ * @unreleased add module styles to override currency-input placeholder styling.
  * @since 3.0.0
  */
 const CustomAmount = (

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
@@ -3,6 +3,7 @@ import {__} from '@wordpress/i18n';
 import CurrencyInput from 'react-currency-input-field';
 import { CurrencyInputOnChangeValues } from "react-currency-input-field/dist/components/CurrencyInputProps";
 
+import styles from "../../styles.module.scss"
 /**
  * @since 3.0.0
  */
@@ -42,7 +43,7 @@ const CustomAmount = (
                      */
                     groupSeparator.replace(/\u00A0/g, ' ')
                 }
-                className="givewp-fields-amount__input givewp-fields-amount__input-custom"
+                className={`${styles.customAmount} givewp-fields-amount__input givewp-fields-amount__input-custom`}
                 aria-invalid={fieldError ? 'true' : 'false'}
                 id="amount-custom"
                 name="amount-custom"
@@ -50,7 +51,9 @@ const CustomAmount = (
                 defaultValue={defaultValue}
                 value={value}
                 decimalsLimit={2}
-                onValueChange={(value) => {onValueChange(value !== undefined ? value : '')}}
+                onValueChange={(value) => {
+                    onValueChange(value !== undefined ? value : '');
+                }}
             />
         </div>
     );

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -157,3 +157,14 @@
         }
     }
 }
+
+.customAmount{
+    color: #4d4d4d;
+    font-weight: 500;
+
+    &::placeholder{
+        color: var(--givewp-grey-500);
+        font-weight: 500;
+        opacity: 0.6;
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-2458]

## Description
These changes help improve the color contrast of the placeholder text styles for our field inputs. Specifically the custom amount field placeholder which uses a currency-input had a different color than other fields. To ensure consistency and compliance I've updated the placeholder color of all fields to `var(--givewp-grey-400);`

<img width="1516" alt="Screenshot 2025-05-12 at 10 57 16 PM" src="https://github.com/user-attachments/assets/71c41072-5ef5-469d-83f8-34508fd30d57" />

## Affects
- Input placeholders

## Visuals
<img width="1487" alt="Screenshot 2025-05-12 at 10 42 12 PM" src="https://github.com/user-attachments/assets/c3c2d682-9acf-451e-ba24-104aecd110bc" />

<img width="1516" alt="Screenshot 2025-05-13 at 7 34 15 AM" src="https://github.com/user-attachments/assets/3a94c681-51b8-483a-aaeb-97bd243d1c25" />


## Testing Instructions
- Visually view a couple of text placeholders to verify the colors are the same.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2458]: https://stellarwp.atlassian.net/browse/GIVE-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ