### PR TITLE
Fix: Update Campaign blocks to properly render v2 forms

### DIFF
--- a/src/Campaigns/Actions/RenderDonateButton.php
+++ b/src/Campaigns/Actions/RenderDonateButton.php
@@ -2,60 +2,41 @@
 
 namespace Give\Campaigns\Actions;
 
-use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
-use Give\DonationForms\Models\DonationForm;
+use Give\Campaigns\Models\Campaign;
 
 /**
+ * @unreleased Remove BlockRenderController dependency
  * @since 4.0.0
  */
 class RenderDonateButton
 {
     /**
+     * @unreleased Replace BlockRenderController::render with give_form_shortcode
      * @since 4.0.0
      */
-    private BlockRenderController $blockRenderController;
-
-    /**
-     * @since 4.0.0
-     */
-    public function __construct(BlockRenderController $blockRenderController)
+    public function __invoke(Campaign $campaign, array $attributes, string $buttonText): string
     {
-        $this->blockRenderController = $blockRenderController;
-    }
+        $isEditor = defined('REST_REQUEST') && REST_REQUEST;
 
-    /**
-     * @since 4.0.0
-     */
-    public function __invoke(int $formId, string $buttonText): string
-    {
-        if (!$this->isFormPublished($formId)) {
-            return '';
+        ob_start();
+
+        if ($isEditor) {
+            echo sprintf(
+                '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
+                esc_html($buttonText)
+            );
+        } else {
+            echo give_form_shortcode([
+                'id' => $campaign->defaultFormId,
+                'campaign_id' => $campaign->id,
+                'display_style' => 'modal',
+                'continue_button_title' => $buttonText,
+                'use_default_form' => true,
+                'button_color' => $campaign->primaryColor,
+                'block_id' => $attributes['blockId'] ?? '',
+            ]);
         }
 
-        $blockRender = $this->blockRenderController->render([
-            'formId' => $formId,
-            'openFormButton' => esc_html($buttonText),
-            'formFormat' => 'modal',
-        ]);
-
-        return $blockRender ?? sprintf(
-            '<button type="button" class="givewp-donation-form-modal__open">%s</button>',
-            esc_html($buttonText)
-        );
-    }
-
-    /**
-     * @since 4.0.0
-     */
-    private function isFormPublished(int $formId): bool
-    {
-        if (!$formId) {
-            return false;
-        }
-
-        /** @var DonationForm $form */
-        $form = DonationForm::find($formId);
-
-        return $form && $form->status->isPublished();
+        return (string) ob_get_clean();
     }
 }

--- a/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonations/resources/views/render.php
@@ -30,7 +30,7 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donations)) : ?>
             <div class="givewp-campaign-donations-block__donate-button">
                 <?php
-                echo give(RenderDonateButton::class)($campaign->defaultFormId, $donateButtonText);
+                echo give(RenderDonateButton::class)($campaign, $attributes, $donateButtonText);
                 ?>
             </div>
         <?php
@@ -60,7 +60,7 @@ $blockInlineStyles = sprintf(
                     <?php
                     $firstDonationButtonText = __('Be the first', 'give');
 
-                    echo give(RenderDonateButton::class)($campaign->defaultFormId, $firstDonationButtonText);
+                    echo give(RenderDonateButton::class)($campaign, $attributes, $firstDonationButtonText);
                     ?>
                 </div>
             <?php

--- a/src/Campaigns/Blocks/CampaignDonations/styles.scss
+++ b/src/Campaigns/Blocks/CampaignDonations/styles.scss
@@ -124,7 +124,7 @@
         &__load-more-button,
         &__donate-button button.givewp-donation-form-modal__open,
         &__empty-button button.givewp-donation-form-modal__open {
-            background: none;
+            background: none !important;
             border-radius: 0.5rem;
             border: 1px solid var(--givewp-primary-color);
             color: var(--givewp-primary-color) !important;
@@ -134,7 +134,7 @@
             padding: 0.25rem 1rem !important;
 
             &:hover {
-                background: var(--givewp-primary-color);
+                background: var(--givewp-primary-color) !important;
                 color: var(--givewp-shades-white) !important;
             }
         }

--- a/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
+++ b/src/Campaigns/Blocks/CampaignDonors/resources/views/render.php
@@ -32,7 +32,7 @@ $blockInlineStyles = sprintf(
         if ($attributes['showButton'] && ! empty($donors)) : ?>
             <div class="givewp-campaign-donors-block__donate-button">
                 <?php
-                echo give(RenderDonateButton::class)($campaign->defaultFormId, $donateButtonText);
+                echo give(RenderDonateButton::class)($campaign, $attributes, $donateButtonText);
                 ?>
             </div>
         <?php
@@ -66,7 +66,7 @@ $blockInlineStyles = sprintf(
                     <?php
                     $firstDonationButtonText = __('Be the first donor', 'give');
 
-                    echo give(RenderDonateButton::class)($campaign->defaultFormId, $firstDonationButtonText);
+                    echo give(RenderDonateButton::class)($campaign, $attributes, $firstDonationButtonText);
                     ?>
                 </div>
             <?php

--- a/src/Campaigns/Blocks/CampaignDonors/styles.scss
+++ b/src/Campaigns/Blocks/CampaignDonors/styles.scss
@@ -139,7 +139,7 @@
         &__load-more-button,
         &__donate-button button.givewp-donation-form-modal__open,
         &__empty-button button.givewp-donation-form-modal__open {
-            background: none;
+            background: none !important;
             border-radius: 0.5rem;
             border: 1px solid var(--givewp-primary-color);
             color: var(--givewp-primary-color) !important;
@@ -149,7 +149,7 @@
             padding: 0.25rem 1rem !important;
 
             &:hover {
-                background: var(--givewp-primary-color);
+                background: var(--givewp-primary-color) !important;
                 color: var(--givewp-shades-white) !important;
             }
         }

--- a/src/Campaigns/ServiceProvider.php
+++ b/src/Campaigns/ServiceProvider.php
@@ -13,7 +13,6 @@ use Give\Campaigns\Actions\FormInheritsCampaignGoal;
 use Give\Campaigns\Actions\LoadCampaignAdminOptions;
 use Give\Campaigns\Actions\PreventDeleteDefaultForm;
 use Give\Campaigns\Actions\RedirectLegacyCreateFormToCreateCampaign;
-use Give\Campaigns\Actions\RenderDonateButton;
 use Give\Campaigns\Actions\ReplaceGiveFormsCptLabels;
 use Give\Campaigns\Actions\UnarchiveCampaignFormAsPublishStatus;
 use Give\Campaigns\ListTable\Routes\DeleteCampaignListTable;
@@ -46,11 +45,6 @@ class ServiceProvider implements ServiceProviderInterface
     public function register(): void
     {
         give()->singleton('campaigns', CampaignRepository::class);
-        give()->bind(RenderDonateButton::class, function () {
-            return new RenderDonateButton(
-                new BlockRenderController()
-            );
-        });
         $this->registerTableNames();
     }
 

--- a/src/DonationForms/Factories/DonationFormFactory.php
+++ b/src/DonationForms/Factories/DonationFormFactory.php
@@ -40,6 +40,7 @@ class DonationFormFactory extends ModelFactory
                     'give'
                 ),
                 'goalAchievedMessage' => __('Thank you to all our donors, we have met our fundraising goal.', 'give'),
+                'inheritCampaignColors' => true,
             ]),
             'blocks' => BlockCollection::fromJson($blocksJson),
         ];

--- a/tests/GiveTests/Unit/Actions/RenderDonateButtonTest.php
+++ b/tests/GiveTests/Unit/Actions/RenderDonateButtonTest.php
@@ -3,8 +3,9 @@
 namespace GiveTests\Unit\Actions;
 
 use Give\Campaigns\Actions\RenderDonateButton;
-use Give\DonationForms\Blocks\DonationFormBlock\Controllers\BlockRenderController;
+use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Models\DonationForm;
+use Give\DonationForms\V2\Models\DonationForm as LegacyDonationForm;
 use Give\DonationForms\ValueObjects\DonationFormStatus;
 use Give\Tests\TestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
@@ -17,77 +18,80 @@ class RenderDonateButtonTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @unreleased Update test with new action signature
      * @since 4.0.0
      */
     public function testItReturnsEmptyIfFormIsNotFound(): void
     {
+        $campaign = Campaign::factory()->create([
+            'defaultFormId' => 123,
+        ]);
+
         $action = give(RenderDonateButton::class);
-        $result = $action(123, 'Donate');
+        $result = $action($campaign, [], 'Donate');
 
         $this->assertEmpty($result);
     }
 
     /**
+     * @unreleased Update test with new action signature
      * @since 4.0.0
      */
     public function testItReturnsEmptyIfFormIsNotPublished(): void
     {
-        $form = DonationForm::factory()->create([
-            'status' => DonationFormStatus::DRAFT(),
-        ]);
+        $campaign = Campaign::factory()->create();
+        $form = DonationForm::find($campaign->defaultFormId);
+        $form->status = DonationFormStatus::DRAFT();
+        $form->save();
 
         $action = give(RenderDonateButton::class);
-        $result = $action($form->id, 'Donate');
+        $result = $action($campaign, [], 'Donate');
 
         $this->assertEmpty($result);
     }
 
     /**
+     * @unreleased Update test with new action signature
      * @since 4.0.0
      */
-    public function testItRendersButtonWithBlockControllerWhenFormIsPublished()
+    public function testItRendersV3ButtonWhenFormIsPublished(): void
     {
-        $form = DonationForm::factory()->create([
-            'status' => DonationFormStatus::PUBLISHED(),
-        ]);
+        $campaign = Campaign::factory()->create();
 
-        $blockControllerMock = $this->createMock(BlockRenderController::class);
-        $blockControllerMock->expects($this->once())
-            ->method('render')
-            ->with([
-                'formId' => $form->id,
-                'openFormButton' => 'Donate Now',
-                'formFormat' => 'modal',
-            ])
-            ->willReturn('<button>Donate Now</button>');
+        $action = give(RenderDonateButton::class);
+        $result = $action($campaign, [], 'Donate Now');
 
-        $action = new RenderDonateButton($blockControllerMock);
-        $result = $action($form->id, 'Donate Now');
+        // Assert the root div contains the correct class and data attributes
+        $this->assertStringContainsString("class='root-data-givewp-embed'", $result);
+        $this->assertStringContainsString("data-form-url='http://example.org/?post_type=give_forms&#038;p={$campaign->defaultFormId}'", $result);
+        $this->assertStringContainsString("data-form-view-url='http://example.org/?givewp-route=donation-form-view&form-id={$campaign->defaultFormId}'", $result);
+        $this->assertStringContainsString("data-src='http://example.org/?givewp-route=donation-form-view&form-id={$campaign->defaultFormId}'", $result);
+        $this->assertStringContainsString("data-form-format='modal'", $result);
+        $this->assertStringContainsString("data-open-form-button='Donate Now'", $result);
 
-        $this->assertSame('<button>Donate Now</button>', $result);
+        // Assert the CSS custom properties are set
+        $this->assertStringContainsString("--givewp-primary-color: {$campaign->primaryColor};", $result);
+        $this->assertStringContainsString("--givewp-secondary-color: {$campaign->secondaryColor};", $result);
+
+        // Assert the overall structure
+        $this->assertStringStartsWith("<div class='root-data-givewp-embed'", $result);
+        $this->assertStringEndsWith("</div>", $result);
     }
 
     /**
+     * @unreleased Update test with new action signature
      * @since 4.0.0
      */
-    public function testItRendersDefaultButtonIfBlockControllerReturnsNull()
+    public function testItRendersDefaultButtonIfInEditor(): void
     {
-        $form = DonationForm::factory()->create([
-            'status' => DonationFormStatus::PUBLISHED(),
-        ]);
+        define('REST_REQUEST', true);
 
-        $blockControllerMock = $this->createMock(BlockRenderController::class);
-        $blockControllerMock->expects($this->once())
-            ->method('render')
-            ->willReturn(null);
+        $campaign = Campaign::factory()->create();
 
-        $action = new RenderDonateButton($blockControllerMock);
-        $result = $action($form->id, 'Donate Now');
+        $action = give(RenderDonateButton::class);
+        $result = $action($campaign, [], 'Donate Now');
 
-        $this->assertSame(
-            '<button type="button" class="givewp-donation-form-modal__open">Donate Now</button>',
-            $result
-        );
+        $this->assertStringContainsString('<button type="button" class="givewp-donation-form-modal__open">Donate Now</button>', $result);
     }
 
 }


### PR DESCRIPTION
Resolves [GIVE-2644]

## Description

This PR fixes an issue where Campaign blocks were not properly rendering v2 forms by replacing the `BlockRenderController` with the standard `give_form_shortcode` function. The `RenderDonateButton` action has been refactored to use the shortcode-based approach, which ensures better compatibility with v2 forms and provides consistent rendering behavior across the platform.

## Affects
Campaign blocks rendering donate buttons (Campaign donation and donor blocks)

## Visuals


https://github.com/user-attachments/assets/7f1f5954-e122-4caa-b925-e0e3c69a1364



## Testing Instructions

1. Create a Campaign with a v2 form
2. Add Campaign blocks (donations, donors, donate button) to a page
3. Verify that the donate button renders correctly and opens the form in modal
4. Test both editor preview and frontend display
5. Repeat the same tests with a v3 form

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [x] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed

[GIVE-2644]: https://stellarwp.atlassian.net/browse/GIVE-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ