### PR TITLE
If they are a donor and logged in give them access to donor dash

### DIFF
--- a/src/DonorDashboards/Helpers.php
+++ b/src/DonorDashboards/Helpers.php
@@ -50,6 +50,13 @@ class Helpers
         /** @var WP_User $user */
         $user = wp_get_current_user();
         $allowedRoles = ['administrator', 'give_donor', 'give_subscriber'];
+        // If the user is logged in and they are a donor, return true
+        if ( is_user_logged_in() ) {
+            $donor = give()->donors->get_donor_by('user_id', get_current_user_id());
+            if ($donor) {
+                return true;
+            }
+        }
 
         return (is_user_logged_in() && !empty(array_intersect($allowedRoles, $user->roles))) || (
                 give_is_setting_enabled( give_get_option( 'email_access' ) ) &&


### PR DESCRIPTION
I ran into this issue during testing with Give memberships. If a user signs up for a membership, their role can be different from a Give donor role. I'm not entirely sure I understand why there is a check for role, but I'm hoping a solution like this PR or something like it can be found for users with other custom roles, or even a subscriber role can view their donor dashboard if they've donated. 