### PR TITLE
Fix: add error focus Date and File fields

### DIFF
--- a/src/DonationForms/resources/registrars/templates/fields/Date.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Date.tsx
@@ -7,7 +7,7 @@ import styles from '../styles.module.scss';
 import {useEffect, useRef} from "react";
 
 /**
- * @unreleased add aria-required attribute.
+ * @unreleased add aria-required attribute. manually focus the visible input when error is present.
  */
 export default function Date({
     Label,

--- a/src/DonationForms/resources/registrars/templates/fields/Date.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Date.tsx
@@ -4,6 +4,7 @@ import {format, parse} from 'date-fns';
 import {DateProps} from '@givewp/forms/propTypes';
 import 'react-datepicker/dist/react-datepicker.css';
 import styles from '../styles.module.scss';
+import {useEffect, useRef} from "react";
 
 /**
  * @unreleased add aria-required attribute.
@@ -21,14 +22,23 @@ export default function Date({
     const {setValue} = useFormContext();
     const value = useWatch({name: inputProps.name});
 
+    const ref = useRef(null);
+
     dateFormat = dateFormat.replace('mm', 'MM');
 
+    useEffect(() => {
+        if (fieldError && ref.current) {
+            ref.current.focus();
+        }
+    }, [fieldError]);
+
     return (
-        <label className={styles.dateField}>
+        <label ref={ref} className={styles.dateField}>
             <Label />
             {description && <FieldDescription description={description} />}
             <input type="hidden" {...inputProps} />
             <DatePicker
+                id={inputProps.name}
                 ariaInvalid={fieldError ? 'true' : 'false'}
                 dateFormat={dateFormat}
                 selected={value ? parse(value, dateFormat, new window.Date()) : null}

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -2,7 +2,7 @@ import {FileProps} from '@givewp/forms/propTypes';
 import {useEffect, useRef} from "react";
 
 /**
- * @unreleased add aria-required attribute.
+ * @unreleased add aria-required attribute. manually focus the visible input when error is present.
  */
 export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError, description, inputProps}: FileProps) {
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,4 +1,5 @@
 import {FileProps} from '@givewp/forms/propTypes';
+import {useEffect, useRef} from "react";
 
 /**
  * @unreleased add aria-required attribute.
@@ -7,6 +8,13 @@ export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError,
     const FieldDescription = window.givewp.form.templates.layouts.fieldDescription;
     const {setValue} = window.givewp.form.hooks.useFormContext();
     const {name} = inputProps;
+    const ref = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (fieldError && ref.current) {
+            ref.current.focus();
+        }
+    }, [fieldError]);
 
     return (
         <>
@@ -16,6 +24,7 @@ export default function File({Label, allowedMimeTypes, ErrorMessage, fieldError,
             {description && <FieldDescription description={description} />}
 
             <input
+                ref={ref}
                 id={`${name}-field`}
                 type="file"
                 aria-invalid={fieldError ? 'true' : 'false'}


### PR DESCRIPTION
Resolves [GIVE-2439]

## Description
This PR improves the accessibility of the `File` and `Date` input field by ensuring keyboard focus automatically moves to the field when an error is present. Previously, if there was an error, pressing Tab would skip the field entirely and jump to the page footer, making it difficult for keyboard and screen reader users to fix the issue.

This occurred because the registered ref for the field is spread across the hidden input, resulting in the error focus going to the hidden input instead of the visible one.

## Affects
Date field
File field

## Visuals
https://github.com/user-attachments/assets/a2d14232-d272-4578-8a80-9aa7caa35b38

## Testing Instructions
ZIP: https://github.com/impress-org/givewp/actions/runs/15476305685
- Create a donation form with the `File` & `Date` block.
- Make both blocks required.
- Attempt a donation with each block without filling one to verify that when the error occurs from it being required & unfilled. The focus state automatically shifts to that field.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2439]: https://stellarwp.atlassian.net/browse/GIVE-2439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ