### PR TITLE
Feature: only display v3-cube on forms list when option based forms a…

### DIFF
--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -123,7 +123,7 @@ const columnFilters: Array<ColumnFilterConfig> = [
                 <>
                     <div className={styles.titleContainer}>
                         <div className={styles.migratedForm}>
-                            {item?.v3form && <CubeTooltip />}
+                            {item?.v3form && window?.GiveDonationForms?.isOptionBasedFormEditorEnabled && <CubeTooltip />}
                             <Interweave attributes={{className: 'interweave'}} content={item?.title} />
                         </div>
                         {item?.isDefaultCampaignForm && (

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -108,6 +108,9 @@ if (isCampaignDetailsPage) {
     });
 }
 
+/**
+ * @unreleased add option based form editor enabled check.
+ */
 const columnFilters: Array<ColumnFilterConfig> = [
     {
         column: 'title',


### PR DESCRIPTION
Resolves [GIVE-2322]

## Description

This PR hides the Visual Builder icon for forms on sites where the v2 options-based form editor is not enabled. Since users who are only using Visual Builder (VFB) forms don’t need an icon to distinguish them, we check the `.isOptionBasedFormEditorEnabled` flag to conditionally display the icon only when relevant.

## Affects
Campaign Forms List 

## Visuals
https://github.com/user-attachments/assets/c406c8a8-df6c-4c2a-926d-1650a55d028f

## Testing Instructions
- Enabled the option based form editor from the Advanced tab in the Give settings.
- View a Campaigns form list (be sure to have at least one v3 form & one v2 form)
- While enabled you should see a small purple cube indicator - so you can easily tell which forms are v3.
- Disable the setting - the indicator should not show.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2322]: https://stellarwp.atlassian.net/browse/GIVE-2322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ