### PR TITLE
Refactor: add records empty slate

### DIFF
--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/index.tsx
@@ -1,26 +1,42 @@
+import { Children } from 'react';
 import Notice from '@givewp/admin/components/Notices';
-import {AdminSectionsWrapper} from '@givewp/components/AdminDetailsPage/AdminSection';
-import {__} from '@wordpress/i18n';
-import {useFormState} from 'react-hook-form';
-import {RecordsSlot} from '../../slots';
+import { AdminSectionsWrapper } from '@givewp/components/AdminDetailsPage/AdminSection';
+import { __ } from '@wordpress/i18n';
+import { useFormState } from 'react-hook-form';
+import { RecordsSlot } from '../../slots';
+import { NotesIcon } from '@givewp/admin/components/PrivateNotes/Icons';
+import styles from './styles.module.scss';
 
 /**
  * @unreleased
  */
 export default function SubscriptionDetailsPageRecordsTab() {
-    const {isDirty} = useFormState();
+    const { isDirty } = useFormState();
 
     return (
         <>
             {isDirty && (
-                <div style={{marginBottom: 'var(--givewp-spacing-4)'}}>
+                <div style={{ marginBottom: 'var(--givewp-spacing-4)' }}>
                     <Notice type="info">
                         {__('Some changes made to this subscription will only affect future renewals.', 'give')}
                     </Notice>
                 </div>
             )}
             <AdminSectionsWrapper>
-                <RecordsSlot />
+                <RecordsSlot>
+                    {(fills) => {
+                        if (!fills || Children.count(fills) === 0) {
+                            return (
+                                <div className={styles.emptyState}>
+                                    <NotesIcon />
+                                    <p className={styles.description}>{__('No records found', 'give')}</p>
+                                </div>
+                            );
+                        }
+
+                        return fills;
+                    }}
+                </RecordsSlot>
             </AdminSectionsWrapper>
         </>
     );

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/styles.module.scss
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/styles.module.scss
@@ -1,0 +1,16 @@
+.emptyState {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--givewp-spacing-4);
+    align-items: center;
+    text-align: center;
+    background: var(--givewp-shades-white);
+    padding: 40px 0;
+    height: 236px;
+}
+.description {
+    font-size: 0.875rem;
+    line-height: 1.43;
+    color: var(--givewp-neutral-500);
+}


### PR DESCRIPTION
## Description

### Changes Made
New Files Added:
src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/styles.module.scss - Styling for the empty state component

Files Modified:
src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Records/index.tsx - Added empty state logic and UI based on whether there are any slot fills available.

## Affects
Subscription Records Tab

## Visuals
https://github.com/user-attachments/assets/94c112fc-e984-4c32-8da8-5a2f524f8faf

## Testing Instructions
- Visit a Subscription through the edit button on the subscription list table
- Navigate to the Records tab - verify that the empty state displays.
- Install & Activate Give-Funds
- Revisit the Records tab & verify the empty state no longer displays & that the give-funds logic is visible and working

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

