### PR TITLE
Feature: add filter for custom fields on donation details

### DIFF
--- a/src/Donations/ViewModels/DonationViewModel.php
+++ b/src/Donations/ViewModels/DonationViewModel.php
@@ -119,29 +119,29 @@ class DonationViewModel
      */
     private function getCustomFields(): array
     {
-        $form = $this->getDonationForm();
-
-        if (!$form) {
-            return [];
-        }
-
         $customFields = [];
-        $displayedFields = $this->getDisplayedDonationMetaFieldsForForm($form);
 
-        foreach ($displayedFields as $field) {
-            $value = $this->getFieldValue($field);
+        // get custom fields from v3 forms
+        $v3Form = $this->getDonationForm();
 
-            if (empty($value)) {
-                continue;
+        if ($v3Form) {
+            $displayedFields = $this->getDisplayedDonationMetaFieldsForForm($v3Form);
+
+            foreach ($displayedFields as $field) {
+                $value = $this->getFieldValue($field);
+
+                if (empty($value)) {
+                    continue;
+                }
+
+                $customFields[] = [
+                    'label' => method_exists($field, 'getLabel') ? $field->getLabel() : $field->getName(),
+                    'value' => $value,
+                ];
             }
-
-            $customFields[] = [
-                'label' => method_exists($field, 'getLabel') ? $field->getLabel() : $field->getName(),
-                'value' => $value,
-            ];
         }
 
-        return $customFields;
+        return apply_filters('givewp_donation_details_custom_fields', $customFields, $this->donation->id);
     }
 
     /**


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2616]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This adds a filter for the donation details custom fields.  Currently the filter is very simple, just an array of objects with label and value.  In the future we'll likely add field types but this is a good start.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Donation details

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1347" alt="Screenshot 2025-07-08 at 6 22 53 PM" src="https://github.com/user-attachments/assets/19d64a01-47c5-435e-9c83-50531a55822f" />

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Hook into the filter and add new custom fields

```php
add_filter('givewp_donation_details_custom_fields', function ($customFields, $donationId) {
    $customFields[] = [
        'label' => 'Custom Field',
        'value' => 'Custom Value',
    ];

    return $customFields;
}, 10, 2);
```

Can also be used with FFM via https://github.com/impress-org/give-form-field-manager/pull/427

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2616]: https://stellarwp.atlassian.net/browse/GIVE-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ