### PR TITLE
Feature: Add subscription notes endpoint for GIVE API

### DIFF
--- a/src/API/REST/V3/Routes/Subscriptions/SubscriptionNotesController.php
+++ b/src/API/REST/V3/Routes/Subscriptions/SubscriptionNotesController.php
@@ -104,7 +104,7 @@ class SubscriptionNotesController extends WP_REST_Controller
         $perPage = $request->get_param('per_page');
 
         $query = SubscriptionNote::query()
-            ->where('subscriptionId', $subscription->id)
+            ->where('comments.comment_post_ID', $subscription->id)
             ->limit($perPage)
             ->offset(($page - 1) * $perPage)
             ->orderBy('createdAt', 'DESC');
@@ -116,7 +116,7 @@ class SubscriptionNotesController extends WP_REST_Controller
             return $this->prepare_response_for_collection($item);
         }, $notes);
 
-        $totalNotes = SubscriptionNote::query()->where('subscriptionId', $subscription->id)->count();
+        $totalNotes = SubscriptionNote::query()->where('comments.comment_post_ID', $subscription->id)->count();
         $totalPages = (int)ceil($totalNotes / $perPage);
 
         $response = rest_ensure_response($notes);

--- a/src/API/REST/V3/Routes/Subscriptions/SubscriptionNotesController.php
+++ b/src/API/REST/V3/Routes/Subscriptions/SubscriptionNotesController.php
@@ -168,6 +168,12 @@ class SubscriptionNotesController extends WP_REST_Controller
             'type' => new SubscriptionNoteType($request->get_param('type')),
         ]);
 
+        $fieldsUpdate = $this->update_additional_fields_for_object($note, $request);
+
+        if (is_wp_error($fieldsUpdate)) {
+            return $fieldsUpdate;
+        }
+
         $response = $this->prepare_item_for_response($note, $request);
         $response->set_status(201);
 
@@ -233,6 +239,12 @@ class SubscriptionNotesController extends WP_REST_Controller
 
         if ($note->isDirty()) {
             $note->save();
+        }
+
+        $fieldsUpdate = $this->update_additional_fields_for_object($note, $request);
+
+        if (is_wp_error($fieldsUpdate)) {
+            return $fieldsUpdate;
         }
 
         $response = $this->prepare_item_for_response($note, $request);
@@ -336,6 +348,7 @@ class SubscriptionNotesController extends WP_REST_Controller
 
         $response = new WP_REST_Response($note->toArray());
         $response->add_links($links);
+        $response->data = $this->add_additional_fields_to_object($response->data, $request);
 
         return $response;
     }
@@ -366,9 +379,9 @@ class SubscriptionNotesController extends WP_REST_Controller
      */
     public function get_item_schema(): array
     {
-        return [
+        $schema = [
             'schema' => 'http://json-schema.org/draft-07/schema#',
-            'title' => 'subscription-note',
+            'title' => 'givewp/subscription-note',
             'type' => 'object',
             'properties' => [
                 'id' => [
@@ -401,6 +414,8 @@ class SubscriptionNotesController extends WP_REST_Controller
                 ],
             ],
         ];
+
+        return $this->add_additional_fields_schema($schema);
     }
 
     /**

--- a/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
+++ b/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Give\Subscriptions\DataTransferObjects;
+
+use DateTime;
+use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Subscriptions\Models\SubscriptionNote;
+use Give\Subscriptions\ValueObjects\SubscriptionNoteType;
+
+/**
+ * Class SubscriptionNoteQueryData
+ *
+ * @unreleased
+ */
+final class SubscriptionNoteQueryData
+{
+    /**
+     * @var int
+     */
+    public $id;
+    /**
+     * @var string
+     */
+    public $userId;
+    /**
+     * @var string
+     */
+    public $content;
+    /**
+     * @var int
+     */
+    public $subscriptionId;
+    /**
+     * @var SubscriptionNoteType
+     */
+    public $type;
+    /**
+     * @var DateTime
+     */
+    public $createdAt;
+
+    /**
+     * Convert data from Subscription Note Object to Subscription Note Model
+     *
+     * @unreleased
+     */
+    public static function fromObject($subscriptionNoteQueryObject): self
+    {
+        $self = new static();
+
+        $self->id = (int)$subscriptionNoteQueryObject->id;
+        $self->userId = (int)$subscriptionNoteQueryObject->userId ?? 0;
+        $self->content = $subscriptionNoteQueryObject->content;
+        $self->subscriptionId = (int)$subscriptionNoteQueryObject->subscriptionId;
+        $self->type = $subscriptionNoteQueryObject->type ? new SubscriptionNoteType($subscriptionNoteQueryObject->type) : SubscriptionNoteType::ADMIN();
+        $self->createdAt = Temporal::toDateTime($subscriptionNoteQueryObject->createdAt);
+
+        return $self;
+    }
+
+    /**
+     * Convert DTO to Subscription Note
+     */
+    public function toSubscriptionNote(): SubscriptionNote
+    {
+        $attributes = get_object_vars($this);
+
+        return new SubscriptionNote($attributes);
+    }
+}

--- a/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
+++ b/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
@@ -21,10 +21,6 @@ final class SubscriptionNoteQueryData
     /**
      * @var string
      */
-    public $userId;
-    /**
-     * @var string
-     */
     public $content;
     /**
      * @var int
@@ -49,7 +45,6 @@ final class SubscriptionNoteQueryData
         $self = new static();
 
         $self->id = (int)$subscriptionNoteQueryObject->id;
-        $self->userId = (int)$subscriptionNoteQueryObject->userId ?? 0;
         $self->content = $subscriptionNoteQueryObject->content;
         $self->subscriptionId = (int)$subscriptionNoteQueryObject->subscriptionId;
         $self->type = $subscriptionNoteQueryObject->type ? new SubscriptionNoteType($subscriptionNoteQueryObject->type) : SubscriptionNoteType::ADMIN();

--- a/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
+++ b/src/Subscriptions/DataTransferObjects/SubscriptionNoteQueryData.php
@@ -55,6 +55,8 @@ final class SubscriptionNoteQueryData
 
     /**
      * Convert DTO to Subscription Note
+     *
+     * @unreleased
      */
     public function toSubscriptionNote(): SubscriptionNote
     {

--- a/src/Subscriptions/Factories/SubscriptionNoteFactory.php
+++ b/src/Subscriptions/Factories/SubscriptionNoteFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Give\Subscriptions\Factories;
+
+use Give\Framework\Models\Factories\ModelFactory;
+
+class SubscriptionNoteFactory extends ModelFactory
+{
+    /**
+     * @unreleased
+     */
+    public function definition(): array
+    {
+        return [
+            'subscriptionId' => 1,
+            'content' => $this->faker->text,
+        ];
+    }
+}

--- a/src/Subscriptions/Factories/SubscriptionNoteFactory.php
+++ b/src/Subscriptions/Factories/SubscriptionNoteFactory.php
@@ -4,6 +4,9 @@ namespace Give\Subscriptions\Factories;
 
 use Give\Framework\Models\Factories\ModelFactory;
 
+/**
+ * @unreleased
+ */
 class SubscriptionNoteFactory extends ModelFactory
 {
     /**

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -73,6 +73,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     protected $relationships = [
         'donor' => Relationship::BELONGS_TO,
         'donations' => Relationship::HAS_MANY,
+        'notes' => Relationship::HAS_MANY,
     ];
 
     /**
@@ -110,15 +111,28 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     }
 
     /**
+     * @unreleased
+     *
+     * @return ModelQueryBuilder<SubscriptionNote>
+     */
+    public function notes(): ModelQueryBuilder
+    {
+        return give()->subscriptions->notes->queryBySubscriptionId($this->id);
+    }
+
+    /**
      * Get Subscription notes
      *
+     * @unreleased Deprecated in favor of ->notes()
      * @since 2.19.6
+     *
+     * @deprecated Access notes via $subscription->notes() instead.
      *
      * @return object[]
      */
     public function getNotes(): array
     {
-        return give()->subscriptions->getNotesBySubscriptionId($this->id);
+        return $this->notes()->get()->toArray();
     }
 
     /**

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -123,16 +123,16 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * Get Subscription notes
      *
-     * @unreleased Deprecated in favor of ->notes()
+     * @deprecated Access notes via $subscription->notes()->getAll() instead.
      * @since 2.19.6
-     *
-     * @deprecated Access notes via $subscription->notes() instead.
      *
      * @return object[]
      */
     public function getNotes(): array
     {
-        return $this->notes()->get()->toArray();
+        _give_deprecated_function(__METHOD__, '4.6.0', '$subscription->notes()->getAll()');
+
+        return give()->subscriptions->getNotesBySubscriptionId($this->id);
     }
 
     /**

--- a/src/Subscriptions/Models/SubscriptionNote.php
+++ b/src/Subscriptions/Models/SubscriptionNote.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Give\Subscriptions\Models;
+
+use DateTime;
+use Give\Subscriptions\Factories\SubscriptionNoteFactory;
+use Give\Subscriptions\ValueObjects\SubscriptionNoteType;
+use Give\Framework\Exceptions\Primitives\Exception;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Models\Contracts\ModelCrud;
+use Give\Framework\Models\Contracts\ModelHasFactory;
+use Give\Framework\Models\Model;
+use Give\Framework\Models\ModelQueryBuilder;
+use Give\Framework\Models\ValueObjects\Relationship;
+use Give\Subscriptions\DataTransferObjects\SubscriptionNoteQueryData;
+
+/**
+ * @unreleased
+ *
+ * @property int $id
+ * @property int $userId
+ * @property string $content
+ * @property int $subscriptionId
+ * @property SubscriptionNoteType $type
+ * @property DateTime $createdAt
+ * @property Subscription $subscription
+ */
+class SubscriptionNote extends Model implements ModelCrud, ModelHasFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $properties = [
+        'id' => 'int',
+        'userId' => 'int',
+        'content' => 'string',
+        'subscriptionId' => 'int',
+        'type' => SubscriptionNoteType::class,
+        'createdAt' => DateTime::class,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $relationships = [
+        'subscription' => Relationship::BELONGS_TO,
+    ];
+
+    /**
+     * @unreleased
+     *
+     * @return SubscriptionNote|null
+     */
+    public static function find($id)
+    {
+        return give()->subscriptions->notes->getById($id);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return $this
+     *
+     * @throws Exception|InvalidArgumentException
+     */
+    public static function create(array $attributes): SubscriptionNote
+    {
+        $subscriptionNote = new static($attributes);
+
+        give()->subscriptions->notes->insert($subscriptionNote);
+
+        return $subscriptionNote;
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception|InvalidArgumentException
+     */
+    public function save()
+    {
+        if (! $this->id) {
+            give()->subscriptions->notes->insert($this);
+        } else {
+            give()->subscriptions->notes->update($this);
+        }
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception|InvalidArgumentException
+     */
+    public function delete(): bool
+    {
+        return give()->subscriptions->notes->delete($this);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return ModelQueryBuilder<SubscriptionNote>
+     */
+    public static function query(): ModelQueryBuilder
+    {
+        return give()->subscriptions->notes->prepareQuery();
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return ModelQueryBuilder<Subscription>
+     */
+    public function subscription(): ModelQueryBuilder
+    {
+        return give()->subscriptions->queryById($this->subscriptionId);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @param  object  $object
+     */
+    public static function fromQueryBuilderObject($object): SubscriptionNote
+    {
+        return SubscriptionNoteQueryData::fromObject($object)->toSubscriptionNote();
+    }
+
+    /**
+     * @unreleased
+     */
+    public static function factory(): SubscriptionNoteFactory
+    {
+        return new SubscriptionNoteFactory(static::class);
+    }
+}

--- a/src/Subscriptions/Models/SubscriptionNote.php
+++ b/src/Subscriptions/Models/SubscriptionNote.php
@@ -18,7 +18,6 @@ use Give\Subscriptions\DataTransferObjects\SubscriptionNoteQueryData;
  * @unreleased
  *
  * @property int $id
- * @property int $userId
  * @property string $content
  * @property int $subscriptionId
  * @property SubscriptionNoteType $type
@@ -32,7 +31,6 @@ class SubscriptionNote extends Model implements ModelCrud, ModelHasFactory
      */
     protected $properties = [
         'id' => 'int',
-        'userId' => 'int',
         'content' => 'string',
         'subscriptionId' => 'int',
         'type' => SubscriptionNoteType::class,

--- a/src/Subscriptions/Repositories/SubscriptionNotesRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionNotesRepository.php
@@ -38,10 +38,8 @@ class SubscriptionNotesRepository
 
     /**
      * @unreleased
-     *
-     * @return SubscriptionNote|null
      */
-    public function getById(int $noteId)
+    public function getById(int $noteId): ?SubscriptionNote
     {
         return $this->prepareQuery()
             ->where('comments.comment_ID', $noteId)
@@ -53,7 +51,7 @@ class SubscriptionNotesRepository
      *
      * @throws Exception|InvalidArgumentException
      */
-    public function insert(SubscriptionNote $subscriptionNote)
+    public function insert(SubscriptionNote $subscriptionNote): void
     {
         if (! $subscriptionNote->type) {
             $subscriptionNote->type = SubscriptionNoteType::ADMIN();
@@ -110,7 +108,7 @@ class SubscriptionNotesRepository
      *
      * @throws Exception|InvalidArgumentException
      */
-    public function update(SubscriptionNote $subscriptionNote)
+    public function update(SubscriptionNote $subscriptionNote): void
     {
         $this->validateSubscriptionNote($subscriptionNote);
 
@@ -190,10 +188,8 @@ class SubscriptionNotesRepository
 
     /**
      * @unreleased
-     *
-     * @return void
      */
-    private function validateSubscriptionNote(SubscriptionNote $subscriptionNote)
+    private function validateSubscriptionNote(SubscriptionNote $subscriptionNote): void
     {
         foreach ($this->requiredSubscriptionProperties as $key) {
             if (! isset($subscriptionNote->$key)) {
@@ -234,7 +230,7 @@ class SubscriptionNotesRepository
     /**
      * @unreleased
      */
-    private function upsertSubscriptionNoteType(SubscriptionNote $subscriptionNote)
+    private function upsertSubscriptionNoteType(SubscriptionNote $subscriptionNote): void
     {
         $table = DB::table('commentmeta');
 

--- a/src/Subscriptions/Repositories/SubscriptionNotesRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionNotesRepository.php
@@ -44,7 +44,7 @@ class SubscriptionNotesRepository
     public function getById(int $noteId)
     {
         return $this->prepareQuery()
-            ->where('comment_ID', $noteId)
+            ->where('comments.comment_ID', $noteId)
             ->get();
     }
 
@@ -76,6 +76,7 @@ class SubscriptionNotesRepository
                     'comment_date_gmt' => get_gmt_from_date($dateCreatedFormatted),
                     'comment_post_ID' => $subscriptionNote->subscriptionId,
                     'comment_type' => self::COMMENT_TYPE,
+                    'user_id' => is_admin() ? get_current_user_id() : 0,
                 ]);
 
             $commentId = DB::last_insert_id();
@@ -124,6 +125,7 @@ class SubscriptionNotesRepository
                     'comment_content' => $subscriptionNote->content,
                     'comment_post_ID' => $subscriptionNote->subscriptionId,
                     'comment_type' => self::COMMENT_TYPE,
+                    'user_id' => is_admin() ? get_current_user_id() : 0,
                 ]);
 
             if ($subscriptionNote->isDirty('type') && $subscriptionNote->type->isDonor()) {
@@ -182,8 +184,8 @@ class SubscriptionNotesRepository
     public function queryBySubscriptionId(int $subscriptionId): ModelQueryBuilder
     {
         return $this->prepareQuery()
-            ->where('comment_post_ID', $subscriptionId)
-            ->orderBy('comment_ID', 'DESC');
+            ->where('comments.comment_post_ID', $subscriptionId)
+            ->orderBy('comments.comment_ID', 'DESC');
     }
 
     /**
@@ -213,20 +215,20 @@ class SubscriptionNotesRepository
     {
         $builder = new ModelQueryBuilder(SubscriptionNote::class);
 
-        return $builder->from('comments')
+        return $builder->from('comments', 'comments')
             ->select(
-                ['comment_ID', 'id'],
-                ['comment_post_ID', 'subscriptionId'],
-                ['comment_content', 'content'],
-                ['comment_date', 'createdAt']
+                ['comments.comment_ID', 'id'],
+                ['comments.comment_post_ID', 'subscriptionId'],
+                ['comments.comment_content', 'content'],
+                ['comments.comment_date', 'createdAt']
             )
             ->attachMeta(
                 'commentmeta',
-                'comment_ID',
+                'comments.comment_ID',
                 'comment_ID',
                 ...SubscriptionNoteMetaKeys::getColumnsForAttachMetaQuery()
             )
-            ->where('comment_type', self::COMMENT_TYPE);
+            ->where('comments.comment_type', self::COMMENT_TYPE);
     }
 
     /**

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -123,21 +123,24 @@ class SubscriptionRepository
     }
 
     /**
+     * @deprecated Use give()->subscriptions->notes()->queryBySubscriptionId()->getAll() instead.
      * @since 2.19.6
      *
      * @return object[]
      */
     public function getNotesBySubscriptionId(int $id): array
     {
-        $notes = DB::table('comments')
-            ->select(
-                ['comment_content', 'note'],
-                ['comment_date', 'date']
-            )
-            ->where('comment_post_ID', $id)
-            ->where('comment_type', 'give_sub_note')
-            ->orderBy('comment_date', 'DESC')
-            ->getAll();
+        _give_deprecated_function(__METHOD__, '4.6.0', 'give()->subscriptions->notes()->queryBySubscriptionId()->getAll()');
+
+        $notes = array_map(
+            static function ($note) {
+                return array_merge($note->toArray(), [
+                    'note' => $note->comment_content,
+                    'date' => $note->comment_date,
+                ]);
+            },
+            $this->notes->queryBySubscriptionId($id)->getAll()
+        );
 
         if (!$notes) {
             return [];

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -19,10 +19,16 @@ use Give\Subscriptions\ValueObjects\SubscriptionMode;
 use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 
 /**
+ * @unreleased Add notes repository
  * @since 2.19.6
  */
 class SubscriptionRepository
 {
+    /**
+     * @var SubscriptionNotesRepository
+     */
+    public $notes;
+
     /**
      * @var string[]
      */
@@ -34,6 +40,14 @@ class SubscriptionRepository
         'status',
         'donationFormId',
     ];
+
+    /**
+     * @unreleased
+     */
+    public function __construct()
+    {
+        $this->notes = give(SubscriptionNotesRepository::class);
+    }
 
     /**
      * @since 2.19.6

--- a/src/Subscriptions/ServiceProvider.php
+++ b/src/Subscriptions/ServiceProvider.php
@@ -20,6 +20,8 @@ class ServiceProvider implements ServiceProviderInterface
 {
     /**
      * @inheritDoc
+     *
+     * @unreleased Register Subscription Repository to container
      */
     public function register()
     {

--- a/src/Subscriptions/ServiceProvider.php
+++ b/src/Subscriptions/ServiceProvider.php
@@ -13,6 +13,7 @@ use Give\Subscriptions\ListTable\SubscriptionsListTable;
 use Give\Subscriptions\Migrations\AddPaymentModeToSubscriptionTable;
 use Give\Subscriptions\Migrations\BackfillMissingCampaignIdForDonations;
 use Give\Subscriptions\Migrations\CreateSubscriptionTables;
+use Give\Subscriptions\Repositories\SubscriptionNotesRepository;
 use Give\Subscriptions\Repositories\SubscriptionRepository;
 
 class ServiceProvider implements ServiceProviderInterface
@@ -23,6 +24,7 @@ class ServiceProvider implements ServiceProviderInterface
     public function register()
     {
         give()->singleton('subscriptions', SubscriptionRepository::class);
+        give()->singleton('subscriptionNotes', SubscriptionNotesRepository::class);
         give()->singleton(SubscriptionsListTable::class, function() {
             $listTable = new SubscriptionsListTable();
             Hooks::doAction('givewp_subscriptions_list_table', $listTable);

--- a/src/Subscriptions/ValueObjects/SubscriptionNoteMetaKeys.php
+++ b/src/Subscriptions/ValueObjects/SubscriptionNoteMetaKeys.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Give\Subscriptions\ValueObjects;
+
+use Give\Framework\Support\ValueObjects\Enum;
+use Give\Framework\Support\ValueObjects\EnumInteractsWithQueryBuilder;
+
+/**
+ * @unreleased
+ *
+ * @method static SubscriptionNoteMetaKeys TYPE()
+ * @method bool isType()
+ */
+class SubscriptionNoteMetaKeys extends Enum
+{
+    use EnumInteractsWithQueryBuilder;
+
+    const TYPE = 'note_type';
+}

--- a/src/Subscriptions/ValueObjects/SubscriptionNoteType.php
+++ b/src/Subscriptions/ValueObjects/SubscriptionNoteType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Subscriptions\ValueObjects;
+
+use Give\Framework\Support\ValueObjects\Enum;
+
+/**
+ * @unreleased
+ *
+ * @method static SubscriptionNoteType ADMIN()
+ * @method static SubscriptionNoteType DONOR()
+ * @method bool isAdmin()
+ * @method bool isDonor()
+ */
+class SubscriptionNoteType extends Enum
+{
+    const ADMIN = 'admin';
+    const DONOR = 'donor';
+}

--- a/tests/TestTraits/RefreshDatabase.php
+++ b/tests/TestTraits/RefreshDatabase.php
@@ -15,9 +15,10 @@ trait RefreshDatabase {
     public function refreshDatabase()
     {
 	    $giveTables = DB::get_col("SHOW TABLES LIKE '%give%'");
-        $wpTables = DB::get_col("SHOW TABLES LIKE '%post%'");
+        $wpCommentTables = DB::get_col("SHOW TABLES LIKE '%comment%'");
+        $wpPostTables = DB::get_col("SHOW TABLES LIKE '%post%'");
 
-        foreach (array_merge($giveTables, $wpTables) as $table) {
+        foreach (array_merge($giveTables, $wpCommentTables, $wpPostTables) as $table) {
             DB::query("TRUNCATE TABLE $table");
         }
     }

--- a/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionNoteRouteTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionNoteRouteTest.php
@@ -1,0 +1,486 @@
+<?php
+
+namespace Give\Tests\Unit\API\REST\V3\Routes\Subscriptions;
+
+use Exception;
+use Give\API\REST\V3\Routes\Subscriptions\SubscriptionNotesController;
+use Give\API\REST\V3\Routes\Subscriptions\ValueObjects\SubscriptionRoute;
+use Give\Subscriptions\Models\Subscription;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * @unreleased
+ *
+ * @coversDefaultClass SubscriptionNotesController
+ */
+class SubscriptionNoteRouteTest extends RestApiTestCase
+{
+    use RefreshDatabase;
+    use HasDefaultWordPressUsers;
+
+    /**
+     * @unreleased
+     *
+     * @var SubscriptionNotesController
+     */
+    private $controller;
+
+    /**
+     * @unreleased
+     *
+     * @var Subscription
+     */
+    private $subscription;
+
+    /**
+     * @unreleased
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new SubscriptionNotesController();
+        $this->subscription = Subscription::factory()->createWithDonation();
+
+        // Register the routes
+        $this->controller->register_routes();
+    }
+
+    /**
+     * @unreleased
+     */
+        public function testControllerInstantiation()
+    {
+        $controller = new SubscriptionNotesController();
+
+        $this->assertInstanceOf(SubscriptionNotesController::class, $controller);
+
+        // Test that the controller has correct namespace and rest_base using reflection
+        $reflection = new \ReflectionClass($controller);
+        $namespaceProperty = $reflection->getProperty('namespace');
+        $namespaceProperty->setAccessible(true);
+        $restBaseProperty = $reflection->getProperty('rest_base');
+        $restBaseProperty->setAccessible(true);
+
+        $this->assertEquals(SubscriptionRoute::NAMESPACE, $namespaceProperty->getValue($controller));
+        $this->assertEquals(SubscriptionRoute::BASE, $restBaseProperty->getValue($controller));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemsPermissionCheck()
+    {
+        $response = $this->handleGetItemsRequest($this->subscription->id, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemsWithNonexistentSubscription()
+    {
+        $response = $this->handleGetItemsRequest(99999);
+
+        $this->assertErrorResponse('subscription_not_found', $response, 404);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCreateItemPermissionCheck()
+    {
+        $noteData = [
+            'content' => 'Test note',
+            'type' => 'admin',
+        ];
+
+        $response = $this->handleCreateItemRequest($this->subscription->id, $noteData, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCreateItemWithNonexistentSubscription()
+    {
+        $noteData = [
+            'content' => 'Test note',
+            'type' => 'admin',
+        ];
+
+        $response = $this->handleCreateItemRequest(99999, $noteData);
+
+        $this->assertErrorResponse('subscription_not_found', $response, 404);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemPermissionCheck()
+    {
+        $response = $this->handleGetItemRequest($this->subscription->id, 1, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateItemPermissionCheck()
+    {
+        $updateData = [
+            'content' => 'Updated content',
+        ];
+
+        $response = $this->handleUpdateItemRequest($this->subscription->id, 1, $updateData, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteItemPermissionCheck()
+    {
+        $response = $this->handleDeleteItemRequest($this->subscription->id, 1, false);
+
+        $this->assertErrorResponse('rest_forbidden', $response, 401);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testControllerHasCorrectPermissionMethods()
+    {
+        $controller = new SubscriptionNotesController();
+
+        $this->assertTrue(method_exists($controller, 'get_items_permissions_check'));
+        $this->assertTrue(method_exists($controller, 'create_item_permissions_check'));
+        $this->assertTrue(method_exists($controller, 'get_item_permissions_check'));
+        $this->assertTrue(method_exists($controller, 'update_item_permissions_check'));
+        $this->assertTrue(method_exists($controller, 'delete_item_permissions_check'));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemsPermissionsCheckRequiresViewReportsCapability()
+    {
+        $request = new WP_REST_Request();
+
+        // User without capability should be denied
+        wp_set_current_user(0); // Anonymous user
+        $result = $this->controller->get_items_permissions_check($request);
+        $this->assertFalse($result);
+
+        // User with capability should be allowed
+        wp_set_current_user(self::$users['administrator']);
+        $result = $this->controller->get_items_permissions_check($request);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testCreateItemPermissionsCheckRequiresEditPaymentsCapability()
+    {
+        $request = new WP_REST_Request();
+
+        // User without capability should be denied
+        wp_set_current_user(0); // Anonymous user
+        $result = $this->controller->create_item_permissions_check($request);
+        $this->assertFalse($result);
+
+        // User with capability should be allowed
+        wp_set_current_user(self::$users['administrator']);
+        $result = $this->controller->create_item_permissions_check($request);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemPermissionsCheckRequiresViewReportsCapability()
+    {
+        $request = new WP_REST_Request();
+
+        // User without capability should be denied
+        wp_set_current_user(0); // Anonymous user
+        $result = $this->controller->get_item_permissions_check($request);
+        $this->assertFalse($result);
+
+        // User with capability should be allowed
+        wp_set_current_user(self::$users['administrator']);
+        $result = $this->controller->get_item_permissions_check($request);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testUpdateItemPermissionsCheckRequiresEditPaymentsCapability()
+    {
+        $request = new WP_REST_Request();
+
+        // User without capability should be denied
+        wp_set_current_user(0); // Anonymous user
+        $result = $this->controller->update_item_permissions_check($request);
+        $this->assertFalse($result);
+
+        // User with capability should be allowed
+        wp_set_current_user(self::$users['administrator']);
+        $result = $this->controller->update_item_permissions_check($request);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testDeleteItemPermissionsCheckRequiresEditPaymentsCapability()
+    {
+        $request = new WP_REST_Request();
+
+        // User without capability should be denied
+        wp_set_current_user(0); // Anonymous user
+        $result = $this->controller->delete_item_permissions_check($request);
+        $this->assertFalse($result);
+
+        // User with capability should be allowed
+        wp_set_current_user(self::$users['administrator']);
+        $result = $this->controller->delete_item_permissions_check($request);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetCollectionParams()
+    {
+        $controller = new SubscriptionNotesController();
+        $params = $controller->get_collection_params();
+
+        $this->assertIsArray($params);
+        $this->assertArrayHasKey('page', $params);
+        $this->assertArrayHasKey('per_page', $params);
+        $this->assertEquals(1, $params['page']['default']);
+        $this->assertEquals(30, $params['per_page']['default']);
+
+        // Verify removed parameters
+        $this->assertArrayNotHasKey('context', $params);
+        $this->assertArrayNotHasKey('search', $params);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetItemSchema()
+    {
+        $controller = new SubscriptionNotesController();
+        $schema = $controller->get_item_schema();
+
+        $this->assertIsArray($schema);
+        $this->assertArrayHasKey('schema', $schema);
+        $this->assertArrayHasKey('title', $schema);
+        $this->assertArrayHasKey('type', $schema);
+        $this->assertArrayHasKey('properties', $schema);
+
+        $properties = $schema['properties'];
+        $this->assertArrayHasKey('id', $properties);
+        $this->assertArrayHasKey('content', $properties);
+        $this->assertArrayHasKey('subscriptionId', $properties);
+        $this->assertArrayHasKey('type', $properties);
+        $this->assertArrayHasKey('createdAt', $properties);
+
+        // Verify property types
+        $this->assertEquals('integer', $properties['id']['type']);
+        $this->assertEquals('string', $properties['content']['type']);
+        $this->assertEquals('integer', $properties['subscriptionId']['type']);
+        $this->assertEquals('string', $properties['type']['type']);
+        $this->assertEquals('string', $properties['createdAt']['type']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetPublicItemSchema()
+    {
+        $controller = new SubscriptionNotesController();
+        $schema = $controller->get_public_item_schema();
+
+        $this->assertIsArray($schema);
+        $this->assertArrayHasKey('properties', $schema);
+        $this->assertArrayHasKey('_links', $schema['properties']);
+        $this->assertEquals('object', $schema['properties']['_links']['type']);
+        $this->assertTrue($schema['properties']['_links']['readonly']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetEndpointArgsForItemSchemaCreatable()
+    {
+        $controller = new SubscriptionNotesController();
+        $args = $controller->get_endpoint_args_for_item_schema(WP_REST_Server::CREATABLE);
+
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('subscriptionId', $args);
+        $this->assertArrayHasKey('content', $args);
+        $this->assertArrayHasKey('type', $args);
+        $this->assertArrayNotHasKey('id', $args);
+
+        // Verify required fields for creation
+        $this->assertTrue($args['content']['required']);
+        $this->assertTrue($args['type']['required']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetEndpointArgsForItemSchemaEditable()
+    {
+        $controller = new SubscriptionNotesController();
+        $args = $controller->get_endpoint_args_for_item_schema(WP_REST_Server::EDITABLE);
+
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('subscriptionId', $args);
+        $this->assertArrayHasKey('content', $args);
+        $this->assertArrayHasKey('type', $args);
+        $this->assertArrayHasKey('id', $args);
+
+        // Verify fields are not required for updates
+        $this->assertFalse($args['content']['required']);
+        $this->assertFalse($args['type']['required']);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testGetEndpointArgsForItemSchemaDeletable()
+    {
+        $controller = new SubscriptionNotesController();
+        $args = $controller->get_endpoint_args_for_item_schema(WP_REST_Server::DELETABLE);
+
+        $this->assertIsArray($args);
+        $this->assertArrayHasKey('subscriptionId', $args);
+        $this->assertArrayHasKey('id', $args);
+        $this->assertArrayNotHasKey('content', $args);
+        $this->assertArrayNotHasKey('type', $args);
+    }
+
+    /**
+     * Helper method to handle GET items requests
+     *
+     * @unreleased
+     */
+    private function handleGetItemsRequest(
+        int $subscriptionId,
+        bool $authenticatedAsAdmin = true,
+        array $queryParams = []
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'GET',
+            '/' . SubscriptionRoute::NAMESPACE . '/' . SubscriptionRoute::BASE . '/' . $subscriptionId . '/notes',
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        if (!empty($queryParams)) {
+            $request->set_query_params($queryParams);
+        }
+
+        return $this->dispatchRequest($request);
+    }
+
+    /**
+     * Helper method to handle POST requests
+     *
+     * @unreleased
+     */
+    private function handleCreateItemRequest(
+        int $subscriptionId,
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'POST',
+            '/' . SubscriptionRoute::NAMESPACE . '/' . SubscriptionRoute::BASE . '/' . $subscriptionId . '/notes',
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
+    }
+
+    /**
+     * Helper method to handle GET single item requests
+     *
+     * @unreleased
+     */
+    private function handleGetItemRequest(
+        int $subscriptionId,
+        int $noteId,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'GET',
+            '/' . SubscriptionRoute::NAMESPACE . '/' . SubscriptionRoute::BASE . '/' . $subscriptionId . '/notes/' . $noteId,
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        return $this->dispatchRequest($request);
+    }
+
+    /**
+     * Helper method to handle PUT/PATCH requests
+     *
+     * @unreleased
+     */
+    private function handleUpdateItemRequest(
+        int $subscriptionId,
+        int $noteId,
+        array $data,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'PUT',
+            '/' . SubscriptionRoute::NAMESPACE . '/' . SubscriptionRoute::BASE . '/' . $subscriptionId . '/notes/' . $noteId,
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        $request->set_body_params($data);
+
+        return $this->dispatchRequest($request);
+    }
+
+    /**
+     * Helper method to handle DELETE requests
+     *
+     * @unreleased
+     */
+    private function handleDeleteItemRequest(
+        int $subscriptionId,
+        int $noteId,
+        bool $authenticatedAsAdmin = true
+    ): WP_REST_Response {
+        $request = $this->createRequest(
+            'DELETE',
+            '/' . SubscriptionRoute::NAMESPACE . '/' . SubscriptionRoute::BASE . '/' . $subscriptionId . '/notes/' . $noteId,
+            [],
+            $authenticatedAsAdmin ? 'administrator' : 'anonymous'
+        );
+
+        return $this->dispatchRequest($request);
+    }
+}

--- a/tests/Unit/Subscriptions/LegacyCompatibilityTest.php
+++ b/tests/Unit/Subscriptions/LegacyCompatibilityTest.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace Give\Tests\Unit\Subscriptions;
+
+use Exception;
+use Give\Framework\Database\DB;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\Models\SubscriptionNote;
+use Give\Subscriptions\ValueObjects\SubscriptionNoteType;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * Temporary test class to verify compatibility between new SubscriptionNote
+ * model/repository and legacy CRUD functions from give-recurring-functions.php
+ *
+ * @unreleased
+ */
+class LegacyCompatibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+        /**
+     * @unreleased
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Try to load legacy functions
+        if (!function_exists('give_get_subscription_notes')) {
+            $functionsFile = GIVE_PLUGIN_DIR . '../give-recurring/includes/give-recurring-functions.php';
+            if (file_exists($functionsFile)) {
+                require_once $functionsFile;
+            }
+        }
+
+        // Skip entire class if required functions are not available
+        if (!function_exists('give_get_subscription_notes') ||
+            !function_exists('give_insert_subscription_note') ||
+            !function_exists('give_delete_subscription_note')) {
+            $this->markTestSkipped('Legacy recurring functions not available - give-recurring plugin may not be installed');
+        }
+    }
+
+    /**
+     * Test that notes created with legacy functions can be read by new model
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testLegacyToNewCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create note using legacy function
+        $legacyNoteId = give_insert_subscription_note($subscription->id, 'Legacy note content');
+
+        $this->assertNotFalse($legacyNoteId);
+        $this->assertIsNumeric($legacyNoteId);
+
+        // Read using new model
+        $newModelNote = SubscriptionNote::find($legacyNoteId);
+
+        $this->assertInstanceOf(SubscriptionNote::class, $newModelNote);
+        $this->assertEquals($subscription->id, $newModelNote->subscriptionId);
+        $this->assertEquals('Legacy note content', $newModelNote->content);
+        $this->assertEquals(SubscriptionNoteType::ADMIN, $newModelNote->type->getValue());
+    }
+
+    /**
+     * Test that notes created with new model can be read by legacy functions
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testNewToLegacyCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create note using new model
+        $newModelNote = SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => 'New model note content',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        $this->assertNotNull($newModelNote->id);
+
+        // Read using legacy function
+        $legacyNotes = give_get_subscription_notes($subscription->id);
+
+        $this->assertIsArray($legacyNotes);
+        $this->assertCount(1, $legacyNotes);
+
+        $legacyNote = $legacyNotes[0];
+        $this->assertEquals($newModelNote->id, $legacyNote->comment_ID);
+        $this->assertEquals($subscription->id, $legacyNote->comment_post_ID);
+        $this->assertEquals('New model note content', $legacyNote->comment_content);
+        $this->assertEquals('give_sub_note', $legacyNote->comment_type);
+    }
+
+    /**
+     * Test that both systems can coexist and work with each other's data
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testBidirectionalCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create notes using both methods
+        $legacyNoteId = give_insert_subscription_note($subscription->id, 'Legacy note 1');
+
+        $newModelNote = SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => 'New model note 1',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        $legacyNoteId2 = give_insert_subscription_note($subscription->id, 'Legacy note 2');
+
+        // Verify both systems can see all notes
+        $legacyNotes = give_get_subscription_notes($subscription->id);
+        $this->assertCount(3, $legacyNotes);
+
+        $newModelNotes = SubscriptionNote::query()
+            ->where('comments.comment_post_ID', $subscription->id)
+            ->getAll();
+        $this->assertCount(3, $newModelNotes);
+
+        // Verify content matches
+        $legacyContents = array_map(function($note) {
+            return $note->comment_content;
+        }, $legacyNotes);
+
+        $newModelContents = array_map(function($note) {
+            return $note->content;
+        }, $newModelNotes);
+
+        sort($legacyContents);
+        sort($newModelContents);
+
+        $this->assertEquals($legacyContents, $newModelContents);
+    }
+
+    /**
+     * Test that deletion works across both systems
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testDeletionCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create note with legacy function
+        $legacyNoteId = give_insert_subscription_note($subscription->id, 'Note to delete');
+
+        // Verify it exists in new model
+        $noteFromNewModel = SubscriptionNote::find($legacyNoteId);
+        $this->assertInstanceOf(SubscriptionNote::class, $noteFromNewModel);
+
+        // Delete using legacy function
+        $deleteResult = give_delete_subscription_note($legacyNoteId, $subscription->id);
+        $this->assertTrue($deleteResult);
+
+        // Verify it's gone from new model
+        $deletedNote = SubscriptionNote::find($legacyNoteId);
+        $this->assertNull($deletedNote);
+
+        // Test reverse: create with new model, delete with legacy
+        $newModelNote = SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Another note to delete',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        // Delete using legacy function
+        $deleteResult2 = give_delete_subscription_note($newModelNote->id, $subscription->id);
+        $this->assertTrue($deleteResult2);
+
+        // Verify it's gone
+        $deletedNote2 = SubscriptionNote::find($newModelNote->id);
+        $this->assertNull($deletedNote2);
+    }
+
+    /**
+     * Test that donor notes work correctly with both systems
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testDonorNoteTypeCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create donor note using new model
+        $donorNote = SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Donor note content',
+            'type' => SubscriptionNoteType::DONOR(),
+        ]);
+
+        // Verify the meta entry exists for donor type
+        $metaQuery = DB::table('commentmeta')
+            ->where('comment_ID', $donorNote->id)
+            ->where('meta_key', 'note_type')
+            ->get();
+
+        $this->assertNotNull($metaQuery);
+        $this->assertEquals(SubscriptionNoteType::DONOR, $metaQuery->meta_value);
+
+        // Verify legacy functions can read it
+        if (function_exists('give_get_subscription_notes')) {
+            $legacyNotes = give_get_subscription_notes($subscription->id);
+            $this->assertCount(1, $legacyNotes);
+
+            $legacyNote = $legacyNotes[0];
+            $this->assertEquals('Donor note content', $legacyNote->comment_content);
+        }
+    }
+
+    /**
+     * Test that admin notes (no meta) work correctly with both systems
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testAdminNoteTypeCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create admin note using legacy function (no meta should be created)
+        $legacyNoteId = give_insert_subscription_note($subscription->id, 'Admin note content');
+
+        // Verify no meta entry exists (admin is default)
+        $metaQuery = DB::table('commentmeta')
+            ->where('comment_ID', $legacyNoteId)
+            ->where('meta_key', 'note_type')
+            ->get();
+
+        $this->assertNull($metaQuery);
+
+        // Verify new model reads it as admin type
+        $noteFromNewModel = SubscriptionNote::find($legacyNoteId);
+        $this->assertEquals(SubscriptionNoteType::ADMIN, $noteFromNewModel->type->getValue());
+    }
+
+    /**
+     * Test that search functionality works across both systems
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testSearchCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create notes with searchable content
+        give_insert_subscription_note($subscription->id, 'This note contains keyword SEARCHABLE');
+        give_insert_subscription_note($subscription->id, 'This note does not contain the term');
+        give_insert_subscription_note($subscription->id, 'Another SEARCHABLE note here');
+
+        // Test legacy search functionality
+        $searchResults = give_get_subscription_notes($subscription->id, 'SEARCHABLE');
+        $this->assertCount(2, $searchResults);
+
+        foreach ($searchResults as $note) {
+            $this->assertStringContainsString('SEARCHABLE', $note->comment_content);
+        }
+    }
+
+    /**
+     * Test that date handling is consistent between both systems
+     *
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testDateHandlingCompatibility()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+
+        // Create note with legacy function
+        $legacyNoteId = give_insert_subscription_note($subscription->id, 'Date test note');
+
+        // Check that new model can read the date
+        $noteFromNewModel = SubscriptionNote::find($legacyNoteId);
+        $this->assertInstanceOf(\DateTime::class, $noteFromNewModel->createdAt);
+
+        // Verify the date is recent (within last minute)
+        $timeDiff = time() - $noteFromNewModel->createdAt->getTimestamp();
+        $this->assertLessThan(60, $timeDiff);
+        $this->assertGreaterThanOrEqual(0, $timeDiff);
+
+        // Create note with new model
+        $newModelNote = SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => 'New model date test',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        // Verify legacy functions can read the date
+        if (function_exists('give_get_subscription_notes')) {
+            $legacyNotes = give_get_subscription_notes($subscription->id);
+            $newModelNoteFromLegacy = null;
+
+            foreach ($legacyNotes as $note) {
+                if ($note->comment_ID == $newModelNote->id) {
+                    $newModelNoteFromLegacy = $note;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($newModelNoteFromLegacy);
+            $this->assertNotEmpty($newModelNoteFromLegacy->comment_date);
+
+            // Verify date formats are compatible
+            $legacyDate = strtotime($newModelNoteFromLegacy->comment_date);
+            $newModelDate = $newModelNote->createdAt->getTimestamp();
+
+            // Should be within a few seconds of each other
+            $this->assertLessThan(5, abs($legacyDate - $newModelDate));
+        }
+    }
+}

--- a/tests/Unit/Subscriptions/Models/TestSubscriptionNote.php
+++ b/tests/Unit/Subscriptions/Models/TestSubscriptionNote.php
@@ -27,7 +27,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_model_instantiation()
+    public function testModelInstantiation()
     {
         $subscriptionNote = new SubscriptionNote([
             'subscriptionId' => 123,
@@ -47,13 +47,12 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_properties_are_correctly_typed()
+    public function testPropertiesAreCorrectlyTyped()
     {
         $createdAt = Temporal::getCurrentDateTime();
 
         $subscriptionNote = new SubscriptionNote([
             'id' => 1,
-            'userId' => 1,
             'content' => 'Test content',
             'subscriptionId' => 123,
             'type' => SubscriptionNoteType::DONOR(),
@@ -61,7 +60,6 @@ class TestSubscriptionNote extends TestCase
         ]);
 
         $this->assertIsInt($subscriptionNote->id);
-        $this->assertIsInt($subscriptionNote->userId);
         $this->assertIsString($subscriptionNote->content);
         $this->assertIsInt($subscriptionNote->subscriptionId);
         $this->assertInstanceOf(SubscriptionNoteType::class, $subscriptionNote->type);
@@ -73,7 +71,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_query_should_return_model_query_builder()
+    public function testQueryShouldReturnModelQueryBuilder()
     {
         $queryBuilder = SubscriptionNote::query();
 
@@ -87,7 +85,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @throws Exception
      */
-    public function test_factory_should_create_subscription_note()
+    public function testFactoryShouldCreateSubscriptionNote()
     {
         $subscriptionNote = SubscriptionNote::factory()->make([
             'subscriptionId' => 123,
@@ -104,7 +102,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_factory_method_returns_correct_factory()
+    public function testFactoryMethodReturnsCorrectFactory()
     {
         $factory = SubscriptionNote::factory();
 
@@ -116,13 +114,12 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_from_query_builder_object_should_create_subscription_note_from_object()
+    public function testFromQueryBuilderObjectShouldCreateSubscriptionNoteFromObject()
     {
         $createdAt = Temporal::getCurrentDateTime();
 
         $object = (object) [
             'id' => 1,
-            'userId' => 1,
             'content' => 'Test content from object',
             'subscriptionId' => 123,
             'type' => SubscriptionNoteType::DONOR(),
@@ -133,7 +130,6 @@ class TestSubscriptionNote extends TestCase
 
         $this->assertInstanceOf(SubscriptionNote::class, $subscriptionNote);
         $this->assertEquals(1, $subscriptionNote->id);
-        $this->assertEquals(1, $subscriptionNote->userId);
         $this->assertEquals('Test content from object', $subscriptionNote->content);
         $this->assertEquals(123, $subscriptionNote->subscriptionId);
         $this->assertEquals(SubscriptionNoteType::DONOR(), $subscriptionNote->type->getValue());
@@ -145,7 +141,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_from_query_builder_object_should_default_to_admin_type_when_type_is_null()
+    public function testFromQueryBuilderObjectShouldDefaultToAdminTypeWhenTypeIsNull()
     {
         $object = (object) [
             'id' => 1,
@@ -166,7 +162,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_from_query_builder_object_should_default_to_admin_type_when_type_is_empty()
+    public function testFromQueryBuilderObjectShouldDefaultToAdminTypeWhenTypeIsEmpty()
     {
         $object = (object) [
             'id' => 1,
@@ -189,7 +185,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @throws Exception
      */
-    public function test_subscription_relationship_returns_query_builder()
+    public function testSubscriptionRelationshipReturnsQueryBuilder()
     {
         $subscription = Subscription::factory()->createWithDonation();
         $subscriptionNote = new SubscriptionNote([
@@ -208,7 +204,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_model_has_correct_property_definitions()
+    public function testModelHasCorrectPropertyDefinitions()
     {
         $subscriptionNote = new SubscriptionNote;
 
@@ -219,7 +215,6 @@ class TestSubscriptionNote extends TestCase
 
         $expectedProperties = [
             'id' => 'int',
-            'userId' => 'int',
             'content' => 'string',
             'subscriptionId' => 'int',
             'type' => SubscriptionNoteType::class,
@@ -234,7 +229,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_model_has_correct_relationship_definitions()
+    public function testModelHasCorrectRelationshipDefinitions()
     {
         $subscriptionNote = new SubscriptionNote;
 
@@ -252,7 +247,7 @@ class TestSubscriptionNote extends TestCase
      *
      * @return void
      */
-    public function test_type_enum_values()
+    public function testTypeEnumValues()
     {
         $adminType = SubscriptionNoteType::ADMIN();
         $donorType = SubscriptionNoteType::DONOR();

--- a/tests/Unit/Subscriptions/Models/TestSubscriptionNote.php
+++ b/tests/Unit/Subscriptions/Models/TestSubscriptionNote.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Give\Tests\Unit\Subscriptions\Models;
+
+use DateTime;
+use Exception;
+use Give\Framework\Models\ModelQueryBuilder;
+use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Subscriptions\Factories\SubscriptionNoteFactory;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\Models\SubscriptionNote;
+use Give\Subscriptions\ValueObjects\SubscriptionNoteType;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ *
+ * @coversDefaultClass \Give\Subscriptions\Models\SubscriptionNote
+ */
+class TestSubscriptionNote extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_model_instantiation()
+    {
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => 123,
+            'content' => 'Test content',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        $this->assertInstanceOf(SubscriptionNote::class, $subscriptionNote);
+        $this->assertEquals(123, $subscriptionNote->subscriptionId);
+        $this->assertEquals('Test content', $subscriptionNote->content);
+        $this->assertInstanceOf(SubscriptionNoteType::class, $subscriptionNote->type);
+        $this->assertEquals(SubscriptionNoteType::ADMIN, $subscriptionNote->type->getValue());
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_properties_are_correctly_typed()
+    {
+        $createdAt = Temporal::getCurrentDateTime();
+
+        $subscriptionNote = new SubscriptionNote([
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Test content',
+            'subscriptionId' => 123,
+            'type' => SubscriptionNoteType::DONOR(),
+            'createdAt' => $createdAt,
+        ]);
+
+        $this->assertIsInt($subscriptionNote->id);
+        $this->assertIsInt($subscriptionNote->userId);
+        $this->assertIsString($subscriptionNote->content);
+        $this->assertIsInt($subscriptionNote->subscriptionId);
+        $this->assertInstanceOf(SubscriptionNoteType::class, $subscriptionNote->type);
+        $this->assertInstanceOf(DateTime::class, $subscriptionNote->createdAt);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_query_should_return_model_query_builder()
+    {
+        $queryBuilder = SubscriptionNote::query();
+
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function test_factory_should_create_subscription_note()
+    {
+        $subscriptionNote = SubscriptionNote::factory()->make([
+            'subscriptionId' => 123,
+            'content' => 'Factory created note',
+        ]);
+
+        $this->assertInstanceOf(SubscriptionNote::class, $subscriptionNote);
+        $this->assertEquals(123, $subscriptionNote->subscriptionId);
+        $this->assertEquals('Factory created note', $subscriptionNote->content);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_factory_method_returns_correct_factory()
+    {
+        $factory = SubscriptionNote::factory();
+
+        $this->assertInstanceOf(SubscriptionNoteFactory::class, $factory);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_from_query_builder_object_should_create_subscription_note_from_object()
+    {
+        $createdAt = Temporal::getCurrentDateTime();
+
+        $object = (object) [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Test content from object',
+            'subscriptionId' => 123,
+            'type' => SubscriptionNoteType::DONOR(),
+            'createdAt' => Temporal::getFormattedDateTime($createdAt),
+        ];
+
+        $subscriptionNote = SubscriptionNote::fromQueryBuilderObject($object);
+
+        $this->assertInstanceOf(SubscriptionNote::class, $subscriptionNote);
+        $this->assertEquals(1, $subscriptionNote->id);
+        $this->assertEquals(1, $subscriptionNote->userId);
+        $this->assertEquals('Test content from object', $subscriptionNote->content);
+        $this->assertEquals(123, $subscriptionNote->subscriptionId);
+        $this->assertEquals(SubscriptionNoteType::DONOR(), $subscriptionNote->type->getValue());
+        $this->assertEquals($createdAt->format('Y-m-d H:i:s'), $subscriptionNote->createdAt->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_from_query_builder_object_should_default_to_admin_type_when_type_is_null()
+    {
+        $object = (object) [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Test content',
+            'subscriptionId' => 123,
+            'type' => null,
+            'createdAt' => Temporal::getFormattedDateTime(Temporal::getCurrentDateTime()),
+        ];
+
+        $subscriptionNote = SubscriptionNote::fromQueryBuilderObject($object);
+
+        $this->assertEquals(SubscriptionNoteType::ADMIN(), $subscriptionNote->type->getValue());
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_from_query_builder_object_should_default_to_admin_type_when_type_is_empty()
+    {
+        $object = (object) [
+            'id' => 1,
+            'userId' => 1,
+            'content' => 'Test content',
+            'subscriptionId' => 123,
+            'type' => '',
+            'createdAt' => Temporal::getFormattedDateTime(Temporal::getCurrentDateTime()),
+        ];
+
+        $subscriptionNote = SubscriptionNote::fromQueryBuilderObject($object);
+
+        $this->assertEquals(SubscriptionNoteType::ADMIN(), $subscriptionNote->type->getValue());
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function test_subscription_relationship_returns_query_builder()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test content',
+            'type' => SubscriptionNoteType::DONOR(),
+        ]);
+
+        $relationshipQuery = $subscriptionNote->subscription();
+
+        $this->assertInstanceOf(ModelQueryBuilder::class, $relationshipQuery);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_model_has_correct_property_definitions()
+    {
+        $subscriptionNote = new SubscriptionNote;
+
+        $reflection = new \ReflectionClass($subscriptionNote);
+        $propertiesProperty = $reflection->getProperty('properties');
+        $propertiesProperty->setAccessible(true);
+        $properties = $propertiesProperty->getValue($subscriptionNote);
+
+        $expectedProperties = [
+            'id' => 'int',
+            'userId' => 'int',
+            'content' => 'string',
+            'subscriptionId' => 'int',
+            'type' => SubscriptionNoteType::class,
+            'createdAt' => DateTime::class,
+        ];
+
+        $this->assertEquals($expectedProperties, $properties);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_model_has_correct_relationship_definitions()
+    {
+        $subscriptionNote = new SubscriptionNote;
+
+        $reflection = new \ReflectionClass($subscriptionNote);
+        $relationshipsProperty = $reflection->getProperty('relationships');
+        $relationshipsProperty->setAccessible(true);
+        $relationships = $relationshipsProperty->getValue($subscriptionNote);
+
+        $this->assertArrayHasKey('subscription', $relationships);
+        $this->assertEquals('belongs-to', $relationships['subscription']);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function test_type_enum_values()
+    {
+        $adminType = SubscriptionNoteType::ADMIN();
+        $donorType = SubscriptionNoteType::DONOR();
+
+        $this->assertEquals('admin', $adminType->getValue());
+        $this->assertEquals('donor', $donorType->getValue());
+        $this->assertTrue($adminType->isAdmin());
+        $this->assertTrue($donorType->isDonor());
+        $this->assertFalse($adminType->isDonor());
+        $this->assertFalse($donorType->isAdmin());
+    }
+}

--- a/tests/Unit/Subscriptions/Repositories/TestSubscriptionNoteRepository.php
+++ b/tests/Unit/Subscriptions/Repositories/TestSubscriptionNoteRepository.php
@@ -1,0 +1,450 @@
+<?php
+
+namespace Give\Tests\Unit\Subscriptions\Repositories;
+
+use Exception;
+use Give\Framework\Database\DB;
+use Give\Framework\Exceptions\Primitives\InvalidArgumentException;
+use Give\Framework\Models\ModelQueryBuilder;
+use Give\Framework\Support\Facades\DateTime\Temporal;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\Models\SubscriptionNote;
+use Give\Subscriptions\Repositories\SubscriptionNotesRepository;
+use Give\Subscriptions\ValueObjects\SubscriptionNoteType;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+
+/**
+ * @unreleased
+ *
+ * @coversDefaultClass SubscriptionNotesRepository
+ */
+class TestSubscriptionNoteRepository extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldAddSubscriptionNoteToDatabase()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test subscription note',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+
+        $repository->insert($subscriptionNote);
+
+        $this->assertNotNull($subscriptionNote->id);
+        $this->assertNotNull($subscriptionNote->createdAt);
+
+        // Verify it was inserted into the comments table
+        $commentQuery = DB::table('comments')
+            ->where('comment_ID', $subscriptionNote->id)
+            ->get();
+
+        $this->assertNotNull($commentQuery);
+        $this->assertEquals($subscriptionNote->content, $commentQuery->comment_content);
+        $this->assertEquals($subscription->id, $commentQuery->comment_post_ID);
+        $this->assertEquals('give_sub_note', $commentQuery->comment_type);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldDefaultToAdminTypeWhenTypeIsNull()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test note without type',
+        ]);
+
+        $repository->insert($subscriptionNote);
+
+        $this->assertEquals(SubscriptionNoteType::ADMIN, $subscriptionNote->type->getValue());
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldCreateMetaEntryForDonorType()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test donor note',
+            'type' => SubscriptionNoteType::DONOR(),
+        ]);
+
+        $repository->insert($subscriptionNote);
+
+        // Verify meta entry was created for donor type
+        $metaQuery = DB::table('commentmeta')
+            ->where('comment_ID', $subscriptionNote->id)
+            ->where('meta_key', 'note_type')
+            ->get();
+
+        $this->assertNotNull($metaQuery);
+        $this->assertEquals(SubscriptionNoteType::DONOR, $metaQuery->meta_value);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldFailValidationWhenSubscriptionIdIsMissing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'subscriptionId' is required.");
+
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'content' => 'Test note without subscription ID',
+        ]);
+
+        $repository->insert($subscriptionNote);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldFailValidationWhenContentIsMissing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'content' is required.");
+
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+        ]);
+
+        $repository->insert($subscriptionNote);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldFailValidationWhenSubscriptionDoesNotExist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid subscriptionId, Subscription does not exist');
+
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => 99999, // Non-existent subscription
+            'content' => 'Test note for invalid subscription',
+        ]);
+
+        $repository->insert($subscriptionNote);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testUpdateShouldModifySubscriptionNoteInDatabase()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        // Create a note first
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Original content',
+            'type' => SubscriptionNoteType::ADMIN(),
+        ]);
+        $repository->insert($subscriptionNote);
+
+        // Update the note
+        $subscriptionNote->content = 'Updated content';
+        $repository->update($subscriptionNote);
+
+        // Verify the update in the database
+        $commentQuery = DB::table('comments')
+            ->where('comment_ID', $subscriptionNote->id)
+            ->get();
+
+        $this->assertEquals('Updated content', $commentQuery->comment_content);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testUpdateShouldFailValidationWhenRequiredFieldsAreMissing()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'id' => 1,
+            'content' => 'Content without subscription ID',
+        ]);
+
+        $repository->update($subscriptionNote);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testDeleteShouldRemoveSubscriptionNoteFromDatabase()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        // Create a note first
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Note to be deleted',
+            'type' => SubscriptionNoteType::DONOR(),
+        ]);
+        $repository->insert($subscriptionNote);
+
+        $noteId = $subscriptionNote->id;
+
+        // Delete the note
+        $result = $repository->delete($subscriptionNote);
+
+        $this->assertTrue($result);
+
+        // Verify it was deleted from comments table
+        $commentQuery = DB::table('comments')
+            ->where('comment_ID', $noteId)
+            ->get();
+
+        $this->assertNull($commentQuery);
+
+        // Verify meta was also deleted
+        $metaQuery = DB::table('commentmeta')
+            ->where('comment_ID', $noteId)
+            ->get();
+
+        $this->assertNull($metaQuery);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testQueryByIdShouldReturnQueryBuilder()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $queryBuilder = $repository->queryBySubscriptionId($subscription->id);
+
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testQueryByIdShouldFilterBySubscription()
+    {
+        $subscription1 = Subscription::factory()->createWithDonation();
+        $subscription2 = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        // Create notes for both subscriptions
+        $note1 = new SubscriptionNote([
+            'subscriptionId' => $subscription1->id,
+            'content' => 'Note for subscription 1',
+        ]);
+        $note2 = new SubscriptionNote([
+            'subscriptionId' => $subscription2->id,
+            'content' => 'Note for subscription 2',
+        ]);
+
+        $repository->insert($note1);
+        $repository->insert($note2);
+
+        // Test that the query builder is properly filtered
+        $queryBuilder = $repository->queryBySubscriptionId($subscription1->id);
+
+        // Verify the query builder is configured correctly
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+
+        // Verify the query has the correct subscription filter by checking raw queries in comments table
+        $directQuery = DB::table('comments')
+            ->where('comment_post_ID', $subscription1->id)
+            ->where('comment_type', 'give_sub_note')
+            ->get();
+
+        $this->assertNotNull($directQuery);
+        $this->assertEquals($subscription1->id, $directQuery->comment_post_ID);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     */
+    public function testPrepareQueryShouldReturnModelQueryBuilder()
+    {
+        $repository = new SubscriptionNotesRepository();
+
+        $queryBuilder = $repository->prepareQuery();
+
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldSetCreatedAtWhenNotProvided()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test note for timestamp',
+        ]);
+
+        // Ensure createdAt is null before insert
+        $this->assertNull($subscriptionNote->createdAt);
+
+        $repository->insert($subscriptionNote);
+
+        // After insert, createdAt should be set
+        $this->assertNotNull($subscriptionNote->createdAt);
+        $this->assertInstanceOf(\DateTime::class, $subscriptionNote->createdAt);
+
+        // Verify it's a recent timestamp (within last minute)
+        $timeDiff = time() - $subscriptionNote->createdAt->getTimestamp();
+        $this->assertLessThan(60, $timeDiff);
+        $this->assertGreaterThanOrEqual(0, $timeDiff);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldPreserveProvidedCreatedAt()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        $customCreatedAt = Temporal::getCurrentDateTime()->modify('-1 day');
+
+        $subscriptionNote = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Test note with custom timestamp',
+            'createdAt' => $customCreatedAt,
+        ]);
+
+        $repository->insert($subscriptionNote);
+
+        $this->assertEquals(
+            $customCreatedAt->format('Y-m-d H:i:s'),
+            $subscriptionNote->createdAt->format('Y-m-d H:i:s')
+        );
+    }
+
+    /**
+     * @unreleased
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function testQueryByIdShouldOrderByDescending()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $repository = new SubscriptionNotesRepository();
+
+        // Create multiple notes
+        $note1 = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'First note',
+        ]);
+        $note2 = new SubscriptionNote([
+            'subscriptionId' => $subscription->id,
+            'content' => 'Second note',
+        ]);
+
+        $repository->insert($note1);
+        $repository->insert($note2);
+
+        // Test that the query builder has the correct ordering by checking the raw query structure
+        $queryBuilder = $repository->queryBySubscriptionId($subscription->id);
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+
+        // Verify that both notes exist and the newer note has a higher ID
+        $note1Query = DB::table('comments')
+            ->where('comment_ID', $note1->id)
+            ->get();
+        $note2Query = DB::table('comments')
+            ->where('comment_ID', $note2->id)
+            ->get();
+
+        $this->assertNotNull($note1Query);
+        $this->assertNotNull($note2Query);
+        $this->assertEquals($subscription->id, $note1Query->comment_post_ID);
+        $this->assertEquals($subscription->id, $note2Query->comment_post_ID);
+
+        // Newer note (note2) should have higher ID than older note (note1)
+        $this->assertGreaterThan($note1->id, $note2->id);
+    }
+}


### PR DESCRIPTION
Resolves GIVE-2679

## Description

This PR implements a new subscription notes endpoint for the Give API that provides comprehensive functionality for managing subscription-related notes. The implementation follows the existing model/repository pattern and extends the Give API V3 with new REST endpoints.

### 🆕 Key Features Added

- **`SubscriptionNote` model** with structured data handling and validation  
- **`SubscriptionNoteRepository`** for persistence and retrieval logic  
- **`SubscriptionNoteController`** exposing a complete set of RESTful endpoints under `/givewp/v3/subscriptions/{id}/notes`  
- **Supporting infrastructure** including DTOs, ValueObjects, and Factory classes  
- **Improved legacy compatibility** to ensure seamless integration with existing recurring features  

### 🗃️ Deprecated Methods

As part of this update, we are deprecating legacy note access methods that were introduced before the current repository-based structure:

- `Subscription::getNotes()`
- `SubscriptionRepository::getNotesBySubscriptionId()`

These methods remain available for backward compatibility but are now marked as deprecated in favor of using the `SubscriptionNoteRepository`.

### 🔗 API Endpoint Structure

- `GET /givewp/v3/subscriptions/{id}/notes` – List all notes for a subscription  
- `GET /givewp/v3/subscriptions/{id}/notes/{note_id}` – Retrieve a single note  
- `POST /givewp/v3/subscriptions/{id}/notes` – Create a new note  
- `PUT /givewp/v3/subscriptions/{id}/notes/{note_id}` – Update an existing note  
- `DELETE /givewp/v3/subscriptions/{id}/notes/{note_id}` – Delete a note  

## Affects

- Subscription Notes API  
- Legacy subscription note access via model and repository  

## Visuals

N/A

## Testing Instructions

1. **API Testing:**
   - Test the new subscription notes endpoints using a REST client
   - Verify CRUD operations work correctly for subscription notes
   - Confirm proper validation and error handling

2. **Legacy Compatibility:**
   - Run existing recurring donation tests to ensure no regressions
   - Verify that legacy Give recurring functions continue to work as expected

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks  
- [x] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed