### PR TITLE
Fix: bulk actions selector on campaign forms list

### DIFF
--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/index.tsx
@@ -71,24 +71,24 @@ export default function CampaignsDetailsPage({campaignId}) {
           if (headerRef.current) {
             const height = headerRef.current.offsetHeight;
             setHeaderHeight(height);
-            
+
             // Update CSS variable directly
             document.documentElement.style.setProperty('--header-height', `${height}px`);
           }
         };
-        
+
         // Initial measurement
         updateHeaderHeight();
-        
+
         // Listen for resize events
         window.addEventListener('resize', updateHeaderHeight);
-        
+
         // Use ResizeObserver to detect content changes
         const resizeObserver = new ResizeObserver(updateHeaderHeight);
         if (headerRef.current) {
           resizeObserver.observe(headerRef.current);
         }
-        
+
         // Clean up
         return () => {
           window.removeEventListener('resize', updateHeaderHeight);
@@ -120,11 +120,11 @@ export default function CampaignsDetailsPage({campaignId}) {
 
     // Close context menu when clicked outside
     useEffect(() => {
-        document.addEventListener('click', (e) => {
-            if (show.contextMenu) {
-                return;
-            }
+        if (!show.contextMenu) {
+            return;
+        }
 
+        const handleClickOutside = (e: MouseEvent) => {
             if (
                 e.target instanceof HTMLElement &&
                 !e.target.closest(`.${styles.campaignButtonDots}`) &&
@@ -133,8 +133,14 @@ export default function CampaignsDetailsPage({campaignId}) {
                 setShow({contextMenu: false});
                 (document.querySelector(`.${styles.campaignButtonDots}`) as HTMLElement)?.blur();
             }
-        });
-    }, []);
+        };
+
+        document.addEventListener('click', handleClickOutside);
+
+        return () => {
+            document.removeEventListener('click', handleClickOutside);
+        };
+    }, [show.contextMenu]);
 
     // Set default values when campaign is loaded
     useEffect(() => {


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

**Problems with the original code:**

- No cleanup function - The event listener was never removed, causing memory leaks
- Logic error - The show.contextMenu check was using stale closure values
- Always active - The listener was always active on the document, interfering with other dropdowns
- Missing dependencies - The effect wasn't reactive to state changes

**The fix:**

- Conditional effect - Now only runs when show.contextMenu is true
- Proper cleanup - Returns a cleanup function that removes the event listener
- Correct dependencies - Added show.contextMenu to the dependency array
- Better event handling - Extracted the handler into a separate function
- Now the document click listener is only active when the context menu is actually open, preventing interference with other dropdown elements in your UI. The listener is automatically removed when the context menu closes or when the component unmounts.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The bulk actions selector on campaign forms list

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Make sure the bulk actions selector works & you can also still close the campaign hamburger menu by clicking outside

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

