### PR TITLE
Fix: Update donor details SendEmailButton to use semantic anchor element

### DIFF
--- a/src/Donors/resources/admin/components/DonorDetailsPage/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/index.tsx
@@ -55,14 +55,18 @@ export default function DonorDetailsPage() {
     const { record: donor } = useDonorEntityRecord();
 
     const SendEmailButton = ({ className }: { className: string }) => {
+        if (!donor?.email) {
+            return null;
+        }
+
         return (
-            <button
-                type="button"
+            <a
+                href={`mailto:${donor.email}`}
                 className={className}
-                onClick={() => { }} // TODO: Add email sending logic
+                aria-label={__('Send email to donor', 'give')}
             >
                 {__('Send Email', 'give')}
-            </button>
+            </a>
         );
     };
 


### PR DESCRIPTION
Resolves [GIVE-2584]

## Description

This PR updates the SendEmailButton component in the donor details page to use proper semantic HTML and improve accessibility. The component now uses an anchor element instead of a button for mailto links, which is the semantically correct approach for navigating to external resources (email client). The change includes proper email validation checks and accessibility improvements.

The implementation:
- Changes from `<button>` to `<a>` element for semantic correctness
- Adds `mailto:` link using the donor's email address
- Returns `null` when the donor has no email property to prevent rendering
- Includes proper `aria-label` for screen reader accessibility

## Affects
Donor details page SendEmailButton component

## Visuals

https://github.com/user-attachments/assets/159d0b96-4864-4295-9682-0ebf3d0e79f9

## Testing Instructions

1. Navigate to the donor details page in the admin
2. Verify that donors with email addresses show a "Send Email" link
3. Click the link to verify it opens the default email client with the donor's email pre-filled
4. Test with donors that don't have email addresses to ensure the button doesn't render

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed
