### PR TITLE
Fix: language pack not loaded (Don't use get_user_locale() in Ajax)

### DIFF
--- a/src/Helpers/Language.php
+++ b/src/Helpers/Language.php
@@ -14,7 +14,7 @@ class Language
     {
         $giveRelativePath = self::getRelativePath();
 
-        $locale = is_admin() && function_exists('get_user_locale') ? get_user_locale() : get_locale();
+        $locale = is_admin() && ! wp_doing_ajax() && function_exists('get_user_locale') ? get_user_locale() : get_locale();
         $locale = apply_filters('plugin_locale', $locale, 'give'); // Traditional WordPress plugin locale filter.
 
         // Setup paths to current locale file.


### PR DESCRIPTION
In a French receipt, texts are in English. These texts are displayed in Ajax, so `get_user_locale()` was used. Its value is `"site-default`" and we try to load` give-site-default.mo` as language pack.