### PR TITLE
Fix: PHP 8 errors and warnings

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -213,6 +213,7 @@ add_action( 'give_complete_donation', '_give_save_donor_billing_address', 9999 )
 /**
  * Verify addon dependency before addon update
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 4.1.0 add bailout for GiveWP to protect it from licensing issues
  * @since 2.1.4
  *
@@ -221,7 +222,7 @@ add_action( 'give_complete_donation', '_give_save_donor_billing_address', 9999 )
  *
  * @return WP_Error
  */
-function __give_verify_addon_dependency_before_update( $error, $hook_extra ) {
+function give_verify_addon_dependency_before_update( $error, $hook_extra ) {
 	// Bailout.
 	if (
 		is_wp_error( $error )
@@ -270,18 +271,19 @@ function __give_verify_addon_dependency_before_update( $error, $hook_extra ) {
 	return $error;
 }
 
-add_filter( 'upgrader_pre_install', '__give_verify_addon_dependency_before_update', 10, 2 );
+add_filter( 'upgrader_pre_install', 'give_verify_addon_dependency_before_update', 10, 2 );
 
 /**
  * Function to add suppress_filters param if WPML add-on is activated.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.1.4
  *
  * @param array WP query argument for Total Goal.
  *
  * @return array WP query argument for Total Goal.
  */
-function __give_wpml_total_goal_shortcode_agrs( $args ) {
+function give_wpml_total_goal_shortcode_agrs( $args ) {
 	$args['suppress_filters'] = true;
 
 	return $args;
@@ -290,10 +292,11 @@ function __give_wpml_total_goal_shortcode_agrs( $args ) {
 /**
  * Function to remove WPML post where filter in goal total amount shortcode.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.1.4
  * @global SitePress $sitepress
  */
-function __give_remove_wpml_parse_query_filter() {
+function give_remove_wpml_parse_query_filter() {
 	global $sitepress;
 	remove_action( 'parse_query', [ $sitepress, 'parse_query' ] );
 }
@@ -302,10 +305,11 @@ function __give_remove_wpml_parse_query_filter() {
 /**
  * Function to add WPML post where filter in goal total amount shortcode.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.1.4
  * @global SitePress $sitepress
  */
-function __give_add_wpml_parse_query_filter() {
+function give_add_wpml_parse_query_filter() {
 	global $sitepress;
 	add_action( 'parse_query', [ $sitepress, 'parse_query' ] );
 }
@@ -322,11 +326,11 @@ function give_add_support_for_wpml() {
 
 	if ( is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' ) ) {
 
-		add_filter( 'give_totals_goal_shortcode_query_args', '__give_wpml_total_goal_shortcode_agrs' );
+		add_filter( 'give_totals_goal_shortcode_query_args', 'give_wpml_total_goal_shortcode_agrs');
 
 		// @see https://wpml.org/forums/topic/problem-with-query-filter-in-get_posts-function/#post-271309
-		add_action( 'give_totals_goal_shortcode_before_render', '__give_remove_wpml_parse_query_filter', 99 );
-		add_action( 'give_totals_goal_shortcode_after_render', '__give_add_wpml_parse_query_filter', 99 );
+		add_action( 'give_totals_goal_shortcode_before_render', 'give_remove_wpml_parse_query_filter', 99 );
+		add_action( 'give_totals_goal_shortcode_after_render', 'give_add_wpml_parse_query_filter', 99 );
 	}
 }
 

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -1029,9 +1029,10 @@ function give_get_user_roles() {
  *
  * @since 2.0
  * @since 2.11.0 decode url before parsing and sanitizing url when set $post.
+ * @unreleased rename function - PHP 8 compatibility
  * @return void
  */
-function __give_ajax_donor_manage_addresses() {
+function give_ajax_donor_manage_addresses() {
 	// Bailout.
 	if (
 		empty( $_POST['form'] ) ||
@@ -1119,7 +1120,7 @@ function __give_ajax_donor_manage_addresses() {
 				end( $array_keys ) :
 				$address_type;
 
-			$response_data['address_html'] = __give_get_format_address(
+			$response_data['address_html'] = give_get_format_address(
 				end( $donor->address['billing'] ),
 				[
 					// We can add only billing address from donor screen.
@@ -1172,7 +1173,7 @@ function __give_ajax_donor_manage_addresses() {
 				);
 			}
 
-			$response_data['address_html'] = __give_get_format_address(
+			$response_data['address_html'] = give_get_format_address(
 				$is_multi_address_type ?
 					$donor->address[ $address_type ][ $address_id ] :
 					$donor->address[ $address_type ],
@@ -1193,41 +1194,43 @@ function __give_ajax_donor_manage_addresses() {
 	wp_send_json_success( $response_data );
 }
 
-add_action( 'wp_ajax_donor_manage_addresses', '__give_ajax_donor_manage_addresses' );
+add_action( 'wp_ajax_donor_manage_addresses', 'give_ajax_donor_manage_addresses');
 
 /**
  * Admin donor billing address label
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param string $address_label
  *
  * @return string
  */
-function __give_donor_billing_address_label( $address_label ) {
+function give_donor_billing_address_label( $address_label ) {
 	$address_label = __( 'Billing Address', 'give' );
 
 	return $address_label;
 }
 
-add_action( 'give_donor_billing_address_label', '__give_donor_billing_address_label' );
+add_action( 'give_donor_billing_address_label', 'give_donor_billing_address_label');
 
 /**
  * Admin donor personal address label
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param string $address_label
  *
  * @return string
  */
-function __give_donor_personal_address_label( $address_label ) {
+function give_donor_personal_address_label( $address_label ) {
 	$address_label = __( 'Personal Address', 'give' );
 
 	return $address_label;
 }
 
-add_action( 'give_donor_personal_address_label', '__give_donor_personal_address_label' );
+add_action( 'give_donor_personal_address_label', 'give_donor_personal_address_label');
 
 /**
  * Update Donor Information when User Profile is updated from admin.

--- a/includes/admin/admin-filters.php
+++ b/includes/admin/admin-filters.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  1. User can only set absolute integer value as number of decimals.
  *  2. number_decimals setting will be zero if no decimal separator defined
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since   1.8
  * @used-by Give_Plugin_Settings::give_settings()
  *
@@ -27,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return  mixed
  */
-function __give_sanitize_number_decimals_setting_field( $value ) {
+function give_sanitize_number_decimals_setting_field( $value ) {
 	$value_changed = false;
 	$show_notice   = false;
 	$old_value     = $value;
@@ -65,7 +66,7 @@ function __give_sanitize_number_decimals_setting_field( $value ) {
 	return absint( $value );
 }
 
-add_filter( 'give_admin_settings_sanitize_option_number_decimals', '__give_sanitize_number_decimals_setting_field', 10 );
+add_filter( 'give_admin_settings_sanitize_option_number_decimals', 'give_sanitize_number_decimals_setting_field', 10 );
 
 
 /**
@@ -74,6 +75,7 @@ add_filter( 'give_admin_settings_sanitize_option_number_decimals', '__give_sanit
  *  1. User can only set absolute integer value as number of decimals.
  *  2. number_decimals setting will be zero if no decimal separator defined
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since   1.8
  * @used-by Give_Plugin_Settings::give_settings()
  *
@@ -81,7 +83,7 @@ add_filter( 'give_admin_settings_sanitize_option_number_decimals', '__give_sanit
  *
  * @return  mixed
  */
-function __give_validate_decimal_separator_setting_field( $value ) {
+function give_validate_decimal_separator_setting_field( $value ) {
 	$thousand_separator = isset( $_POST['thousands_separator'] ) ? give_clean( $_POST['thousands_separator'] ) : '';
 	$decimal_separator  = isset( $_POST['decimal_separator'] ) ? give_clean( $_POST['decimal_separator'] ) : '';
 
@@ -94,18 +96,19 @@ function __give_validate_decimal_separator_setting_field( $value ) {
 	return $value;
 }
 
-add_filter( 'give_admin_settings_sanitize_option_decimal_separator', '__give_validate_decimal_separator_setting_field', 10 );
+add_filter( 'give_admin_settings_sanitize_option_decimal_separator', 'give_validate_decimal_separator_setting_field', 10 );
 
 /**
  * Change $delimiter text to symbol.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 1.8.14
  *
  * @param string $delimiter
  *
  * @return string $delimiter.
  */
-function __give_import_delimiter_set_callback( $delimiter ) {
+function give_import_delimiter_set_callback( $delimiter ) {
 	$delimite_type = array(
 		'csv'                  => ',',
 		'tab-separated-values' => "\t",
@@ -114,7 +117,7 @@ function __give_import_delimiter_set_callback( $delimiter ) {
 	return ( array_key_exists( $delimiter, $delimite_type ) ? $delimite_type[ $delimiter ] : ',' );
 }
 
-add_filter( 'give_import_delimiter_set', '__give_import_delimiter_set_callback', 10 );
+add_filter( 'give_import_delimiter_set', 'give_import_delimiter_set_callback', 10 );
 
 /**
  * Give unset the page id from the core setting data from the json files.

--- a/includes/admin/class-addon-activation-banner.php
+++ b/includes/admin/class-addon-activation-banner.php
@@ -172,7 +172,7 @@ class Give_Addon_Activation_Banner {
 			foreach ( $give_addons as $banner_addon_name => $addon ) {
 
 				// User meta key.
-				$user_id = __give_get_active_by_user_meta( $banner_addon_name );
+				$user_id = give_get_active_by_user_meta( $banner_addon_name );
 
 				if ( ! $user_id ) {
 					$option_key = self::get_banner_user_meta_key( $banner_addon_name );
@@ -251,7 +251,7 @@ class Give_Addon_Activation_Banner {
 			$add_on_state = get_user_meta( $this->user_id, "give_addon_activation_ignore_{$addon_sanitized_name}", true );
 
 			// Get the option key.
-			$activate_by_user = (int) __give_get_active_by_user_meta( $addon_sanitized_name );
+			$activate_by_user = (int) give_get_active_by_user_meta( $addon_sanitized_name );
 
 			// Remove plugin file and get the Add-on's folder name only.
 			$file_path = $this->get_plugin_folder_name( $addon['file'] );
@@ -486,7 +486,7 @@ class Give_Addon_Activation_Banner {
 				if ( $plugin_file === $addon['plugin_main_file'] ) {
 
 					// Get the user meta key.
-					$user_id = (int) __give_get_active_by_user_meta( $banner_addon_name );
+					$user_id = (int) give_get_active_by_user_meta( $banner_addon_name );
 
 					if ( $user_id ) {
 						// Get user meta for this add-on.

--- a/includes/admin/donors/donors.php
+++ b/includes/admin/donors/donors.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Get formatted address
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param array $address
@@ -28,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return string
  */
-function __give_get_format_address( $address, $address_args = array() ) {
+function give_get_format_address( $address, $address_args = array() ) {
 	$address_html = '';
 	$address_args = wp_parse_args(
 		$address_args,
@@ -613,7 +614,7 @@ function give_donor_view( $donor ) {
 									case is_array( end( $addresses ) ):
 										$index = 1;
 										foreach ( $addresses as $id => $address ) {
-											echo __give_get_format_address(
+											echo give_get_format_address(
 												$address,
 												array(
 													'type' => $address_type,
@@ -627,7 +628,7 @@ function give_donor_view( $donor ) {
 										break;
 
 									case is_string( end( $addresses ) ):
-										echo __give_get_format_address(
+										echo give_get_format_address(
 											$addresses,
 											array(
 												'type' => $address_type,

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -677,6 +677,14 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 
 	$data = (array) apply_filters( 'give_save_import_donation_to_db', $data );
 
+  //  print_r($row_data);
+
+   // var_dump($isSubscription); exit;
+
+    // check duplicate donation
+    // - get subscription id
+    // -- duplicate subscription check?
+
 	$data['amount'] = give_maybe_sanitize_amount( $data['amount'] );
 	$diff           = [];
 
@@ -911,6 +919,42 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 				if ( 'pending' !== $status ) {
 					$payment->update_status( $status );
 				}
+
+                $isSubscription = ! empty(array_filter($row_data, function($value) {
+                    return $value === 'subscription';
+                }));
+
+                if ($isSubscription && defined('GIVE_RECURRING_VERSION')) {
+                    // Column names are translatable in CSV file and user can decide what columns to import/export
+                    // There is no other way to identify the columns we need except using the translatable strings,
+                    // and even this is not 100% reliable because it can be in different language for which we don't have translations
+
+                    $billingPeriod = array_filter($main_key, function($value) {
+                        return $value === __( 'Subscription Billing Period', 'give-recurring' );
+                    });
+
+                    $billingTimes = array_filter($main_key, function($value) {
+                        return $value === __( 'Subscription Billing Times', 'give-recurring' );
+                    });
+
+                    $billingFrequency = array_filter($main_key, function($value) {
+                        return $value === __( 'Subscription Billing Frequency', 'give-recurring' );
+                    });
+
+                    var_dump($row_data[key($billingPeriod)]);
+                    var_dump($row_data[key($billingTimes)]);
+                    var_dump($row_data[key($billingFrequency)]);
+
+                    exit;
+
+                    if ( ! empty($billingPeriod) && ! empty($billingTimes) && ! empty($billingFrequency) ) {
+
+                    }
+
+                    $payment->update_meta( '_give_subscription_payment',  1);
+                    $payment->update_meta( '_give_is_donation_recurring',  1);
+                    $payment->update_meta( 'subscription_id',  1);
+                }
 			} else {
 				$report['failed_donation'] = ( ! empty( $report['failed_donation'] ) ? ( absint( $report['failed_donation'] ) + 1 ) : 1 );
 				$payment_id                = false;

--- a/includes/admin/import-functions.php
+++ b/includes/admin/import-functions.php
@@ -677,14 +677,6 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 
 	$data = (array) apply_filters( 'give_save_import_donation_to_db', $data );
 
-  //  print_r($row_data);
-
-   // var_dump($isSubscription); exit;
-
-    // check duplicate donation
-    // - get subscription id
-    // -- duplicate subscription check?
-
 	$data['amount'] = give_maybe_sanitize_amount( $data['amount'] );
 	$diff           = [];
 
@@ -919,42 +911,6 @@ function give_save_import_donation_to_db( $raw_key, $row_data, $main_key = [], $
 				if ( 'pending' !== $status ) {
 					$payment->update_status( $status );
 				}
-
-                $isSubscription = ! empty(array_filter($row_data, function($value) {
-                    return $value === 'subscription';
-                }));
-
-                if ($isSubscription && defined('GIVE_RECURRING_VERSION')) {
-                    // Column names are translatable in CSV file and user can decide what columns to import/export
-                    // There is no other way to identify the columns we need except using the translatable strings,
-                    // and even this is not 100% reliable because it can be in different language for which we don't have translations
-
-                    $billingPeriod = array_filter($main_key, function($value) {
-                        return $value === __( 'Subscription Billing Period', 'give-recurring' );
-                    });
-
-                    $billingTimes = array_filter($main_key, function($value) {
-                        return $value === __( 'Subscription Billing Times', 'give-recurring' );
-                    });
-
-                    $billingFrequency = array_filter($main_key, function($value) {
-                        return $value === __( 'Subscription Billing Frequency', 'give-recurring' );
-                    });
-
-                    var_dump($row_data[key($billingPeriod)]);
-                    var_dump($row_data[key($billingTimes)]);
-                    var_dump($row_data[key($billingFrequency)]);
-
-                    exit;
-
-                    if ( ! empty($billingPeriod) && ! empty($billingTimes) && ! empty($billingFrequency) ) {
-
-                    }
-
-                    $payment->update_meta( '_give_subscription_payment',  1);
-                    $payment->update_meta( '_give_is_donation_recurring',  1);
-                    $payment->update_meta( 'subscription_id',  1);
-                }
 			} else {
 				$report['failed_donation'] = ( ! empty( $report['failed_donation'] ) ? ( absint( $report['failed_donation'] ) + 1 ) : 1 );
 				$payment_id                = false;

--- a/includes/admin/tools/data/class-give-tools-delete-test-transactions.php
+++ b/includes/admin/tools/data/class-give-tools-delete-test-transactions.php
@@ -73,7 +73,7 @@ class Give_Tools_Delete_Test_Transactions extends Give_Batch_Export {
 
 		$offset     = ( $this->step - 1 ) * $this->per_step;
 		$step_items = array_slice( $items, $offset, $this->per_step );
-		$meta_table = __give_v20_bc_table_details( 'payment' );
+		$meta_table = give_v20_bc_table_details( 'payment' );
 
 		if ( $step_items ) {
 			foreach ( $step_items as $item ) {

--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -101,7 +101,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 			}
 
 			$sql        = [];
-			$meta_table = __give_v20_bc_table_details( 'form' );
+			$meta_table = give_v20_bc_table_details( 'form' );
 
 			foreach ( $step_ids as $type => $ids ) {
 

--- a/includes/admin/tools/views/html-admin-page-system-info.php
+++ b/includes/admin/tools/views/html-admin-page-system-info.php
@@ -536,7 +536,7 @@ $give_updates = Give_Updates::get_instance();
 			$db_table_list = '';
 
 			/* @var  Give_DB $table */
-			foreach ( __give_get_tables() as $table ) {
+			foreach ( give_get_tables() as $table ) {
 				$db_table_list .= sprintf(
 					'<li><mark class="%1$s"><span class="dashicons dashicons-%2$s"></mark> %3$s</li>',
 					$table->installed()

--- a/includes/admin/upgrades/class-give-updates.php
+++ b/includes/admin/upgrades/class-give-updates.php
@@ -145,28 +145,29 @@ class Give_Updates {
 		 * Setup hooks.
 		 */
 		add_action( 'init', [ $this, '__register_upgrade' ], 9999 );
-		add_action( 'give_set_upgrade_completed', [ $this, '__flush_resume_updates' ], 9999 );
-		add_action( 'wp_ajax_give_db_updates_info', [ $this, '__give_db_updates_info' ] );
-		add_action( 'wp_ajax_give_run_db_updates', [ $this, '__give_start_updating' ] );
-		add_action( 'admin_init', [ $this, '__redirect_admin' ] );
-		add_action( 'admin_init', [ $this, '__pause_db_update' ], - 1 );
-		add_action( 'admin_init', [ $this, '__restart_db_update' ], - 1 );
-		add_action( 'admin_notices', [ $this, '__show_notice' ] );
-		add_action( 'give_restart_db_upgrade', [ $this, '__health_background_update' ] );
+		add_action( 'give_set_upgrade_completed', [$this, 'flush_resume_updates'], 9999 );
+		add_action( 'wp_ajax_give_db_updates_info', [$this, 'give_db_updates_info'] );
+		add_action( 'wp_ajax_give_run_db_updates', [$this, 'give_start_updating'] );
+		add_action( 'admin_init', [$this, 'redirect_admin'] );
+		add_action( 'admin_init', [$this, 'pause_db_update'], - 1 );
+		add_action( 'admin_init', [$this, 'restart_db_update'], - 1 );
+		add_action( 'admin_notices', [$this, 'show_notice'] );
+		add_action( 'give_restart_db_upgrade', [$this, 'health_background_update'] );
 
 		if ( is_admin() ) {
-			add_action( 'admin_init', [ $this, '__change_donations_label' ], 9999 );
-			add_action( 'admin_menu', [ $this, '__register_menu' ], 55 );
+			add_action( 'admin_init', [$this, 'change_donations_label'], 9999 );
+			add_action( 'admin_menu', [$this, 'register_menu'], 55 );
 		}
 	}
 
 	/**
 	 * Register plugin add-on updates.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.8.12
 	 * @access public
 	 */
-	public function __register_plugin_addon_updates() {
+	public function register_plugin_addon_updates() {
 		$addons         = give_get_plugins( [ 'only_premium_add_ons' => true ] );
 		$plugin_updates = get_plugin_updates();
 
@@ -202,10 +203,11 @@ class Give_Updates {
 	/**
 	 * Rename `Donations` menu title if updates exists
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.8.12
 	 * @access public
 	 */
-	function __change_donations_label() {
+	function change_donations_label() {
 		global $menu;
 
 		// Bailout.
@@ -236,12 +238,13 @@ class Give_Updates {
 	/**
 	 * Register updates menu
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.8.12
 	 * @access public
 	 */
-	public function __register_menu() {
+	public function register_menu() {
 		// Load plugin updates.
-		$this->__register_plugin_addon_updates();
+		$this->register_plugin_addon_updates();
 
 		// Bailout.
 		if ( ! $this->get_total_update_count() ) {
@@ -286,10 +289,11 @@ class Give_Updates {
 	/**
 	 * Show update related notices
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 */
-	public function __redirect_admin() {
+	public function redirect_admin() {
 		// Show db upgrade completed notice.
 		if (
 			! wp_doing_ajax() &&
@@ -308,6 +312,7 @@ class Give_Updates {
 	/**
 	 * Pause db upgrade
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0.1
 	 * @access public
 	 *
@@ -315,7 +320,7 @@ class Give_Updates {
 	 *
 	 * @return bool
 	 */
-	public function __pause_db_update( $force = false ) {
+	public function pause_db_update( $force = false ) {
 		// Bailout.
 		if (
 			! $force &&
@@ -333,7 +338,7 @@ class Give_Updates {
 
 		delete_option( 'give_upgrade_error' );
 
-		$this->__health_background_update( $this );
+		$this->health_background_update( $this );
 		$batch = self::$background_updater->get_all_batch();
 
 		// Bailout: if batch is empty
@@ -372,12 +377,13 @@ class Give_Updates {
 	/**
 	 * Restart db upgrade
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0.1
 	 * @access public
 	 *
 	 * @return bool
 	 */
-	public function __restart_db_update() {
+	public function restart_db_update() {
 		// Bailout.
 		if (
 			wp_doing_ajax() ||
@@ -415,12 +421,13 @@ class Give_Updates {
 	/**
 	 * Health check for updates.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 *
 	 * @param Give_Updates $give_updates
 	 */
-	public function __health_background_update( $give_updates ) {
+	public function health_background_update( $give_updates ) {
 		if ( ! $this->is_doing_updates() ) {
 			return;
 		}
@@ -503,7 +510,7 @@ class Give_Updates {
 			self::$background_updater->delete( $batch->key );
 
 			if ( self::$background_updater->has_queue() ) {
-				$this->__health_background_update( $this );
+				$this->health_background_update( $this );
 			} else {
 				delete_site_transient( self::$background_updater->get_identifier() . '_process_lock' );
 				wp_clear_scheduled_hook( self::$background_updater->get_cron_identifier() );
@@ -578,10 +585,11 @@ class Give_Updates {
 	/**
 	 * Show update related notices
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 */
-	public function __show_notice() {
+	public function show_notice() {
 		$current_screen = get_current_screen();
 		$hide_on_pages  = [
 			'give_forms_page_give-updates',
@@ -743,10 +751,11 @@ class Give_Updates {
 	/**
 	 * Delete resume updates
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.8.12
 	 * @access public
 	 */
-	public function __flush_resume_updates() {
+	public function flush_resume_updates() {
 		$this->step = $this->percentage = 0;
 
 		$this->update = ( $this->get_total_db_update_count() > $this->update ) ?
@@ -758,12 +767,13 @@ class Give_Updates {
 	/**
 	 * Initialize updates
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 *
 	 * @return void
 	 */
-	public function __give_start_updating() {
+	public function give_start_updating() {
 		// Check permission.
 		if (
 			! current_user_can( 'manage_give_settings' ) ||
@@ -790,12 +800,13 @@ class Give_Updates {
 	/**
 	 * This function handle ajax query for dn update status.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 *
 	 * @return string
 	 */
-	public function __give_db_updates_info() {
+	public function give_db_updates_info() {
 		// Check permission.
 		if ( ! current_user_can( 'manage_give_settings' ) ) {
 			give_die();

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -84,7 +84,7 @@ function give_do_automatic_upgrades() {
 			// Do nothing on fresh install.
 			if ( ! doing_action( 'give_upgrades' ) ) {
 				give_v201_create_tables();
-				Give_Updates::get_instance()->__health_background_update( Give_Updates::get_instance() );
+				Give_Updates::get_instance()->health_background_update( Give_Updates::get_instance() );
 				Give_Updates::$background_updater->dispatch();
 			}
 
@@ -111,7 +111,7 @@ function give_do_automatic_upgrades() {
 			// Do nothing on fresh install.
 			if ( ! doing_action( 'give_upgrades' ) ) {
 				give_v201_create_tables();
-				Give_Updates::get_instance()->__health_background_update( Give_Updates::get_instance() );
+				Give_Updates::get_instance()->health_background_update( Give_Updates::get_instance() );
 				Give_Updates::$background_updater->dispatch();
 			}
 

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -761,9 +761,10 @@ add_action( 'wp_ajax_nopriv_give_confirm_email_for_donations_access', 'give_conf
  * Render receipt by ajax
  * Note: only for internal use
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.0
  */
-function __give_get_receipt() {
+function give_get_receipt() {
 
 	$get_data = give_clean( filter_input_array( INPUT_GET ) );
 
@@ -776,8 +777,8 @@ function __give_get_receipt() {
 
 	wp_send_json( $data );
 }
-add_action( 'wp_ajax_get_receipt', '__give_get_receipt' );
-add_action( 'wp_ajax_nopriv_get_receipt', '__give_get_receipt' );
+add_action( 'wp_ajax_get_receipt', 'give_get_receipt');
+add_action( 'wp_ajax_nopriv_get_receipt', 'give_get_receipt');
 
 /**
  * Get ajax url to render content from other website into thickbox

--- a/includes/class-give-background-updater.php
+++ b/includes/class-give-background-updater.php
@@ -89,7 +89,7 @@ class Give_Background_Updater extends WPBackgroundProcess
 
             delete_option('give_paused_batches');
 
-            Give_Updates::get_instance()->__pause_db_update(true);
+            Give_Updates::get_instance()->pause_db_update(true);
 
             delete_option('give_pause_upgrade');
 
@@ -373,7 +373,7 @@ class Give_Background_Updater extends WPBackgroundProcess
             ! in_array($resume_update['update_info']['id'], $give_updates->get_update_ids())
         ) {
             if ( ! $this->is_paused_process()) {
-                $give_updates->__pause_db_update(true);
+                $give_updates->pause_db_update(true);
             }
 
             update_option('give_upgrade_error', 1, false);
@@ -403,7 +403,7 @@ class Give_Background_Updater extends WPBackgroundProcess
             }
         } catch (Exception $e) {
             if ( ! $this->is_paused_process()) {
-                $give_updates->__pause_db_update(true);
+                $give_updates->pause_db_update(true);
             }
 
             $log_data = 'Update Task' . "\n";

--- a/includes/class-give-cache.php
+++ b/includes/class-give-cache.php
@@ -81,7 +81,7 @@ class Give_Cache {
 		add_action( 'give_save_settings_give_settings', array( __CLASS__, 'flush_cache' ) );
 
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
-		add_action( 'admin_notices', array( $this, '__notices' ) );
+		add_action( 'admin_notices', array($this, 'notices') );
 	}
 
 	/**
@@ -149,11 +149,12 @@ class Give_Cache {
 	/**
 	 * Notices function.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0.5
 	 * @access public
 	 * @credit WooCommerce
 	 */
-	public function __notices() {
+	public function notices() {
 		if ( ! function_exists( 'w3tc_pgcache_flush' ) || ! function_exists( 'w3_instance' ) ) {
 			return;
 		}

--- a/includes/class-give-comment.php
+++ b/includes/class-give-comment.php
@@ -98,7 +98,7 @@ class Give_Comment {
 			add_filter( 'comments_clauses', array( $this, 'hide_comments_pre_wp_41' ), 10, 1 );
 			add_filter( 'comment_feed_where', array( $this, 'hide_comments_from_feeds' ), 10, 1 );
 			add_filter( 'wp_count_comments', array( $this, 'remove_comments_from_comment_counts' ), 10, 2 );
-			add_filter( 'get_comment_author', array( $this, '__get_comment_author' ), 10, 3 );
+			add_filter( 'get_comment_author', array($this, 'get_comment_author'), 10, 3 );
 		}
 	}
 
@@ -432,6 +432,7 @@ class Give_Comment {
 	/**
 	 * Get donor name
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.2.0
 	 * @access public
 	 *
@@ -441,7 +442,7 @@ class Give_Comment {
 	 *
 	 * @return mixed
 	 */
-	public function __get_comment_author( $author, $comment_id, $comment ) {
+	public function get_comment_author( $author, $comment_id, $comment ) {
 		if ( in_array( $comment->comment_type, $this->comment_types ) ) {
 			switch ( $comment->comment_type ) {
 				case 'give_payment_note':

--- a/includes/class-give-cron.php
+++ b/includes/class-give-cron.php
@@ -63,11 +63,12 @@ class Give_Cron {
 	/**
 	 * Setup
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since 1.8.13
 	 */
 	private function setup() {
-		add_filter( 'cron_schedules', array( self::$instance, '__add_schedules' ) );
-		add_action( 'wp', array( self::$instance, '__schedule_events' ) );
+		add_filter( 'cron_schedules', array( self::$instance, 'add_schedules' ) );
+		add_action( 'wp', array( self::$instance, 'schedule_events' ) );
 	}
 
 	/**
@@ -76,10 +77,12 @@ class Give_Cron {
 	 * @param array $schedules An array of non-default cron schedules.
 	 *
 	 * @return array            An array of non-default cron schedules.
+     *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.3.2
 	 * @access public
 	 */
-	public function __add_schedules( $schedules = array() ) {
+	public function add_schedules( $schedules = array() ) {
 		// Adds once weekly to the existing schedules.
 		$schedules['weekly'] = array(
 			'interval' => 604800, // 7 * 24 * 3600
@@ -105,10 +108,12 @@ class Give_Cron {
 	 * Schedules our events
 	 *
 	 * @return void
+     *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  1.3.2
 	 * @access public
 	 */
-	public function __schedule_events() {
+	public function schedule_events() {
 		$this->monthly_events();
 		$this->weekly_events();
 		$this->daily_events();

--- a/includes/class-give-logging.php
+++ b/includes/class-give-logging.php
@@ -191,6 +191,7 @@ class Give_Logging {
 	 *
 	 * @return int             The ID of the newly created log item.
 	 */
+    //phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 	public function insert_log( $log_data = [], $log_meta = [] ) {
 		// Extract data from parameters
 		$data = $this->getLogData( $log_data, $log_meta );

--- a/includes/class-give-session.php
+++ b/includes/class-give-session.php
@@ -184,11 +184,11 @@ class Give_Session {
 		add_action( 'wp_logout', [ $this, 'destroy_session' ] );
 
 		if ( ! is_user_logged_in() ) {
-			add_filter( 'nonce_user_logged_out', [ $this, '__nonce_user_logged_out' ] );
+			add_filter( 'nonce_user_logged_out', [$this, 'nonce_user_logged_out'] );
 		}
 
 		// Remove old sessions.
-		Give_Cron::add_daily_event( [ $this, '__cleanup_sessions' ] );
+		Give_Cron::add_daily_event( [$this, 'cleanup_sessions'] );
 	}
 
 	/**
@@ -214,13 +214,13 @@ class Give_Session {
 	 */
 	public function get_session_cookie() {
 		$session      = [];
-		$cookie_value = isset( $_COOKIE[ $this->cookie_name ] ) ? give_clean( $_COOKIE[ $this->cookie_name ] ) : $this->__handle_ajax_cookie(); // @codingStandardsIgnoreLine.
+		$cookie_value = isset( $_COOKIE[ $this->cookie_name ] ) ? give_clean( $_COOKIE[ $this->cookie_name ] ) : $this->handle_ajax_cookie(); // @codingStandardsIgnoreLine.
 
 		if ( empty( $cookie_value ) || ! is_string( $cookie_value ) ) {
 			return $session;
 		}
 
-		list( $donor_id, $session_expiration, $session_expiring, $cookie_hash ) = explode( '||', $cookie_value );
+		[ $donor_id, $session_expiration, $session_expiring, $cookie_hash ] = explode( '||', $cookie_value );
 
 		if ( empty( $donor_id ) ) {
 			return $session;
@@ -253,12 +253,14 @@ class Give_Session {
 	/**
 	 * Load session cookie by ajax
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since 2.2.6
 	 * @access private
 	 *
 	 * @return array|bool|string
 	 */
-	private function __handle_ajax_cookie() {
+	private function handle_ajax_cookie()
+    {
 		$cookie = false;
 
 		// @see https://github.com/impress-org/give/issues/3705
@@ -489,7 +491,7 @@ class Give_Session {
 		if ( $this->session_data_changed && $this->has_session() ) {
 			global $wpdb;
 
-			Give()->session_db->__replace(
+			Give()->session_db->replace(
 				Give()->session_db->table_name,
 				[
 					'session_key'    => $this->donor_id,
@@ -575,6 +577,7 @@ class Give_Session {
 	 * When a user is logged out, ensure they have a unique nonce by using the donor/session ID.
 	 * Note: for internal logic only.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.2.0
 	 * @access public
 	 *
@@ -582,7 +585,7 @@ class Give_Session {
 	 *
 	 * @return string
 	 */
-	public function __nonce_user_logged_out( $uid ) {
+	public function nonce_user_logged_out( $uid ) {
 		return $this->has_session() && $this->donor_id ? $this->donor_id : $uid;
 	}
 
@@ -591,10 +594,11 @@ class Give_Session {
 	 * Cleanup session data from the database and clear caches.
 	 * Note: for internal logic only.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.2.0
 	 * @access public
 	 */
-	public function __cleanup_sessions() { // @codingStandardsIgnoreLine
+	public function cleanup_sessions() { // @codingStandardsIgnoreLine
 		Give()->session_db->delete_expired_sessions();
 	}
 

--- a/includes/class-notices.php
+++ b/includes/class-notices.php
@@ -55,7 +55,7 @@ class Give_Notices {
 	 */
 	public function __construct() {
 		add_action( 'admin_notices', [ $this, 'render_admin_notices' ], 999 );
-		add_action( 'admin_footer', [ $this, '__reveal_notices' ] );
+		add_action( 'admin_footer', [$this, 'reveal_notices'] );
 		add_action( 'give_dismiss_notices', [ $this, 'dismiss_notices' ] );
 
 		add_action( 'give_frontend_notices', [ $this, 'render_frontend_notices' ], 999 );
@@ -415,9 +415,10 @@ class Give_Notices {
 	 * Show notices
 	 * Note: only for internal use
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since 2.3.0
 	 */
-	public function __reveal_notices() {
+	public function reveal_notices() {
 		?>
 		<script>
 			jQuery(document).ready(function($){

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -106,19 +106,19 @@ class Give_DB_Meta extends Give_DB {
 		}
 
 		if ( in_array( 'posts_where', $this->supports ) ) {
-			add_filter( 'posts_where', [ $this, '__rename_meta_table_name_in_query' ], 99999, 2 );
+			add_filter( 'posts_where', [$this, 'rename_meta_table_name_in_query'], 99999, 2 );
 		}
 
 		if ( in_array( 'posts_join', $this->supports ) ) {
-			add_filter( 'posts_join', [ $this, '__rename_meta_table_name_in_query' ], 99999, 2 );
+			add_filter( 'posts_join', [$this, 'rename_meta_table_name_in_query'], 99999, 2 );
 		}
 
 		if ( in_array( 'posts_groupby', $this->supports ) ) {
-			add_filter( 'posts_groupby', [ $this, '__rename_meta_table_name_in_query' ], 99999, 2 );
+			add_filter( 'posts_groupby', [$this, 'rename_meta_table_name_in_query'], 99999, 2 );
 		}
 
 		if ( in_array( 'posts_orderby', $this->supports ) ) {
-			add_filter( 'posts_orderby', [ $this, '__rename_meta_table_name_in_query' ], 99999, 2 );
+			add_filter( 'posts_orderby', [$this, 'rename_meta_table_name_in_query'], 99999, 2 );
 		}
 	}
 
@@ -284,6 +284,7 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Rename query clauses of every query for new meta table
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.0
 	 * @access public
 	 *
@@ -292,10 +293,10 @@ class Give_DB_Meta extends Give_DB {
 	 *
 	 * @return string
 	 */
-	public function __rename_meta_table_name_in_query( $clause, $wp_query ) {
+	public function rename_meta_table_name_in_query( $clause, $wp_query ) {
 		// Add new table to sql query.
 		if ( $this->is_post_type_query( $wp_query ) && ! empty( $wp_query->meta_query->queries ) ) {
-			$clause = $this->__rename_meta_table_name( $clause, current_filter() );
+			$clause = $this->rename_meta_table_name( $clause, current_filter() );
 		}
 
 		return $clause;
@@ -305,12 +306,13 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Rename query clauses for new meta table
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @param $clause
 	 * @param $filter
 	 *
 	 * @return mixed
 	 */
-	public function __rename_meta_table_name( $clause, $filter ) {
+	public function rename_meta_table_name( $clause, $filter ) {
 		global $wpdb;
 
 		$clause = str_replace( "{$wpdb->postmeta}.post_id", "{$this->table_name}.{$this->meta_type}_id", $clause );

--- a/includes/database/class-give-db-sessions.php
+++ b/includes/database/class-give-db-sessions.php
@@ -223,6 +223,7 @@ class Give_DB_Sessions extends Give_DB {
 	 * Replace table data
 	 * Note: only for internal use
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.2.0
 	 * @access public
 	 *
@@ -230,7 +231,7 @@ class Give_DB_Sessions extends Give_DB {
 	 * @param array  $data       Data.
 	 * @param array  $format     Array for data format of each key:value in data.
 	 */
-	public function __replace( $table_name, $data, $format = null ) {
+	public function replace( $table_name, $data, $format = null ) {
 		global $wpdb;
 
 		wp_cache_set( $data['session_key'], $data['session_value'], $this->cache_group, $data['session_expiry'] - time() );

--- a/includes/deprecated/deprecated-functions.php
+++ b/includes/deprecated/deprecated-functions.php
@@ -1035,7 +1035,7 @@ function give_get_donor_latest_comment( $donor_id, $form_id = 0 ) {
 function give_email_tag_receipt_id( $tag_args ) {
 	$receipt_id = '';
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
 			$receipt_id = give_get_payment_key( $tag_args['payment_id'] );

--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -5,13 +5,14 @@ use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 /**
  * Insert donor comment to donation.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.21.0 remove anonymous
  * @since 2.2.0
  *
  * @param  int  $donation_id
  * @param  array  $donation_data
  */
-function __give_insert_donor_donation_comment( $donation_id, $donation_data ) {
+function give_insert_donor_donation_comment( $donation_id, $donation_data ) {
 	if ( ! empty( $_POST['give_comment'] ) ) {
         $donation = give()->donations->getById($donation_id);
         $donation->comment = sanitize_textarea_field(trim($_POST['give_comment']));
@@ -19,16 +20,17 @@ function __give_insert_donor_donation_comment( $donation_id, $donation_data ) {
     }
 }
 
-add_action( 'give_insert_payment', '__give_insert_donor_donation_comment', 10, 2 );
+add_action( 'give_insert_payment', 'give_insert_donor_donation_comment', 10, 2 );
 
 
 
 /**
  * Validate donor comment
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.0
  */
-function __give_validate_donor_comment() {
+function give_validate_donor_comment() {
 	// Check wp_check_comment_data_max_lengths for comment length validation.
 	if ( ! empty( $_POST['give_comment'] ) ) {
 		$max_lengths = wp_get_comment_fields_max_lengths();
@@ -39,18 +41,19 @@ function __give_validate_donor_comment() {
 		}
 	}
 }
-add_action( 'give_checkout_error_checks', '__give_validate_donor_comment', 10, 1 );
+add_action( 'give_checkout_error_checks', 'give_validate_donor_comment', 10, 1 );
 
 
 /**
  * Update donor comment status when donation status update
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.0
  *
  * @param $donation_id
  * @param $status
  */
-function __give_update_donor_donation_comment_status( $donation_id, $status ) {
+function give_update_donor_donation_comment_status( $donation_id, $status ) {
 	$approve = absint( 'publish' === $status );
 
 	/* @var WP_Comment $note */
@@ -61,16 +64,17 @@ function __give_update_donor_donation_comment_status( $donation_id, $status ) {
 	}
 }
 
-add_action( 'give_update_payment_status', '__give_update_donor_donation_comment_status', 10, 2 );
+add_action( 'give_update_payment_status', 'give_update_donor_donation_comment_status', 10, 2 );
 
 /**
  * Remove donor comment when donation delete
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.0
  *
  * @param $donation_id
  */
-function __give_remove_donor_donation_comment( $donation_id ) {
+function give_remove_donor_donation_comment( $donation_id ) {
 	/* @var WP_Comment $note */
 	$donor_comment = give_get_donor_donation_comment( $donation_id, give_get_payment_donor_id( $donation_id ) );
 
@@ -79,7 +83,7 @@ function __give_remove_donor_donation_comment( $donation_id ) {
 	}
 }
 
-add_action( 'give_payment_deleted', '__give_remove_donor_donation_comment', 10 );
+add_action( 'give_payment_deleted', 'give_remove_donor_donation_comment', 10 );
 
 
 /**

--- a/includes/donors/actions.php
+++ b/includes/donors/actions.php
@@ -12,7 +12,7 @@ use Give\Framework\PaymentGateways\PaymentGatewayRegister;
  * @param  int  $donation_id
  * @param  array  $donation_data
  */
-function give_insert_donor_donation_comment( $donation_id, $donation_data ) {
+function _give_insert_donor_donation_comment( $donation_id, $donation_data ) {
 	if ( ! empty( $_POST['give_comment'] ) ) {
         $donation = give()->donations->getById($donation_id);
         $donation->comment = sanitize_textarea_field(trim($_POST['give_comment']));
@@ -20,7 +20,7 @@ function give_insert_donor_donation_comment( $donation_id, $donation_data ) {
     }
 }
 
-add_action( 'give_insert_payment', 'give_insert_donor_donation_comment', 10, 2 );
+add_action( 'give_insert_payment', '_give_insert_donor_donation_comment', 10, 2 );
 
 
 

--- a/includes/donors/backward-compatibility.php
+++ b/includes/donors/backward-compatibility.php
@@ -2,6 +2,7 @@
 /**
  * Get donor address from donor meta instead of user meta
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param $meta_value
@@ -11,7 +12,7 @@
  *
  * @return string|array
  */
-function __give_v20_bc_user_address( $meta_value, $user_id, $meta_key, $single ) {
+function give_v20_bc_user_address( $meta_value, $user_id, $meta_key, $single ) {
 	if (
 		give_has_upgrade_completed( 'v20_upgrades_user_address' ) &&
 		'_give_user_address' === $meta_key
@@ -26,4 +27,4 @@ function __give_v20_bc_user_address( $meta_value, $user_id, $meta_key, $single )
 	return $meta_value;
 }
 
-add_filter( 'get_user_metadata', '__give_v20_bc_user_address', 10, 4 );
+add_filter( 'get_user_metadata', 'give_v20_bc_user_address', 10, 4 );

--- a/includes/emails/class-give-email-tags.php
+++ b/includes/emails/class-give-email-tags.php
@@ -72,7 +72,7 @@ class Give_Email_Template_Tags {
 	 * }
 	 */
 	public function add( $args ) {
-		__give_211_bc_email_template_tag_param( $args, func_get_args() );
+		give_211_bc_email_template_tag_param( $args, func_get_args() );
 
 		if ( is_callable( $args['func'] ) ) {
 			$this->tags[ $args['tag'] ] = [
@@ -206,7 +206,7 @@ class Give_Email_Template_Tags {
  *                    Check Give_Email_Template_Tags::add function description for more information
  */
 function give_add_email_tag( $args ) {
-	__give_211_bc_email_template_tag_param( $args, func_get_args() );
+	give_211_bc_email_template_tag_param( $args, func_get_args() );
 
 	Give()->email_tags->add( $args );
 }
@@ -550,7 +550,7 @@ function give_email_tag_first_name( $tag_args ) {
 	$firstname = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -604,7 +604,7 @@ function give_email_tag_fullname( $tag_args ) {
 	$fullname = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -653,7 +653,7 @@ function give_email_tag_username( $tag_args ) {
 	$username = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -706,7 +706,7 @@ function give_email_tag_user_email( $tag_args ) {
 	$email = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -754,7 +754,7 @@ function give_email_tag_billing_address( $tag_args ) {
 	$address = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -804,7 +804,7 @@ function give_email_tag_date( $tag_args ) {
 	$date = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -838,7 +838,7 @@ function give_email_tag_amount( $tag_args ) {
 	$amount = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -886,7 +886,7 @@ function give_email_tag_payment_id( $tag_args ) {
 	$payment_id = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -918,7 +918,7 @@ function give_email_tag_donation( $tag_args ) {
 	$donation_form_title = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -965,7 +965,7 @@ function give_email_tag_form_title( $tag_args ) {
     $donation_form_title = '';
 
     // Backward compatibility.
-    $tag_args = __give_20_bc_str_type_email_tag_param($tag_args);
+    $tag_args = give_20_bc_str_type_email_tag_param($tag_args);
 
     switch (true) {
         case give_check_variable($tag_args, 'isset', 0, 'payment_id'):
@@ -1005,7 +1005,7 @@ function give_email_tag_company_name( $tag_args ) {
 	$company_name = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -1041,10 +1041,10 @@ function give_email_tag_payment_method( $tag_args ) {
 	$payment_method = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -1083,7 +1083,7 @@ function give_email_tag_payment_total( $tag_args ) {
 	$payment_total = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
@@ -1120,7 +1120,7 @@ function give_email_tag_sitename( $tag_args = [] ) {
 	$sitename = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	/**
 	 * Filter the {sitename} email template tag output.
@@ -1148,7 +1148,7 @@ function give_email_tag_sitename( $tag_args = [] ) {
  */
 function give_email_tag_receipt_link( $tag_args ) {
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	$donation_id = give_check_variable( $tag_args, 'empty', 0, 'payment_id' );
 	$receipt_url = give_get_view_receipt_url( $donation_id );
@@ -1188,7 +1188,7 @@ function give_email_tag_receipt_link( $tag_args ) {
  */
 function give_email_tag_receipt_link_url( $tag_args ) {
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	$receipt_link_url = give_get_view_receipt_url( give_check_variable( $tag_args, 'empty', 0, 'payment_id' ) );
 
@@ -1222,7 +1222,7 @@ function give_email_tag_donation_history_link( $tag_args ) {
 	$email_access_link = '';
 
 	// Backward compatibility.
-	$tag_args = __give_20_bc_str_type_email_tag_param( $tag_args );
+	$tag_args = give_20_bc_str_type_email_tag_param( $tag_args );
 
 	switch ( true ) {
 
@@ -1314,13 +1314,14 @@ function give_email_tag_donation_history_link( $tag_args ) {
  *
  * Note: from 2.0 email tag render function will start accepting array values.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param $tag_args
  *
  * @return array
  */
-function __give_20_bc_str_type_email_tag_param( $tag_args ) {
+function give_20_bc_str_type_email_tag_param( $tag_args ) {
 	if ( ! is_array( $tag_args ) ) {
 		switch ( true ) {
 			case ( 'give_payment' === get_post_type( $tag_args ) ):
@@ -1352,9 +1353,10 @@ function __give_20_bc_str_type_email_tag_param( $tag_args ) {
  * @param string|array $args      Function arguments.
  * @param array        $func_args Deprecated argument list.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.1
  */
-function __give_211_bc_email_template_tag_param( &$args, $func_args = [] ) {
+function give_211_bc_email_template_tag_param( &$args, $func_args = [] ) {
 
 	/**
 	 * This is for backward-compatibility, i.e.; if the parameters are
@@ -1645,6 +1647,7 @@ function give_email_donor_comment( $tag_args ) {
  * This function helps to render meta data with from dynamic meta data email tag.
  * Note: meta data email tag must be in given format {meta_*}
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0.3
  * @see   https://github.com/impress-org/give/issues/2801#issuecomment-365136602
  *
@@ -1653,7 +1656,7 @@ function give_email_donor_comment( $tag_args ) {
  *
  * @return mixed
  */
-function __give_render_metadata_email_tag( $content, $tag_args ) {
+function give_render_metadata_email_tag( $content, $tag_args ) {
 	preg_match_all( '/{meta_([A-z0-9\-\_\ ]+)}/s', $content, $matches );
 
 	if ( ! empty( $matches[0] ) ) {
@@ -1746,4 +1749,4 @@ function __give_render_metadata_email_tag( $content, $tag_args ) {
 	return $content;
 }
 
-add_filter( 'give_email_template_tags', '__give_render_metadata_email_tag', 10, 2 );
+add_filter( 'give_email_template_tags', 'give_render_metadata_email_tag', 10, 2 );

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -333,13 +333,14 @@ add_filter( 'give_currency_filter', 'give_format_price_for_right_to_left_support
 /**
  * Validate active gateway value before returning result.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.1.0
  *
  * @param $value
  *
  * @return array
  */
-function __give_validate_active_gateways( $value ) {
+function give_validate_active_gateways( $value ) {
 	$gateways        = array_keys( give_get_payment_gateways() );
 	$active_gateways = is_array( $value ) ? array_keys( $value ) : [];
 
@@ -369,4 +370,4 @@ function __give_validate_active_gateways( $value ) {
 	return $value;
 }
 
-add_filter( 'give_get_option_gateways', '__give_validate_active_gateways', 10, 1 );
+add_filter( 'give_get_option_gateways', 'give_validate_active_gateways', 10, 1 );

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -597,7 +597,7 @@ function give_format_decimal($args)
     $args = wp_parse_args(
         $args,
         [
-            'amount' => '',
+            'amount' => 0,
             'donation_id' => 0,
             'currency' => '',
             'dp' => false,

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -218,6 +218,7 @@ function give_sanitize_amount_for_db($number, $args = [])
 /**
  * Sanitize Amount before saving to database
  *
+ * @unreleased PHP 8 compatibility
  * @since      1.8.12
  *
  * @param int|float|string $number Expects either a float or a string with a decimal separator only (no thousands)
@@ -230,16 +231,6 @@ function give_maybe_sanitize_amount($number, $args = [])
     // Bailout.
     if (empty($number) || ( ! is_numeric($number) && ! is_string($number))) {
         return $number;
-    }
-
-    $func_args = func_get_args();
-
-    // Backward compatibility.
-    if (isset($func_args[1]) && (is_bool($func_args[1]) || is_numeric($func_args[1]))) {
-        $args = [
-            'number_decimals' => $func_args[1],
-            'trim_zeros' => isset($func_args[2]) ? $func_args[2] : false,
-        ];
     }
 
     $args = wp_parse_args(
@@ -305,6 +296,7 @@ function give_maybe_sanitize_amount($number, $args = [])
  *
  * Returns a sanitized amount by stripping out thousands separators.
  *
+ * @unreleased PHP 8 compatibility
  * @since      1.0
  *
  * @param int|float|string $number Expects either a float or a string with a decimal separator only (no thousands)
@@ -317,17 +309,6 @@ function give_sanitize_amount($number, $args = [])
     // Bailout.
     if (empty($number) || ( ! is_numeric($number) && ! is_string($number))) {
         return $number;
-    }
-
-    // Get function arguments.
-    $func_args = func_get_args();
-
-    // Backward compatibility.
-    if (isset($func_args[1]) && (is_bool($func_args[1]) || is_numeric($func_args[1]))) {
-        $args = [
-            'number_decimals' => $func_args[1],
-            'trim_zeros' => isset($func_args[2]) ? $func_args[2] : false,
-        ];
     }
 
     $args = wp_parse_args(
@@ -597,6 +578,7 @@ function give_human_format_large_amount($amount, $args = [])
 /**
  * Returns a nicely formatted amount with custom decimal separator.
  *
+ * @unreleased PHP 8 compatibility
  * @since 1.0
  *
  * @param array           $args        {
@@ -612,16 +594,6 @@ function give_human_format_large_amount($amount, $args = [])
  */
 function give_format_decimal($args)
 {
-    // Backward compatibility.
-    if ( ! is_array($args)) {
-        $func_args = func_get_args();
-        $args = [
-            'amount' => $func_args[0],
-            'dp' => isset($func_args[1]) ? $func_args[1] : false,
-            'sanitize' => isset($func_args[2]) ? $func_args[2] : true,
-        ];
-    }
-
     $args = wp_parse_args(
         $args,
         [

--- a/includes/forms/template.php
+++ b/includes/forms/template.php
@@ -2349,9 +2349,10 @@ add_filter( 'give_donate_form', 'give_members_only_form', 10, 2 );
  * @param array            $args
  * @param Give_Donate_Form $form
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 1.8.17
  */
-function __give_form_add_donation_hidden_field( $form_id, $args, $form ) {
+function give_form_add_donation_hidden_field( $form_id, $args, $form ) {
 	$id_prefix = ! empty( $args['id_prefix'] ) ? $args['id_prefix'] : '';
 	?>
 	<input type="hidden" name="give-form-id-prefix" value="<?php echo $id_prefix; ?>"/>
@@ -2400,7 +2401,7 @@ function __give_form_add_donation_hidden_field( $form_id, $args, $form ) {
 	}
 }
 
-add_action( 'give_donation_form_top', '__give_form_add_donation_hidden_field', 0, 3 );
+add_action( 'give_donation_form_top', 'give_form_add_donation_hidden_field', 0, 3 );
 
 /**
  * Add currency settings on donation form.
@@ -2409,9 +2410,11 @@ add_action( 'give_donation_form_top', '__give_form_add_donation_hidden_field', 0
  * @param Give_Donate_Form $form
  *
  * @return array
+ *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 1.8.17
  */
-function __give_form_add_currency_settings( $form_html_tags, $form ) {
+function give_form_add_currency_settings( $form_html_tags, $form ) {
 	$form_currency     = give_get_currency( $form->ID );
 	$currency_settings = give_get_currency_formatting_settings( $form_currency );
 
@@ -2432,7 +2435,7 @@ function __give_form_add_currency_settings( $form_html_tags, $form ) {
 	return $form_html_tags;
 }
 
-add_filter( 'give_form_html_tags', '__give_form_add_currency_settings', 0, 2 );
+add_filter( 'give_form_html_tags', 'give_form_add_currency_settings', 0, 2 );
 
 /**
  * Adds classes to progress bar container.

--- a/includes/gateways/actions.php
+++ b/includes/gateways/actions.php
@@ -98,11 +98,12 @@ add_action( 'wp_ajax_nopriv_give_donation_form_nonce', 'give_donation_form_nonce
  * Create all nonce of donation form using Ajax call.
  * Note: only for internal use
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.2.0
  *
  * @return void
  */
-function __give_donation_form_reset_all_nonce() {
+function give_donation_form_reset_all_nonce() {
 	if ( isset( $_POST['give_form_id'] ) ) {
 
 		// Get donation form id.
@@ -127,8 +128,8 @@ function __give_donation_form_reset_all_nonce() {
 	wp_send_json_error();
 }
 
-add_action( 'wp_ajax_give_donation_form_reset_all_nonce', '__give_donation_form_reset_all_nonce' );
-add_action( 'wp_ajax_nopriv_give_donation_form_reset_all_nonce', '__give_donation_form_reset_all_nonce' );
+add_action( 'wp_ajax_give_donation_form_reset_all_nonce', 'give_donation_form_reset_all_nonce');
+add_action( 'wp_ajax_nopriv_give_donation_form_reset_all_nonce', 'give_donation_form_reset_all_nonce');
 
 /**
  * Sets an error within the donation form if no gateways are enabled.

--- a/includes/install.php
+++ b/includes/install.php
@@ -96,7 +96,7 @@ function give_run_install()
     update_option('give_default_api_version', 'v' . $api->get_version(), false);
 
     // Create databases.
-    __give_register_tables();
+    give_register_tables();
 
     // Add a temporary option to note that Give pages have been created.
     Give_Cache::set('_give_installed', $options, 30, true);
@@ -499,7 +499,7 @@ add_action('admin_init', 'give_create_pages', -1);
 function give_install_tables_on_plugin_update($old_version)
 {
     update_option('give_version_upgraded_from', $old_version, false);
-    __give_register_tables();
+    give_register_tables();
 }
 
 add_action('update_option_give_version', 'give_install_tables_on_plugin_update', 0, 2);
@@ -510,9 +510,10 @@ add_action('update_option_give_version', 'give_install_tables_on_plugin_update',
  *
  * Note: only for internal purpose use
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @sice 2.3.1
  */
-function __give_get_tables()
+function give_get_tables()
 {
     $tables = [
         'donors_db' => new Give_DB_Donors(),
@@ -532,13 +533,14 @@ function __give_get_tables()
  * Register classes
  * Note: only for internal purpose use
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.21.0 Install migration table on fresh install because this table is required to run migrations.
  * @since 2.3.1
  * @throws DatabaseMigrationException
  */
-function __give_register_tables()
+function give_register_tables()
 {
-    $tables = __give_get_tables();
+    $tables = give_get_tables();
 
     /* @var Give_DB $table */
     foreach ($tables as $table) {

--- a/includes/libraries/browser.php
+++ b/includes/libraries/browser.php
@@ -216,7 +216,10 @@ class Browser {
 
 	public $OPERATING_SYSTEM_UNKNOWN = 'unknown';
 
-	function Browser( $useragent = "" ) {
+    /**
+     * @unreleased rename function - PHP 8 compatibility
+     */
+	public function __construct( $useragent = "" ) {
 		$this->reset();
 		if ( $useragent != "" ) {
 			$this->setUserAgent( $useragent );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1166,10 +1166,12 @@ function give_get_completed_upgrades() {
  * @param string $type Context for table
  *
  * @return null|array
+ *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  * @global wpdb  $wpdb
  */
-function __give_v20_bc_table_details( $type ) {
+function give_v20_bc_table_details( $type ) {
 	global $wpdb;
 	$table = [];
 
@@ -1635,7 +1637,7 @@ function give_doing_it_wrong( $function, $message, $version = null ) {
 function give_ignore_user_abort() {
 	ignore_user_abort( true );
 
-	if ( ! give_is_func_disabled( 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) {
+	if ( ! give_is_func_disabled( 'set_time_limit' )) {
 		set_time_limit( 0 );
 	}
 }
@@ -1855,9 +1857,11 @@ function give_is_donor_comment_field_enabled( $form_id ) {
  * @param string $banner_addon_name Give add-on name.
  *
  * @return array
+ *              
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.1.0
  */
-function __give_get_active_by_user_meta( $banner_addon_name ) {
+function give_get_active_by_user_meta( $banner_addon_name ) {
 	global $wpdb;
 
 	// Get the option key.

--- a/includes/payments/backward-compatibility.php
+++ b/includes/payments/backward-compatibility.php
@@ -686,6 +686,7 @@ if ( give_has_upgrade_completed( 'v20_upgrades_payment_metadata' ) ) {
 /**
  * Delete pre upgrade cache for donations.
  *
+ * @unreleased rename function - PHP 8 compatibility
  * @since 2.0
  *
  * @param $check
@@ -693,7 +694,7 @@ if ( give_has_upgrade_completed( 'v20_upgrades_payment_metadata' ) ) {
  *
  * @return mixed
  */
-function __give_20_bc_flush_cache( $check, $object_id ) {
+function give_20_bc_flush_cache( $check, $object_id ) {
 	if ( 'give_payment' === get_post_type( $object_id ) ) {
 		Give_Cache::delete_group( $object_id, 'give-donations' );
 	}
@@ -703,6 +704,6 @@ function __give_20_bc_flush_cache( $check, $object_id ) {
 
 // Apply only if upgrade does not complete.
 if ( ! give_has_upgrade_completed( 'v20_move_metadata_into_new_table' ) ) {
-	add_action( 'update_post_metadata', '__give_20_bc_flush_cache', 9999, 2 );
-	add_action( 'add_post_metadata', '__give_20_bc_flush_cache', 9999, 2 );
+	add_action( 'update_post_metadata', 'give_20_bc_flush_cache', 9999, 2 );
+	add_action( 'add_post_metadata', 'give_20_bc_flush_cache', 9999, 2 );
 }

--- a/includes/payments/class-give-sequential-donation-number.php
+++ b/includes/payments/class-give-sequential-donation-number.php
@@ -58,14 +58,15 @@ class Give_Sequential_Donation_Number {
 	 * @since 2.1.0
 	 */
 	public function init() {
-        add_action('wp_insert_post', array($this, '__save_donation_title'), 10, 3);
-        add_action('after_delete_post', array($this, '__remove_serial_number'), 10, 1);
+        add_action('wp_insert_post', array($this, 'save_donation_title'), 10, 3);
+        add_action('after_delete_post', array($this, 'remove_serial_number'), 10, 1);
     }
 
 	/**
 	 * Set serialize donation number as donation title.
 	 * Note: only for internal use
 	 *
+     * @unreleased rename function - PHP 8 compatibility
      * @since 3.0.0 replace wp_update_post with DB::update to avoid affecting the post update date and invalidating the donation model's updatedAt date
 	 * @since  2.1.0
 	 * @access public
@@ -76,7 +77,7 @@ class Give_Sequential_Donation_Number {
 	 *
 	 * @return void
 	 */
-	public function __save_donation_title( $donation_id, $post, $existing_donation_updated ) {
+	public function save_donation_title( $donation_id, $post, $existing_donation_updated ) {
 		// Bailout
 		if (
 			! give_is_setting_enabled( give_get_option( 'sequential-ordering_status', 'disabled' ) )
@@ -86,7 +87,7 @@ class Give_Sequential_Donation_Number {
 			return;
 		}
 
-		$serial_number = $this->__set_donation_number( $donation_id );
+		$serial_number = $this->set_donation_number( $donation_id );
 		$serial_code   = $this->set_number_padding( $serial_number );
 
 		// Add prefix.
@@ -136,6 +137,7 @@ class Give_Sequential_Donation_Number {
 	 * Set donation number
 	 * Note: only for internal use
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.1.0
 	 * @access public
 	 *
@@ -143,7 +145,7 @@ class Give_Sequential_Donation_Number {
 	 *
 	 * @return int
 	 */
-	public function __set_donation_number( $donation_id ) {
+	public function set_donation_number( $donation_id ) {
 		$table_data = array(
 			'payment_id' => $donation_id,
 		);
@@ -177,6 +179,7 @@ class Give_Sequential_Donation_Number {
 	 * Remove sequential donation data
 	 * Note: only internal use.
 	 *
+     * @unreleased rename function - PHP 8 compatibility
 	 * @since  2.1.0
 	 * @access public
 	 *
@@ -184,7 +187,7 @@ class Give_Sequential_Donation_Number {
 	 *
 	 * @return bool
 	 */
-	public function __remove_serial_number( $donation_id ) {
+	public function remove_serial_number( $donation_id ) {
 		return Give()->sequential_donation_db->delete( $this->get_serial_number( $donation_id ) );
 	}
 

--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -279,7 +279,7 @@ class Give_Payment_Stats extends Give_Stats {
 	public function get_best_selling( $number = 10 ) {
 		global $wpdb;
 
-		$meta_table = __give_v20_bc_table_details( 'form' );
+		$meta_table = give_v20_bc_table_details( 'form' );
 
 		$give_forms = $wpdb->get_results(
 			$wpdb->prepare(

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -909,7 +909,7 @@ class Give_Payments_Query extends Give_Stats {
 		if ( ! empty( $this->args['meta_query'] ) ) {
 			$meta_query_obj = new WP_Meta_Query( $this->args['meta_query'] );
 			$where          = implode( ' ', $meta_query_obj->get_sql( 'post', $wpdb->posts, 'ID' ) ) . " {$where}";
-			$where          = Give()->payment_meta->__rename_meta_table_name( $where, 'posts_where' );
+			$where          = Give()->payment_meta->rename_meta_table_name( $where, 'posts_where' );
 		}
 
 		// Set sql query.

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -420,7 +420,7 @@ function give_delete_donation( $payment_id = 0, $update_donor = true ) {
 		// Remove the payment ID from the donor.
 		$donor->remove_payment( $payment_id );
 	}
-	
+
     // Remove the payment.
     wp_delete_post( $payment_id, true );
 
@@ -825,7 +825,7 @@ function give_get_total_donations() {
 function give_get_total_earnings( $recalculate = false ) {
 
 	$total      = get_option( 'give_earnings_total', 0 );
-	$meta_table = __give_v20_bc_table_details( 'payment' );
+	$meta_table = give_v20_bc_table_details( 'payment' );
 
 	// Calculate total earnings.
 	if ( ! $total || $recalculate ) {
@@ -1376,7 +1376,7 @@ function give_set_payment_transaction_id( $payment_id = 0, $transaction_id = '' 
 function give_get_donation_id_by_key( $key ) {
 	global $wpdb;
 
-	$meta_table = __give_v20_bc_table_details( 'payment' );
+	$meta_table = give_v20_bc_table_details( 'payment' );
 
 	$purchase = $wpdb->get_var(
 		$wpdb->prepare(
@@ -1412,7 +1412,7 @@ function give_get_donation_id_by_key( $key ) {
  */
 function give_get_purchase_id_by_transaction_id( $key ) {
 	global $wpdb;
-	$meta_table = __give_v20_bc_table_details( 'payment' );
+	$meta_table = give_v20_bc_table_details( 'payment' );
 
 	$purchase = $wpdb->get_var( $wpdb->prepare( "SELECT {$meta_table['column']['id']} FROM {$meta_table['name']} WHERE meta_key = '_give_payment_transaction_id' AND meta_value = %s LIMIT 1", $key ) );
 

--- a/src/Donations/LegacyListeners/InsertSequentialId.php
+++ b/src/Donations/LegacyListeners/InsertSequentialId.php
@@ -14,6 +14,6 @@ class InsertSequentialId
      */
     public function __invoke(Donation $donation)
     {
-        give()->seq_donation_number->__save_donation_title($donation->id, get_post($donation->id), false);
+        give()->seq_donation_number->save_donation_title($donation->id, get_post($donation->id), false);
     }
 }

--- a/src/Donations/LegacyListeners/RemoveSequentialId.php
+++ b/src/Donations/LegacyListeners/RemoveSequentialId.php
@@ -14,6 +14,6 @@ class RemoveSequentialId
      */
     public function __invoke(Donation $donation)
     {
-        give()->seq_donation_number->__remove_serial_number($donation->id);
+        give()->seq_donation_number->remove_serial_number($donation->id);
     }
 }

--- a/src/Framework/Http/Response/Traits/ResponseTrait.php
+++ b/src/Framework/Http/Response/Traits/ResponseTrait.php
@@ -123,6 +123,7 @@ trait ResponseTrait
      * @param  Cookie|mixed  $cookie
      * @return $this
      */
+    //phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
     public function withCookie($cookie)
     {
         if (is_string($cookie) && function_exists('cookie')) {

--- a/src/Log/Migrations/MigrateExistingLogs.php
+++ b/src/Log/Migrations/MigrateExistingLogs.php
@@ -149,7 +149,7 @@ class MigrateExistingLogs extends Migration
                         $context
                     )->save();
                 } catch (\Exception $exception) {
-                    $give_updates->__pause_db_update(true);
+                    $give_updates->pause_db_update(true);
                     update_option('give_upgrade_error', 1, false);
                 }
             }

--- a/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
+++ b/src/Revenue/Migrations/AddPastDonationsToRevenueTable.php
@@ -85,7 +85,7 @@ class AddPastDonationsToRevenueTable extends Migration
                 try {
                     $revenueRepository->insert($revenueData);
                 } catch (Exception $e) {
-                    $give_updates->__pause_db_update(true);
+                    $give_updates->pause_db_update(true);
                     update_option('give_upgrade_error', 1, false);
 
                     Log::error(

--- a/tests/Unit/Donations/Models/TestDonation.php
+++ b/tests/Unit/Donations/Models/TestDonation.php
@@ -92,7 +92,7 @@ class TestDonation extends TestCase
         $donor = Donor::factory()->create();
         $donation = Donation::factory()->create(['donorId' => $donor->id]);
 
-        give()->seq_donation_number->__save_donation_title($donation->id, get_post($donation->id), false);
+        give()->seq_donation_number->save_donation_title($donation->id, get_post($donation->id), false);
 
         $this->assertEquals(1, $donation->getSequentialId());
     }

--- a/tests/includes/legacy/tests-email-tags.php
+++ b/tests/includes/legacy/tests-email-tags.php
@@ -758,19 +758,19 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 		 * Case 1: donor meta data tests.
 		 */
 		$donor_tag_args = array( 'donor_id' => $donor_id );
-		$this->assertEquals( 'Admin', __give_render_metadata_email_tag( '{meta_donor__give_donor_first_name}', $donor_tag_args ) );
-		$this->assertEquals( 'User', __give_render_metadata_email_tag( '{meta_donor__give_donor_last_name}', $donor_tag_args ) );
+		$this->assertEquals( 'Admin', give_render_metadata_email_tag( '{meta_donor__give_donor_first_name}', $donor_tag_args ) );
+		$this->assertEquals( 'User', give_render_metadata_email_tag( '{meta_donor__give_donor_last_name}', $donor_tag_args ) );
 
 		Give()->donor_meta->update_meta( $donor_id, '_give_stripe_customer_id', 2 );
 
-		$this->assertEquals( 2, __give_render_metadata_email_tag( '{meta_donor__give_stripe_customer_id}', $donor_tag_args ) );
-		$this->assertEquals( $donor_id, __give_render_metadata_email_tag( '{meta_donor_id}', $donor_tag_args ) );
-		$this->assertEquals( 1, __give_render_metadata_email_tag( '{meta_donor_user_id}', $donor_tag_args ) );
-		$this->assertEquals( 'Admin User', __give_render_metadata_email_tag( '{meta_donor_name}', $donor_tag_args ) );
-		$this->assertEquals( 'admin@example.org', __give_render_metadata_email_tag( '{meta_donor_email}', $donor_tag_args ) );
+		$this->assertEquals( 2, give_render_metadata_email_tag( '{meta_donor__give_stripe_customer_id}', $donor_tag_args ) );
+		$this->assertEquals( $donor_id, give_render_metadata_email_tag( '{meta_donor_id}', $donor_tag_args ) );
+		$this->assertEquals( 1, give_render_metadata_email_tag( '{meta_donor_user_id}', $donor_tag_args ) );
+		$this->assertEquals( 'Admin User', give_render_metadata_email_tag( '{meta_donor_name}', $donor_tag_args ) );
+		$this->assertEquals( 'admin@example.org', give_render_metadata_email_tag( '{meta_donor_email}', $donor_tag_args ) );
 
-		$this->assertEquals( 'Admin User', __give_render_metadata_email_tag( '{meta_donor_name}', array( 'user_id' => 1 ) ) );
-		$this->assertEquals( 'Admin User', __give_render_metadata_email_tag( '{meta_donor_name}', array( 'payment_id' => $payment_id ) ) );
+		$this->assertEquals( 'Admin User', give_render_metadata_email_tag( '{meta_donor_name}', array('user_id' => 1 ) ) );
+		$this->assertEquals( 'Admin User', give_render_metadata_email_tag( '{meta_donor_name}', array('payment_id' => $payment_id ) ) );
 
 		/*
 		 * Case 2: donation meta data tests.

--- a/tests/includes/legacy/tests-email-tags.php
+++ b/tests/includes/legacy/tests-email-tags.php
@@ -658,12 +658,12 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 			)
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/action=view_in_browser/',
 			$receipt_link_url
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/_give_hash=/',
 			$receipt_link_url
 		);
@@ -684,17 +684,17 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 			)
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/>View the receipt in your browser &raquo;<\/a>/',
 			$receipt_link
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/<a href=".+?\?action=view_in_browser/',
 			$receipt_link
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/_give_hash=/',
 			$receipt_link
 		);
@@ -719,12 +719,12 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 
 		$link = give_email_tag_donation_history_link( array( 'user_id' => 1 ) );
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/target="_blank">View your donation history &raquo;<\/a>/',
 			$link
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/<a href=".+?\?give_nl=/',
 			$link
 		);
@@ -736,7 +736,7 @@ class Tests_Email_Tags extends Give_Unit_Test_Case {
 			)
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/View your donation history: .+?\?give_nl=/',
 			$link
 		);

--- a/tests/includes/legacy/tests-formatting.php
+++ b/tests/includes/legacy/tests-formatting.php
@@ -459,7 +459,11 @@ class Tests_Formatting extends Give_Unit_Test_Case {
 	 * @dataProvider give_format_decimal_provider
 	 */
 	public function test_give_format_decimal( $number, $expected, $decimal_place = false ) {
-		$output = give_format_decimal( $number, $decimal_place );
+		$output = give_format_decimal( [
+            'amount' => $number,
+            'currency' => give_get_currency(),
+            'dp' => $decimal_place
+        ]);
 
 		$this->assertSame(
 			$expected,

--- a/tests/includes/legacy/tests-misc-functions.php
+++ b/tests/includes/legacy/tests-misc-functions.php
@@ -373,7 +373,7 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 
 		$receipt_link_url = give_get_receipt_url( $payment );
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/donation_id=/',
 			$receipt_link_url
 		);
@@ -392,12 +392,12 @@ class Tests_MISC_Functions extends Give_Unit_Test_Case {
 
 		$receipt_link_url = give_get_receipt_link( $payment );
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/donation_id=/',
 			$receipt_link_url
 		);
 
-		$this->assertRegExp(
+		$this->assertMatchesRegularExpression(
 			'/<a href=".+?\?donation_id=/',
 			$receipt_link_url
 		);


### PR DESCRIPTION

## Description
This pull request focuses on renaming internal functions throughout the codebase to improve PHP 8 compatibility. The main change is the removal of leading double underscores from custom function names, which helps prevent conflicts with PHP magic methods and aligns with best practices. The updates affect action/filter hooks, function definitions, and their usages in several files, ensuring consistency and compatibility.


## Affects

Core

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->



## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

