### PR TITLE
Fix: Add Missing Label Association for Text Field

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Text.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Text.tsx
@@ -14,12 +14,14 @@ export default function Text({
 }: FieldHasDescriptionProps) {
     const autoComplete = autoCompleteAttr(inputProps?.name);
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
+    const inputId = `givewp-fields-text-${inputProps.name}-input`;
 
     return (
-        <label className={fieldError && 'givewp-field-error-label'}>
+        <label className={fieldError && 'givewp-field-error-label'} htmlFor={inputId}>
             <Label />
             {description && <FieldDescription description={description} />}
             <input
+                id={inputId}
                 type="text"
                 aria-invalid={fieldError ? 'true' : 'false'}
                 placeholder={placeholder}

--- a/src/DonationForms/resources/registrars/templates/fields/Text.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Text.tsx
@@ -2,7 +2,7 @@ import {FieldHasDescriptionProps} from '@givewp/forms/propTypes';
 import autoCompleteAttr from '@givewp/forms/registrars/templates/fields/utils/autoCompleteAttr';
 
 /**
- * @unreleased Add autoComplete support
+ * @unreleased Add autoComplete support and aria-labelledby and aria-describedby attributes.
  */
 export default function Text({
     Label,
@@ -14,16 +14,31 @@ export default function Text({
 }: FieldHasDescriptionProps) {
     const autoComplete = autoCompleteAttr(inputProps?.name);
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
-    const inputId = `givewp-fields-text-${inputProps.name}-input`;
+    const baseId = `givewp-fields-text-${inputProps.name}`;
+    const inputId = `${baseId}-input`;
+    const labelId = `${baseId}-label`;
+    const descriptionId = `${baseId}-description`;
 
     return (
-        <label className={fieldError && 'givewp-field-error-label'} htmlFor={inputId}>
-            <Label />
-            {description && <FieldDescription description={description} />}
+        <label
+            className={fieldError && 'givewp-field-error-label'}
+            htmlFor={inputId}
+        >
+            <span id={labelId}>
+                <Label />
+            </span>
+            {description && (
+                <span id={descriptionId}>
+                    <FieldDescription description={description} />
+                </span>
+            )}
+
             <input
                 id={inputId}
                 type="text"
                 aria-invalid={fieldError ? 'true' : 'false'}
+                aria-labelledby={labelId}
+                aria-describedby={description ? descriptionId : undefined}
                 placeholder={placeholder}
                 {...inputProps}
                 autoComplete={autoComplete}


### PR DESCRIPTION
Resolves [GIVE-2504]

## Description
This PR ensures proper label and description association for the text field in the Donation Form by correctly setting the id on the input element and referencing it in the corresponding `<label>` using `htmlFor`. Additionally, it sets `aria-labelledby `and `aria-describedby` attributes to ensure that both the label and optional field description are properly announced by screen readers. Previously, the text field lacked a valid id, and screen readers were unable to associate the label or description with the input. This fix improves accessibility and ensures compliance with form labeling and description best practices.

## Affects
Text field

## Visuals
https://github.com/user-attachments/assets/fdea8254-011d-4c34-9db9-791355822a94

![CleanShot 2025-05-16 at 08 30 06](https://github.com/user-attachments/assets/798ec906-18c1-4265-92fd-d3dd6741a03f)

## Testing Instructions
1.	Using FFM, add a Text Field block to the Donation Form
2.	Publish or preview the Donation Form
3.	Open the form and inspect the Text Field input using browser dev tools
4.	Confirm the input element has:
•	A valid id attribute
•	An aria-labelledby attribute matching the id of the label element
•	An aria-describedby attribute pointing to the element that contains the description (if a description is present)
5.	Confirm the <label> element has a htmlFor attribute matching the input’s id
6.	(Optional) Use a screen reader to verify:
•	The label is announced when the input is focused
•	The description text is read after the label (if provided)

## Pre-review Checklist
- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2504]: https://stellarwp.atlassian.net/browse/GIVE-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ