### PR TITLE
Fix: multiselect focus contrast (GIVE-2467)

### DIFF
--- a/src/DonationForms/resources/registrars/templates/styles.module.scss
+++ b/src/DonationForms/resources/registrars/templates/styles.module.scss
@@ -31,8 +31,21 @@
 }
 
 .multiSelectField {
+    &:hover {
+        :global {
+            .givewp-fields-multiSelect__option--is-focused {
+                box-shadow: none;
+            }
+        }
+    }
+
     :global {
         .givewp-fields-multiSelect {
+            &__input {
+                padding-bottom: 8px;
+                margin-bottom: -8px;
+            }
+
             &__control {
                 border-color: rgb(102, 102, 102);
                 box-shadow: none;
@@ -82,9 +95,21 @@
                 background-color: rgb(102, 102, 102);
             }
 
+            &__menu {
+                margin-top: 0;
+            }
+
+            &__menu-list {
+                padding: 0;
+            }
+
             &__option {
+                color: var(--givewp-grey-700);
+
                 &--is-focused {
                     background-color: var(--givewp-grey-25);
+                    box-shadow: inset 0 0 0 var(--outline-width) var(--form-element-focus-color);
+                    border-radius: 4px;
                     cursor: pointer;
                 }
             }


### PR DESCRIPTION
Resolves [GIVE-2467] ## Description Enhances the color contrast for focused elements in the multiselect component, ensuring compliance with WCAG guidelines and improving usability for visually impaired users. ## Affects <!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). --> ## Visuals <!-- Include screenshots or video to better communicate your changes. --> ## Testing Instructions <!-- Help others test your PR as efficiently as possible. --> ## Pre-review Checklist - [ ] Acceptance criteria satisfied and marked in related issue - [ ] Relevant `@unreleased` tags included in DocBlocks - [ ] Includes unit tests - [ ] Reviewed by the designer (if follows a design) - [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed