### PR TITLE
Fix: This string is not formatted correctly for translation

### DIFF
--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
 
             $disconnected = sprintf(
                 __( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="%s">Click here</a> to enable it.</em>', 'give' ),
-                admin_url( '/tools.php?page=sendwp' )
+                esc_url( admin_url( '/tools.php?page=sendwp' ) )
             );
 
             // Checks if SendWP is connected

--- a/includes/admin/settings/class-settings-email.php
+++ b/includes/admin/settings/class-settings-email.php
@@ -57,7 +57,8 @@ if ( ! class_exists( 'Give_Settings_Email' ) ) :
             $connected .= '</a>.';
 
             $disconnected = sprintf(
-                __( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="' . admin_url( '/tools.php?page=sendwp' ) . '">Click here</a> to enable it.</em>', 'give' )
+                __( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="%s">Click here</a> to enable it.</em>', 'give' ),
+                admin_url( '/tools.php?page=sendwp' )
             );
 
             // Checks if SendWP is connected


### PR DESCRIPTION
Fix: This string is not formatted correctly for translation

Fix https://wordpress.org/support/topic/this-string-is-not-formatted-correctly-for-translation-8/