### PR TITLE
New: test donation tag indicator for admin donation details

### DIFF
--- a/src/Donations/resources/admin/components/DonationDetailsPage/DonationDetailsPage.module.scss
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/DonationDetailsPage.module.scss
@@ -1,5 +1,4 @@
 .statusBadge {
-    --statusBadgeIconColor: var(--givewp-grey-500);
     --statusBadgeBgColor: var(--givewp-grey-25);
     --statusBadgeTextColor: var(--givewp-grey-900);
 
@@ -16,30 +15,27 @@
     padding: var(--givewp-spacing-1) var(--givewp-spacing-3);
     text-align: center;
 
-    &.statusBadge--pending {
-        --statusBadgeIconColor: var(--givewp-orange-500);
-        --statusBadgeBgColor: var(--givewp-orange-25);
-        --statusBadgeTextColor: var(--givewp-orange-900);
-    }
-
+    &.statusBadge--pending,
     &.statusBadge--processing {
-        --statusBadgeIconColor: var(--givewp-blue-500);
-        --statusBadgeBgColor: var(--givewp-blue-25);
+        --statusBadgeBgColor: var(--givewp-blue-100);
         --statusBadgeTextColor: var(--givewp-blue-900);
     }
 
     &.statusBadge--publish {
-        --statusBadgeIconColor: var(--givewp-green-500);
-        --statusBadgeBgColor: var(--givewp-green-25);
+        --statusBadgeBgColor: var(--givewp-green-100);
         --statusBadgeTextColor: var(--givewp-green-900);
     }
 
     &.statusBadge--failed,
     &.statusBadge--cancelled,
     &.statusBadge--revoked {
-        --statusBadgeIconColor: var(--givewp-red-500);
-        --statusBadgeBgColor: var(--givewp-red-25);
+        --statusBadgeBgColor: var(--givewp-red-100);
         --statusBadgeTextColor: var(--givewp-red-900);
+    }
+
+    &.testBadge {
+        --statusBadgeBgColor: var(--givewp-orange-400);
+        --statusBadgeTextColor: var(--givewp-shades-white);
     }
 }
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/styles.module.scss
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/styles.module.scss
@@ -76,10 +76,7 @@
         width: 0.75rem;
     }
 
-    &--pending {
-        --statusOptionColor: var(--givewp-orange-500);
-    }
-
+    &--pending,
     &--processing {
         --statusOptionColor: var(--givewp-blue-500);
     }

--- a/src/Donations/resources/admin/components/DonationDetailsPage/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/index.tsx
@@ -29,7 +29,7 @@ const { donationStatuses } = getDonationOptionsWindowData();
 /**
  * @unreleased
  */
-const StatusBadge = ({ status }: { status: string }) => {
+const StatusBadge = ({ status, isTest }: { status: string, isTest: boolean }) => {
     const statusMap = donationStatuses;
 
     if (!statusMap[status]) {
@@ -37,9 +37,16 @@ const StatusBadge = ({ status }: { status: string }) => {
     }
 
     return (
-        <div className={`${styles.statusBadge} ${styles[`statusBadge--${status}`]}`}>
-            {statusMap[status]}
-        </div>
+        <>
+            <div className={`${styles.statusBadge} ${styles[`statusBadge--${status}`]}`}>
+                {statusMap[status]}
+            </div>
+            {isTest && (
+                <div className={`${styles.statusBadge} ${styles.testBadge}`}>
+                    {__('Test Donation', 'give')}
+                </div>
+            )}
+        </>
     );
 };
 
@@ -112,7 +119,7 @@ export default function DonationDetailsPage() {
             breadcrumbUrl={`${adminUrl}edit.php?post_type=give_forms&page=give-donations`}
             breadcrumbTitle={sprintf('#%s', donation?.id)}
             pageTitle={donation?.amount?.value != null ? formatter.format(donation?.amount?.value) : ''}
-            StatusBadge={() => <StatusBadge status={donation?.status} />}
+            StatusBadge={() => <StatusBadge status={donation?.status} isTest={donation?.mode === 'test'} />}
             ContextMenuItems={ContextMenuItems}
         >
             <ConfirmationDialog


### PR DESCRIPTION
## Description

This PR adds a visual "Test Donation" tag indicator to the donation details page that helps administrators quickly identify donations made in test mode versus live mode. The tag appears right after the donation status badge and is only shown for test donations, keeping the interface clean for live donations which are the expected default.

The implementation includes:
- Orange "Test Donation" tag that appears next to the status badge for test donations
- No visual indicator for live donations (as this is the expected normal state) 
- Improved status color consistency across the donation details interface
- Clean integration with existing donation status UI components

## Affects

- Donation details page admin interface
- Donation status badge styling and layout
- Test vs live donation visual identification
- Admin user experience when managing donations

## Visuals

The attached screenshot shows the new "Test Donation" tag appearing next to the "Completed" status, making it immediately clear this donation was made in test mode.

## Testing Instructions

1. Create both test and live donations in your GiveWP installation
2. Navigate to the donation details page for a test donation
3. Verify the orange "Test Donation" tag appears next to the status badge
4. Navigate to a live donation details page
5. Confirm no test donation tag is displayed (clean interface)
6. Test with different donation statuses to ensure the tag works consistently
7. Verify the status badge colors are consistent and properly styled

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant @unreleased tags included in DocBlocks
- [ ] Includes unit tests
- [x] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed
