### PR TITLE
Fix: Divi compatibility issues

### DIFF
--- a/give.php
+++ b/give.php
@@ -250,6 +250,7 @@ final class Give
         Give\Campaigns\ServiceProvider::class,
         Give\FeatureFlags\OptionBasedFormEditor\ServiceProvider::class,
         Give\ThirdPartySupport\ServiceProvider::class,
+        Give\ThirdPartyCompatibility\ServiceProvider::class,
         Give\API\REST\V3\Routes\ServiceProvider::class,
         Give\Framework\PaymentGateways\ServiceProvider::class,
     ];

--- a/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
+++ b/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
@@ -9,6 +9,10 @@ class DeregisterEntityScripts
 {
     public function __invoke()
     {
+        if ( ! isset($_GET['page']) || $_GET['page'] !== 'et_theme_builder') {
+            return;
+        }
+
         global $wp_scripts;
 
         $registered_scripts = $wp_scripts->registered;

--- a/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
+++ b/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Give\ThirdPartyCompatibility\Divi;
+
+/**
+ * @unreleased
+ */
+class DeregisterEntityScripts
+{
+    public function __invoke()
+    {
+        $entities = [
+            'givewp-campaign-entity',
+            'givewp-form-entity',
+            'givewp-donor-entity',
+        ];
+
+        if (
+            isset($_GET['page'])
+            && $_GET['page'] == 'et_theme_builder'
+        ) {
+            foreach ($entities as $entity) {
+                wp_dequeue_script($entity);
+                wp_deregister_script($entity);
+            }
+        }
+    }
+}

--- a/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
+++ b/src/ThirdPartyCompatibility/Divi/DeregisterEntityScripts.php
@@ -9,19 +9,14 @@ class DeregisterEntityScripts
 {
     public function __invoke()
     {
-        $entities = [
-            'givewp-campaign-entity',
-            'givewp-form-entity',
-            'givewp-donor-entity',
-        ];
+        global $wp_scripts;
 
-        if (
-            isset($_GET['page'])
-            && $_GET['page'] == 'et_theme_builder'
-        ) {
-            foreach ($entities as $entity) {
-                wp_dequeue_script($entity);
-                wp_deregister_script($entity);
+        $registered_scripts = $wp_scripts->registered;
+
+        foreach ($registered_scripts as $handle => $script) {
+            if (preg_match('/^givewp-.*-entity$/', $handle)) {
+                wp_dequeue_script($handle);
+                wp_deregister_script($handle);
             }
         }
     }

--- a/src/ThirdPartyCompatibility/ServiceProvider.php
+++ b/src/ThirdPartyCompatibility/ServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Give\ThirdPartyCompatibility;
+
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider as CoreServiceProvider;
+use Give\ThirdPartyCompatibility\Divi\DeregisterEntityScripts;
+
+/**
+ * @unreleased
+ */
+class ServiceProvider implements CoreServiceProvider
+{
+    public function register()
+    {
+        Hooks::addAction('wp_print_scripts', DeregisterEntityScripts::class);
+    }
+
+    public function boot()
+    {
+    }
+}


### PR DESCRIPTION

## Description

This PR resolves the issue with the Divi theme builder. The problem with the Divi theme builder is that it deregisters WP core scripts that are used by GiveWP entities. The issue is resolved by deregistering GiveWP entities on Divi theme builder pages. 


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

Make sure GiveWP 4.0 + and the Divi theme are installed.

In WP Admin, Go to Divi > Theme Builder.

In any template, click Add Global Body.

Click Build Global Body.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

