### PR TITLE
Fix: Add Focus Outline to Multi-Select Field for Improved Accessibility

### DIFF
--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -13,6 +13,7 @@
 
         .react-datepicker__day {
             &--selected {
+
                 &,
                 &:hover {
                     background-color: var(--givewp-primary-color);
@@ -39,6 +40,11 @@
 
                 &:hover {
                     border-color: var(--givewp-primary-color);
+                }
+
+                &--is-focused {
+                    border-color: transparent;
+                    box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color);
                 }
             }
 


### PR DESCRIPTION
Resolves [GIVE-2448] 

## Description 
This PR enhances accessibility by adding a visible focus outline to the multi-select field in the Donation Form. Previously, there was no clear visual indication when the field was focused, making it difficult for keyboard and screen reader users to navigate the form effectively.

## Affects
Multi-select Field

## Visuals
https://github.com/user-attachments/assets/f4e1d44d-6b62-4905-9957-1fb863ef2319

## Testing Instructions
1.	Using FFM, add a Multi-Select field to a Donation Form
2.	Publish or preview the Donation Form
3.	Navigate to the Multi-Select field using the keyboard (e.g., press Tab until it is focused)
4.	Confirm that a visible focus style is applied when the field receives focus (e.g., a colored outline or box-shadow)

## Pre-review Checklist
- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2448]: https://stellarwp.atlassian.net/browse/GIVE-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ