### PR TITLE
Fix: use campaign colors for grid and block goal progress

### DIFF
--- a/src/Campaigns/Blocks/CampaignGoal/app/styles.scss
+++ b/src/Campaigns/Blocks/CampaignGoal/app/styles.scss
@@ -49,7 +49,7 @@
             height: 8px;
             border-radius: 14px;
             box-shadow: inset 0 1px 4px 0 rgba(0, 0, 0, 0.09);
-            background-color: #2d802f;
+            background: var(--givewp-secondary-color, #2d802f);
         }
     }
 }

--- a/src/Campaigns/Blocks/CampaignGoal/render.php
+++ b/src/Campaigns/Blocks/CampaignGoal/render.php
@@ -15,8 +15,14 @@ if (
     return;
 }
 
+$blockInlineStyles = sprintf(
+    '--givewp-primary-color: %s; --givewp-secondary-color: %s;',
+    esc_attr($campaign->primaryColor ?? '#0b72d9'),
+    esc_attr($campaign->secondaryColor ?? '#27ae60')
+);
+
 ?>
 
-<div <?= get_block_wrapper_attributes() ?>>
+<div <?= get_block_wrapper_attributes(['style' => $blockInlineStyles]) ?>>
     <div data-givewp-campaign-goal data-id="<?= $campaign->id ?>"></div>
 </div>

--- a/src/Campaigns/Blocks/CampaignGrid/app/index.tsx
+++ b/src/Campaigns/Blocks/CampaignGrid/app/index.tsx
@@ -5,6 +5,7 @@ import CampaignCard from '../../shared/components/CampaignCard';
 import {CampaignGridType} from '../types';
 
 import './styles.scss';
+import {Spinner as GiveSpinner} from '@givewp/components';
 
 const getGridSettings = (layout: string) => {
     switch (layout) {
@@ -29,7 +30,9 @@ export default ({attributes}: { attributes: CampaignGridType }) => {
     });
 
     if (!hasResolved) {
-        return null;
+        return <div className="givewp-campaign-grid__loading">
+            <GiveSpinner />
+        </div>;
     }
 
     return (

--- a/src/Campaigns/Blocks/CampaignGrid/app/styles.scss
+++ b/src/Campaigns/Blocks/CampaignGrid/app/styles.scss
@@ -8,4 +8,11 @@
         justify-content: center;
         margin-top: 16px;
     }
+
+    &__loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
+    }
 }

--- a/src/Campaigns/Blocks/shared/components/CampaignCard/index.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignCard/index.tsx
@@ -17,10 +17,15 @@ export default ({showImage, showGoal, showDescription, campaign}: {
     return (
         <div
             className="give-campaigns-component-campaign"
-            {...(campaign.pagePermalink && !campaignWindowData.isAdmin && {
-                style: {
+            style={{
+                // @ts-ignore
+                '--givewp-primary-color': campaign.primaryColor ?? '#0b72d9',
+                '--givewp-secondary-color': campaign.secondaryColor ?? '#27ae60',
+                ...(campaign.pagePermalink && !campaignWindowData.isAdmin && {
                     cursor: 'pointer',
-                },
+                })
+            }}
+            {...(campaign.pagePermalink && !campaignWindowData.isAdmin && {
                 onClick: () => window.location = campaign.pagePermalink
             })}
         >

--- a/src/Campaigns/Blocks/shared/components/CampaignCard/styles.scss
+++ b/src/Campaigns/Blocks/shared/components/CampaignCard/styles.scss
@@ -84,7 +84,7 @@
                 height: 8px;
                 border-radius: 14px;
                 box-shadow: inset 0 1px 4px 0 rgba(0, 0, 0, 0.09);
-                background-color: #2d802f;
+                background: var(--givewp-secondary-color, #2d802f);
             }
         }
     }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2622]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The goal progress colors were being hard-coded, this updates them to use the campaign settings.

Also added a simple loading state to the campaign grid.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

- The campaign grid
- The campaign page goal block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1275" alt="Screenshot 2025-06-02 at 11 19 40 AM" src="https://github.com/user-attachments/assets/60e939c6-3f7c-4b03-a0db-adfafdf5c101" />

<img width="1231" alt="Screenshot 2025-06-02 at 11 19 48 AM" src="https://github.com/user-attachments/assets/f37e32ad-c6f7-4684-9926-711ee696c050" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/15419472325

- Create campaigns with different color settings
- Check the campaign grid and page(s) for accurate colors

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2622]: https://stellarwp.atlassian.net/browse/GIVE-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ