### PR TITLE
Fix: use currency from donation in DonationStats

### DIFF
--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationStats/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationStats/index.tsx
@@ -19,40 +19,39 @@ interface DonationStatsProps {
         paymentMethod: string;
         mode: string;
     };
-    details?: Array<{ label: string; [key: string]: any }>;
     isResolving: boolean;
+    currency: string;
 }
 
 /**
  * @unreleased
  */
-export default function DonationStats({ donation, details, isResolving }: DonationStatsProps) {
-    const { adminUrl, isFeeRecoveryEnabled, currency } = getDonationOptionsWindowData();
+export default function DonationStats({ donation, isResolving, currency }: DonationStatsProps) {
+    const { isFeeRecoveryEnabled, currency: defaultCurrency } = getDonationOptionsWindowData();
     const {intendedAmount, feeAmountRecovered, eventTicketAmount} = donation;
-    // Handle event ticket value for Statwidget Ex: "$100.00" to "100.00"
     const eventTicketValue = parseFloat(eventTicketAmount);
-    const shouldShowEventTicketStat = eventTicketValue > 0;
+    const shouldShowEventTicketStat = eventTicketValue > 0;    
 
     return (
         <div className={styles.container}>
             <StatWidget
                 label={__('Donation amount', 'give')}
                 value={parseFloat(intendedAmount) || 0}
-                formatter={amountFormatter(currency)}
+                formatter={amountFormatter(currency ?? defaultCurrency)}
                 loading={isResolving}
             />
             {shouldShowEventTicketStat && (
                 <StatWidget
                     label={__('Event ticket', 'give')}
                     value={eventTicketValue}
-                    formatter={amountFormatter(currency)}
+                    formatter={amountFormatter(currency ?? defaultCurrency)}
                     loading={isResolving}
                 />
             )}
             <StatWidget
                 label={__('Fees recovered', 'give')}
                 value={parseFloat(String(feeAmountRecovered))}
-                formatter={amountFormatter(currency)}
+                formatter={amountFormatter(currency ?? defaultCurrency)}
                 loading={isResolving}
                 href={'https://givewp.com/addons/fee-recovery/'}
                 inActive={!isFeeRecoveryEnabled}

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/index.tsx
@@ -22,7 +22,7 @@ export default function DonationDetailsPageOverviewTab() {
         <div className={styles.overview}>
             <DonationStats
                 donation={statistics.donation}
-                details={statistics.receipt?.donationDetails}
+                currency={donation?.amount?.currency}
                 isResolving={isResolving}
             />
 


### PR DESCRIPTION
## Description
Removes the unused details prop from the DonationStat component and passes the actual donation currency to ensure the correct currency symbol is shown, rather than defaulting to the global settings currency.

## Affects
DonationStats

## Visuals
Problem - Donation made with Euros*
<img width="1869" alt="Screenshot 2025-06-26 at 3 51 13 PM" src="https://github.com/user-attachments/assets/514af22b-dd74-47d5-8bc7-2db9e023e520" />

Solution
<img width="1869" alt="Screenshot 2025-06-26 at 3 50 15 PM" src="https://github.com/user-attachments/assets/1a49c120-8ba8-4a5f-b33f-6bf6557fd898" />

## Testing Instructions
- Use Currency switcher to make a donation with a different currency.
- View the Donation Overview and ensure the correct symbol is shown.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

