### PR TITLE
Fix: prevent CSS selector escaping in custom form styles

### DIFF
--- a/src/Settings/DonationForms/Actions/SanitizeCustomFormStyles.php
+++ b/src/Settings/DonationForms/Actions/SanitizeCustomFormStyles.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Give\Settings\DonationForms\Actions;
+
+/**
+ * @unreleased
+ */
+class SanitizeCustomFormStyles
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke($value, $option, $raw_value)
+    {
+        if ($option['id'] === 'custom_form_styles') {
+            return wp_strip_all_tags($raw_value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Settings/ServiceProvider.php
+++ b/src/Settings/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Give\Settings;
 
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderInterface;
+use Give\Settings\DonationForms\Actions\SanitizeCustomFormStyles;
 use Give\Settings\Security\Actions\RegisterPage;
 use Give\Settings\Security\Actions\RegisterSection;
 use Give\Settings\Security\Actions\RegisterSettings;
@@ -31,6 +32,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased Add custom form styles sanitization
      * @since 3.17.0
      */
     private function registerSecuritySettings(): void
@@ -38,5 +40,6 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addFilter('give-settings_get_settings_pages', RegisterPage::class);
         Hooks::addFilter('give_get_sections_security', RegisterSection::class);
         Hooks::addFilter('give_get_settings_security', RegisterSettings::class);
+        Hooks::addFilter('give_admin_settings_sanitize_option', SanitizeCustomFormStyles::class, '__invoke', 10, 3);
     }
 }


### PR DESCRIPTION
Resolves [GIVE-2589]

## Description

This PR fixes an issue where CSS selectors containing the `>` (direct descendant) symbol were being converted to `&gt;` when saved in the Custom Styles field (GiveWP > Settings > Advanced > Donation Forms). This happened because we were sanitizing that setting with `wp_kses_post()` which escapes unwanted HTML entities, breaking valid CSS selectors like `.parent > .child`.

The fix implements a custom sanitization method specifically for the `custom_form_styles` option that uses `wp_strip_all_tags()`. This allows CSS selectors to remain intact while still preventing malicious code injection by stripping HTML tags.

## Affects
Global CSS settings

## Visuals

https://github.com/user-attachments/assets/efbe4d74-2384-4b78-9d8c-4ad783518742

## Testing Instructions

1. Navigate to GiveWP > Settings > Advanced > Donation Forms
2. In the Custom Styles field, enter CSS that includes the `>` symbol, for example:

```css
.givewp-fields-amount__level-container > button {
	border-radius: 100%;
}
   
.givewp-fields-gateways__gateway > label {
    font-family: Verdana, sans-serif;
    font-weight: bold;
}
```

3. Click Save Settings
4. Return to the Custom Styles field and verify that the `>` symbols are preserved (not converted to `&gt;`)
5. Test on a donation form to ensure the CSS is applied correctly

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed

[GIVE-2589]: https://stellarwp.atlassian.net/browse/GIVE-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ