### PR TITLE
feature: add Donor Details page slot-fill system

### DIFF
--- a/src/Donors/resources/admin/components/DonorDetailsPage/README.md
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/README.md
@@ -43,7 +43,7 @@ registerPlugin(
     'givewp-{addonName}-{referenceToSlotName}', // Unique plugin name.
     {
         render: YourCustomSection,
-        scope: 'givewp-donors-details-page', // Required scope for donor details page
+        scope: 'givewp-donor-details-page', // Required scope for donor details page
     }
 );
 ```
@@ -101,7 +101,7 @@ export default function YourCustomSection() {
 
 - **name**: A unique identifier for your plugin extension
 - **render**: The React component to render
-- **scope**: Must be `'givewp-donors-details-page'` for donor details page extensions
+- **scope**: Must be `'givewp-donor-details-page'` for donor details page extensions
 
 ### Fill Component
 
@@ -158,7 +158,7 @@ if (isDirty && isValid) {
 
 ## Important Notes
 
-- The plugin scope `givewp-donors-details-page` is required for donor details page extensions
+- The plugin scope `givewp-donor-details-page` is required for donor details page extensions
 - All GiveWP admin components are available through the global `window.givewp.admin.components` object
 - Your component will be automatically inserted into the donor details page
 - Follow WordPress React patterns and accessibility guidelines

--- a/src/Donors/resources/admin/components/DonorDetailsPage/README.md
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/README.md
@@ -27,6 +27,10 @@ declare global {
                     AdminSection: React.ComponentType<any>;
                     AdminSectionField: React.ComponentType<any>;
                 };
+                hooks: {
+                    useFormContext: () => any;
+                    useFormState: () => any;
+                };
             };
         };
     }
@@ -52,8 +56,16 @@ Use the `Fill` component to add content to the donor details page:
 import { Fill } from "@wordpress/components";
 
 export default function YourCustomSection() {
-    // Access GiveWP admin components from the global window object
+    // Access GiveWP admin components and hooks from the global window object
     const { AdminSection, AdminSectionField } = window.givewp.admin.components;
+    const { useFormContext, useFormState } = window.givewp.admin.hooks;
+
+    // Use the form hooks to access form data and state
+    const { watch, setValue } = useFormContext();
+    const { isDirty, isValid } = useFormState();
+
+    // Example: Watch a specific form field
+    const donorEmail = watch('email');
 
     return (
         <Fill name="GiveWP/DonorDetails/Profile/Sections">
@@ -63,12 +75,18 @@ export default function YourCustomSection() {
             >
                 <AdminSectionField subtitle="Field Label">
                     <p>Your custom content goes here.</p>
+                    <p>Current email: {donorEmail}</p>
                 </AdminSectionField>
 
-                <AdminSectionField subtitle="Another Field">
+                <AdminSectionField subtitle="Form Actions">
                     <div>
-                        <p>You can add any React components or HTML here.</p>
-                        <button>Custom Button</button>
+                        <p>Form is dirty: {isDirty ? 'Yes' : 'No'}</p>
+                        <p>Form is valid: {isValid ? 'Yes' : 'No'}</p>
+                        <button
+                            onClick={() => setValue('customField', 'new value')}
+                        >
+                            Update Custom Field
+                        </button>
                     </div>
                 </AdminSectionField>
             </AdminSection>
@@ -95,6 +113,41 @@ Access these components via `window.givewp.admin.components`:
 
 - **AdminSection**: Container for your section with title and description
 - **AdminSectionField**: Individual field within a section with subtitle
+
+### GiveWP Admin Hooks
+
+Access these React hooks via `window.givewp.admin.hooks`:
+
+- **useFormContext**: Access to react-hook-form context methods (watch, setValue, getValues, etc.)
+- **useFormState**: Access to form state information (isDirty, isValid, errors, etc.)
+
+These hooks provide access to the form context established by the donor details page, allowing you to:
+- Read current form values
+- Update form fields programmatically
+- Check form validation state
+- Access form errors and other state
+
+#### Example Hook Usage
+
+```typescript
+const { watch, setValue, getValues } = useFormContext();
+const { isDirty, isValid, errors } = useFormState();
+
+// Watch specific fields
+const donorName = watch('name');
+const donorEmail = watch('email');
+
+// Update fields
+setValue('customField', 'new value');
+
+// Get all form values
+const allValues = getValues();
+
+// Check form state
+if (isDirty && isValid) {
+    // Form has changes and is valid
+}
+```
 
 ## Example Use Cases
 

--- a/src/Donors/resources/admin/components/DonorDetailsPage/README.md
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/README.md
@@ -1,0 +1,111 @@
+# Donor Details Page Extension
+
+This guide explains how to extend the GiveWP Donor Details page using WordPress slots and the plugin registration system.
+
+## Overview
+
+This system allows you to add custom sections to the donor details page using WordPress's slot-fill pattern and plugin registration system.
+
+## Basic Setup
+
+### 1. Register Your Plugin
+
+Use WordPress's `registerPlugin` function to register your extension:
+
+```typescript
+import { registerPlugin } from '@wordpress/plugins';
+import YourCustomSection from './components/YourCustomSection';
+
+/**
+ * Extend the Window interface to include givewp admin components
+ */
+declare global {
+    interface Window {
+        givewp: {
+            admin: {
+                components: {
+                    AdminSection: React.ComponentType<any>;
+                    AdminSectionField: React.ComponentType<any>;
+                };
+            };
+        };
+    }
+}
+
+/**
+ * Register your custom donor details page extension
+ */
+registerPlugin(
+    'givewp-{addonName}-{referenceToSlotName}', // Unique plugin name.
+    {
+        render: YourCustomSection,
+        scope: 'givewp-donors-details-page', // Required scope for donor details page
+    }
+);
+```
+
+### 2. Create Your Section Component
+
+Use the `Fill` component to add content to the donor details page:
+
+```typescript
+import { Fill } from "@wordpress/components";
+
+export default function YourCustomSection() {
+    // Access GiveWP admin components from the global window object
+    const { AdminSection, AdminSectionField } = window.givewp.admin.components;
+
+    return (
+        <Fill name="GiveWP/DonorDetails/Profile/Sections">
+            <AdminSection
+                title="Your Section Title"
+                description="A description of what this section contains."
+            >
+                <AdminSectionField subtitle="Field Label">
+                    <p>Your custom content goes here.</p>
+                </AdminSectionField>
+
+                <AdminSectionField subtitle="Another Field">
+                    <div>
+                        <p>You can add any React components or HTML here.</p>
+                        <button>Custom Button</button>
+                    </div>
+                </AdminSectionField>
+            </AdminSection>
+        </Fill>
+    );
+}
+```
+
+## Key Components
+
+### registerPlugin Parameters
+
+- **name**: A unique identifier for your plugin extension
+- **render**: The React component to render
+- **scope**: Must be `'givewp-donors-details-page'` for donor details page extensions
+
+### Fill Component
+
+- **name**: Must be `"GiveWP/DonorDetails/Profile/Sections"` to target the donor details page sections area
+
+### GiveWP Admin Components
+
+Access these components via `window.givewp.admin.components`:
+
+- **AdminSection**: Container for your section with title and description
+- **AdminSectionField**: Individual field within a section with subtitle
+
+## Example Use Cases
+
+- Add custom donor information displays
+- Show integration-specific data
+- Display related records or statistics
+- Add custom actions or controls
+
+## Important Notes
+
+- The plugin scope `givewp-donors-details-page` is required for donor details page extensions
+- All GiveWP admin components are available through the global `window.givewp.admin.components` object
+- Your component will be automatically inserted into the donor details page
+- Follow WordPress React patterns and accessibility guidelines

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/index.tsx
@@ -3,6 +3,7 @@ import DonorAddress from './Address';
 import DonorCustomFields from './CustomFields';
 import DonorEmailAddress from './EmailAddress';
 import DonorPersonalDetails from './PersonalDetails';
+import { ProfileSectionsSlot } from '../../slots';
 
 /**
  * @unreleased
@@ -15,6 +16,7 @@ export default function DonorDetailsPageProfileTab() {
                 <DonorAddress />
                 <DonorEmailAddress />
                 <DonorCustomFields />
+                <ProfileSectionsSlot />
             </AdminSectionsWrapper>
         </>
     );

--- a/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
@@ -1,5 +1,8 @@
 import {createSlotFill} from '@wordpress/components';
 
+/**
+ * @unreleased
+ */
 const {Slot: ProfileSectionsSlot, Fill: ProfileSectionsFill} = createSlotFill('GiveWP/DonorDetails/Profile/Sections');
 
 export {

--- a/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
@@ -1,0 +1,8 @@
+import {createSlotFill} from '@wordpress/components';
+
+const {Slot: ProfileSectionsSlot, Fill: ProfileSectionsFill} = createSlotFill('GiveWP/DonorDetails/Profile/Sections');
+
+export {
+    ProfileSectionsSlot,
+    ProfileSectionsFill,
+};

--- a/src/Views/Components/AdminDetailsPage/index.tsx
+++ b/src/Views/Components/AdminDetailsPage/index.tsx
@@ -12,6 +12,8 @@ import {FormProvider, SubmitHandler, useForm} from 'react-hook-form';
 import {__} from '@wordpress/i18n';
 import {useDispatch} from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { SlotFillProvider } from '@wordpress/components';
+import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal Dependencies
@@ -26,6 +28,7 @@ import styles from './AdminDetailsPage.module.scss';
 import ErrorBoundary from './ErrorBoundary';
 import TabPanels from './Tabs/TabPanels';
 import DefaultPrimaryActionButton from './DefaultPrimaryActionButton';
+import AdminSection, { AdminSectionField, AdminSectionsWrapper } from './AdminSection';
 
 import './store';
 
@@ -56,6 +59,8 @@ export default function AdminDetailsPage<T extends Record<string, any>>({
     const contextMenuRef = useRef<HTMLDivElement>(null);
 
     const dispatch = useDispatch(`givewp/admin-details-page-notifications`);
+
+    exposeSharedComponents();
 
     useEffect(() => {
         apiFetch({
@@ -158,68 +163,85 @@ export default function AdminDetailsPage<T extends Record<string, any>>({
     return (
         <ErrorBoundary>
             <FormProvider {...methods}>
-                <form id={'givewp-details-form'} onSubmit={handleSubmit(onSubmit)}>
-                    <article className={`interface-interface-skeleton__content ${styles.page}`}>
-                        <TabsRouter tabDefinitions={tabDefinitions}>
-                            <header className={styles.pageHeader}>
-                                <div className={styles.breadcrumb}>
-                                    <a href={breadcrumbUrl}>{objectTypePlural.charAt(0).toUpperCase() + objectTypePlural.slice(1)}</a>
-                                    <BreadcrumbSeparatorIcon />
-                                    <span>{breadcrumbTitle || record?.name}</span>
-                                </div>
-                                <div className={styles.flexContainer}>
-                                    <div className={styles.flexRow}>
-                                        <h1 className={styles.pageTitle}>{pageTitle || record?.name}</h1>
-                                        {StatusBadge && <StatusBadge />}
+                <SlotFillProvider>
+                    <form id={'givewp-details-form'} onSubmit={handleSubmit(onSubmit)}>
+                        <article className={`interface-interface-skeleton__content ${styles.page}`}>
+                            <TabsRouter tabDefinitions={tabDefinitions}>
+                                <header className={styles.pageHeader}>
+                                    <div className={styles.breadcrumb}>
+                                        <a href={breadcrumbUrl}>{objectTypePlural.charAt(0).toUpperCase() + objectTypePlural.slice(1)}</a>
+                                        <BreadcrumbSeparatorIcon />
+                                        <span>{breadcrumbTitle || record?.name}</span>
                                     </div>
+                                    <div className={styles.flexContainer}>
+                                        <div className={styles.flexRow}>
+                                            <h1 className={styles.pageTitle}>{pageTitle || record?.name}</h1>
+                                            {StatusBadge && <StatusBadge />}
+                                        </div>
 
-                                    <div className={`${styles.flexRow} ${styles.justifyContentEnd}`}>
-                                        {SecondaryActionButton && (
-                                            <SecondaryActionButton
-                                                className={`button button-tertiary ${styles.secondaryActionButton}`}
+                                        <div className={`${styles.flexRow} ${styles.justifyContentEnd}`}>
+                                            {SecondaryActionButton && (
+                                                <SecondaryActionButton
+                                                    className={`button button-tertiary ${styles.secondaryActionButton}`}
+                                                />
+                                            )}
+
+                                            <PrimaryActionButton
+                                                isSaving={isSaving}
+                                                formState={formState}
+                                                className={`button button-primary ${styles.primaryActionButton}`}
                                             />
-                                        )}
 
-                                        <PrimaryActionButton
-                                            isSaving={isSaving}
-                                            formState={formState}
-                                            className={`button button-primary ${styles.primaryActionButton}`}
-                                        />
+                                            {ContextMenuItems && (
+                                                <>
+                                                    <button
+                                                        ref={contextMenuButtonRef}
+                                                        className={`button button-secondary ${styles.contextMenuButton}`}
+                                                        onClick={(e) => {
+                                                            e.preventDefault();
+                                                            setShowContextMenu(!showContextMenu);
+                                                        }}
+                                                    >
+                                                        <DotsIcons />
+                                                    </button>
 
-                                        {ContextMenuItems && (
-                                            <>
-                                                <button
-                                                    ref={contextMenuButtonRef}
-                                                    className={`button button-secondary ${styles.contextMenuButton}`}
-                                                    onClick={(e) => {
-                                                        e.preventDefault();
-                                                        setShowContextMenu(!showContextMenu);
-                                                    }}
-                                                >
-                                                    <DotsIcons />
-                                                </button>
-
-                                                {!isSaving && showContextMenu && (
-                                                    <div ref={contextMenuRef} className={styles.contextMenu}>
-                                                        <ContextMenuItems className={styles.contextMenuItem} />
-                                                    </div>
-                                                )}
-                                            </>
-                                        )}
+                                                    {!isSaving && showContextMenu && (
+                                                        <div ref={contextMenuRef} className={styles.contextMenu}>
+                                                            <ContextMenuItems className={styles.contextMenuItem} />
+                                                        </div>
+                                                    )}
+                                                </>
+                                            )}
+                                        </div>
                                     </div>
-                                </div>
-                                <TabList tabDefinitions={tabDefinitions} />
-                            </header>
+                                    <TabList tabDefinitions={tabDefinitions} />
+                                </header>
 
-                            <TabPanels tabDefinitions={tabDefinitions} />
+                                <TabPanels tabDefinitions={tabDefinitions} />
 
-                            {children}
-                        </TabsRouter>
-                    </article>
-                </form>
+                                {children}
+                            </TabsRouter>
+                        </article>
+                    </form>
 
-                <NotificationPlaceholder type="snackbar" />
+                    <NotificationPlaceholder type="snackbar" />
+
+                    <PluginArea scope={`givewp-${objectTypePlural}-details-page`} />
+                </SlotFillProvider>
             </FormProvider>
         </ErrorBoundary>
     );
+}
+
+const exposeSharedComponents = (): void => {
+    (window as any).givewp = (window as any).givewp || {};
+    (window as any).givewp.admin = (window as any).givewp.admin || {};
+    (window as any).givewp.admin.components = (window as any).givewp.admin.components || {};
+
+    Object.assign((window as any).givewp.admin, {
+        components: {
+            AdminSection,
+            AdminSectionField,
+        }
+    });
 }

--- a/src/Views/Components/AdminDetailsPage/index.tsx
+++ b/src/Views/Components/AdminDetailsPage/index.tsx
@@ -4,7 +4,7 @@
 import {useEffect, useState, useRef} from 'react';
 import {JSONSchemaType} from 'ajv';
 import {ajvResolver} from '@hookform/resolvers/ajv';
-import {FormProvider, SubmitHandler, useForm} from 'react-hook-form';
+import {FormProvider, SubmitHandler, useForm, useFormContext, useFormState} from 'react-hook-form';
 
 /**
  * WordPress Dependencies
@@ -242,6 +242,10 @@ const exposeSharedComponents = (): void => {
         components: {
             AdminSection,
             AdminSectionField,
+        },
+        hooks: {
+            useFormContext,
+            useFormState,
         }
     });
 }

--- a/src/Views/Components/AdminDetailsPage/index.tsx
+++ b/src/Views/Components/AdminDetailsPage/index.tsx
@@ -60,7 +60,7 @@ export default function AdminDetailsPage<T extends Record<string, any>>({
 
     const dispatch = useDispatch(`givewp/admin-details-page-notifications`);
 
-    exposeSharedComponents();
+    exposeAdminComponentsAndHooks();
 
     useEffect(() => {
         apiFetch({
@@ -233,10 +233,11 @@ export default function AdminDetailsPage<T extends Record<string, any>>({
     );
 }
 
-const exposeSharedComponents = (): void => {
+const exposeAdminComponentsAndHooks = (): void => {
     (window as any).givewp = (window as any).givewp || {};
     (window as any).givewp.admin = (window as any).givewp.admin || {};
     (window as any).givewp.admin.components = (window as any).givewp.admin.components || {};
+    (window as any).givewp.admin.hooks = (window as any).givewp.admin.hooks || {};
 
     Object.assign((window as any).givewp.admin, {
         components: {

--- a/src/Views/Components/AdminDetailsPage/index.tsx
+++ b/src/Views/Components/AdminDetailsPage/index.tsx
@@ -226,7 +226,7 @@ export default function AdminDetailsPage<T extends Record<string, any>>({
 
                     <NotificationPlaceholder type="snackbar" />
 
-                    <PluginArea scope={`givewp-${objectTypePlural}-details-page`} />
+                    <PluginArea scope={`givewp-${objectType}-details-page`} />
                 </SlotFillProvider>
             </FormProvider>
         </ErrorBoundary>


### PR DESCRIPTION
Resolves [GIVE-2581]

## Description

This PR introduces a comprehensive slot-fill system for the Donor Details page, enabling developers to extend the page with custom sections through WordPress's plugin registration system. The implementation provides access to form context hooks and shared admin components, allowing for seamless integration with the existing form state and UI patterns.

### Key Features Added:

1. **Slot-Fill Architecture**: Implemented WordPress slot-fill pattern using `PluginArea` and `Fill` components to allow extensions to inject custom content into the Donor Details page.

2. **Shared Component Exposure**: Exposed `AdminSection` and `AdminSectionField` components globally via `window.givewp.admin.components` for consistent UI patterns across extensions.

3. **Form Context Integration**: Added global access to `useFormContext` and `useFormState` hooks via `window.givewp.admin.hooks`, enabling extensions to interact with the donor form data and state.

4. **Developer Documentation**: Created comprehensive [README](https://github.com/impress-org/givewp/blob/feature/donor-details-slot-fill/src/Donors/resources/admin/components/DonorDetailsPage/README.md) with TypeScript interfaces, usage examples, and best practices for extending the Donor Details page.

### Technical Implementation

- Added slot definition (`GiveWP/DonorDetails/Profile/Sections`) in the Profile tab component
- Enhanced `AdminDetailsPage` component to expose shared components and hooks globally

## Affects

- **Donor Details Page**: Now supports extensibility through plugin registration
- **AdminDetailsPage Component**: Enhanced to expose shared components and form hooks globally
- **Developer Experience**: New extensibility API for donor details page customizations

## Visuals
![CleanShot 2025-06-09 at 19 15 14](https://github.com/user-attachments/assets/d5f03386-b361-4a46-b25e-23ab8dd0a60c)

## Testing Instructions

1. **Basic Slot-Fill Test**:
   - Register a test extension using the documented pattern in the [README](https://github.com/impress-org/givewp/blob/feature/donor-details-slot-fill/src/Donors/resources/admin/components/DonorDetailsPage/README.md) 
   - Verify the custom section appears in the Donor Details page Profile tab
   - Confirm proper styling and layout integration

2. **Form Context Test**:
   - Create an extension that uses `useFormContext` to watch form fields
   - Create an extension that uses `useFormState` to check form validation state
   - Verify hooks provide access to the correct form context and state

3. **Component Access Test**:
   - Verify `AdminSection` and `AdminSectionField` components are available globally
   - Test that components render consistently with the existing UI patterns

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2581]: https://stellarwp.atlassian.net/browse/GIVE-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ