### PR TITLE
Fix: normalize header keys to prevent "Missing PayPal webhook header" errors in servers that change the header keys

### DIFF
--- a/src/Framework/Exceptions/Primitives/HttpHeaderException.php
+++ b/src/Framework/Exceptions/Primitives/HttpHeaderException.php
@@ -5,7 +5,10 @@ namespace Give\Framework\Exceptions\Primitives;
 use Give\Framework\Exceptions\Contracts\LoggableException;
 use Give\Framework\Exceptions\Traits\Loggable;
 
-class HttpHeaderException extends \HttpHeaderException implements LoggableException
+/**
+ * @unreleased Extends \Exception instead of \HttpHeaderException 
+ */
+class HttpHeaderException extends \Exception implements LoggableException
 {
     use Loggable;
 }

--- a/src/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeaders.php
+++ b/src/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeaders.php
@@ -3,6 +3,7 @@
 namespace Give\PaymentGateways\PayPalCommerce\DataTransferObjects;
 
 use Give\Framework\Exceptions\Primitives\HttpHeaderException;
+use Give\Framework\PaymentGateways\Log\PaymentGatewayLog;
 
 class PayPalWebhookHeaders
 {
@@ -42,6 +43,7 @@ class PayPalWebhookHeaders
      * A strange thing here is that the headers are inconsistent between live and sandbox mode, so this also checks for
      * both forms of the headers (studly case and all caps).
      *
+     * @unreleased Normalize header keys to lowercase and replace underscores with hyphens.
      * @since 2.9.0
      *
      * @param array $headers
@@ -51,43 +53,42 @@ class PayPalWebhookHeaders
      */
     public static function fromHeaders(array $headers)
     {
+        $normalizedHeaders = [];
+        foreach ($headers as $key => $value) {
+            $normalizedHeaders[str_replace('_', '-', strtolower($key))] = $value;
+        }
+    
         $headerKeys = [
-            'transmissionId' => 'Paypal-Transmission-Id',
-            'transmissionTime' => 'Paypal-Transmission-Time',
-            'transmissionSig' => 'Paypal-Transmission-Sig',
-            'certUrl' => 'Paypal-Cert-Url',
-            'authAlgo' => 'Paypal-Auth-Algo',
+            'transmissionId' => 'paypal-transmission-id',
+            'transmissionTime' => 'paypal-transmission-time',
+            'transmissionSig' => 'paypal-transmission-sig',
+            'certUrl' => 'paypal-cert-url',
+            'authAlgo' => 'paypal-auth-algo',
         ];
-
+    
         $payPalHeaders = new self();
         $missingKeys = [];
-        foreach ($headerKeys as $property => $key) {
-            if ( ! isset($headers[$key])) {
-                $key = strtoupper($key);
-            }
-
-            if (isset($headers[$key])) {
-                $payPalHeaders->$property = $headers[$key];
+    
+        foreach ($headerKeys as $property => $expectedKey) {
+            if (isset($normalizedHeaders[$expectedKey])) {
+                $payPalHeaders->$property = $normalizedHeaders[$expectedKey];
             } else {
-                $missingKeys[] = $key;
+                $missingKeys[] = $expectedKey;
             }
         }
-
+    
         if ( ! empty($missingKeys)) {
-            give_record_gateway_error(
+            PaymentGatewayLog::error(
                 'Missing PayPal webhook header',
-                print_r(
-                    [
-                        'missingKeys' => $missingKeys,
-                        'headers' => $headers,
-                    ],
-                    true
-                )
+                [
+                    'missingKeys' => $missingKeys,
+                    'headers' => $headers,
+                ]
             );
-
-            throw new HttpHeaderException("Missing PayPal header: $key");
+    
+            throw new HttpHeaderException("Missing PayPal headers: " . implode(', ', $missingKeys));
         }
-
+    
         return $payPalHeaders;
     }
 }

--- a/tests/Unit/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeadersTest.php
+++ b/tests/Unit/PaymentGateways/PayPalCommerce/DataTransferObjects/PayPalWebhookHeadersTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Give\Tests\Unit\PaymentGateways\PayPalCommerce\DataTransferObjects;
+
+use Give\Framework\Exceptions\Primitives\HttpHeaderException;
+use Give\PaymentGateways\PayPalCommerce\DataTransferObjects\PayPalWebhookHeaders;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ */
+class PayPalWebhookHeadersTest extends TestCase
+{        
+    /**
+     * @unreleased
+     *
+     * @return array
+     */
+    private function getDefaultHeaders(): array
+    {
+        return [
+            'paypal-transmission-id' => 'test-id',
+            'paypal-transmission-time' => '2023-01-01T00:00:00Z',
+            'paypal-transmission-sig' => 'test-sig',
+            'paypal-cert-url' => 'https://test.com/cert',
+            'paypal-auth-algo' => 'SHA256',
+        ];
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersWithStandardFormat()
+    {
+        $webhookHeaders = PayPalWebhookHeaders::fromHeaders($this->getDefaultHeaders());
+
+        $this->assertEquals('test-id', $webhookHeaders->transmissionId);
+        $this->assertEquals('2023-01-01T00:00:00Z', $webhookHeaders->transmissionTime);
+        $this->assertEquals('test-sig', $webhookHeaders->transmissionSig);
+        $this->assertEquals('https://test.com/cert', $webhookHeaders->certUrl);
+        $this->assertEquals('SHA256', $webhookHeaders->authAlgo);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersWithUppercaseFormat()
+    {
+        $headers = array_change_key_case($this->getDefaultHeaders(), CASE_UPPER);
+        $webhookHeaders = PayPalWebhookHeaders::fromHeaders($headers);
+
+        $this->assertEquals('test-id', $webhookHeaders->transmissionId);
+        $this->assertEquals('2023-01-01T00:00:00Z', $webhookHeaders->transmissionTime);
+        $this->assertEquals('test-sig', $webhookHeaders->transmissionSig);
+        $this->assertEquals('https://test.com/cert', $webhookHeaders->certUrl);
+        $this->assertEquals('SHA256', $webhookHeaders->authAlgo);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersWithUnderscoreFormat()
+    {
+        $headers = array_combine(
+            array_map(
+                fn($key) => str_replace('-', '_', $key),
+                array_keys($this->getDefaultHeaders())
+            ),
+            array_values($this->getDefaultHeaders())
+        );
+
+        $webhookHeaders = PayPalWebhookHeaders::fromHeaders($headers);
+
+        $this->assertEquals('test-id', $webhookHeaders->transmissionId);
+        $this->assertEquals('2023-01-01T00:00:00Z', $webhookHeaders->transmissionTime);
+        $this->assertEquals('test-sig', $webhookHeaders->transmissionSig);
+        $this->assertEquals('https://test.com/cert', $webhookHeaders->certUrl);
+        $this->assertEquals('SHA256', $webhookHeaders->authAlgo);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersWithMixedFormat()
+    {
+        $headers = [
+            'Paypal-Transmission-Id' => 'test-id',
+            'PAYPAL_TRANSMISSION_TIME' => '2023-01-01T00:00:00Z',
+            'paypal-transmission-sig' => 'test-sig',
+            'Paypal_Cert_Url' => 'https://test.com/cert',
+            'PAYPAL-AUTH-ALGO' => 'SHA256',
+        ];
+
+        $webhookHeaders = PayPalWebhookHeaders::fromHeaders($headers);
+
+        $this->assertEquals('test-id', $webhookHeaders->transmissionId);
+        $this->assertEquals('2023-01-01T00:00:00Z', $webhookHeaders->transmissionTime);
+        $this->assertEquals('test-sig', $webhookHeaders->transmissionSig);
+        $this->assertEquals('https://test.com/cert', $webhookHeaders->certUrl);
+        $this->assertEquals('SHA256', $webhookHeaders->authAlgo);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersThrowsExceptionWhenMissingRequiredHeaders()
+    {
+        $headers = array_slice($this->getDefaultHeaders(), 0, 2);
+
+        $this->expectException(HttpHeaderException::class);
+        $this->expectExceptionMessage('Missing PayPal headers: paypal-transmission-sig, paypal-cert-url, paypal-auth-algo');
+
+        PayPalWebhookHeaders::fromHeaders($headers);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testFromHeadersWithEmptyHeaders()
+    {
+        $this->expectException(HttpHeaderException::class);
+        $this->expectExceptionMessage('Missing PayPal headers: paypal-transmission-id, paypal-transmission-time, paypal-transmission-sig, paypal-cert-url, paypal-auth-algo');
+
+        PayPalWebhookHeaders::fromHeaders([]);
+    }
+} 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2630]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Some users were experiencing the _"Missing PayPal webhook header"_ error due to inconsistent header formats in their server configurations. This was happening because different web servers (Apache, Nginx) and their configurations can modify HTTP headers in various ways:

1. Converting headers to uppercase (e.g., `PAYPAL-TRANSMISSION-ID`)
2. Replacing hyphens with underscores (e.g., `paypal_transmission_id`)
3. Using mixed case formats (e.g., `Paypal-Transmission-Id`)

Our code was only handling the standard lowercase format with (`Paypal-Transmission-Id`), causing the webhook validation to fail when receiving headers in different formats.

Although we already had fixed it partially here: https://github.com/impress-org/givewp/pull/5403

It wasn't enough to cover all possible scenarios.

So now we've implemented a robust header normalization process that:

1. Converts all header keys to lowercase
2. Standardizes separators by replacing underscores with hyphens
3. Maintains the original header values

This ensures that regardless of how the server modifies the headers, our webhook validation will work correctly.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

PayPal webhook events.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

![image](https://github.com/user-attachments/assets/00502386-3f83-4658-8827-a76df9be87ac)


<!-- Help others test your PR as efficiently as possible. -->

**For devs:**

Run `composer test -- --filter PayPalWebhookHeadersTest` in your terminal

**For QA:**

Create some donations and subscriptions using PayPal donations and make sure the updates made through webhook events are working as expected.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2630]: https://stellarwp.atlassian.net/browse/GIVE-2630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ