### PR TITLE
Fix: recurring email templates in form builder

### DIFF
--- a/src/FormBuilder/Actions/ConvertLegacyNotificationToEmailNotificationData.php
+++ b/src/FormBuilder/Actions/ConvertLegacyNotificationToEmailNotificationData.php
@@ -84,6 +84,25 @@ class ConvertLegacyNotificationToEmailNotificationData
             $key = str_replace("_give_{$this->id}_", '', $field['id']);
             $defaultValues[$key] = $field['default'] ?? '';
         }
+
+        if (!isset($defaultValues['email_message'])) {
+            foreach ($this->fields as $field) {
+                if (strpos($field['id'], '_message') !== false) {
+                    $defaultValues['email_message'] = $field['default'] ?? '';
+                    break;
+                }
+            }
+        }
+
+        if (!isset($defaultValues['email_subject'])) {
+            foreach ($this->fields as $field) {
+                if (strpos($field['id'], '_subject') !== false) {
+                    $defaultValues['email_subject'] = $field['default'] ?? '';
+                    break;
+                }
+            }
+        }
+
         return $defaultValues;
     }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/settings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/settings.tsx
@@ -29,10 +29,10 @@ const EmailTemplateSettings = ({notification, templateTagsRef, settings, setSett
 
     const option = {
         status: config.defaultValues.notification ?? 'global',
-        email_subject: config.defaultValues.email_subject,
-        email_header: config.defaultValues.email_header,
-        email_message: config.defaultValues.email_message.replace(/\n/g, '<br />'),
-        email_content_type: config.defaultValues.email_content_type,
+        email_subject: config.defaultValues?.email_subject,
+        email_header: config.defaultValues?.email_header,
+        email_message: config.defaultValues?.email_message?.replace(/\n/g, '<br />'),
+        email_content_type: config.defaultValues?.email_content_type,
         recipient: [emailDefaultAddress],
         ...emailTemplateOptions[notification],
     };


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2649]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The recurring emails in the form builder were causing a blank white page on selection.  This is because they use different field id mapping that core.  This does the proper field mapping and adds some conditionals when missing.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
Form builder recurring emails settings

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1493" alt="Screenshot 2025-06-13 at 8 18 11 AM" src="https://github.com/user-attachments/assets/41dd4b69-fcec-4835-83d6-7da9a86848ad" />

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/15634341320

- Install recurring and enable renewal emails
- Go to the form builder, settings, email and interact with recurring email templates

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2649]: https://stellarwp.atlassian.net/browse/GIVE-2649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ