### PR TITLE
Changed: Add additional countries to Stripe application fee exclusions

### DIFF
--- a/src/PaymentGateways/Stripe/ApplicationFee.php
+++ b/src/PaymentGateways/Stripe/ApplicationFee.php
@@ -56,10 +56,20 @@ class ApplicationFee
     /**
      * Return whether country support application fee.
      *
+     * @unreleased Add India, Malaysia, Mexico, Singapore, Thailand to the list of unsupported countries
      * @since 2.10.2
      */
     public function doesCountrySupportApplicationFee(): bool
     {
-        return 'BR' !== $this->accountDetail->accountCountry;
+        $unsupportedCountries = [
+            'BR', // Brazil
+            'IN', // India
+            'MY', // Malaysia
+            'MX', // Mexico
+            'SG', // Singapore
+            'TH', // Thailand
+        ];
+
+        return !in_array($this->accountDetail->accountCountry, $unsupportedCountries);
     }
 }

--- a/tests/Unit/PaymentGateways/Stripe/ApplicationFeeTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/ApplicationFeeTest.php
@@ -30,62 +30,58 @@ final class ApplicationFeeTest extends TestCase
 
         $this->setUpStripeAccounts();
         $this->repository = new AccountDetailRepository();
-        $this->gate = new ApplicationFee($this->repository->getAccountDetail('account_1'));
+        $this->gate = new ApplicationFee($this->repository->getAccountDetail('account_br'));
     }
 
     private function setUpStripeAccounts()
     {
+        $accounts = [];
+        $countries = $this->unsupportedCountriesProvider();
+        $countries['United States'] = ['account_us', 'US'];
+
+        foreach ($countries as $countryName => $data) {
+            [$accountSlug, $countryCode] = $data;
+
+            $accounts[$accountSlug] = [
+                'type' => 'manual',
+                'account_name' => $countryName . ' Account',
+                'account_slug' => $accountSlug,
+                'account_email' => 'dummy@example.com',
+                'account_country' => $countryCode,
+                'account_id' => $accountSlug,
+                'live_secret_key' => 'dummy',
+                'test_secret_key' => 'dummy',
+                'live_publishable_key' => 'dummy',
+                'test_publishable_key' => 'dummy',
+                'statement_descriptor' => get_bloginfo('name'),
+            ];
+        }
+
         give_update_option(
             '_give_stripe_get_all_accounts',
-            [
-                'account_1' => [
-                    'type' => 'manual',
-                    'account_name' => 'Account 1',
-                    'account_slug' => 'account_1',
-                    'account_email' => '',
-                    'account_country' => 'BR',
-                    'account_id' => 'account_1',
-                    'live_secret_key' => 'dummy',
-                    'test_secret_key' => 'dummy',
-                    'live_publishable_key' => 'dummy',
-                    'test_publishable_key' => 'dummy',
-                    'statement_descriptor' => get_bloginfo('name'),
-                ],
-                'account_2' => [
-                    'type' => 'manual',
-                    'account_name' => 'Account 2',
-                    'account_slug' => 'account_2',
-                    'account_email' => '',
-                    'account_country' => 'US',
-                    'account_id' => 'account_2',
-                    'live_secret_key' => 'dummy',
-                    'test_secret_key' => 'dummy',
-                    'live_publishable_key' => 'dummy',
-                    'test_publishable_key' => 'dummy',
-                    'statement_descriptor' => get_bloginfo('name'),
-                ],
-            ]
+            $accounts
+        );
+    }
+
+    /**
+     * @dataProvider unsupportedCountriesProvider
+     */
+    public function testCanNotAddFeeIfMerchantCountryIsUnsupported(string $accountSlug, string $countryCode)
+    {
+        $applicationFee = new ApplicationFee($this->repository->getAccountDetail($accountSlug));
+        $this->assertFalse(
+            $applicationFee->doesCountrySupportApplicationFee(),
+            "Country {$countryCode} should not support application fees"
         );
     }
 
     public function testCanAddFeeIfMerchantCountryIsUS()
     {
         give()->singleton(ApplicationFee::class, function () {
-            return new ApplicationFee($this->repository->getAccountDetail('account_2'));
+            return new ApplicationFee($this->repository->getAccountDetail('account_us'));
         });
 
         $this->assertTrue(
-            ApplicationFee::canAddFee()
-        );
-    }
-
-    public function testCanNotAddFeeIfMerchantCountryIsBR()
-    {
-        give()->singleton(ApplicationFee::class, function () {
-            return new ApplicationFee($this->repository->getAccountDetail('account_1'));
-        });
-
-        $this->assertFalse(
             ApplicationFee::canAddFee()
         );
     }
@@ -99,9 +95,21 @@ final class ApplicationFeeTest extends TestCase
 
     public function testIsCountrySupportApplicationFee()
     {
-        $applicationFee = new ApplicationFee($this->repository->getAccountDetail('account_2'));
+        $applicationFee = new ApplicationFee($this->repository->getAccountDetail('account_us'));
         $this->assertTrue(
             $applicationFee->doesCountrySupportApplicationFee()
         );
+    }
+
+    public function unsupportedCountriesProvider(): array
+    {
+        return [
+            'Brazil' => ['account_br', 'BR'],
+            'India' => ['account_in', 'IN'],
+            'Malaysia' => ['account_my', 'MY'],
+            'Mexico' => ['account_mx', 'MX'],
+            'Singapore' => ['account_sg', 'SG'],
+            'Thailand' => ['account_th', 'TH'],
+        ];
     }
 }


### PR DESCRIPTION
Resolves GIVE-2607

## Description

This PR expands the list of countries excluded from Stripe application fees to include India, Malaysia, Mexico, Singapore, and Thailand alongside the existing Brazil exclusion. These countries do not support Stripe application fees, and previously users in these regions had to use the Stripe add-on via API connection as a workaround.

By adding these countries to the exclusion list in the core plugin code, users can now use Stripe Connect directly without encountering application fee issues.

## Affects
Stripe Fee

## Visuals

N/A - This is a backend logic change with no visual interface modifications.

## Testing Instructions

1. **Unit Tests**: Run the updated `ApplicationFeeTest` to verify all unsupported countries are properly excluded:
   ```bash
   vendor/bin/phpunit tests/Unit/PaymentGateways/Stripe/ApplicationFeeTest.php
   ```

2. **Manual Testing**: 
   - Set up Stripe accounts with country codes: BR, IN, MY, MX, SG, TH
   - Verify that `ApplicationFee::canAddFee()` returns `false` for these countries
   - Verify that `ApplicationFee::canAddFee()` returns `true` for supported countries like US

3. **Integration Testing**:
   - Test donation flow with Stripe Connect for accounts in the newly added countries
   - Ensure no application fee is added

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [x] Includes unit tests
- [ ] Reviewed by the designer (if follows a design) - N/A
- [x] Self Review of code and UX completed