### PR TITLE
Fix: ensure useFormData is watching only the address fields that live in the billingAddress block

### DIFF
--- a/src/DonationForms/resources/app/hooks/useFormData.ts
+++ b/src/DonationForms/resources/app/hooks/useFormData.ts
@@ -1,6 +1,7 @@
 import type {DonationTotals} from '@givewp/forms/app/store/donation-summary';
 import {useDonationSummaryContext} from '@givewp/forms/app/store/donation-summary';
 import type {subscriptionPeriod} from '@givewp/forms/registrars/templates/groups/DonationAmount/subscriptionPeriod';
+import { useDonationFormState } from '@givewp/forms/app/store';
 
 /**
  * Zero decimal currencies are currencies that do not have a minor unit.
@@ -87,24 +88,37 @@ const getSubscriptionTotal = (totals: DonationTotals, amount: number) => {
 const normalizeAmount = (amount: number) => Math.round(amount * 100) / 100;
 
 /**
+ * @unreleased Uses refs from the global form context to ensure the billing address fields are available.
  * @since 4.0.0
  */
 export default function useFormData() {
     const {totals} = useDonationSummaryContext();
     const {useWatch} = window.givewp.form.hooks;
+    const { refs } = useDonationFormState();
+    const billingAddressGroupExists = !!refs?.billingAddress?.current;
 
     const firstName = useWatch({name: 'firstName'}) as string;
     const lastName = useWatch({name: 'lastName'}) as string | undefined;
     const email = useWatch({name: 'email'}) as string;
     const phone = useWatch({name: 'phone'}) as string | undefined;
-    const billingAddress = {
-        addressLine1: useWatch({name: 'address1'}) as string | undefined,
-        addressLine2: useWatch({name: 'address2'}) as string | undefined,
-        city: useWatch({name: 'city'}) as string | undefined,
-        state: useWatch({name: 'state'}) as string | undefined,
-        postalCode: useWatch({name: 'zip'}) as string | undefined,
-        country: useWatch({name: 'country'}) as string | undefined,
-    };
+
+    const billingAddress = billingAddressGroupExists
+        ? {
+            addressLine1: useWatch({name: 'address1'}) as string | undefined,
+            addressLine2: useWatch({name: 'address2'}) as string | undefined,
+            city: useWatch({name: 'city'}) as string | undefined,
+            state: useWatch({name: 'state'}) as string | undefined,
+            postalCode: useWatch({name: 'zip'}) as string | undefined,
+            country: useWatch({name: 'country'}) as string | undefined,
+        }
+        : {
+            addressLine1: undefined,
+            addressLine2: undefined,
+            city: undefined,
+            state: undefined,
+            postalCode: undefined,
+            country: undefined,
+        };
     const amount = useWatch({name: 'amount'}) as string;
     const currency = useWatch({name: 'currency'}) as string;
     const subscriptionPeriod = useWatch({name: 'subscriptionPeriod'}) as subscriptionPeriod | undefined;

--- a/src/DonationForms/resources/app/store/index.tsx
+++ b/src/DonationForms/resources/app/store/index.tsx
@@ -1,7 +1,7 @@
-import {createContext, ReactNode, useContext, useReducer} from 'react';
+import {createContext, ReactNode, useContext, useReducer, MutableRefObject} from 'react';
 import type {Gateway} from '@givewp/forms/types';
-import reducer from '@givewp/forms/app/store/reducer';
 import {ObjectSchema} from 'joi';
+import reducer from '@givewp/forms/app/store/reducer';
 
 const StoreContext = createContext(null);
 StoreContext.displayName = 'DonationFormState';
@@ -9,12 +9,18 @@ StoreContext.displayName = 'DonationFormState';
 const StoreContextDispatch = createContext(null);
 StoreContextDispatch.displayName = 'DonationFormStateDispatch';
 
+/**
+ * @unreleased Adds a refs property to the state to store references to form elements.
+ */
+interface DonationFormState {
+    gateways: Gateway[];
+    defaultValues: object;
+    validationSchema: ObjectSchema;
+    refs?: Record<string, MutableRefObject<HTMLElement | null> | null>;
+}
+
 type PropTypes = {
-    initialState: {
-        gateways: Gateway[];
-        defaultValues: object;
-        validationSchema: ObjectSchema;
-    };
+    initialState: DonationFormState;
     children: ReactNode;
 };
 
@@ -31,7 +37,7 @@ const DonationFormStateProvider = ({initialState, children}: PropTypes) => {
     );
 };
 
-const useDonationFormState = () => useContext<PropTypes['initialState']>(StoreContext);
+const useDonationFormState = () => useContext<DonationFormState>(StoreContext);
 const useDonationFormStateDispatch = () => useContext(StoreContextDispatch);
 
 export {DonationFormStateProvider, useDonationFormState, useDonationFormStateDispatch};

--- a/src/DonationForms/resources/app/store/reducer.ts
+++ b/src/DonationForms/resources/app/store/reducer.ts
@@ -1,4 +1,5 @@
 const UPDATE_DEFAULT_VALUES = 'update_default_values';
+const SET_FORM_REFS = 'set_form_refs';
 
 /**
  * @since 3.0.0
@@ -13,7 +14,14 @@ export default function reducer(state, action) {
                     ...action.values,
                 },
             };
-
+        case SET_FORM_REFS:
+            return {
+                ...state,
+                refs: {
+                    ...state.refs,
+                    ...action.refs,
+                },
+            };
         default:
             return state;
     }
@@ -26,5 +34,15 @@ export function setFormDefaultValues(values: object) {
     return {
         type: UPDATE_DEFAULT_VALUES,
         values,
+    };
+}
+
+/**
+ * @unreleased
+ */
+export function setFormRefs(refs: Record<string, any>) {
+    return {
+        type: SET_FORM_REFS,
+        refs,
     };
 }

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -1,9 +1,11 @@
 import type {BillingAddressProps} from '@givewp/forms/propTypes';
-import {FC, useEffect, useState} from 'react';
+import {FC, useEffect, useState, useRef} from 'react';
 import {__} from '@wordpress/i18n';
 import {ErrorMessage} from '@hookform/error-message';
 import {useCallback} from '@wordpress/element';
 import autoCompleteAttr from '@givewp/forms/registrars/templates/fields/utils/autoCompleteAttr';
+import {useDonationFormStateDispatch} from '@givewp/forms/app/store';
+import {setFormRefs} from '@givewp/forms/app/store/reducer';
 
 /**
  * @since 3.0.0
@@ -210,6 +212,7 @@ function StateFieldContainer({
 }
 
 /**
+ * @unreleased Set the billingAddress ref in the global form context for flexible access across the application.
  * @since 3.4.0 Update city and zip components before rendering to display required asterisk
  * @since 3.0.0
  */
@@ -219,6 +222,13 @@ export default function BillingAddress({
     apiUrl,
     name,
 }: BillingAddressProps) {
+    const billingAddressRef = useRef<HTMLDivElement>(null);
+    const dispatch = useDonationFormStateDispatch();
+
+    useEffect(() => {
+        dispatch(setFormRefs({ billingAddress: billingAddressRef }));
+    }, [dispatch]);
+
     // these are necessary to set the required indicator on the city and zip field labels
     // the actual validation will come from the server as we don't yet have the ability to update the actual client validation rules here
     const [cityRequired, setCityRequired] = useState(false);
@@ -228,7 +238,7 @@ export default function BillingAddress({
     const ZipWithRequired = () => <Zip validationRules={{required: zipRequired}} />;
 
     return (
-        <>
+        <div ref={billingAddressRef}>
             <fieldset>
                 {groupLabel && <legend>{groupLabel}</legend>}
                 <Country />
@@ -244,6 +254,6 @@ export default function BillingAddress({
                 />
                 <ZipWithRequired />
             </fieldset>
-        </>
+        </div>
     );
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2626]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that was preventing the PayPal modal from opening when a custom field with the meta key "country" was added to a v3 form.

Why does it work?

Because our v3 forms will throw the following error when trying to save a field with the same meta key name:

> ERROR: the form was not saved due to a meta key name conflict. A field already exists on this form with the meta key 'country'. Meta key names must be unique. Change the conflicting meta key and try to save again.

So it ensures that if we have the billingAddress block added to the form, only the country field of this block can be present in the same form.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2626]: https://stellarwp.atlassian.net/browse/GIVE-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ