### PR TITLE
Fix: allow multiple form ids to be filtered by the donor wall

### DIFF
--- a/includes/donors/class-give-donor-wall.php
+++ b/includes/donors/class-give-donor-wall.php
@@ -121,8 +121,6 @@ class Give_Donor_Wall {
 
 		$atts      = $this->parse_atts( $atts );
 
-        _give_redirect_form_id($atts['form_id']);
-
 		$donations = $this->get_donation_data( $atts );
 		$html      = '';
 
@@ -368,6 +366,7 @@ class Give_Donor_Wall {
 		$query_atts['tags']          = $atts['tags'];
 		$query_atts['only_comments'] = ( true === $atts['only_comments'] );
 		$query_atts['anonymous']     = ( true === $atts['anonymous'] );
+
 
 		return $query_atts;
 	}


### PR DESCRIPTION
Resolves: [GIVE-2617]

## Description
This PR fixes an issue with the donor wall block's form filtering functionality. Previously, when multiple form IDs were provided (e.g. "12,25,40"), only the first form ID was being processed due to `_give_redirect_form_id()` being called directly on the comma-separated string in `Give_Donor_Wall::render_shortcode()`.

This call was redundant since form ID redirection is already handled properly in `Give_Donor_Wall_Block::render_block()` where each form ID is mapped and redirected before being passed to the shortcode renderer:

```php
'form_id' => implode(',',
    array_map(
        static function ($id) {
            _give_redirect_form_id($id);
            return $id;
        },
        $this->getAsArray($attributes['formID'])
    )
),
```

Removing the redundant redirect call in `Give_Donor_Wall` ensures all form IDs are properly processed and displayed in the donor wall.

## Affects
Donor Wall block & shortcode.

## Visuals

https://github.com/user-attachments/assets/2ba7b186-7d08-48bd-9a0d-5737a3bbe2c5



## Testing Instructions
- Create a page with the donor wall block & shortcode.
- Use the Wall settings and switch to form id.
- in both instances add multiple form ids.
- Verify that they work correctly on both the frontend & backend.

## Pre-review Checklist
-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

