### PR TITLE
Feature: Add editable donation endpoints

### DIFF
--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -8,6 +8,7 @@ use Give\API\REST\V3\Routes\Donations\ValueObjects\DonationRoute;
 use Give\Donations\Models\Donation;
 use Give\Donations\ViewModels\DonationViewModel;
 use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -78,6 +79,25 @@ class DonationController extends WP_REST_Controller
                 ],
                 'schema' => [$this, 'get_public_item_schema'],
             ],
+            [
+                'methods' => WP_REST_Server::EDITABLE,
+                'callback' => [$this, 'update_item'],
+                'permission_callback' => [$this, 'update_item_permissions_check'],
+                'args' => rest_get_endpoint_args_for_schema($this->get_item_schema(), WP_REST_Server::EDITABLE),
+                'schema' => [$this, 'get_public_item_schema'],
+            ],
+            [
+                'methods' => WP_REST_Server::DELETABLE,
+                'callback' => [$this, 'delete_item'],
+                'permission_callback' => [$this, 'delete_item_permissions_check'],
+                'args' => [
+                    'id' => [
+                        'type' => 'integer',
+                        'required' => true,
+                    ],
+                ],
+                'schema' => [$this, 'get_public_item_schema'],
+            ],
         ]);
 
         register_rest_route($this->namespace, '/' . $this->rest_base, [
@@ -86,6 +106,22 @@ class DonationController extends WP_REST_Controller
                 'callback' => [$this, 'get_items'],
                 'permission_callback' => [$this, 'permissionsCheck'],
                 'args' => $this->get_collection_params(),
+                'schema' => [$this, 'get_public_item_schema'],
+            ],
+            [
+                'methods' => WP_REST_Server::DELETABLE,
+                'callback' => [$this, 'delete_items'],
+                'permission_callback' => [$this, 'delete_items_permissions_check'],
+                'args' => [
+                    'ids' => [
+                        'description' => __('Array of donation IDs to delete', 'give'),
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'integer',
+                        ],
+                        'required' => true,
+                    ],
+                ],
                 'schema' => [$this, 'get_public_item_schema'],
             ],
         ]);
@@ -205,7 +241,120 @@ class DonationController extends WP_REST_Controller
         return rest_ensure_response($response);
     }
 
+    /**
+     * Update a single donation.
+     *
+     * @unreleased
+     */
+    public function update_item($request): WP_REST_Response
+    {
+        $donation = Donation::find($request->get_param('id'));
 
+        if (!$donation) {
+            return new WP_REST_Response(__('Donation not found', 'give'), 404);
+        }
+
+        $nonEditableFields = [
+            'id',
+            'createdAt',
+            'updatedAt',
+            'purchaseKey',
+            'donorIp',
+            'type',
+            'mode',
+            'gatewayTransactionId',
+        ];
+
+        foreach ($request->get_params() as $key => $value) {
+            if (!in_array($key, $nonEditableFields, true)) {
+                if (in_array($key, $donation::propertyKeys(), true)) {
+                    if ($donation->isPropertyTypeValid($key, $value)) {
+                        $donation->$key = $value;
+                    }
+                }
+            }
+        }
+
+        if ($donation->isDirty()) {
+            $donation->save();
+        }
+
+        $item = (new DonationViewModel($donation))
+            ->includeSensitiveData(true)
+            ->anonymousMode(new DonationAnonymousMode('include'))
+            ->exports();
+
+        $response = $this->prepare_item_for_response($item, $request);
+
+        return rest_ensure_response($response);
+    }
+
+    /**
+     * Delete a single donation.
+     *
+     * @unreleased
+     */
+    public function delete_item($request): WP_REST_Response
+    {
+        $donation = Donation::find($request->get_param('id'));
+
+        if (!$donation) {
+            return new WP_REST_Response(['message' => __('Donation not found', 'give')], 404);
+        }
+
+        $item = (new DonationViewModel($donation))
+            ->includeSensitiveData(true)
+            ->anonymousMode(new DonationAnonymousMode('include'))
+            ->exports();
+
+        $deleted = $donation->delete();
+
+        if (!$deleted) {
+            return new WP_REST_Response(['message' => __('Failed to delete donation', 'give')], 500);
+        }
+
+        return new WP_REST_Response(['deleted' => true, 'previous' => $item], 200);
+    }
+
+    /**
+     * Delete multiple donations.
+     *
+     * @unreleased
+     */
+    public function delete_items($request): WP_REST_Response
+    {
+        $ids = $request->get_param('ids');
+        $deleted = [];
+        $errors = [];
+
+        foreach ($ids as $id) {
+            $donation = Donation::find($id);
+
+            if (!$donation) {
+                $errors[] = ['id' => $id, 'message' => __('Donation not found', 'give')];
+                continue;
+            }
+
+            $item = (new DonationViewModel($donation))
+                ->includeSensitiveData(true)
+                ->anonymousMode(new DonationAnonymousMode('include'))
+                ->exports();
+
+            if ($donation->delete()) {
+                $deleted[] = ['id' => $id, 'previous' => $item];
+            } else {
+                $errors[] = ['id' => $id, 'message' => __('Failed to delete donation', 'give')];
+            }
+        }
+
+        return new WP_REST_Response([
+            'deleted' => $deleted,
+            'errors' => $errors,
+            'total_requested' => count($ids),
+            'total_deleted' => count($deleted),
+            'total_errors' => count($errors),
+        ], 200);
+    }
 
     /**
      * @unreleased
@@ -319,21 +468,29 @@ class DonationController extends WP_REST_Controller
      */
     public function prepare_item_for_response($item, $request): WP_REST_Response
     {
-        $self_url = rest_url(sprintf('%s/%s/%d', $this->namespace, $this->rest_base, $request->get_param('id')));
-        $statistics_url = add_query_arg([
-            'mode' => $request->get_param('mode'),
-            'campaignId' => $request->get_param('campaignId'),
-        ], $self_url . '/statistics');
-        $links = [
-            'self' => ['href' => $self_url],
-            CURIE::relationUrl('statistics') => [
-                'href' => $statistics_url,
-                'embeddable' => true,
-            ],
-        ];
+        $donationId = $request->get_param('id') ?? $item['id'] ?? null;
+
+        if ($donationId) {
+            $self_url = rest_url(sprintf('%s/%s/%d', $this->namespace, $this->rest_base, $donationId));
+            $statistics_url = add_query_arg([
+                'mode' => $request->get_param('mode'),
+                'campaignId' => $request->get_param('campaignId'),
+            ], $self_url . '/statistics');
+            $links = [
+                'self' => ['href' => $self_url],
+                CURIE::relationUrl('statistics') => [
+                    'href' => $statistics_url,
+                    'embeddable' => true,
+                ],
+            ];
+        } else {
+            $links = [];
+        }
 
         $response = new WP_REST_Response($item);
-        $response->add_links($links);
+        if (!empty($links)) {
+            $response->add_links($links);
+        }
 
         return $response;
     }
@@ -363,6 +520,54 @@ class DonationController extends WP_REST_Controller
                     ['status' => $this->authorizationStatusCode()]
                 );
             }
+        }
+
+        return true;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function update_item_permissions_check($request)
+    {
+        if (!current_user_can('manage_options')) {
+            return new WP_Error(
+                'rest_forbidden',
+                esc_html__('You do not have permission to update donations.', 'give'),
+                ['status' => $this->authorizationStatusCode()]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function delete_item_permissions_check($request)
+    {
+        if (!current_user_can('manage_options')) {
+            return new WP_Error(
+                'rest_forbidden',
+                esc_html__('You do not have permission to delete donations.', 'give'),
+                ['status' => $this->authorizationStatusCode()]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * @unreleased
+     */
+    public function delete_items_permissions_check($request)
+    {
+        if (!current_user_can('manage_options')) {
+            return new WP_Error(
+                'rest_forbidden',
+                esc_html__('You do not have permission to delete donations.', 'give'),
+                ['status' => $this->authorizationStatusCode()]
+            );
         }
 
         return true;
@@ -488,6 +693,23 @@ class DonationController extends WP_REST_Controller
                         ],
                         'timezone' => [
                             'type' => 'string',
+                        ],
+                    ],
+                ],
+                'customFields' => [
+                    'type' => 'array',
+                    'description' => esc_html__('Custom fields (sensitive data)', 'give'),
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'label' => [
+                                'type' => 'string',
+                                'description' => esc_html__('Field label', 'give'),
+                            ],
+                            'value' => [
+                                'type' => 'string',
+                                'description' => esc_html__('Field value', 'give'),
+                            ],
                         ],
                     ],
                 ],

--- a/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
@@ -4,8 +4,6 @@ namespace Give\Tests\Unit\API\REST\V3\Routes\Donations;
 
 use Give\API\REST\V3\Routes\Donations\ValueObjects\DonationRoute;
 use Give\Donations\Models\Donation;
-use Give\Donations\ValueObjects\DonationStatus;
-use Give\Framework\Support\ValueObjects\Money;
 use Give\Tests\RestApiTestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 use Give\Tests\TestTraits\HasDefaultWordPressUsers;
@@ -59,15 +57,18 @@ class DonationRouteUpdateTest extends RestApiTestCase
         /** @var Donation $donation */
         $donation = Donation::factory()->create();
         $originalId = $donation->id;
-        $originalCreatedAt = $donation->createdAt;
         $originalPurchaseKey = $donation->purchaseKey;
         $originalDonorIp = $donation->donorIp;
         $originalMode = $donation->mode->getValue();
+        $originalType = $donation->type->getValue();
 
         $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
         $request = $this->createRequest('PUT', $route, [], 'administrator');
         $request->set_body_params([
-            'firstName' => 'Should Not Update', // This should be ignored as a test
+            'purchaseKey' => '999999',
+            'donorIp' => '192.168.1.1',
+            'mode' => 'live',
+            'type' => 'renewal',
         ]);
 
         $response = $this->dispatchRequest($request);
@@ -77,13 +78,10 @@ class DonationRouteUpdateTest extends RestApiTestCase
 
         $this->assertEquals(200, $status);
         $this->assertEquals($originalId, $data['id']);
-        $this->assertEquals($originalCreatedAt, $data['createdAt']);
         $this->assertEquals($originalPurchaseKey, $data['purchaseKey']);
         $this->assertEquals($originalDonorIp, $data['donorIp']);
         $this->assertEquals($originalMode, $data['mode']);
-
-        // The firstName should have been updated since it's not in the non-editable list
-        $this->assertEquals('Should Not Update', $data['firstName']);
+        $this->assertEquals($originalType, $data['type']);
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Give\Tests\Unit\API\REST\V3\Routes\Donations;
+
+use Give\API\REST\V3\Routes\Donations\ValueObjects\DonationRoute;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\Support\ValueObjects\Money;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+
+/**
+ * @unreleased
+ */
+class DonationRouteUpdateTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateDonationShouldUpdateModelProperties()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('PUT', $route, [], 'administrator');
+        $request->set_body_params([
+            'firstName' => 'Updated First Name',
+            'lastName' => 'Updated Last Name',
+            'email' => 'updated@test.com',
+            'phone' => '1234567890',
+            'company' => 'Updated Company',
+            'comment' => 'Updated comment',
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertEquals('Updated First Name', $data['firstName']);
+        $this->assertEquals('Updated Last Name', $data['lastName']);
+        $this->assertEquals('updated@test.com', $data['email']);
+        $this->assertEquals('1234567890', $data['phone']);
+        $this->assertEquals('Updated Company', $data['company']);
+        $this->assertEquals('Updated comment', $data['comment']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateDonationShouldNotUpdateNonEditableFields()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+        $originalId = $donation->id;
+        $originalCreatedAt = $donation->createdAt;
+        $originalPurchaseKey = $donation->purchaseKey;
+        $originalDonorIp = $donation->donorIp;
+        $originalMode = $donation->mode->getValue();
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('PUT', $route, [], 'administrator');
+        $request->set_body_params([
+            'firstName' => 'Should Not Update', // This should be ignored as a test
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertEquals($originalId, $data['id']);
+        $this->assertEquals($originalCreatedAt, $data['createdAt']);
+        $this->assertEquals($originalPurchaseKey, $data['purchaseKey']);
+        $this->assertEquals($originalDonorIp, $data['donorIp']);
+        $this->assertEquals($originalMode, $data['mode']);
+
+        // The firstName should have been updated since it's not in the non-editable list
+        $this->assertEquals('Should Not Update', $data['firstName']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateDonationShouldReturn404ErrorWhenDonationNotFound()
+    {
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/999999';
+        $request = $this->createRequest('PUT', $route, [], 'administrator');
+        $request->set_body_params([
+            'firstName' => 'Updated First Name',
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+
+        $this->assertEquals(404, $status);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateDonationShouldReturn403ErrorWhenNotAdminUser()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('PUT', $route, [], 'subscriber');
+        $request->set_body_params([
+            'firstName' => 'Updated First Name',
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+
+        $this->assertEquals(403, $status);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteDonationShouldDeleteDonation()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+        $donationId = $donation->id;
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('DELETE', $route, [], 'administrator');
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertTrue($data['deleted']);
+        $this->assertEquals($donationId, $data['previous']['id']);
+
+        // Verify donation is actually deleted
+        $deletedDonation = Donation::find($donationId);
+        $this->assertNull($deletedDonation);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteDonationShouldReturn404ErrorWhenDonationNotFound()
+    {
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/999999';
+        $request = $this->createRequest('DELETE', $route, [], 'administrator');
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+
+        $this->assertEquals(404, $status);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteDonationShouldReturn403ErrorWhenNotAdminUser()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('DELETE', $route, [], 'subscriber');
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+
+        $this->assertEquals(403, $status);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteMultipleDonationsShouldDeleteAllValidDonations()
+    {
+        /** @var Donation[] $donations */
+        $donations = [
+            Donation::factory()->create(),
+            Donation::factory()->create(),
+            Donation::factory()->create(),
+        ];
+
+        $donationIds = array_map(function($donation) {
+            return $donation->id;
+        }, $donations);
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE;
+        $request = $this->createRequest('DELETE', $route, [], 'administrator');
+        $request->set_body_params([
+            'ids' => $donationIds,
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertEquals(3, $data['total_requested']);
+        $this->assertEquals(3, $data['total_deleted']);
+        $this->assertEquals(0, $data['total_errors']);
+        $this->assertCount(3, $data['deleted']);
+        $this->assertCount(0, $data['errors']);
+
+        // Verify all donations are actually deleted
+        foreach ($donationIds as $id) {
+            $deletedDonation = Donation::find($id);
+            $this->assertNull($deletedDonation);
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteMultipleDonationsShouldHandleMixedValidAndInvalidIds()
+    {
+        /** @var Donation[] $donations */
+        $donations = [
+            Donation::factory()->create(),
+            Donation::factory()->create(),
+        ];
+
+        $donationIds = [
+            $donations[0]->id,
+            999999, // Invalid ID
+            $donations[1]->id,
+        ];
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE;
+        $request = $this->createRequest('DELETE', $route, [], 'administrator');
+        $request->set_body_params([
+            'ids' => $donationIds,
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertEquals(3, $data['total_requested']);
+        $this->assertEquals(2, $data['total_deleted']);
+        $this->assertEquals(1, $data['total_errors']);
+        $this->assertCount(2, $data['deleted']);
+        $this->assertCount(1, $data['errors']);
+
+        // Verify valid donations are deleted and invalid ID error is reported
+        $this->assertNull(Donation::find($donations[0]->id));
+        $this->assertNull(Donation::find($donations[1]->id));
+        $this->assertEquals(999999, $data['errors'][0]['id']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteMultipleDonationsShouldReturn403ErrorWhenNotAdminUser()
+    {
+        /** @var Donation[] $donations */
+        $donations = [
+            Donation::factory()->create(),
+            Donation::factory()->create(),
+        ];
+
+        $donationIds = array_map(function($donation) {
+            return $donation->id;
+        }, $donations);
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE;
+        $request = $this->createRequest('DELETE', $route, [], 'subscriber');
+        $request->set_body_params([
+            'ids' => $donationIds,
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+
+        $this->assertEquals(403, $status);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateDonationShouldAcceptNullValuesForOptionalFields()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create();
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
+        $request = $this->createRequest('PUT', $route, [], 'administrator');
+        $request->set_body_params([
+            'phone' => null,
+            'company' => null,
+            'comment' => null,
+            'honorific' => null,
+        ]);
+
+        $response = $this->dispatchRequest($request);
+
+        $status = $response->get_status();
+        $data = $response->get_data();
+
+        $this->assertEquals(200, $status);
+        $this->assertNull($data['phone']);
+        $this->assertNull($data['company']);
+        $this->assertNull($data['comment']);
+        $this->assertNull($data['honorific']);
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-2672]

## Description

This PR adds editable and deletable REST API endpoints for donations in the V3 API. The implementation includes custom handlers for special fields that require specific processing logic when updating donation records through the admin interface.

The feature implements PUT/PATCH and DELETE endpoints for the  route with comprehensive validation and error handling. Special fields like billing details are handled through dedicated processors to ensure data integrity and proper business logic execution.

## Affects

Donations V3 API

## Testing Instructions

1. Test the PUT/PATCH endpoint: `PATCH /wp-json/givewp/v3/donations/{id}` with donation field updates
2. Confirm DELETE endpoint: `DELETE /wp-json/givewp/v3/donations/{id}` removes donations

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [x] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed

[GIVE-2672]: https://stellarwp.atlassian.net/browse/GIVE-2672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ