### PR TITLE
Fix: update campaign donate button block to support v2 forms

### DIFF
--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -1,6 +1,5 @@
 <?php
 
-use Give\Campaigns\Actions\RenderDonateButton;
 use Give\Campaigns\Models\Campaign;
 use Give\Campaigns\Repositories\CampaignRepository;
 
@@ -9,30 +8,35 @@ use Give\Campaigns\Repositories\CampaignRepository;
  * @var Campaign $campaign
  */
 
-if (
-    ! isset($attributes['campaignId']) ||
-    ! ($campaign = give(CampaignRepository::class)->getById($attributes['campaignId']))
-) {
+if (!isset($attributes['campaignId']) || !($campaign = give(CampaignRepository::class)->getById($attributes['campaignId']))) {
     return;
 }
 
 $blockInlineStyles = sprintf(
     '--givewp-primary-color: %s;',
-    esc_attr($campaign->primaryColor ?? '#0b72d9')
+    esc_attr($campaign->primaryColor)
 );
+
+$useDefaultForm = (bool)filter_var($attributes['useDefaultForm'], FILTER_VALIDATE_BOOLEAN);
+$hasSelectedForm = isset($attributes['selectedForm']);
+$selectedFormId = $hasSelectedForm ? (int)$attributes['selectedForm'] : null;
+$formId = $useDefaultForm || ! $hasSelectedForm ? $campaign->defaultFormId : $selectedFormId;
+$buttonText = esc_html($attributes['buttonText'] ?? __('Donate', 'give'));
 ?>
 
-<div
+<div <?php echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block', 'style' => esc_attr($blockInlineStyles)])); ?>>
     <?php
-    echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block'])); ?>
-    style="<?php
-    echo esc_attr($blockInlineStyles); ?>">
-    <?php
-    echo give(RenderDonateButton::class)(
-        ($attributes['useDefaultForm'] || ! isset($attributes['selectedForm']))
-            ? $campaign->defaultFormId
-            : $attributes['selectedForm'],
-        $attributes['buttonText'] ?? __('Donate', 'give'),
-    );
+    ob_start();
+    echo give_form_shortcode([
+        'id' => $formId,
+        'campaign_id' => $campaign->id,
+        'display_style' => 'modal',
+        'continue_button_title' => $buttonText,
+        'use_default_form' => $useDefaultForm,
+        'button_color' => $campaign->primaryColor,
+    ]);
+
+    $final_output = ob_get_clean();
+    echo $final_output;
     ?>
 </div>

--- a/src/Campaigns/Blocks/DonateButton/render.php
+++ b/src/Campaigns/Blocks/DonateButton/render.php
@@ -22,19 +22,28 @@ $hasSelectedForm = isset($attributes['selectedForm']);
 $selectedFormId = $hasSelectedForm ? (int)$attributes['selectedForm'] : null;
 $formId = $useDefaultForm || ! $hasSelectedForm ? $campaign->defaultFormId : $selectedFormId;
 $buttonText = esc_html($attributes['buttonText'] ?? __('Donate', 'give'));
+$isEditor = defined('REST_REQUEST') && REST_REQUEST;
 ?>
 
 <div <?php echo wp_kses_data(get_block_wrapper_attributes(['class' => 'givewp-campaign-donate-button-block', 'style' => esc_attr($blockInlineStyles)])); ?>>
     <?php
     ob_start();
-    echo give_form_shortcode([
+    if ($isEditor) {
+        echo sprintf(
+            '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+            esc_html($buttonText)
+        );
+    } else {
+        echo give_form_shortcode([
         'id' => $formId,
         'campaign_id' => $campaign->id,
         'display_style' => 'modal',
         'continue_button_title' => $buttonText,
         'use_default_form' => $useDefaultForm,
         'button_color' => $campaign->primaryColor,
-    ]);
+        'block_id' => $attributes['blockId'] ?? '',
+        ]);
+    }
 
     $final_output = ob_get_clean();
     echo $final_output;

--- a/src/Campaigns/Blocks/DonateButton/styles.scss
+++ b/src/Campaigns/Blocks/DonateButton/styles.scss
@@ -9,3 +9,47 @@
         }
     }
 }
+
+.givewp-donation-form-link,
+.givewp-donation-form-modal__open {
+    color: var(--givewp-secondary-color, #ffffff);
+    background: var(--givewp-primary-color, #2271b1);
+    padding: 0.75rem 1.25rem !important;
+    cursor: pointer;
+    border: none;
+    border-radius: 5px;
+    font-size: 1rem;
+    font-weight: 500 !important;
+    text-decoration: none !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue',
+    sans-serif;
+    width: 100%;
+}
+
+.components-input-control__label {
+    width: 100%;
+}
+
+.wp-block-givewp-campaign-form {
+    position: relative;
+
+    form[id*='give-form'] #give-gateway-radio-list > li input[type='radio'] {
+        display: inline-block;
+    }
+
+    iframe {
+        pointer-events: none;
+        width: 100% !important;
+    }
+}
+
+.give-change-donation-form-btn {
+    svg {
+        margin-top: 3px;
+    }
+}
+
+.givewp-default-form-toggle{
+    margin-top: var(--givewp-spacing-4);
+}
+


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2435]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This updates the campaign donate button to support v2 forms by using `give_form_shortcode` which supports both form types.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The campaign donate button block

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->


https://github.com/user-attachments/assets/bde80f74-f9f2-4eaf-b98b-8a54bf6f8340


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/15567129875

- Create a campaign with a v2 form
- Make the v2 form the default form
- Visit the campaign landing page and the button should still be there and work properly
- Now make sure campaigns with v3 forms still work as expected


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2435]: https://stellarwp.atlassian.net/browse/GIVE-2435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ