### PR TITLE
Fix: Elementor legacy form widget preview

### DIFF
--- a/src/ThirdPartySupport/Elementor/Actions/RegisterWidgetEditorScripts.php
+++ b/src/ThirdPartySupport/Elementor/Actions/RegisterWidgetEditorScripts.php
@@ -21,6 +21,7 @@ class RegisterWidgetEditorScripts
     const CAMPAIGN_WIDGET_SCRIPT_NAME = 'givewp-elementor-campaign-widget';
     const CAMPAIGN_GRID_WIDGET_SCRIPT_NAME = 'givewp-elementor-campaign-grid-widget';
     const CAMPAIGN_COMMENTS_WIDGET_SCRIPT_NAME = 'givewp-elementor-campaign-comments-widget';
+    const LEGACY_GIVE_FORM_WIDGET_SCRIPT_NAME = 'givewp-elementor-legacy-give-form-widget';
 
     /**
      * @since 4.7.0
@@ -32,7 +33,8 @@ class RegisterWidgetEditorScripts
         $this->registerFormGridWidgetScripts();
         $this->registerCampaignWidgetScripts();
         $this->registerCampaignGridWidgetScripts();
-            $this->registerCampaignCommentsWidgetScripts();
+        $this->registerCampaignCommentsWidgetScripts();
+        $this->registerLegacyGiveFormWidgetScripts();
     }
 
 
@@ -65,6 +67,29 @@ class RegisterWidgetEditorScripts
         wp_register_style(
             self::CAMPAIGN_GOAL_WIDGET_SCRIPT_NAME,
             GIVE_PLUGIN_URL . 'build/campaignGoalBlockApp.css',
+            [],
+            $scriptAsset['version']
+        );
+    }
+
+    /**
+     * @unreleased
+     */
+    private function registerLegacyGiveFormWidgetScripts()
+    {
+        $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/elementorLegacyGiveFormWidget.asset.php');
+
+        wp_register_script(
+            self::LEGACY_GIVE_FORM_WIDGET_SCRIPT_NAME,
+            GIVE_PLUGIN_URL . 'build/elementorLegacyGiveFormWidget.js',
+            $scriptAsset['dependencies'],
+            $scriptAsset['version'],
+            true
+        );
+
+        wp_register_style(
+            self::LEGACY_GIVE_FORM_WIDGET_SCRIPT_NAME,
+            GIVE_PLUGIN_URL . 'build/elementorLegacyGiveFormWidget.css',
             [],
             $scriptAsset['version']
         );

--- a/src/ThirdPartySupport/Elementor/ServiceProvider.php
+++ b/src/ThirdPartySupport/Elementor/ServiceProvider.php
@@ -56,6 +56,14 @@ class ServiceProvider implements ServiceProviderInterface
                     'icon' => 'dashicons dashicons-give',
                 ]
             );
+
+            $elements_manager->add_category(
+                'givewp-category',
+                [
+                    'title' => __('GiveWP', 'give'),
+                    'icon' => 'dashicons dashicons-give',
+                ]
+            );
         });
 
         Hooks::addAction('givewp_campaign_page_created', SetupElementorCampaignTemplate::class);

--- a/src/ThirdPartySupport/Elementor/Widgets/V1/GiveFormWidget.php
+++ b/src/ThirdPartySupport/Elementor/Widgets/V1/GiveFormWidget.php
@@ -6,6 +6,7 @@ use Give\DonationForms\Models\DonationForm;
 use Give\Framework\Database\DB;
 use Give\Helpers\Form\Utils;
 use Elementor\Widget_Base;
+use Give\ThirdPartySupport\Elementor\Actions\RegisterWidgetEditorScripts;
 
 /**
  * Elementor Give Form Widget.
@@ -405,5 +406,21 @@ class GiveFormWidget extends Widget_Base
     private function getFormTemplate($formId)
     {
         return Give()->form_meta->get_meta($formId, '_give_form_template', true);
+    }
+
+    /**
+     * @unreleased
+     */
+    public function get_script_depends(): array
+    {
+        return [RegisterWidgetEditorScripts::LEGACY_GIVE_FORM_WIDGET_SCRIPT_NAME];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function get_style_depends(): array
+    {
+        return [RegisterWidgetEditorScripts::LEGACY_GIVE_FORM_WIDGET_SCRIPT_NAME];
     }
 }

--- a/src/ThirdPartySupport/Elementor/Widgets/V1/resources/formWidget.jsx
+++ b/src/ThirdPartySupport/Elementor/Widgets/V1/resources/formWidget.jsx
@@ -1,0 +1,32 @@
+import renderDonationForm from '@givewp/src/DonationForms/Blocks/DonationFormBlock/resources/app/renderDonationForm';
+
+/**
+ * @unreleased
+ */
+export default class GiveFormWidget extends elementorModules.frontend.handlers.Base {
+    render() {
+        const roots = document.querySelectorAll(`[data-id="${this.getID()}"] .root-data-givewp-embed`);
+
+        roots?.forEach((root) => {
+            renderDonationForm(root);
+        });
+    }
+
+    onInit() {
+        this.render();
+    }
+}
+
+/**
+ * Register JS Handler
+ *
+ * When Elementor frontend was initiated, and the widget is ready, register the widet
+ * JS handler.
+ */
+window.addEventListener('elementor/frontend/init', () => {
+    const addHandler = ($element) => {
+        elementorFrontend.elementsHandler.addHandler(GiveFormWidget, {$element});
+    };
+
+    elementorFrontend.hooks.addAction('frontend/element_ready/Give Form.default', addHandler);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -213,6 +213,7 @@ const entry = {
     elementorCampaignGridWidget: srcPath('ThirdPartySupport/Elementor/Widgets/V2/ElementorCampaignGridWidget/resources/widget.jsx'),
     elementorCampaignWidget: srcPath('ThirdPartySupport/Elementor/Widgets/V2/ElementorCampaignWidget/resources/widget.jsx'),
     elementorCampaignCommentsWidget: srcPath('ThirdPartySupport/Elementor/Widgets/V2/ElementorCampaignCommentsWidget/resources/widget.jsx'),
+    elementorLegacyGiveFormWidget: srcPath('ThirdPartySupport/Elementor/Widgets/V1/resources/formWidget.jsx'),
     ...legacyScriptsEntry,
     ...legacyStyleEntry,
 };


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-2822]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This fixes the legacy form widget script preview in the editor by registering a necessary js script that is used in the editor for v3 forms.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The legacy form widget

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

<img width="1512" height="868" alt="Screenshot 2025-08-25 at 10 00 13 AM" src="https://github.com/user-attachments/assets/24f7f7b4-e624-47f4-9ed3-61454bf0fe04" />

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

ZIP: https://github.com/impress-org/givewp/actions/runs/17214314578

- Make sure the Elementor legacy form widget works properly with v3 and v2 forms (to match old add-on functionality)
- Make sure the GiveWP category shows up when the old add-on is not installed
- Make sure there no regression issues 

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-2822]: https://stellarwp.atlassian.net/browse/GIVE-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ