### PR TITLE
Feature: Set default overlay settings when applying a header background image

### DIFF
--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from "react";
 import {__} from '@wordpress/i18n';
 import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-state';
@@ -6,6 +7,7 @@ import {upload} from '@wordpress/icons';
 import {ClassicEditor} from '@givewp/form-builder-library';
 
 /**
+ * @unreleased set image overlay color and opacity for background image to improve accessibility contrast against text.
  * @since 3.16.2 Replace TextareaControl component with ClassicEditor component on the description option
  */
 export default function Header({dispatch, publishSettings}) {
@@ -18,8 +20,22 @@ export default function Header({dispatch, publishSettings}) {
             description,
             designSettingsImageUrl,
             designSettingsImageStyle = 'background',
+            designSettingsImageColor
         },
     } = useFormState();
+
+    useEffect(() => {
+        if (designSettingsImageUrl && designSettingsImageStyle === 'background' && !designSettingsImageColor) {
+            dispatch(setFormSettings({
+                designSettingsImageColor: '#000000',
+                designSettingsImageOpacity: '25'
+            }));
+            publishSettings({
+                designSettingsImageColor: '#000000',
+                designSettingsImageOpacity: '25'
+            });
+        }
+    }, [designSettingsImageUrl]);
 
     const resetSettings = () => {
         const reset = {


### PR DESCRIPTION
Resolves [GIVE-2506]

## Description
This PR improves the contrast of white text over header background images by applying default values for the overlay color and opacity when a background image is selected.

The goal is to ensure that the form title and description have sufficient contrast with the image by default, improving accessibility and readability.

Since the overlay controls are located in the Styles tab, but may not be mounted immediately, the logic to apply these defaults was added to the General Settings panel (Header component). This ensures the defaults are applied even if the Styles tab is never opened.

## Affects
Header image
Header image styles & settings

## Visuals
https://github.com/user-attachments/assets/26bf4e63-99b3-416c-a5c6-f0675045ed74

## Testing Instructions
- Create a form with classic template.
- Add a header image preferably with a lighter color, it should apply as the background style.
- Verify the overlay settings and opacity are automatically applied so that the white text is visible over the new image.
- Switch to the styles tab from the right sidebar and adjust the image color and opacity settings to verify they still work as well.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2506]: https://stellarwp.atlassian.net/browse/GIVE-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ