### PR TITLE
feature: Add aria-support to donation confirmation secure badge

### DIFF
--- a/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/DonationReceipt.tsx
@@ -4,11 +4,12 @@ import {DonationReceiptProps} from '@givewp/forms/propTypes';
 import {Interweave} from 'interweave';
 
 /**
+ * @unreleased include aria-live and role attributes to the secure badge for screen readers.
  * @since 3.0.0
  */
 const SecureBadge = () => {
     return (
-        <aside className="givewp-form-secure-badge">
+        <aside className="givewp-form-secure-badge" role="status" aria-live="polite">
             <i className="fa-regular fa-circle-check givewp-form-secure-badge-icon"></i>
             {__('Success!', 'give')}
         </aside>


### PR DESCRIPTION
Resolves [GIVE-2469]

## Description
GIVE-029 from the accessibility audit:
“The success message is visually displayed but not programmatically defined, so it’s not announced by screen readers.”


This PR ensures screen readers detect and announce the message when it appears, improving accessibility for visually impaired users.

Aria attributes:
- role="status"
- aria-live="polite"

## Affects
Donation Confirmation page
Success badge

## Visuals
https://github.com/user-attachments/assets/fee35272-e055-405c-9440-d2c4dd7fbf2c

## Testing Instructions
- Complete a donation
- Verify that the success message can be read by screen readers

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2469]: https://stellarwp.atlassian.net/browse/GIVE-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ