### PR TITLE
Fix: file upload a11y error (GIVE-2447)

### DIFF
--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -46,6 +46,7 @@ export interface FieldHasDescriptionProps extends FieldProps {
 
 export interface FileProps extends FieldHasDescriptionProps {
     allowedMimeTypes: string[];
+    maxUploadSize: number;
 }
 
 export interface DateProps extends Omit<FieldHasDescriptionProps, 'placeholder'> {

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,11 +1,12 @@
 import {FileProps} from '@givewp/forms/propTypes';
+import {__, sprintf} from '@wordpress/i18n';
 
 /**
- * @unreleased add aria-required attribute.
+ * @unreleased Add aria-required attribute and file size validation.
  */
-export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError, description, inputProps}: FileProps) {
+export default function File({Label, allowedMimeTypes, maxUploadSize, ErrorMessage, fieldError, description, inputProps}: FileProps) {
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
-    const {setValue} = window.givewp.form.hooks.useFormContext();
+    const {setValue, setError} = window.givewp.form.hooks.useFormContext();
     const {name} = inputProps;
 
     return (
@@ -21,7 +22,14 @@ export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError,
                 aria-invalid={fieldError ? 'true' : 'false'}
                 accept={allowedMimeTypes.join(',')}
                 onChange={(e) => {
-                    setValue(name, e.target.files[0]);
+                    const file = e.target.files[0];
+
+                    if (file.size > maxUploadSize) {
+                        setError(name, {message: sprintf(__('The selected file must be less than or equal to %d bytes.', 'give'), maxUploadSize)});
+                    } else {
+                        setError(name, undefined);
+                        setValue(name, file);
+                    }
                 }}
                 aria-required={inputProps['aria-required']}
             />

--- a/src/Framework/FieldsAPI/File.php
+++ b/src/Framework/FieldsAPI/File.php
@@ -24,6 +24,7 @@ class File extends Field
     const TYPE = 'file';
 
     protected $allowedMimeTypes = [];
+    protected $maxUploadSize = null;
 
     /**
      * Set the maximum file size.
@@ -75,6 +76,7 @@ class File extends Field
         }
 
         $this->rules((new FileRule())->maxSize($maxUploadSize));
+        $this->maxUploadSize = $maxUploadSize;
 
         return $this;
     }


### PR DESCRIPTION
Resolves [GIVE-2447] ## Description Addresses an accessibility error in the file upload component. This PR ensures that error messages are properly announced to screen readers and that the upload field meets accessibility standards. ## Affects <!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). --> ## Visuals <!-- Include screenshots or video to better communicate your changes. --> ## Testing Instructions <!-- Help others test your PR as efficiently as possible. --> ## Pre-review Checklist - [ ] Acceptance criteria satisfied and marked in related issue - [ ] Relevant `@unreleased` tags included in DocBlocks - [ ] Includes unit tests - [ ] Reviewed by the designer (if follows a design) - [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed