### PR TITLE
Fix: PayPal closing modal when a custom country field is added to v3 forms

### DIFF
--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -361,6 +361,7 @@ class FormBuilderViewModel
      * as not to be too confusing. This array is used to prevent the user from creating meta keys that conflict with the
      * existing meta or field names.
      *
+     * @unreleased Add country, state, city, zip, address1, and address2 to the disallowed field names.
      * @since 3.0.0
      */
     protected function getDisallowedFieldNames(): array
@@ -376,6 +377,12 @@ class FormBuilderViewModel
                 'login',
                 'consent',
                 'donation-summary',
+                'country',
+                'state',
+                'city',
+                'zip',
+                'address1',
+                'address2',                
             ]
         );
 

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -116,7 +116,7 @@ import createSubscriptionPlan from './resources/js/createSubscriptionPlan';
         formData.append('give_last', lastName);
         formData.append('give_email', email);
 
-        if (country) {
+        if (country && country.length === 2) {
             formData.append('card_address', addressLine1);
             formData.append('card_address_2', addressLine2);
             formData.append('card_city', city);

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -103,6 +103,9 @@ class FormBuilderViewModelTest extends TestCase
         );
     }
 
+    /**
+     * @unreleased Add country, state, city, zip, address1, and address2 to the disallowed field names.     
+     */
     private function getDisallowedFieldNames(): array
     {
         $disallowedFieldNames = array_merge(
@@ -116,6 +119,12 @@ class FormBuilderViewModelTest extends TestCase
                 'login',
                 'consent',
                 'donation-summary',
+                'country',
+                'state',
+                'city',
+                'zip',
+                'address1',
+                'address2',                
             ]
         );
 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2626]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that was preventing the PayPal modal from opening when a custom field with the meta key "country" was added to a v3 form.

To accomplish that, the following was implemented:

1. Add the billing address fields (country, zip, etc.) to the disallowed list of custom field names.  This will ensure we don't get a conflicting unique field name. So is still possible to add a custom `country` field, but it will be like `country_1` instead of our `country` field.
2. Sanitize the country field value to ensure it matches the 2-digit code syntax we are expecting. This would just be a safeguard and dosen't have any validation if the country code is valid.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

PayPal Donations on V3 forms

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add a custom text field to a V3 form and set the name to "country," then make sure the PayPal modal opens and the donation is finished as expected;
2. Add the billing address block to a V3 form, then make sure the PayPal modal opens and the donation is finished as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2626]: https://stellarwp.atlassian.net/browse/GIVE-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ