### PR TITLE
Fix: PayPal donations with zero decimal currencies (like Japanese Yen) with Fee Recovery enabled are not working

### DIFF
--- a/src/DonationForms/resources/app/hooks/useFormData.ts
+++ b/src/DonationForms/resources/app/hooks/useFormData.ts
@@ -87,6 +87,7 @@ const getSubscriptionTotal = (totals: DonationTotals, amount: number) => {
 const normalizeAmount = (amount: number) => Math.round(amount * 100) / 100;
 
 /**
+ * @unreleased Set minor units for donation and subscription amounts when currency is zero decimal
  * @since 4.0.0
  */
 export default function useFormData() {
@@ -117,11 +118,11 @@ export default function useFormData() {
     const subscriptionAmountTotal = getSubscriptionTotal(totals, Number(amount));
     const subscriptionAmountTotalInMinorUnits = amountToMinorUnit(subscriptionAmountTotal.toString(), currency);
 
-    const donationAmount = Number(amount);
-    const donationAmountMinor = amountToMinorUnit(amount, currency);
+    const donationAmount = zeroDecimalCurrencies.includes(currency) ? amountTotalInMinorUnits : amountTotal;
+    const subscriptionAmount = zeroDecimalCurrencies.includes(currency) ? subscriptionAmountTotalInMinorUnits : subscriptionAmountTotal;    
 
     const isOneTime = donationType === 'single';
-    const isRecurring = donationType === 'subscription';
+    const isRecurring = donationType === 'subscription';    
 
     return {
         firstName,
@@ -130,7 +131,7 @@ export default function useFormData() {
         phone,
         currency,
         billingAddress,
-        amount: isOneTime ? amountTotal : subscriptionAmountTotal,
+        amount: isOneTime ? donationAmount : subscriptionAmount,
         amountInMinorUnits: isOneTime ? amountTotalInMinorUnits : subscriptionAmountTotalInMinorUnits,
         isOneTime,
         isRecurring,


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2705]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR fixes a bug that prevented the PayPal modal from opening when donations were made with Fee Recovery in currencies that do not support decimals. A browser console error was being thrown, saying that decimals are not supported.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

PayPal Donations made with zero decimal currencies and Fee Recovery

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Set a V3 form with PayPal and Fee Recovery enabled
2. Go to `GiveWP > Settings > General > Currency` and choose the `Japanese Yen (¥)` option
3. Create some test donations and make sure they get finished with the proper amounts

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2705]: https://stellarwp.atlassian.net/browse/GIVE-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ