### PR TITLE
Refactor: add information about Stripe fees

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ If you are a GiveWP customer with an active license of any of our popular add-on
 
 GiveWP comes with several payment gateway options:
 
-* **Stripe Donations** -- Accept donations through any payment method (like Apple Pay, Google Pay, or ACH) activated in your Stripe accounts.
+* **Stripe Donations** -- Accept donations through any payment method (like Apple Pay, Google Pay, or ACH) activated in your Stripe accounts. Additional fees may apply for free users. Read our [Stripe documentation](https://docs.givewp.com/stripe-fees) for more information.
 * **PayPal Donations** -- Allow worldwide donations with PayPal Donations. No additional fees applied.
 * **Venmo Donations** -- Give donors the option to pay through Venmo with their account balance or connected bank account.
 * **Offline Donations** -- Enable your donors to send checks or physical donations with an offline gateway with instructions.

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -109,9 +109,9 @@
                             : $this->image('stripe@2x.min.png'),
                         'icon_alt' => esc_html__('Stripe', 'give'),
                         'title' => esc_html__('Connect to Stripe', 'give'),
-                        'description' => esc_html__(
-                            'Stripe is one of the most popular payment gateways, and for good reason! Receive one-time and Recurring Donations (add-on) using many of the most popular payment methods.',
-                            'give'
+                        'description' => sprintf(
+                            __('Stripe is one of the most popular payment gateways, and for good reason! Receive one-time and Recurring Donations (add-on) using many of the most popular payment methods. Additional fees may apply for free users. Read our <a href="%s" target="_blank" rel="noopener noreferrer">Stripe documentation</a> for more information.', 'give'), 
+                            'https://docs.givewp.com/stripe-fees'
                         ),
                         'action' => ($this->isStripeSetup()) ? sprintf(
                             '<a href="%s"><i class="fab fa-stripe-s"></i>&nbsp;&nbsp;Stripe Settings</a>',

--- a/src/Onboarding/Setup/templates/stories/src/stripe.js
+++ b/src/Onboarding/Setup/templates/stories/src/stripe.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import stripe from '../../../../../../../../assets/dist/images/setup-page/stripe@2x.min.png';
 import template from '../../row-item.html';
 
@@ -8,7 +9,10 @@ export default () => {
         .replace(/{{\s*title\s*}}/gi, 'Connect to Stripe')
         .replace(
             /{{\s*description\s*}}/gi,
-            'Stripe is one of the most popular payment gateways, and for good reason! Receive one-time and Recurring Donations (add-on) using many of the most popular payment methods.'
+            sprintf(
+                __('Stripe is one of the most popular payment gateways, and for good reason! Receive one-time and Recurring Donations (add-on) using many of the most popular payment methods. Additional fees may apply for free users. Read our <a href="%s" target="_blank" rel="noopener noreferrer">Stripe documentation</a> for more information.', 'give'), 
+                'https://docs.givewp.com/stripe-fees' 
+            )
         )
         .replace(/{{\s*action\s*}}/gi, '<button><i class="fab fa-stripe-s"></i>&nbsp;&nbsp;Connect to Stripe</button>');
 };

--- a/src/PaymentGateways/Stripe/Admin/AccountManagerSettingField.php
+++ b/src/PaymentGateways/Stripe/Admin/AccountManagerSettingField.php
@@ -155,9 +155,9 @@ class AccountManagerSettingField
 
             <p class="give-stripe-subheading-description">
                 <?php
-                esc_html_e(
-                    'Connect to the Stripe payment gateway using this section. Multiple Stripe accounts can be connected simultaneously. All donation forms will use the "Default Account" unless configured otherwise. To specify a different Stripe account for a form, configure the settings within the "Stripe Account" tab on the individual form edit screen.',
-                    'give'
+                printf(
+                    __('Connect to the Stripe payment gateway using this section. Multiple Stripe accounts can be connected simultaneously. All donation forms will use the "Default Account" unless configured otherwise. To specify a different Stripe account for a form, configure the settings within the "Stripe Account" tab on the individual form edit screen. An additional 2%% fee is applied to donations for free users (removed with any premium product license). Read our <a href="%s" target="_blank" rel="noopener noreferrer">Stripe documentation</a> for more information.', 'give'),
+                    'https://docs.givewp.com/stripe-fees'
                 );
                 ?>
             </p>


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2692]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds information about Stripe fees in the WP readme file and in all places where it is possible to connect a Stripe account.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Stripe Copies

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/ee0fd2da-1385-4944-a7ae-6946b25946e4" />

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/f60f27bc-f260-46ab-a255-5b0e9f698eca" />

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/45d075da-357a-4e6a-94a4-479d74eca76c" />

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

In the `readme.txt` file and in `GiveWP > Setup` page, make sure this copy is displayed:

> Additional fees may apply for free users. Read our [Stripe documentation](https://docs.givewp.com/stripe-fees) for more information.

In the `GiveWP > Settings > Payment Gateways > Stripe` page, make sure this copy is displayed:

> An additional 2% fee is applied to donations for free users (removed with any premium product license). Read our [Stripe documentation](https://docs.givewp.com/stripe-fees) for more information.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2692]: https://stellarwp.atlassian.net/browse/GIVE-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ