### PR TITLE
Feature: Add support for custom REST fields

### DIFF
--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -47,7 +47,6 @@ class DonationController extends WP_REST_Controller
     }
 
     /**
-     * @unreleased Add support for additional fields
      * @since 4.6.0
      */
     public function register_routes()
@@ -83,14 +82,6 @@ class DonationController extends WP_REST_Controller
                             'include',
                             'redact',
                         ],
-                    ],
-                    'additionalFields' => [
-                        'description' => __(
-                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                            'give'
-                        ),
-                        'type' => 'string',
-                        'default' => '',
                     ],
                 ],
                 'schema' => [$this, 'get_public_item_schema'],
@@ -146,14 +137,6 @@ class DonationController extends WP_REST_Controller
                         'type' => 'boolean',
                         'default' => false,
                         'description' => 'Whether to permanently delete (force=true) or move to trash (force=false, default).',
-                    ],
-                    'additionalFields' => [
-                        'description' => __(
-                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                            'give'
-                        ),
-                        'type' => 'string',
-                        'default' => '',
                     ],
                 ],
                 'schema' => [$this, 'get_public_item_schema'],

--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -47,6 +47,7 @@ class DonationController extends WP_REST_Controller
     }
 
     /**
+     * @unreleased Add support for additional fields
      * @since 4.6.0
      */
     public function register_routes()
@@ -82,6 +83,14 @@ class DonationController extends WP_REST_Controller
                             'include',
                             'redact',
                         ],
+                    ],
+                    'additionalFields' => [
+                        'description' => __(
+                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                            'give'
+                        ),
+                        'type' => 'string',
+                        'default' => '',
                     ],
                 ],
                 'schema' => [$this, 'get_public_item_schema'],
@@ -137,6 +146,14 @@ class DonationController extends WP_REST_Controller
                         'type' => 'boolean',
                         'default' => false,
                         'description' => 'Whether to permanently delete (force=true) or move to trash (force=false, default).',
+                    ],
+                    'additionalFields' => [
+                        'description' => __(
+                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                            'give'
+                        ),
+                        'type' => 'string',
+                        'default' => '',
                     ],
                 ],
                 'schema' => [$this, 'get_public_item_schema'],

--- a/src/API/REST/V3/Routes/Donations/DonationNotesController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationNotesController.php
@@ -42,7 +42,15 @@ class DonationNotesController extends WP_REST_Controller
                         'description' => __('The ID of the donation this note belongs to.', 'give'),
                         'type' => 'integer',
                         'required' => true,
-                    ]
+                    ],
+                    'additionalFields' => [
+                        'description' => __(
+                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                            'give'
+                        ),
+                        'type' => 'string',
+                        'default' => '',
+                    ],
                 ], $this->get_collection_params()) ,
                 'schema' => [$this, 'get_public_item_schema'],
             ],
@@ -438,6 +446,7 @@ class DonationNotesController extends WP_REST_Controller
     }
 
     /**
+     * @unreleased Add support for additional fields
      * @since 4.4.0
      */
     public function get_endpoint_args_for_item_schema($method = WP_REST_Server::CREATABLE): array
@@ -448,6 +457,14 @@ class DonationNotesController extends WP_REST_Controller
         // Common argument for all endpoints
         $args['donationId'] = $schema['properties']['donationId'];
         $args['donationId']['in'] = 'path';
+        $args['additionalFields'] = [
+            'description' => __(
+                'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                'give'
+            ),
+            'type' => 'string',
+            'default' => '',
+        ];
 
         // Arguments for single item endpoints (not for POST)
         if (in_array($method, [WP_REST_Server::READABLE, WP_REST_Server::EDITABLE, WP_REST_Server::DELETABLE], true)) {
@@ -479,6 +496,7 @@ class DonationNotesController extends WP_REST_Controller
                 'enum' => ['admin', 'donation'],
                 'default' => 'admin',
             ];
+            unset($args['additionalFields']);
         } else {
             unset($args['content']);
             unset($args['type']);

--- a/src/API/REST/V3/Routes/Donations/DonationNotesController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationNotesController.php
@@ -42,15 +42,7 @@ class DonationNotesController extends WP_REST_Controller
                         'description' => __('The ID of the donation this note belongs to.', 'give'),
                         'type' => 'integer',
                         'required' => true,
-                    ],
-                    'additionalFields' => [
-                        'description' => __(
-                            'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                            'give'
-                        ),
-                        'type' => 'string',
-                        'default' => '',
-                    ],
+                    ]
                 ], $this->get_collection_params()) ,
                 'schema' => [$this, 'get_public_item_schema'],
             ],
@@ -446,7 +438,6 @@ class DonationNotesController extends WP_REST_Controller
     }
 
     /**
-     * @unreleased Add support for additional fields
      * @since 4.4.0
      */
     public function get_endpoint_args_for_item_schema($method = WP_REST_Server::CREATABLE): array
@@ -457,14 +448,6 @@ class DonationNotesController extends WP_REST_Controller
         // Common argument for all endpoints
         $args['donationId'] = $schema['properties']['donationId'];
         $args['donationId']['in'] = 'path';
-        $args['additionalFields'] = [
-            'description' => __(
-                'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                'give'
-            ),
-            'type' => 'string',
-            'default' => '',
-        ];
 
         // Arguments for single item endpoints (not for POST)
         if (in_array($method, [WP_REST_Server::READABLE, WP_REST_Server::EDITABLE, WP_REST_Server::DELETABLE], true)) {
@@ -496,7 +479,6 @@ class DonationNotesController extends WP_REST_Controller
                 'enum' => ['admin', 'donation'],
                 'default' => 'admin',
             ];
-            unset($args['additionalFields']);
         } else {
             unset($args['content']);
             unset($args['type']);

--- a/src/API/REST/V3/Routes/Donors/DonorController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorController.php
@@ -503,7 +503,6 @@ class DonorController extends WP_REST_Controller
     }
 
     /**
-     * @unreleased Add support for additional fields
      * @since 4.4.0
      */
     public function getSharedParams(): array
@@ -525,14 +524,6 @@ class DonorController extends WP_REST_Controller
                 'type' => 'string',
                 'default' => 'exclude',
                 'enum' => ['exclude', 'include', 'redact'],
-            ],
-            'additionalFields' => [
-                'description' => __(
-                    'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                    'give'
-                ),
-                'type' => 'string',
-                'default' => '',
             ],
         ];
     }

--- a/src/API/REST/V3/Routes/Donors/DonorController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorController.php
@@ -503,6 +503,7 @@ class DonorController extends WP_REST_Controller
     }
 
     /**
+     * @unreleased Add support for additional fields
      * @since 4.4.0
      */
     public function getSharedParams(): array
@@ -524,6 +525,14 @@ class DonorController extends WP_REST_Controller
                 'type' => 'string',
                 'default' => 'exclude',
                 'enum' => ['exclude', 'include', 'redact'],
+            ],
+            'additionalFields' => [
+                'description' => __(
+                    'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                    'give'
+                ),
+                'type' => 'string',
+                'default' => '',
             ],
         ];
     }

--- a/src/API/REST/V3/Routes/Donors/DonorNotesController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorNotesController.php
@@ -433,6 +433,7 @@ class DonorNotesController extends WP_REST_Controller
     }
 
     /**
+     * @unreleased Add support for additional fields
      * @since 4.6.0 Add format to content argument
      * @since 4.4.0
      */
@@ -444,6 +445,14 @@ class DonorNotesController extends WP_REST_Controller
         // Common argument for all endpoints
         $args['donorId'] = $schema['properties']['donorId'];
         $args['donorId']['in'] = 'path';
+        $args['additionalFields'] = [
+            'description' => __(
+                'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
+                'give'
+            ),
+            'type' => 'string',
+            'default' => '',
+        ];
 
         // Arguments for single item endpoints (not for POST)
         if (in_array($method, [WP_REST_Server::READABLE, WP_REST_Server::EDITABLE, WP_REST_Server::DELETABLE], true)) {
@@ -475,6 +484,7 @@ class DonorNotesController extends WP_REST_Controller
                 'enum' => ['admin', 'donor'],
                 'default' => 'admin',
             ];
+            unset($args['additionalFields']);
         } else {
             unset($args['content']);
             unset($args['type']);

--- a/src/API/REST/V3/Routes/Donors/DonorNotesController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorNotesController.php
@@ -142,6 +142,7 @@ class DonorNotesController extends WP_REST_Controller
     /**
      * Create a donor note.
      *
+     * @unreleased Add support updating custom fields
      * @since 4.4.0
      *
      * @param WP_REST_Request $request Full data about the request.
@@ -197,6 +198,7 @@ class DonorNotesController extends WP_REST_Controller
     /**
      * Update a donor note.
      *
+     * @unreleased Add support for updating custom fields
      * @since 4.4.0
      *
      * @param WP_REST_Request $request Full data about the request.
@@ -227,6 +229,11 @@ class DonorNotesController extends WP_REST_Controller
 
         if ($note->isDirty()) {
             $note->save();
+        }
+
+        $fieldsUpdate = $this->update_additional_fields_for_object($note, $request);
+        if (is_wp_error($fieldsUpdate)) {
+            return $fieldsUpdate;
         }
 
         $response = $this->prepare_item_for_response($note, $request);
@@ -308,6 +315,7 @@ class DonorNotesController extends WP_REST_Controller
     }
 
     /**
+     * @unreleased Add support for adding custom fields to the response
      * @since 4.4.0
      */
     public function prepare_item_for_response($note, $request): WP_REST_Response
@@ -326,6 +334,7 @@ class DonorNotesController extends WP_REST_Controller
 
         $response = new WP_REST_Response($note->toArray());
         $response->add_links($links);
+        $response->data = $this->add_additional_fields_to_object($response->data, $request);
 
         return $response;
     }
@@ -350,6 +359,7 @@ class DonorNotesController extends WP_REST_Controller
     /**
      * Get the donor note schema, conforming to JSON Schema.
      *
+     * @unreleased Change title to givewp/donor-note and add custom fields schema
      * @since 4.4.0
      *
      * @return array
@@ -358,7 +368,7 @@ class DonorNotesController extends WP_REST_Controller
     {
         $schema = [
             'schema' => 'http://json-schema.org/draft-07/schema#',
-            'title' => 'donor-note',
+            'title' => 'givewp/donor-note',
             'type' => 'object',
             'properties' => [
                 'id' => [
@@ -398,7 +408,7 @@ class DonorNotesController extends WP_REST_Controller
             ],
         ];
 
-        return $schema;
+        return $this->add_additional_fields_schema($schema);
     }
 
     /**

--- a/src/API/REST/V3/Routes/Donors/DonorNotesController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorNotesController.php
@@ -433,7 +433,6 @@ class DonorNotesController extends WP_REST_Controller
     }
 
     /**
-     * @unreleased Add support for additional fields
      * @since 4.6.0 Add format to content argument
      * @since 4.4.0
      */
@@ -445,14 +444,6 @@ class DonorNotesController extends WP_REST_Controller
         // Common argument for all endpoints
         $args['donorId'] = $schema['properties']['donorId'];
         $args['donorId']['in'] = 'path';
-        $args['additionalFields'] = [
-            'description' => __(
-                'Additional custom fields to include in the response. Use * for all fields or a comma-separated list of field names.',
-                'give'
-            ),
-            'type' => 'string',
-            'default' => '',
-        ];
 
         // Arguments for single item endpoints (not for POST)
         if (in_array($method, [WP_REST_Server::READABLE, WP_REST_Server::EDITABLE, WP_REST_Server::DELETABLE], true)) {
@@ -484,7 +475,6 @@ class DonorNotesController extends WP_REST_Controller
                 'enum' => ['admin', 'donor'],
                 'default' => 'admin',
             ];
-            unset($args['additionalFields']);
         } else {
             unset($args['content']);
             unset($args['type']);

--- a/src/Donors/resources/entity.ts
+++ b/src/Donors/resources/entity.ts
@@ -8,7 +8,7 @@ dispatch(coreStore).addEntities([
         name: 'donor',
         kind: 'givewp',
         baseURL: '/givewp/v3/donors',
-        baseURLParams: {includeSensitiveData: true, anonymousDonors: 'include'},
+        baseURLParams: {includeSensitiveData: true, anonymousDonors: 'include', additionalFields: '*'},
         plural: 'donors',
         label: __('Donor', 'give'),
         supportsPagination: true,

--- a/src/Donors/resources/entity.ts
+++ b/src/Donors/resources/entity.ts
@@ -8,7 +8,7 @@ dispatch(coreStore).addEntities([
         name: 'donor',
         kind: 'givewp',
         baseURL: '/givewp/v3/donors',
-        baseURLParams: {includeSensitiveData: true, anonymousDonors: 'include', additionalFields: '*'},
+        baseURLParams: {includeSensitiveData: true, anonymousDonors: 'include'},
         plural: 'donors',
         label: __('Donor', 'give'),
         supportsPagination: true,


### PR DESCRIPTION
## Description

This PR enhances our API endpoints to support custom REST fields following WP API standards. The implementation adds standardized custom field support across our REST API v3 endpoints, enabling better data extensibility and addon integration capabilities.

### Key Changes:
- **REST API v3 Custom Fields Support**: Enhanced donation, donation-note, donor and donor-note controllers to handle custom field operations (create, read, update)
- **WP API Standards Compliance**: Implemented custom field handling following WordPress REST API conventions
- **Improved Schema Definitions**: Updated endpoint schemas to include custom fields specifications

The changes primarily focus on the core REST API infrastructure, providing a foundation for add-ons to extend data models through standardized custom field mechanisms.

## Affects
REST API v3 endpoints for donations, donation notes, donors and donors notes

## Visuals
N/A

## Testing Instructions
1. Register a custom field with `register_rest_field`:
```php
register_rest_field(
    'givewp/donor',
    'givewp/my-addon',
    [
        'get_callback' => fn ($item, $fieldName, $request) => give()->donor_meta->get_meta($item['id'], 'myaddon_meta', true),
        'update_callback' => fn ($newValue, $item, $fieldName, $request) => give()->donor_meta->update_meta($item['id'], 'myaddon_meta', $newValue),
        'schema' => [
            'type' => 'string',
            'format' => 'text-field',
        ]
    ]
);
```
2. Sent a PUT/PATCH request to the `donor` endpoint passing a `givewp/my-addon` prop with any string value and you that value must be updated in the database, then included in the returned object.
2. Send a GET request to the `donor` endpoint then confirm the returned object contains a `givewp/my-addon` entry with the value saved on the previous test.

## Pre-review Checklist

- [ ] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](mdc:https:/give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed