### PR TITLE
Fix: donation API endpoint permission checks for GiveWP roles

### DIFF
--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -609,10 +609,11 @@ class DonationController extends WP_REST_Controller
      */
     public function permissionsCheck(WP_REST_Request $request)
     {
-        $isAdmin = current_user_can('manage_options');
+        $canEditDonations = current_user_can('manage_options') ||
+            (current_user_can('edit_give_payments') && current_user_can('view_give_payments'));
 
         $includeSensitiveData = $request->get_param('includeSensitiveData');
-        if ( ! $isAdmin && $includeSensitiveData) {
+        if ( !$canEditDonations && $includeSensitiveData) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You do not have permission to include sensitive data.', 'give'),
@@ -622,7 +623,7 @@ class DonationController extends WP_REST_Controller
 
         if ($request->get_param('anonymousDonations') !== null) {
             $donationAnonymousMode = new DonationAnonymousMode($request->get_param('anonymousDonations'));
-            if ( ! $isAdmin && $donationAnonymousMode->isIncluded()) {
+            if ( !$canEditDonations && $donationAnonymousMode->isIncluded()) {
                 return new WP_Error(
                     'rest_forbidden',
                     esc_html__('You do not have permission to include anonymous donations.', 'give'),
@@ -639,7 +640,7 @@ class DonationController extends WP_REST_Controller
      */
     public function update_item_permissions_check($request)
     {
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('edit_give_payments') && !current_user_can('manage_options')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You do not have permission to update donations.', 'give'),
@@ -655,7 +656,7 @@ class DonationController extends WP_REST_Controller
      */
     public function delete_item_permissions_check($request)
     {
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('delete_give_payments') && !current_user_can('manage_options')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You do not have permission to delete donations.', 'give'),
@@ -671,7 +672,7 @@ class DonationController extends WP_REST_Controller
      */
     public function delete_items_permissions_check($request)
     {
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('delete_give_payments') && !current_user_can('manage_options')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You do not have permission to delete donations.', 'give'),
@@ -683,12 +684,11 @@ class DonationController extends WP_REST_Controller
     }
 
     /**
-     * TODO: check permissions for refunding donations
      * @unreleased
      */
     public function refund_item_permissions_check($request)
     {
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('edit_give_payments') && !current_user_can('manage_options')) {
             return new WP_Error(
                 'rest_forbidden',
                 esc_html__('You do not have permission to refund donations.', 'give'),

--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -727,14 +727,17 @@ class DonationController extends WP_REST_Controller
                 'firstName' => [
                     'type' => 'string',
                     'description' => esc_html__('Donor first name', 'give'),
+                    'format' => 'text-field',
                 ],
                 'lastName' => [
                     'type' => 'string',
                     'description' => esc_html__('Donor last name', 'give'),
+                    'format' => 'text-field',
                 ],
                 'honorific' => [
                     'type' => ['string', 'null'],
                     'description' => esc_html__('Donor honorific/prefix', 'give'),
+                    'enum' => give_get_option('title_prefixes', array_values(give_get_default_title_prefixes())),
                 ],
                 'email' => [
                     'type' => 'string',
@@ -744,10 +747,12 @@ class DonationController extends WP_REST_Controller
                 'phone' => [
                     'type' => ['string', 'null'],
                     'description' => esc_html__('Donor phone', 'give'),
+                    'format' => 'text-field',
                 ],
                 'company' => [
                     'type' => ['string', 'null'],
                     'description' => esc_html__('Donor company', 'give'),
+                    'format' => 'text-field',
                 ],
                 'amount' => [
                     'type' => ['object', 'null'],
@@ -756,10 +761,11 @@ class DonationController extends WP_REST_Controller
                             'type' => 'number',
                         ],
                         'amountInMinorUnits' => [
-                            'type' => 'number',
+                            'type' => 'integer',
                         ],
                         'currency' => [
                             'type' => 'string',
+                            'format' => 'text-field',
                         ],
                     ],
                     'description' => esc_html__('Donation amount', 'give'),
@@ -771,10 +777,11 @@ class DonationController extends WP_REST_Controller
                             'type' => 'number',
                         ],
                         'amountInMinorUnits' => [
-                            'type' => 'number',
+                            'type' => 'integer',
                         ],
                         'currency' => [
                             'type' => 'string',
+                            'format' => 'text-field',
                         ],
                     ],
                     'description' => esc_html__('Fee amount recovered', 'give'),
@@ -787,10 +794,11 @@ class DonationController extends WP_REST_Controller
                             'type' => 'number',
                         ],
                         'amountInMinorUnits' => [
-                            'type' => 'number',
+                            'type' => 'integer',
                         ],
                         'currency' => [
                             'type' => 'string',
+                            'format' => 'text-field',
                         ],
                     ],
                     'description' => esc_html__('Event tickets amount', 'give'),
@@ -803,6 +811,7 @@ class DonationController extends WP_REST_Controller
                 'gatewayId' => [
                     'type' => 'string',
                     'description' => esc_html__('Payment gateway ID', 'give'),
+                    'format' => 'text-field',
                 ],
                 'mode' => [
                     'type' => 'string',
@@ -817,29 +826,33 @@ class DonationController extends WP_REST_Controller
                     'type' => ['object', 'null'],
                     'description' => esc_html__('Billing address', 'give'),
                     'properties' => [
-                        'address1' => ['type' => 'string'],
-                        'address2' => ['type' => 'string'],
-                        'city' => ['type' => 'string'],
-                        'state' => ['type' => 'string'],
-                        'country' => ['type' => 'string'],
-                        'zip' => ['type' => 'string'],
+                        'address1' => ['type' => 'string', 'format' => 'text-field'],
+                        'address2' => ['type' => 'string', 'format' => 'text-field'],
+                        'city' => ['type' => 'string', 'format' => 'text-field'],
+                        'state' => ['type' => 'string', 'format' => 'text-field'],
+                        'country' => ['type' => 'string', 'format' => 'text-field'],
+                        'zip' => ['type' => 'string', 'format' => 'text-field'],
                     ],
                 ],
                 'donorIp' => [
                     'type' => ['string', 'null'],
                     'description' => esc_html__('Donor IP address (sensitive data)', 'give'),
+                    'format' => 'text-field',
                 ],
                 'purchaseKey' => [
                     'type' => ['string', 'null'],
                     'description' => esc_html__('Purchase key (sensitive data)', 'give'),
+                    'format' => 'text-field',
                 ],
                 'createdAt' => [
                     'type' => 'string',
                     'description' => esc_html__('Donation creation date', 'give'),
+                    'format' => 'date-time',
                 ],
                 'updatedAt' => [
                     'type' => 'string',
                     'description' => esc_html__('Donation last update date', 'give'),
+                    'format' => 'date-time',
                 ],
                 'customFields' => [
                     'type' => 'array',
@@ -851,10 +864,12 @@ class DonationController extends WP_REST_Controller
                             'label' => [
                                 'type' => 'string',
                                 'description' => esc_html__('Field label', 'give'),
+                                'format' => 'text-field',
                             ],
                             'value' => [
                                 'type' => 'string',
                                 'description' => esc_html__('Field value', 'give'),
+                                'format' => 'text-field',
                             ],
                         ],
                     ],


### PR DESCRIPTION
## Description

This PR fixes the permission checks for the donation API endpoints to properly align with GiveWP's custom user roles and capabilities. The existing implementation was using `manage_options` which only allowed WordPress administrators, but the donation management functionality should be accessible to GiveWP-specific roles.

The changes ensure that:
- Permission checks match the legacy admin interface behavior
- GiveWP Managers and Accountants can access donation data appropriately  
- Workers are properly restricted (matching existing admin page access)
- Sensitive data access is controlled based on proper capabilities

## Affects

- Donation API endpoints (`/donations` collection and individual donation routes)
- Permission checks for viewing, editing, deleting, and refunding donations
- Sensitive data access controls for different user roles
- Integration between new API and existing GiveWP role system

## Testing Instructions

1. Create test users with different GiveWP roles (Manager, Accountant, Worker)
2. Test API access for each role:
   - **Manager**: Should have full access to all endpoints and sensitive data
   - **Accountant**: Should have access to view/edit donations but limited sensitive data
   - **Worker**: Should be blocked from API access (matches admin interface)
   - **Administrator**: Should retain full access
3. Verify that `includeSensitiveData` parameter works correctly for each role
4. Test anonymous donation handling with different permission levels

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks  
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed