### PR TITLE
Feature: Add sidebar SlotFill on the Donor Profile page

### DIFF
--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/index.tsx
@@ -5,9 +5,11 @@ import DonorStats from './DonorStats';
 import DonorContributions from './DonorContributions';
 import DonorPrivateNotes from './DonorPrivateNotes';
 import NotificationPlaceholder from '@givewp/components/AdminDetailsPage/Notifications';
+import {OverviewSidebarSlot} from '../../slots';
 import styles from './styles.module.scss';
 
 /**
+ * @unreleased added sidebar slot
  * @since 4.5.0
  */
 export default function DonorDetailsPageOverviewTab() {
@@ -22,10 +24,11 @@ export default function DonorDetailsPageOverviewTab() {
                 <DonorContributions donorId={donorId} />
                 <DonorTransactions donorId={donorId} />
                 <DonorPrivateNotes donorId={donorId} />
-             </div>
+            </div>
 
             <div className={styles.right}>
                 <DonorSummary donorId={donorId} />
+                <OverviewSidebarSlot />
             </div>
 
             <NotificationPlaceholder type="snackbar" />

--- a/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/slots.ts
@@ -4,8 +4,14 @@ import {createSlotFill} from '@wordpress/components';
  * @since 4.4.0
  */
 const {Slot: ProfileSectionsSlot, Fill: ProfileSectionsFill} = createSlotFill('GiveWP/DonorDetails/Profile/Sections');
+/**
+ * @unreleased
+ */
+const {Slot: OverviewSidebarSlot, Fill: OverviewSidebarFill} = createSlotFill('GiveWP/DonorDetails/Overview/Sidebar');
 
 export {
     ProfileSectionsSlot,
     ProfileSectionsFill,
+    OverviewSidebarSlot,
+    OverviewSidebarFill
 };


### PR DESCRIPTION

## Description

This PR adds a SlotFill sidebar section on the new Donor Profile page

## Affects
Donor Profile

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

