### PR TITLE
Fix: update List Table Modal `A11YDialog`

### DIFF
--- a/src/Donations/resources/components/DonationRowActions.tsx
+++ b/src/Donations/resources/components/DonationRowActions.tsx
@@ -17,7 +17,7 @@ export const DonationRowActions = ({item, removeRow, setUpdateErrors, parameters
         window.location.reload();
     };
 
-    const confirmDelete = (selected) => <p>{sprintf(__('Are you sure you want to move donation #%d to the trash? You can restore it later if needed.', 'give'), item.id)}</p>;
+    const confirmDelete = (selected) => <p>{sprintf(__('Are you sure you want to move donation #%d to the trash?', 'give'), item.id)}</p>;
 
     const confirmModal = (event) => {
         showConfirmModal(__('Move donation to trash', 'give'), confirmDelete, deleteItem, 'danger', __('Trash Donation', 'give'));

--- a/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
+++ b/src/Views/Components/ListTable/ListTablePage/ListTablePage.module.scss
@@ -377,7 +377,7 @@ ul[role='document'] + .flexRow {
 }
 
 .container {
-    z-index: 11;
+    z-index: 9999;
     display: flex;
     opacity: 1;
     animation: appear 180ms ease-in 0s 1;


### PR DESCRIPTION
Resolves https://lw.slack.com/archives/C04SLRDD9CK/p1756844747622119?thread_ts=1756843777.960549&cid=C04SLRDD9CK

## Description
This PR simply updates the z-index for the A11yDialog component so that the container covers not only the Subscriptions-Donation's tab header but also the WordPress sidebar.

It also removes the text context claiming that trash donations can be restored - since this has not yet been implemented.

## Affects
All List Table Modal Contexts

## Visuals

https://github.com/user-attachments/assets/939b0ab0-3066-4998-9e0c-c94ab22d1522


## Testing Instructions
- View the new Subscription screen and navigate to the Donations tab
- Select to trash a renewal
- Verify the blur container visually covers the entire UI

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

