### PR TITLE
Fix: Add default values to GoalSettings for PHP 8.1+ compatibility

### DIFF
--- a/src/DonationForms/Properties/GoalSettings.php
+++ b/src/DonationForms/Properties/GoalSettings.php
@@ -5,6 +5,7 @@ namespace Give\DonationForms\Properties;
 use Give\DonationForms\ValueObjects\GoalType;
 
 /**
+ * @unreleased Add default values to goal settings
  * @since 4.3.0
  */
 class GoalSettings
@@ -17,10 +18,10 @@ class GoalSettings
     public static function fromArray(array $data): GoalSettings
     {
         $settings = new self();
-        $settings->goalSource = $data['goalSource'];
-        $settings->enableDonationGoal = $data['enableDonationGoal'];
-        $settings->goalType = new GoalType($data['goalType']);
-        $settings->goalAmount = $data['goalAmount'];
+        $settings->goalSource = $data['goalSource'] ?? '';
+        $settings->enableDonationGoal = $data['enableDonationGoal'] ?? false;
+        $settings->goalType = new GoalType($data['goalType'] ?? GoalType::AMOUNT);
+        $settings->goalAmount = $data['goalAmount'] ?? 0;
 
         return $settings;
     }


### PR DESCRIPTION
Resolves https://lw.slack.com/archives/C072VS4FT1A/p1750798143514369

## Description

This PR fixes fatal errors that occur in PHP 8.1+ when using the GoalSettings class. The issue occurs when any of the expected keys are missing or null in the data array passed to the fromArray() method, because the strict types declared in the class will trigger a fatal error if invalid values are passed in.

**Root Cause**: PHP 8.1+ enforces stricter type checking, and when properties with strict type declarations receive null or undefined values, it causes fatal errors.

**Solution**: Added default values using the null coalescing operator to ensure all properties receive appropriate fallback values:
- goalSource: defaults to empty string
- enableDonationGoal: defaults to false
- goalType: defaults to GoalType::AMOUNT
- goalAmount: defaults to 0

## Affects
Goal Settings

## Visuals

N/A - This is a backend compatibility fix with no visual interface changes.

## Testing Instructions

1. **PHP 8.1+ Environment**: Test on PHP 8.1 or higher
2. **Create GoalSettings with incomplete data** to verify no fatal errors occur
3. **Test donation form creation** with missing goal settings data
4. **Verify default values** are properly applied when data is missing
5. **Test with complete data** to ensure normal functionality still works

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant @unreleased tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design) - N/A
- [x] Self Review of code and UX completed