### PR TITLE
Refactor: update default donor detail url and preserve legacy view

### DIFF
--- a/includes/admin/donors/class-donor-table.php
+++ b/includes/admin/donors/class-donor-table.php
@@ -272,7 +272,7 @@ class Give_Donor_List_Table extends WP_List_Table {
 				__( 'Unnamed Donor', 'give' )
 			);
 
-		$view_url = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor['id'] );
+		$view_url = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor['id'] );
 		$actions  = $this->get_row_actions( $donor );
 
 		return sprintf(
@@ -338,7 +338,7 @@ class Give_Donor_List_Table extends WP_List_Table {
 
 		$actions = [
 			'id'     => '<span class="give-donor-id">ID: ' . $donor['id'] . '  </span>',
-			'view'   => sprintf( '<a href="%1$s" aria-label="%2$s">%3$s</a>', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor['id'] ), sprintf( esc_attr__( 'View "%s"', 'give' ), esc_attr( $donor['name'] ) ), __( 'View Donor', 'give' ) ),
+			'view'   => sprintf( '<a href="%1$s" aria-label="%2$s">%3$s</a>', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor['id'] ), sprintf( esc_attr__( 'View "%s"', 'give' ), esc_attr( $donor['name'] ) ), __( 'View Donor', 'give' ) ),
 			'delete' => sprintf( '<a class="%1$s" data-id="%2$s" href="#" aria-label="%3$s">%4$s</a>', 'give-single-donor-delete', $donor['id'], sprintf( esc_attr__( 'Delete "%s"', 'give' ), esc_attr( $donor['name'] ) ), __( 'Delete', 'give' ) ),
 		];
 

--- a/includes/admin/donors/donor-actions.php
+++ b/includes/admin/donors/donor-actions.php
@@ -178,7 +178,7 @@ function give_edit_donor( $args ) {
                      array(
                          'post_type'       => 'give_forms',
                          'page'            => 'give-donors',
-                         'view'            => 'overview',
+                         'view'            => 'legacy-overview',
                          'id'              => $donor_id,
                          'give-messages[]' => 'profile-updated',
                      ),
@@ -348,7 +348,7 @@ function give_disconnect_donor_user_id( $args ) {
 		'user_id' => 0,
 	);
 
-	$redirect_url     = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' ) . $donor_id;
+	$redirect_url     = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' ) . $donor_id;
 	$is_donor_updated = $donor->update( $donor_args );
 
 	if ( $is_donor_updated ) {
@@ -455,7 +455,7 @@ function give_add_donor_email( $args ) {
 				);
 			}
 		} else {
-			$redirect = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor_id . '&give-messages[]=email-added' );
+			$redirect = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor_id . '&give-messages[]=email-added' );
 			$output   = array(
 				'success'  => true,
 				'message'  => __( 'Email successfully added to donor.', 'give' ),
@@ -519,13 +519,13 @@ function give_remove_donor_email() {
 
 	$donor = new Give_Donor( $_GET['id'] );
 	if ( $donor->remove_email( $_GET['email'] ) ) {
-		$url        = add_query_arg( 'give-messages[]', 'email-removed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) );
+		$url        = add_query_arg( 'give-messages[]', 'email-removed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ) );
 		$user       = wp_get_current_user();
 		$user_login = ! empty( $user->user_login ) ? $user->user_login : __( 'System', 'give' );
 		$donor_note = sprintf( __( 'Email address %1$s removed by %2$s', 'give' ), $_GET['email'], $user_login );
 		$donor->add_note( $donor_note );
 	} else {
-		$url = add_query_arg( 'give-messages[]', 'email-remove-failed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) );
+		$url = add_query_arg( 'give-messages[]', 'email-remove-failed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ) );
 	}
 
 	wp_safe_redirect( esc_url_raw( $url ) );
@@ -571,14 +571,14 @@ function give_set_donor_primary_email() {
 	$donor = new Give_Donor( $_GET['id'] );
 
 	if ( $donor->set_primary_email( $_GET['email'] ) ) {
-		$url        = add_query_arg( 'give-messages[]', 'primary-email-updated', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) );
+		$url        = add_query_arg( 'give-messages[]', 'primary-email-updated', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ) );
 		$user       = wp_get_current_user();
 		$user_login = ! empty( $user->user_login ) ? $user->user_login : __( 'System', 'give' );
 		$donor_note = sprintf( __( 'Email address %1$s set as primary by %2$s', 'give' ), $_GET['email'], $user_login );
 
 		$donor->add_note( $donor_note );
 	} else {
-		$url = add_query_arg( 'give-messages[]', 'primary-email-failed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) );
+		$url = add_query_arg( 'give-messages[]', 'primary-email-failed', admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ) );
 	}
 
 	wp_safe_redirect( esc_url_raw( $url ) );

--- a/includes/admin/donors/donor-functions.php
+++ b/includes/admin/donors/donor-functions.php
@@ -26,9 +26,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 function give_register_default_donor_views( $views ) {
 
 	$default_views = array(
-		'overview' => 'give_donor_view',
-		'delete'   => 'give_donor_delete_view',
-		'notes'    => 'give_donor_notes_view',
+		'legacy-overview' => 'give_donor_view',
+		'legacy-delete'   => 'give_donor_delete_view',
+		'legacy-notes'    => 'give_donor_notes_view',
 	);
 
 	return array_merge( $views, $default_views );
@@ -49,10 +49,10 @@ add_filter( 'give_donor_views', 'give_register_default_donor_views', 1, 1 );
 function give_register_default_donor_tabs( $tabs ) {
 
 	$default_tabs = array(
-		'overview' => array(
+		'legacy-overview' => array(
 			'title' => __( 'Donor Profile', 'give' ),
 		),
-		'notes'    => array(
+		'legacy-notes'    => array(
 			'title' => __( 'Donor Notes', 'give' ),
 		),
 	);
@@ -73,7 +73,7 @@ add_filter( 'give_donor_tabs', 'give_register_default_donor_tabs', 1, 1 );
  */
 function give_register_delete_donor_tab( $tabs ) {
 
-	$tabs['delete'] = array(
+	$tabs['legacy-delete'] = array(
 		'title' => __( 'Delete Donor', 'give' ),
 	);
 

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -337,7 +337,7 @@ function give_donor_view( $donor ) {
 	?>
 	<div id="donor-summary" class="info-wrapper donor-section postbox">
 		<form id="edit-donor-info" method="post"
-			  action="<?php echo esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ) ); ?>">
+			  action="<?php echo esc_url( admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ) ); ?>">
 			<div class="donor-info">
 				<div class="donor-bio-header clearfix">
 					<div class="avatar-wrap left" id="donor-avatar">
@@ -830,7 +830,7 @@ function give_donor_view( $donor ) {
 						<td>
 							<?php if ( 'primary' !== $key ) : ?>
 								<?php
-								$base_url    = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id );
+								$base_url    = admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id );
 								$promote_url = wp_nonce_url(
 									add_query_arg(
 										array(
@@ -1188,7 +1188,7 @@ function give_donor_delete_view( $donor ) {
 					<input type="submit" disabled="disabled" id="give-delete-donor" class="button-primary"
 						   value="<?php _e( 'Delete Donor', 'give' ); ?>"/>
 					<a id="give-delete-donor-cancel"
-					   href="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=overview&id=' . $donor->id ); ?>"
+					   href="<?php echo admin_url( 'edit.php?post_type=give_forms&page=give-donors&view=legacy-overview&id=' . $donor->id ); ?>"
 					   class="delete"><?php _e( 'Cancel', 'give' ); ?></a>
 				</span>
 

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -105,6 +105,6 @@ class DonorsAdminPage
      */
     public static function isShowingDetailsPage(): bool
     {
-        return isset($_GET['id'], $_GET['page'], $_GET['view']) && 'give-donors' === $_GET['page'] && 'donor-details' === $_GET['view'];
+        return isset($_GET['id'], $_GET['page'], $_GET['view']) && 'give-donors' === $_GET['page'] && 'overview' === $_GET['view'];
     }
 }

--- a/src/Donors/DonorsAdminPage.php
+++ b/src/Donors/DonorsAdminPage.php
@@ -6,9 +6,6 @@ use Give\Donors\Actions\LoadDonorDetailsAssets;
 use Give\Donors\Actions\LoadDonorsListTableAssets;
 use Give\Donors\ListTable\DonorsListTable;
 use Give\Donors\Models\Donor;
-use Give\Framework\Database\DB;
-use Give\Helpers\Hooks;
-use Give\Helpers\Utils;
 
 class DonorsAdminPage
 {
@@ -48,11 +45,8 @@ class DonorsAdminPage
             }
 
             give(LoadDonorDetailsAssets::class)();
-        } else {
-            // TODO: Remove this once the new view is fully launched
-            if (self::isShowing()) {
-                give(LoadDonorsListTableAssets::class)();
-            }
+        } elseif (self::isShowing()) {
+            give(LoadDonorsListTableAssets::class)();
         }
 
         echo '<div id="give-admin-donors-root"></div>';
@@ -105,6 +99,16 @@ class DonorsAdminPage
      */
     public static function isShowingDetailsPage(): bool
     {
-        return isset($_GET['id'], $_GET['page'], $_GET['view']) && 'give-donors' === $_GET['page'] && 'overview' === $_GET['view'];
+        return isset($_GET['id'], $_GET['page']) && 'give-donors' === $_GET['page'];
+    }
+
+    /**
+     * Get the URL for the details page
+     *
+     * @unreleased
+     */
+    public static function getDetailsPageUrl(int $donorId): string
+    {
+        return admin_url("edit.php?post_type=give_forms&page=give-donors&id=$donorId");
     }
 }

--- a/src/Donors/ListTable/Columns/DonorInformationColumn.php
+++ b/src/Donors/ListTable/Columns/DonorInformationColumn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Give\Donors\ListTable\Columns;
 
+use Give\Donors\DonorsAdminPage;
 use Give\Donors\Models\Donor;
 use Give\Framework\ListTable\ModelColumn;
 
@@ -55,10 +56,12 @@ class DonorInformationColumn extends ModelColumn
             </div>
         ';
 
+        $url = DonorsAdminPage::getDetailsPageUrl($model->id);
+
         return sprintf(
             $template,
             get_avatar_url($model->email, ['size' => 64]),
-            admin_url("edit.php?post_type=give_forms&page=give-donors&view=overview&id=$model->id"),
+            $url,
             trim("$model->firstName $model->lastName"),
             $model->email
         );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Updated the new donor details view to be the default (existing) url.  To preserve backwards compatibility with the old view, a new `legacy-` prefix was added to old urls.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The donor details page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1124" alt="Screenshot 2025-06-10 at 1 01 10 PM" src="https://github.com/user-attachments/assets/786bfce1-57cd-42c9-b86e-6f3b46ed953a" />


<img width="1203" alt="Screenshot 2025-06-10 at 1 01 20 PM" src="https://github.com/user-attachments/assets/bc33fb16-03e8-40ed-8479-6c0bdc6d0b6c" />


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Open a donor details screen by default you should see the new view
- Go to donors list and switch to legacy.  Then click on a donor and you should see old view
- Manually you can change `&page=overview` to `&page=legacy-overview`

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

