### PR TITLE
fetaure/add skeleton loader to campaign loading

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/SkeletonLoader.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/SkeletonLoader.tsx
@@ -1,0 +1,49 @@
+import styles from './styles.module.scss';
+
+const SkeletonLoader = () => {
+    return (
+        <>
+            <div className={styles.dateRangeFilter}>
+                {[1, 2, 3, 4, 5].map((i) => (
+                    <div key={i} className={styles.skeletonButton} />
+                ))}
+            </div>
+            <div className={styles.mainGrid}>
+                {/* Stat Widgets */}
+                {[1, 2, 3].map((i) => (
+                    <div key={i} className={styles.statWidget}>
+                        <div className={styles.skeletonHeader} />
+                        <div className={styles.skeletonValue} />
+                        <div className={styles.skeletonFooter} />
+                    </div>
+                ))}
+                
+                {/* Revenue Widget */}
+                <div className={styles.revenueWidget}>
+                    <div className={styles.headerSpacing}>
+                        <div className={styles.skeletonHeader} />
+                        <div className={styles.skeletonSubHeader} />
+                    </div>
+                    <div className={styles.skeletonChart} />
+                </div>
+
+                {/* Nested Grid */}
+                <div className={styles.nestedGrid}>
+                    <div className={styles.progressWidget}>
+                        <div className={styles.headerSpacing}>
+                            <div className={styles.skeletonHeader} />
+                            <div className={styles.skeletonSubHeader} />
+                        </div>
+                        <div className={styles.skeletonChart} />
+                    </div>
+                    <div className={styles.statWidget}>
+                        <div className={styles.skeletonHeader} />
+                        <div className={styles.skeletonValue} />
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default SkeletonLoader; 

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/StatWidget.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/StatWidget.tsx
@@ -2,12 +2,28 @@ import styles from './styles.module.scss';
 import PercentChangePill from './PercentChangePill';
 import HeaderText from '../HeaderText';
 import type {StatWidgetProps} from './types';
-import {Spinner} from '@givewp/components';
 
 /**
+ * Displays a statistic with optional loading state and previous value comparison
+ * 
  * @since 4.0.0
  */
-const StatWidget = ({label, value, previousValue, description, formatter = null, loading = false}: StatWidgetProps) => {
+const StatWidget = ({
+    label,
+    value,
+    previousValue,
+    description,
+    formatter = null,
+    loading = false
+}: StatWidgetProps) => {
+    const renderValue = () => {
+        if (loading) {
+            return <div className={styles.skeletonNumber} />;
+        }
+
+        return formatter ? formatter.format(value) : value;
+    };
+
     return (
         <div className={styles.statWidget}>
             <header>
@@ -15,13 +31,17 @@ const StatWidget = ({label, value, previousValue, description, formatter = null,
             </header>
             <div className={styles.statWidgetAmount}>
                 <div className={styles.statWidgetDisplay}>
-                    {!loading ? formatter?.format(value) ?? value : <span>{<Spinner />}</span>}
+                    {renderValue()}
                 </div>
-                {previousValue !== null && <PercentChangePill value={value} comparison={previousValue} />}
+                {previousValue !== null && (
+                    <PercentChangePill value={value} comparison={previousValue} />
+                )}
             </div>
-            <footer>
-                <div>{description}</div>
-            </footer>
+            {description && (
+                <footer>
+                    <div>{description}</div>
+                </footer>
+            )}
         </div>
     );
 };

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/styles.module.scss
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/styles.module.scss
@@ -78,6 +78,9 @@
     font-weight: 600;
     line-height: 44px;
     color: var(--givewp-neutral-900);
+    min-height: 44px;
+    display: flex;
+    align-items: center;
 }
 
 .revenueWidget {
@@ -140,4 +143,73 @@
         grid-template-columns: 1fr;
         gap: var(--givewp-spacing-3);
     }
+}
+
+@keyframes shimmer {
+    0% {
+        background-position: -200% 0;
+    }
+    100% {
+        background-position: 200% 0;
+    }
+}
+
+// Skeleton Utilities
+@mixin skeleton-base {
+    background: linear-gradient(
+        90deg,
+        var(--givewp-neutral-100) 25%,
+        var(--givewp-neutral-200) 50%,
+        var(--givewp-neutral-100) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+    border-radius: var(--givewp-rounded-4);
+}
+
+// Skeleton Components
+.skeletonNumber {
+    @include skeleton-base;
+    height: 44px;
+    width: 120px;
+}
+
+.skeletonButton {
+    @include skeleton-base;
+    height: 32px;
+    width: 100px;
+    margin: 0 4px;
+}
+
+.skeletonHeader {
+    @include skeleton-base;
+    height: 24px;
+    width: 60%;
+    margin-bottom: 8px;
+}
+
+.skeletonSubHeader {
+    @include skeleton-base;
+    height: 16px;
+    width: 80%;
+}
+
+.skeletonValue {
+    @include skeleton-base;
+    height: 44px;
+    width: 70%;
+    margin: 16px 0;
+}
+
+.skeletonFooter {
+    @include skeleton-base;
+    height: 18px;
+    width: 40%;
+}
+
+.skeletonChart {
+    @include skeleton-base;
+    height: 200px;
+    width: 100%;
+    margin-top: 16px;
 }


### PR DESCRIPTION
## Description
This was a fun friday project for campaigns where I added a skeleton loader to the campaign overview page and the overview stats when you are filtering by the day range.

## Affects
The campaign overview page and the overview stats card


## Visuals
Before
Uploading Old Loading.mov…

After
https://github.com/user-attachments/assets/7454f94b-31bd-4977-ab51-0449bc1971e0


## Testing Instructions
Create or open an existing campaign, you will see the skeleton loader before the data shows. Same applies to when you are filtering by the day range, you should see the skeleton loader before the number shows up.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

