### PR TITLE
Fix: improve accessibility across form modal & new tab display styles

### DIFF
--- a/src/Campaigns/Blocks/shared/components/ModalForm/index.tsx
+++ b/src/Campaigns/Blocks/shared/components/ModalForm/index.tsx
@@ -6,6 +6,7 @@ import ModalCloseIcon from './ModalClose';
 import {Spinner} from '@wordpress/components';
 import './styles.scss';
 import '../EntitySelector/styles/index.scss';
+import {FocusScope} from 'react-aria';
 
 /**
  * @unreleasaed
@@ -113,35 +114,45 @@ export default function ModalForm({dataSrc, embedId, buttonText, isFormRedirect,
                 isDismissable
                 isEntering={isEntering}
             >
-                <button
-                    aria-label={__('Close donation form', 'give')}
-                    aria-hidden="false"
-                    type="button"
-                    className="givewp-donation-form-modal__close"
-                    onClick={closeModal}
+                <Modal 
+                    className="givewp-donation-form-modal"
+                    data-loading={isLoading}
                 >
-                    <ModalCloseIcon />
-                </button>
-                <Modal className="givewp-donation-form-modal">
-                    <Dialog className="givewp-donation-form-modal__dialog" aria-label={__('Donation Form', 'give')}>
-                        <div className="givewp-donation-form-modal__dialog__content">
-                            <IframeResizer
-                                title={__('Donation Form', 'give')}
-                                id={embedId}
-                                src={dataSrcUrl}
-                                checkOrigin={false}
-                                heightCalculationMethod="taggedElement"
-                                style={{
-                                    minWidth: '100%',
-                                    border: 'none',
-                                }}
-                                onInit={(iframe) => {
-                                    iframe.iFrameResizer.resize();
-                                    setLoading(false);
-                                }}
-                            />
-                        </div>
-                    </Dialog>
+                    <FocusScope contain restoreFocus autoFocus>
+                        <Dialog 
+                            className="givewp-donation-form-modal__dialog" 
+                            aria-label={__('Donation Form', 'give')}
+                            role="dialog"
+                            aria-modal="true"
+                        >
+                            <button
+                                aria-label={__('Close donation form', 'give')}
+                                type="button"
+                                className="givewp-donation-form-modal__close"
+                                onClick={closeModal}
+                                tabIndex={0}
+                            >
+                                <ModalCloseIcon />
+                            </button>
+                            <div className="givewp-donation-form-modal__dialog__content">
+                                <IframeResizer
+                                    title={__('Donation Form', 'give')}
+                                    id={embedId}
+                                    src={dataSrcUrl}
+                                    checkOrigin={false}
+                                    heightCalculationMethod="taggedElement"
+                                    style={{
+                                        minWidth: '100%',
+                                        border: 'none',
+                                    }}
+                                    onInit={(iframe) => {
+                                        iframe.iFrameResizer.resize();
+                                        setLoading(false);
+                                    }}
+                                />
+                            </div>
+                        </Dialog>
+                    </FocusScope>
                 </Modal>
             </ModalOverlay>
         </>

--- a/src/Campaigns/Blocks/shared/components/ModalForm/index.tsx
+++ b/src/Campaigns/Blocks/shared/components/ModalForm/index.tsx
@@ -28,6 +28,19 @@ export default function ModalForm({dataSrc, embedId, buttonText, isFormRedirect,
     const [isLoading, setLoading] = useState<boolean>(false);
     const [isEntering, setEntering] = useState<boolean>(false);
 
+    useEffect(() => {
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && isOpen) {
+                closeModal();
+            }
+        };
+
+        document.addEventListener('keydown', handleEscape);
+        return () => {
+            document.removeEventListener('keydown', handleEscape);
+        };
+    }, [isOpen]);
+
     // Preload the iframe document
     useEffect(() => {
         const selector = `link[rel="preload"][href="${dataSrcUrl}"][as="document"]`;

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -56,7 +56,7 @@ function DonationFormBlockApp({
                 href={formUrl} 
                 target={'_blank'} 
                 rel={'noopener noreferrer'}
-                aria-label={`${openFormButton} (Opens in a new tab)`}
+                aria-label={`${openFormButton} ${__('Opens in a new tab', 'give')}`}
             >
                 {openFormButton}
             </a>

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/app/index.tsx
@@ -51,7 +51,13 @@ function DonationFormBlockApp({
 
     if (formFormat === 'newTab') {
         return (
-            <a className={'givewp-donation-form-link'} href={formUrl} target={'_blank'} rel={'noopener noreferrer'}>
+            <a 
+                className={'givewp-donation-form-link'} 
+                href={formUrl} 
+                target={'_blank'} 
+                rel={'noopener noreferrer'}
+                aria-label={`${openFormButton} (Opens in a new tab)`}
+            >
                 {openFormButton}
             </a>
         );


### PR DESCRIPTION
Resolves [GIVE-2502] & [GIVE-2462]

## Description
This update improves modal accessibility by implementing logical focus order and trapping focus inside the modal using the FocusScope component. It also includes an aria label for the new-tab setting so that screen-readers better understand the button action.

Key Fixes:
- Added FocusScope to trap focus within the modal and automatically focus the first element.
- Moved the Close button inside the Dialog element and made it keyboard focusable.
- Set role="dialog" and aria-modal="true" to explicitly define modal semantics.
- Ensured tabIndex={0} is applied where necessary to ensure focusability.
- Added restoreFocus to return focus to the triggering element once the modal is closed.
- ESC key support is assumed to be handled via existing onClick={closeModal} logic.


## Affects
Donation Form Block
Campaign Form Block

## Visuals

https://github.com/user-attachments/assets/a12d16e3-39cc-4de0-af73-389242e506a8

https://github.com/user-attachments/assets/8b98db37-fa08-4cb3-b04c-395204b53ecb



## Testing Instructions
- Add a form block & select the new tab display style.
- View the element for the aria-label or use a screen-reader & navigate to the element to confirm its new label.
- Switch to the modal style & open the modal.
- Using keyboard navigation ensure while pressing tab the modal focus begins with the close but and is trapped within the context of the modal.
- Ensure pressing the ESC key closes the modal.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2502]: https://stellarwp.atlassian.net/browse/GIVE-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-2462]: https://stellarwp.atlassian.net/browse/GIVE-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ