### PR TITLE
Feature: Add Subscription stat cards to Overview

### DIFF
--- a/src/Admin/components/Header/styles.module.scss
+++ b/src/Admin/components/Header/styles.module.scss
@@ -17,7 +17,7 @@
 
 .headerText {
     margin: 0;
-    color: #060c1a;
+    color: #1f2937;
     font-size: 16px;
     font-weight: 600;
     line-height: 24px;

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -15,7 +15,6 @@ export type StatWidgetProps = {
     value: string | React.ReactNode;
     description?: string;
     loading?: boolean;
-    previousValue?: number;
     inActive?: boolean;
     href?: string;
 };
@@ -30,7 +29,6 @@ export default function StatWidget({
     description,
     href,
     loading = false,
-    previousValue = null,
     inActive = false,
 }: StatWidgetProps) {
     return (

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 export type StatWidgetProps = {
     label: string;
-    value: number;
+    value: number | string | React.ReactNode;
     description?: string;
     formatter: Intl.NumberFormat;
     loading?: boolean;
@@ -43,7 +43,7 @@ export default function StatWidget({
             <div className={styles.statWidgetAmount}>
                 <div className={classnames(styles.statWidgetDisplay, {[styles.inActive]: inActive})}>
                     {!loading ? (
-                        formatter?.format(value) ?? value
+                        formatter?.format(parseFloat(value as string)) ?? value
                     ) : (
                         <span>
                             <Spinner size="small" />
@@ -51,7 +51,7 @@ export default function StatWidget({
                     )}
                 {inActive && (<a className={styles.upgradeLink} href={href} data-feerecovery-tooltip={__('Keep 100% of your fundraising revenue by providing donors with the option to cover the credit card processing fees', 'give')}>{__('Upgrade', 'give')}</a>)}
                 </div>
-                {previousValue !== null && <PercentChangePill value={value} comparison={previousValue} />}
+                {previousValue !== null && <PercentChangePill value={parseFloat(value as string)} comparison={previousValue} />}
             </div>
             {description && (
                 <footer>

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -12,9 +12,8 @@ import { __ } from '@wordpress/i18n';
  */
 export type StatWidgetProps = {
     label: string;
-    value: number | string | React.ReactNode;
+    value: string | React.ReactNode;
     description?: string;
-    formatter: Intl.NumberFormat;
     loading?: boolean;
     previousValue?: number;
     inActive?: boolean;
@@ -30,7 +29,6 @@ export default function StatWidget({
     value,
     description,
     href,
-    formatter = null,
     loading = false,
     previousValue = null,
     inActive = false,
@@ -43,7 +41,7 @@ export default function StatWidget({
             <div className={styles.statWidgetAmount}>
                 <div className={classnames(styles.statWidgetDisplay, {[styles.inActive]: inActive})}>
                     {!loading ? (
-                        formatter?.format(parseFloat(value as string)) ?? value
+                        value
                     ) : (
                         <span className={styles.spinnerContainer}>
                             <Spinner size="small" />

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -45,7 +45,7 @@ export default function StatWidget({
                     {!loading ? (
                         formatter?.format(parseFloat(value as string)) ?? value
                     ) : (
-                        <span>
+                        <span className={styles.spinnerContainer}>
                             <Spinner size="small" />
                         </span>
                     )}

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -41,7 +41,7 @@ export default function StatWidget({
                     {!loading ? (
                         value
                     ) : (
-                        <span className={styles.spinnerContainer}>
+                        <span>
                             <Spinner size="small" />
                         </span>
                     )}

--- a/src/Admin/components/StatWidget/index.tsx
+++ b/src/Admin/components/StatWidget/index.tsx
@@ -49,7 +49,6 @@ export default function StatWidget({
                     )}
                 {inActive && (<a className={styles.upgradeLink} href={href} data-feerecovery-tooltip={__('Keep 100% of your fundraising revenue by providing donors with the option to cover the credit card processing fees', 'give')}>{__('Upgrade', 'give')}</a>)}
                 </div>
-                {previousValue !== null && <PercentChangePill value={parseFloat(value as string)} comparison={previousValue} />}
             </div>
             {description && (
                 <footer>

--- a/src/Admin/components/StatWidget/styles.module.scss
+++ b/src/Admin/components/StatWidget/styles.module.scss
@@ -144,12 +144,6 @@
     border-radius: var(--givewp-rounded-8);
 }
 
-.spinnerContainer {
-    display: flex;
-    margin: 0 auto;
-}
-
-
 @media (max-width: 900px) {
     .statWidgetAmount {
         justify-content: center;

--- a/src/Admin/components/StatWidget/styles.module.scss
+++ b/src/Admin/components/StatWidget/styles.module.scss
@@ -144,6 +144,11 @@
     border-radius: var(--givewp-rounded-8);
 }
 
+.spinnerContainer {
+    display: flex;
+    margin: 0 auto;
+}
+
 
 @media (max-width: 900px) {
     .statWidgetAmount {

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationStats/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationStats/index.tsx
@@ -26,22 +26,19 @@ export default function DonationStats({ donation, isResolving }: DonationStatsPr
         <div className={styles.container}>
             <StatWidget
                 label={__('Donation amount', 'give')}
-                value={intendedAmount}
-                formatter={formatter}
+                value={formatter.format(intendedAmount)}
                 loading={isResolving}
             />
             {shouldShowEventTicketStat && (
                 <StatWidget
                     label={__('Event ticket', 'give')}
-                    value={Number(eventTicketsAmount)}
-                    formatter={formatter}
+                    value={formatter.format(Number(eventTicketsAmount))}
                     loading={isResolving}
                 />
             )}
             <StatWidget
                 label={__('Fees recovered', 'give')}
-                value={feeAmountRecovered}
-                formatter={formatter}
+                value={formatter.format(feeAmountRecovered)}
                 loading={isResolving}
                 href={'https://givewp.com/addons/fee-recovery/'}
                 inActive={!isFeeRecoveryEnabled}

--- a/src/Donations/resources/utils.ts
+++ b/src/Donations/resources/utils.ts
@@ -1,7 +1,6 @@
 import {useEntityRecord} from '@wordpress/core-data';
 import {Donation} from '@givewp/donations/admin/components/types';
 import type {GiveDonationOptions} from '@givewp/donations/types';
-import {EntityRecordResolution} from '@wordpress/core-data/build-types/hooks/use-entity-record';
 
 declare const window: {
     GiveDonationOptions: GiveDonationOptions;

--- a/src/Donations/resources/utils.ts
+++ b/src/Donations/resources/utils.ts
@@ -1,6 +1,7 @@
 import {useEntityRecord} from '@wordpress/core-data';
 import {Donation} from '@givewp/donations/admin/components/types';
 import type {GiveDonationOptions} from '@givewp/donations/types';
+import {EntityRecordResolution} from '@wordpress/core-data/build-types/hooks/use-entity-record';
 
 declare const window: {
     GiveDonationOptions: GiveDonationOptions;

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorStats/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorStats/index.tsx
@@ -23,20 +23,17 @@ export default function DonorStats({donorId}: DonorStatsProps) {
         <>
             <StatWidget
                 label={__('Lifetime donations', 'give')}
-                value={stats?.donations?.lifetimeAmount ?? 0}
-                formatter={amountFormatter(currency)}
+                value={amountFormatter(currency).format(stats?.donations?.lifetimeAmount ?? 0)}
                 loading={statsLoading || !statsResolved}
             />
             <StatWidget
                 label={__('Highest donation', 'give')}
-                value={stats?.donations?.highestAmount ?? 0}
-                formatter={amountFormatter(currency)}
+                value={amountFormatter(currency).format(stats?.donations?.highestAmount ?? 0)}
                 loading={statsLoading || !statsResolved}
             />
             <StatWidget
                 label={__('Average donation', 'give')}
-                value={stats?.donations?.averageAmount ?? 0}
-                formatter={amountFormatter(currency)}
+                value={amountFormatter(currency).format(stats?.donations?.averageAmount ?? 0)}
                 loading={statsLoading || !statsResolved}
             />
         </>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -20,7 +20,7 @@ type SubscriptionStatsProps = {
 export default function SubscriptionStats({donations, currency, totalInstallments, loading}: SubscriptionStatsProps) {
     const ongoingInstallments = totalInstallments === 0;
     const paymentsCompleted = donations?.length;
-    const totalContributions = donations?.reduce((acc, donation) => acc + donation.amount.value, 0);
+    const totalContributions = donations?.reduce((acc, donation) => acc + Number(donation.amount.value), 0);
 
     const paymentProgress = (
         <div className={styles.paymentProgress}>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -24,7 +24,7 @@ export default function SubscriptionStats({donations, currency, totalInstallment
 
     const paymentProgress = (
         <div className={styles.paymentProgress}>
-          {paymentsCompleted} / <span>{ongoingInstallments ? '∞' : totalInstallments}</span>
+          {paymentsCompleted} / <span>{ongoingInstallments ? '\u221E'	 : totalInstallments}</span>
         </div>
       );
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -1,15 +1,15 @@
 import StatWidget from '@givewp/admin/components/StatWidget';
 import {__} from '@wordpress/i18n';
 import {amountFormatter} from '@givewp/admin/utils';
-import {getSubscriptionOptionsWindowData} from '@givewp/subscriptions/utils';
+import { Donation } from '@givewp/donations/admin/components/types';
 import styles from './styles.module.scss';
 
 /**
  * @unreleased
  */
 type SubscriptionStatsProps = {
-    totalContributions: number;
-    paymentsCompleted: number;
+    donations: Donation[];
+    currency: string;
     totalInstallments: number;
     loading: boolean;
 }
@@ -17,10 +17,10 @@ type SubscriptionStatsProps = {
 /**
  * @unreleased
  */
-export default function SubscriptionStats({totalContributions, paymentsCompleted, totalInstallments, loading}: SubscriptionStatsProps) {
-    const {currency} = getSubscriptionOptionsWindowData();
-
+export default function SubscriptionStats({donations, currency, totalInstallments, loading}: SubscriptionStatsProps) {
     const ongoingInstallments = totalInstallments === 0;
+    const paymentsCompleted = donations?.length;
+    const totalContributions = donations?.reduce((acc, donation) => acc + donation.amount.value, 0);
 
     const paymentProgress = (
         <div className={styles.paymentProgress}>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -24,7 +24,7 @@ export default function SubscriptionStats({totalContributions, paymentsCompleted
 
     const paymentProgress = (
         <div className={styles.paymentProgress}>
-          {paymentsCompleted} / <span className={styles.installments}>{ongoingInstallments ? '∞' : totalInstallments}</span>
+          {paymentsCompleted} / <span>{ongoingInstallments ? '∞' : totalInstallments}</span>
         </div>
       );
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -31,7 +31,7 @@ export default function SubscriptionStats({totalContributions, paymentsCompleted
     return (
         <div className={styles.container}>
             <StatWidget
-                label={__('Total contributions so far', 'give')}
+                label={__('Total contribution so far', 'give')}
                 value={totalContributions}
                 formatter={amountFormatter(currency)}
                 loading={loading}

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -1,0 +1,47 @@
+import StatWidget from '@givewp/admin/components/StatWidget';
+import {__} from '@wordpress/i18n';
+import {amountFormatter} from '@givewp/admin/utils';
+import {getSubscriptionOptionsWindowData} from '@givewp/subscriptions/utils';
+import styles from './styles.module.scss';
+
+/**
+ * @unreleased
+ */
+type SubscriptionStatsProps = {
+    totalContributions: number;
+    paymentsCompleted: number;
+    totalInstallments: number;
+    loading: boolean;
+}
+
+/**
+ * @unreleased
+ */
+export default function SubscriptionStats({totalContributions, paymentsCompleted, totalInstallments, loading}: SubscriptionStatsProps) {
+    const {currency} = getSubscriptionOptionsWindowData();
+
+    const ongoingInstallments = totalInstallments === 0;
+
+    const paymentProgress = (
+        <div className={styles.paymentProgress}>
+          {paymentsCompleted} / <span className={styles.installments}>{ongoingInstallments ? '∞' : totalInstallments}</span>
+        </div>
+      );
+
+    return (
+        <div className={styles.container}>
+            <StatWidget
+                label={__('Total contributions so far', 'give')}
+                value={totalContributions}
+                formatter={amountFormatter(currency)}
+                loading={loading}
+            />
+            <StatWidget
+                label={__('Payments completed', 'give')}
+                value={paymentProgress}
+                formatter={null}
+                loading={loading}
+            />
+        </div>
+    );
+}

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/index.tsx
@@ -32,14 +32,12 @@ export default function SubscriptionStats({donations, currency, totalInstallment
         <div className={styles.container}>
             <StatWidget
                 label={__('Total contribution so far', 'give')}
-                value={totalContributions}
-                formatter={amountFormatter(currency)}
+                value={amountFormatter(currency).format(totalContributions)}
                 loading={loading}
             />
             <StatWidget
                 label={__('Payments completed', 'give')}
                 value={paymentProgress}
-                formatter={null}
                 loading={loading}
             />
         </div>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/styles.module.scss
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/styles.module.scss
@@ -1,0 +1,15 @@
+.container {
+    display: flex;
+    gap: var(--givewp-spacing-4);
+    grid-column: span 3;
+}
+
+.paymentProgress {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.installments {
+    color: var(--givewp-neutral-500);
+}

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/styles.module.scss
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionStats/styles.module.scss
@@ -9,7 +9,3 @@
     align-items: center;
     gap: 0.25rem;
 }
-
-.installments {
-    color: var(--givewp-neutral-500);
-}

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -9,12 +9,12 @@ import styles from "./styles.module.scss";
  */
 export default function SubscriptionDetailsPageOverviewTab() {
     const {mode, adminUrl} = getSubscriptionOptionsWindowData();
-    const {record: subscription, hasResolved, isResolving } = useSubscriptionEntityRecord();
+    const {record: subscription, hasResolved } = useSubscriptionEntityRecord();
     const {records: donations, hasResolved: donationsResolved, isResolving: donationsLoading} = useDonationsBySubscription(subscription?.id, mode);
     
     return (
         <div className={styles.overview}>
-            <SubscriptionStats donations={donations} currency={subscription?.amount?.currency} totalInstallments={subscription?.installments} loading={isResolving || !hasResolved || donationsLoading || !donationsResolved} />
+            <SubscriptionStats donations={donations} currency={subscription?.amount?.currency} totalInstallments={subscription?.installments} loading={!hasResolved || donationsLoading || !donationsResolved} />
             <div className={styles.left}>
 
             </div>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -1,4 +1,6 @@
-import { useSubscriptionEntityRecord } from "@givewp/subscriptions/utils";
+import { getSubscriptionOptionsWindowData, useSubscriptionEntityRecord } from "@givewp/subscriptions/utils";
+import { useDonationsBySubscription } from "@givewp/subscriptions/hooks";
+
 import SubscriptionStats from "./SubscriptionStats";
 import styles from "./styles.module.scss";
 
@@ -6,11 +8,13 @@ import styles from "./styles.module.scss";
  * @unreleased
  */
 export default function SubscriptionDetailsPageOverviewTab() {
+    const {mode, adminUrl} = getSubscriptionOptionsWindowData();
     const {record: subscription, hasResolved, isResolving } = useSubscriptionEntityRecord();
-
+    const {records: donations, hasResolved: donationsResolved, isResolving: donationsLoading} = useDonationsBySubscription(subscription?.id, mode);
+    
     return (
         <div className={styles.overview}>
-            <SubscriptionStats totalContributions={350} paymentsCompleted={3} totalInstallments={subscription.installments} loading={isResolving || !hasResolved} />
+            <SubscriptionStats donations={donations} currency={subscription.amount.currency} totalInstallments={subscription.installments} loading={isResolving || !hasResolved || donationsLoading || !donationsResolved} />
 
             <div className={styles.left}>
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -14,8 +14,7 @@ export default function SubscriptionDetailsPageOverviewTab() {
     
     return (
         <div className={styles.overview}>
-            <SubscriptionStats donations={donations} currency={subscription.amount.currency} totalInstallments={subscription.installments} loading={isResolving || !hasResolved || donationsLoading || !donationsResolved} />
-
+            <SubscriptionStats donations={donations} currency={subscription?.amount?.currency} totalInstallments={subscription?.installments} loading={isResolving || !hasResolved || donationsLoading || !donationsResolved} />
             <div className={styles.left}>
 
             </div>

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -1,10 +1,24 @@
+import { useSubscriptionEntityRecord } from "@givewp/subscriptions/utils";
+import SubscriptionStats from "./SubscriptionStats";
+import styles from "./styles.module.scss";
+
 /**
  * @unreleased
  */
 export default function SubscriptionDetailsPageOverviewTab() {
+    const {record: subscription, hasResolved, isResolving } = useSubscriptionEntityRecord();
+
     return (
-        <div>
-            <h2>Overview</h2>
+        <div className={styles.overview}>
+            <SubscriptionStats totalContributions={350} paymentsCompleted={3} totalInstallments={subscription.installments} loading={isResolving || !hasResolved} />
+
+            <div className={styles.left}>
+
+            </div>
+
+            <div className={styles.right}>
+
+            </div>
         </div>
     );
 }

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -1,6 +1,5 @@
 import { getSubscriptionOptionsWindowData, useSubscriptionEntityRecord } from "@givewp/subscriptions/utils";
 import { useDonationsBySubscription } from "@givewp/subscriptions/hooks";
-
 import SubscriptionStats from "./SubscriptionStats";
 import styles from "./styles.module.scss";
 

--- a/src/Subscriptions/resources/hooks/index.ts
+++ b/src/Subscriptions/resources/hooks/index.ts
@@ -1,1 +1,2 @@
 export {default as useSubscriptionAmounts} from './useSubscriptionAmounts';
+export {useDonationsBySubscription} from './useDonationsBySubscription';

--- a/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
+++ b/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
@@ -19,7 +19,6 @@ export function useDonationsBySubscription(
 
     return {
         records: entityResult.records as Donation[] | null,
-        record: entityResult.records?.[0] as Donation | null,
         hasResolved: entityResult.hasResolved,
         isResolving: entityResult.isResolving,
     };

--- a/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
+++ b/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
@@ -13,6 +13,9 @@ export function useDonationsBySubscription(
     const queryArgs = {
         subscriptionId,
         mode,
+        status: 'publish',
+        sort: 'createdAt',
+        direction: 'DESC'
     };
 
     const entityResult = useEntityRecords('givewp', 'donation', queryArgs);

--- a/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
+++ b/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
@@ -1,6 +1,4 @@
-import { useState, useEffect } from 'react';
 import { useEntityRecords } from '@wordpress/core-data';
-import apiFetch from '@wordpress/api-fetch';
 import { Donation } from '@givewp/donations/admin/components/types';
 
 /**
@@ -18,11 +16,19 @@ export function useDonationsBySubscription(
         direction: 'DESC'
     };
 
-    const entityResult = useEntityRecords('givewp', 'donation', queryArgs);
+    const {
+        records,
+        hasResolved,
+        isResolving,
+    }: {
+        records: Donation[] | null;
+        hasResolved: boolean;
+        isResolving: boolean;
+    } = useEntityRecords('givewp', 'donation', queryArgs);
 
     return {
-        records: entityResult.records as Donation[] | null,
-        hasResolved: entityResult.hasResolved,
-        isResolving: entityResult.isResolving,
+        records,
+        hasResolved,
+        isResolving,
     };
 }

--- a/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
+++ b/src/Subscriptions/resources/hooks/useDonationsBySubscription.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { useEntityRecords } from '@wordpress/core-data';
+import apiFetch from '@wordpress/api-fetch';
+import { Donation } from '@givewp/donations/admin/components/types';
+
+/**
+ * @unreleased
+ */
+export function useDonationsBySubscription(
+    subscriptionId: number,
+    mode: 'test' | 'live',
+) {
+    const queryArgs = {
+        subscriptionId,
+        mode,
+    };
+
+    const entityResult = useEntityRecords('givewp', 'donation', queryArgs);
+
+    return {
+        records: entityResult.records as Donation[] | null,
+        record: entityResult.records?.[0] as Donation | null,
+        hasResolved: entityResult.hasResolved,
+        isResolving: entityResult.isResolving,
+    };
+}


### PR DESCRIPTION
Resolves [GIVE-2699]

## Description
This PR introduces a SubscriptionStats component to the Subscription Details page Overview tab, displaying key metrics about a subscription's donations and payment progress. It also updates StatWidget to support additional value type.

Displays:
- Total contribution so far (sum of all donation amounts).
- Payments completed (completed installments out of total installments, or ∞ if ongoing).

Key Changes
- New Hook: useDonationsBySubscription. Retrieves donation records associated with a given subscription via useEntityRecords.

StatWidget Enhancements
- Supports value as number | string | React.ReactNode.
- Ensures numeric formatting by parsing values when applicable.

### Why
These changes improve the subscription management experience by giving administrators quick visibility into a subscriber’s payment history and total contributions, while keeping the UI consistent with existing dashboard components.
## Affects
Subscription page 

## Visuals

https://github.com/user-attachments/assets/1c44f088-98e7-47b4-8c7d-85041493fdb6

## Testing Instructions
- Create a form with subscriptions -> set a value/number of installments through the settings.
- Process a payment.
- View the subscription page to verify the amount for total contributions is accurate.
- Veriify the number of payments and installments is accurate.
- Set the number of installments to ongoing -> verify the lemniscate symbol is displayed.
- This updates the values passed to the StatWidget component - we will need to test the other screens to ensure no regressions occur.

## Pre-review Checklist 

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2699]: https://stellarwp.atlassian.net/browse/GIVE-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ