### PR TITLE
Refactor: Replace <dl> tags in donation confirmation field lists

### DIFF
--- a/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
@@ -16,7 +16,7 @@ const SecureBadge = () => {
 };
 
 /**
- *
+ * @unreleased replace <dl> tag with <div>. The <dl> element is reserved for definition lists, the content here represents labeled key-value pairs.
  * @since 3.4.0 updated to render value using Interweave
  * @since 3.0.0
  */
@@ -24,16 +24,23 @@ const Details = ({id, heading, details}: {id: string; heading: string; details: 
     details?.length > 0 && (
         <div className={`details details-${id}`}>
             <h3 className="headline">{heading}</h3>
-            <dl className="details-table">
+            <div className="details-table" role="list">
                 {details.map(({label, value}, index) => (
-                    <div key={index} className={`details-row details-row--${label.toLowerCase().replace(' ', '-')}`}>
-                        <dt className="detail">{label}</dt>
-                        <Interweave className="value" tagName="dd" data-value={value} content={value} />
+                    <div
+                        key={index}
+                        className={`details-row details-row--${label.toLowerCase().replace(' ', '-')}`}
+                        role="listitem"
+                    >
+                        <span className="detail">{label}</span>
+                        <span className="value" data-value={value}>
+                            <Interweave content={value} />
+                        </span>
                     </div>
                 ))}
-            </dl>
+            </div>
         </div>
     );
+
 /**
  * @since 3.0.0
  */


### PR DESCRIPTION
Resolves [GIVE-2468]

## Description
This PR updates the Details component to improve semantic HTML and accessibility compliance by replacing the inappropriate use of the <dl> (definition list) element. The original implementation caused screen readers to incorrectly announce the content as a list of definitions, which is misleading since the content represents labeled key-value pairs, not definitions.

## Affects
Donation Confirmation lists.

## Visuals
<img width="2054" alt="Screenshot 2025-05-20 at 5 10 56 PM" src="https://github.com/user-attachments/assets/cf190fae-0e00-40f2-8abe-9d4818cc4125" />

## Testing Instructions
- Create a donation.
- Verify the donation confirmation lists in the receipt continue to worlk. 

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2468]: https://stellarwp.atlassian.net/browse/GIVE-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ