### PR TITLE
Fix: Style Links in HTML Block to Improve Accessibility and Visual Consistency

### DIFF
--- a/src/DonationForms/resources/registrars/templates/elements/Html.tsx
+++ b/src/DonationForms/resources/registrars/templates/elements/Html.tsx
@@ -1,5 +1,6 @@
 import type {HtmlProps} from '@givewp/forms/propTypes';
+import styles from '../styles.module.scss';
 
 export default function Html({html}: HtmlProps) {
-    return <div dangerouslySetInnerHTML={{__html: html}} />;
+    return <div className={styles.htmlField} dangerouslySetInnerHTML={{__html: html}} />;
 }

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -184,6 +184,12 @@
         &:hover {
             text-decoration: none;
         }
+
+        &:focus {
+            border-radius: 2px;
+            outline: 2px solid var(--givewp-primary-color);
+            text-decoration: none;
+        }
     }
 }
 

--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -177,6 +177,17 @@
     }
 }
 
+.htmlField {
+    a {
+        text-decoration: underline;
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+}
+
+
 .customAmount{
     color: #4d4d4d;
     font-weight: 500;


### PR DESCRIPTION
Resolves [GIVE-2466]

## Description
This PR improves accessibility and visual consistency by ensuring that links within the HTML block of the Donation Form are properly styled. This update addresses an issue where links previously appeared as plain text with only a color difference, making them difficult to recognize, especially for users relying on visual cues.

## Affects
HTML Field

## Visuals
https://github.com/user-attachments/assets/4d5eaaf5-3d53-4bcb-b4f2-8611098eb19c

## Testing Instructions
1.	Using FFM, add an HTML block to a Donation Form
2.	Insert a paragraph containing one or more external links (e.g., using `<a href="https://example.com">Example</a>`)
3.	Publish or preview the Donation Form
4.	Confirm that the links:
•	Are visually distinct from surrounding text (e.g., underlined or styled differently)
•	Respond to hover and focus states (e.g., color change or underline appears)
5.	(Optional) Use a screen reader or accessibility audit tool to confirm that links are properly announced and accessible

## Pre-review Checklist
- [ ] Acceptance criteria satisfied and marked in related issue
- [ ] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2466]: https://stellarwp.atlassian.net/browse/GIVE-2466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ