### PR TITLE
Fix: remove conditional on canSync variable

### DIFF
--- a/src/Subscriptions/ViewModels/SubscriptionViewModel.php
+++ b/src/Subscriptions/ViewModels/SubscriptionViewModel.php
@@ -5,6 +5,7 @@ namespace Give\Subscriptions\ViewModels;
 use Give\API\REST\V3\Routes\Donors\ValueObjects\DonorAnonymousMode;
 use Give\Framework\PaymentGateways\PaymentGatewayRegister;
 use Give\Subscriptions\Models\Subscription;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 
 /**
  * @unreleased
@@ -112,7 +113,7 @@ class SubscriptionViewModel
             $this->subscription->gateway()->toArray(),
             [
                 'subscriptionUrl' => $this->subscription->gateway()->gatewayDashboardSubscriptionUrl($this->subscription),
-                'canSync' => $this->subscription->gateway()->canSyncSubscriptionWithPaymentGateway(),
+                'canSync' => $this->subscription->gateway()->subscriptionModule instanceof SubscriptionTransactionsSynchronizable
             ]
         );
     }

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/index.tsx
@@ -68,7 +68,7 @@ export default function SubscriptionDetailsPage() {
     const { formatter } = useSubscriptionAmounts(subscription);
     const { deleteEntityRecord } = useDispatch(coreDataStore);
     const { syncSubscription, isLoading, hasResolved, syncResult } = useSubscriptionSync();
-    const subscriptionCanSync = subscription?.gateway?.canSync || !subscription?.gateway?.id;
+    const subscriptionCanSync = subscription?.gateway?.canSync;
 
     const PageTitle = () => {
         if (subscription?.amount?.value == null) {

--- a/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemTest.php
@@ -4,6 +4,7 @@ namespace Unit\API\REST\V3\Routes\Subscriptions;
 
 use Exception;
 use Give\API\REST\V3\Routes\Subscriptions\ValueObjects\SubscriptionRoute;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -82,7 +83,7 @@ class SubscriptionRouteGetItemTest extends RestApiTestCase
                 $subscription->gateway()->toArray(),
                 [
                     'subscriptionUrl' => $subscription->gateway()->gatewayDashboardSubscriptionUrl($subscription),      
-                    'canSync' => $subscription->gateway()->canSyncSubscriptionWithPaymentGateway(),
+                    'canSync' => $subscription->gateway()->subscriptionModule instanceof SubscriptionTransactionsSynchronizable,
                 ]
             ),
             'projectedAnnualRevenue' => $subscription->projectedAnnualRevenue()->toArray(),

--- a/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemsTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Subscriptions/SubscriptionRouteGetItemsTest.php
@@ -7,6 +7,7 @@ use Exception;
 use Give\API\REST\V3\Routes\Subscriptions\ValueObjects\SubscriptionRoute;
 use Give\Campaigns\Models\Campaign;
 use Give\Framework\Database\DB;
+use Give\Framework\PaymentGateways\Contracts\Subscription\SubscriptionTransactionsSynchronizable;
 use Give\Framework\Support\ValueObjects\Money;
 use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Subscriptions\Models\Subscription;
@@ -90,7 +91,7 @@ class SubscriptionRouteGetItemsTest extends RestApiTestCase
                 $subscription->gateway()->toArray(),
                 [
                     'subscriptionUrl' => $subscription->gateway()->gatewayDashboardSubscriptionUrl($subscription),
-                    'canSync' => $subscription->gateway()->canSyncSubscriptionWithPaymentGateway(),
+                    'canSync' => $subscription->gateway()->subscriptionModule instanceof SubscriptionTransactionsSynchronizable,
                 ]
             ),
             'projectedAnnualRevenue' => $subscription->projectedAnnualRevenue()->toArray(),


### PR DESCRIPTION
Resolves https://lw.slack.com/archives/C04SLRDD9CK/p1756908964317189?thread_ts=1756843777.960549&cid=C04SLRDD9CK

## Description
Remove the conditional check that would previously show the can sync button if there was no gateway available. This is incorrect though, the button should show only when the gateway allows syncing. 

Also updates the check for the current gateway to see if it has the capability to sync transactions - this will help avoid issues with legacy gateways performing there own sync function through the new UI by hiding the sync subscription button when working with a legacy gateway subscription.

## Affects
Subscription Sync

## Visuals

## Testing Instructions

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

