### PR TITLE
Feature: Add focus border to donation confirmation donor-dashboard link

### DIFF
--- a/src/DonationForms/resources/styles/components/_receipt.scss
+++ b/src/DonationForms/resources/styles/components/_receipt.scss
@@ -218,6 +218,11 @@
             color: var(--givewp-primary-color);
             text-decoration: underline;
             font-weight: 400;
+
+            &:focus {
+                outline: 0.125rem solid var(--givewp-primary-color);
+                outline-offset: 0.25rem;
+            }
         }
 
         .download-btn {


### PR DESCRIPTION
Resolves [GIVE-2473]

## Description
This PR addresses an accessibility issue where the "Go to my Donor Dashboard" link lacked a visible focus indicator. This made it difficult for keyboard users to know when the link was focused, potentially blocking navigation and interaction.


## Affects
Donor dashboard link in the donation confirmation page

## Visuals
https://github.com/user-attachments/assets/8502994d-3b74-4ea1-81f9-5a9ddbb8c203


## Testing Instructions
- Complete a donation.
- On the Donation confirmation page use the tab key to navigate to the Donordashboard link.
- Verify a visible focus outline is shown around the button.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2473]: https://stellarwp.atlassian.net/browse/GIVE-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ