### PR TITLE
Hotfix: Ensure campaignId is saved in donation details

### DIFF
--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -341,7 +341,6 @@ class DonationController extends WP_REST_Controller
             'type',
             'mode',
             'gatewayTransactionId',
-            'campaignId'
         ];
 
         foreach ($request->get_params() as $key => $value) {

--- a/src/Donations/Repositories/DonationRepository.php
+++ b/src/Donations/Repositories/DonationRepository.php
@@ -194,7 +194,7 @@ class DonationRepository
     }
 
     /**
-     * @since 4.8.0 Set campaignId if its null.
+     * @unreleased Moved campaignId assignment logic to getCoreDonationMetaForDatabase method to eliminate code duplication.
      * @since 3.20.0 store meta using native WP functions
      * @since 2.23.0 retrieve the post_parent instead of relying on parentId property
      * @since 2.21.0 replace actions with givewp_donation_creating and givewp_donation_created
@@ -214,10 +214,6 @@ class DonationRepository
         $dateCreatedFormatted = Temporal::getFormattedDateTime($dateCreated);
         $dateUpdated = $donation->updatedAt ?? $dateCreated;
         $dateUpdatedFormatted = Temporal::getFormattedDateTime($dateUpdated);
-
-        if (is_null($donation->campaignId) && $campaign = give()->campaigns->getByFormId($donation->formId)) {
-            $donation->campaignId = $campaign->id;
-        }
 
         DB::query('START TRANSACTION');
 
@@ -395,6 +391,7 @@ class DonationRepository
     }
 
     /**
+     * @unreleased Consolidated campaignId assignment logic from insert method to eliminate duplication and ensure donation model is updated.
      * @since 4.0.0 added campaignId
      * @since 3.9.0 Added meta for phone property
      * @since 3.2.0 added meta for honorific property
@@ -433,8 +430,13 @@ class DonationRepository
         ];
 
         // If the donation is not associated with a campaign, try to find the campaign ID by the form ID
-        if (!$donation->campaignId && $campaign = give()->campaigns->getByFormId($donation->formId)) {
-            $meta[DonationMetaKeys::CAMPAIGN_ID] = $campaign->id;
+        if (!$donation->campaignId) {
+            $campaign = give()->campaigns->getByFormId($donation->formId);
+            $donation->campaignId = $campaign ? $campaign->id : null;
+        }
+
+        if ($donation->campaignId !== null) {
+            $meta[DonationMetaKeys::CAMPAIGN_ID] = $donation->campaignId;
         }
 
         if ($donation->feeAmountRecovered !== null) {

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -26,9 +26,11 @@ export type DonationSummaryGridProps = {
 export function CampaignCard({donation}: {donation: Donation}) {
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">
-            {!donation?.campaignId
+            {!donation
                 ? <Spinner />
-                : <CampaignCardContent campaignId={donation.campaignId} />
+                : donation?.campaignId
+                    ? <CampaignCardContent campaignId={donation.campaignId} />
+                    : <p>{__('No campaign associated with this donation', 'give')}</p>
             }
         </GridCard>
     );
@@ -67,9 +69,11 @@ function CampaignCardContent({campaignId}: {campaignId: number}) {
 export function DonorCard({donation}: {donation: Donation}) {
     return (
         <GridCard heading={__('Associated donor', 'give')} headingId="donor">
-            {!donation?.donorId
+            {!donation
                 ? <Spinner />
-                : <DonorCardContent donorId={donation.donorId} />
+                : donation?.donorId
+                    ? <DonorCardContent donorId={donation.donorId} />
+                    : <p>{__('No donor associated with this donation', 'give')}</p>
             }
         </GridCard>
     );

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -24,38 +24,68 @@ export type DonationSummaryGridProps = {
  * @since 4.6.0
  */
 export function CampaignCard({donation}: {donation: Donation}) {
-    const {campaign, hasResolved: hasResolvedCampaign} = donation?.campaignId
-        ? useCampaignEntityRecord(donation?.campaignId)
-        : {campaign: null, hasResolved: false};
-
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">
-            {!hasResolvedCampaign && <Spinner />}
-            {hasResolvedCampaign && campaign && (
-                <a
-                    href={`edit.php?post_type=give_forms&page=give-campaigns&id=${campaign?.id}&tab=overview`}
-                    className={styles.campaignLink}
-                >
-                    {campaign?.title}
-                </a>
-            )}
+            {!donation?.campaignId
+                ? <Spinner />
+                : <CampaignCardContent campaignId={donation.campaignId} />
+            }
         </GridCard>
     );
 }
 
 /**
+ * @unreleased
+ */
+function CampaignCardContent({campaignId}: {campaignId: number}) {
+    const {campaign, hasResolved: hasResolvedCampaign} = useCampaignEntityRecord(campaignId);
+
+    return (
+        <>
+            {!hasResolvedCampaign
+                ? <Spinner />
+                : campaign ? (
+                    <a
+                        href={`edit.php?post_type=give_forms&page=give-campaigns&id=${campaign?.id}&tab=overview`}
+                        className={styles.campaignLink}
+                    >
+                        {campaign?.title}
+                    </a>
+                ) : (
+                    <p>{__('Campaign not found', 'give')}</p>
+                )
+            }
+        </>
+    );
+}
+
+/**
+ * @unreleased Refactored to only try to load donor when we have a valid donorId from the donation
  * @since 4.8.0 export function for SubscriptionSummaryGrid & add GridCard component
  * @since 4.6.0
  */
 export function DonorCard({donation}: {donation: Donation}) {
-    const {record: donor, hasResolved: hasResolvedDonor, isResolving: isResolvingDonor} = useDonorEntityRecord(donation?.donorId);
-
     return (
         <GridCard heading={__('Associated donor', 'give')} headingId="donor">
-         {!hasResolvedDonor && <Spinner />}
-         {hasResolvedDonor && (
-            <>
-                {donor ? (
+            {!donation?.donorId
+                ? <Spinner />
+                : <DonorCardContent donorId={donation.donorId} />
+            }
+        </GridCard>
+    );
+}
+
+/**
+ * @unreleased
+ */
+function DonorCardContent({donorId}: {donorId: number}) {
+    const {record: donor, hasResolved: hasResolvedDonor} = useDonorEntityRecord(donorId);
+
+    return (
+        <>
+            {!hasResolvedDonor
+                ? <Spinner />
+                : donor ? (
                     <>
                         <a className={styles.donorLink} href={`edit.php?post_type=give_forms&page=give-donors&view=overview&id=${donor.id}`}>
                             {donor.name}
@@ -64,10 +94,9 @@ export function DonorCard({donation}: {donation: Donation}) {
                     </>
                 ) : (
                     <p>{__('No donor associated with this donation', 'give')}</p>
-                )}
-            </>
-         )}
-        </GridCard>
+                )
+            }
+        </>
     );
 }
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -19,11 +19,14 @@ export type DonationSummaryGridProps = {
 };
 
 /**
+ * @unreleased Refactored to only try to load campaign when we have a valid campaignId from the donation
  * @since 4.8.0 export function for SubscriptionSummaryGrid & add GridCard component
  * @since 4.6.0
  */
 export function CampaignCard({donation}: {donation: Donation}) {
-    const {campaign, hasResolved: hasResolvedCampaign} = useCampaignEntityRecord(donation?.campaignId);
+    const {campaign, hasResolved: hasResolvedCampaign} = donation?.campaignId
+        ? useCampaignEntityRecord(donation?.campaignId)
+        : {campaign: null, hasResolved: false};
 
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -26,11 +26,9 @@ export type DonationSummaryGridProps = {
 export function CampaignCard({donation}: {donation: Donation}) {
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">
-            {!donation
+            {!donation?.campaignId
                 ? <Spinner />
-                : donation?.campaignId
-                    ? <CampaignCardContent campaignId={donation.campaignId} />
-                    : <p>{__('No campaign associated with this donation', 'give')}</p>
+                : <CampaignCardContent campaignId={donation.campaignId} />
             }
         </GridCard>
     );
@@ -69,11 +67,9 @@ function CampaignCardContent({campaignId}: {campaignId: number}) {
 export function DonorCard({donation}: {donation: Donation}) {
     return (
         <GridCard heading={__('Associated donor', 'give')} headingId="donor">
-            {!donation
+            {!donation?.donorId
                 ? <Spinner />
-                : donation?.donorId
-                    ? <DonorCardContent donorId={donation.donorId} />
-                    : <p>{__('No donor associated with this donation', 'give')}</p>
+                : <DonorCardContent donorId={donation.donorId} />
             }
         </GridCard>
     );

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -24,68 +24,38 @@ export type DonationSummaryGridProps = {
  * @since 4.6.0
  */
 export function CampaignCard({donation}: {donation: Donation}) {
+    const {campaign, hasResolved: hasResolvedCampaign} = donation?.campaignId
+        ? useCampaignEntityRecord(donation?.campaignId)
+        : {campaign: null, hasResolved: false};
+
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">
-            {!donation?.campaignId
-                ? <Spinner />
-                : <CampaignCardContent campaignId={donation.campaignId} />
-            }
+            {!hasResolvedCampaign && <Spinner />}
+            {hasResolvedCampaign && campaign && (
+                <a
+                    href={`edit.php?post_type=give_forms&page=give-campaigns&id=${campaign?.id}&tab=overview`}
+                    className={styles.campaignLink}
+                >
+                    {campaign?.title}
+                </a>
+            )}
         </GridCard>
     );
 }
 
 /**
- * @unreleased
- */
-function CampaignCardContent({campaignId}: {campaignId: number}) {
-    const {campaign, hasResolved: hasResolvedCampaign} = useCampaignEntityRecord(campaignId);
-
-    return (
-        <>
-            {!hasResolvedCampaign
-                ? <Spinner />
-                : campaign ? (
-                    <a
-                        href={`edit.php?post_type=give_forms&page=give-campaigns&id=${campaign?.id}&tab=overview`}
-                        className={styles.campaignLink}
-                    >
-                        {campaign?.title}
-                    </a>
-                ) : (
-                    <p>{__('Campaign not found', 'give')}</p>
-                )
-            }
-        </>
-    );
-}
-
-/**
- * @unreleased Refactored to only try to load donor when we have a valid donorId from the donation
  * @since 4.8.0 export function for SubscriptionSummaryGrid & add GridCard component
  * @since 4.6.0
  */
 export function DonorCard({donation}: {donation: Donation}) {
+    const {record: donor, hasResolved: hasResolvedDonor, isResolving: isResolvingDonor} = useDonorEntityRecord(donation?.donorId);
+
     return (
         <GridCard heading={__('Associated donor', 'give')} headingId="donor">
-            {!donation?.donorId
-                ? <Spinner />
-                : <DonorCardContent donorId={donation.donorId} />
-            }
-        </GridCard>
-    );
-}
-
-/**
- * @unreleased
- */
-function DonorCardContent({donorId}: {donorId: number}) {
-    const {record: donor, hasResolved: hasResolvedDonor} = useDonorEntityRecord(donorId);
-
-    return (
-        <>
-            {!hasResolvedDonor
-                ? <Spinner />
-                : donor ? (
+         {!hasResolvedDonor && <Spinner />}
+         {hasResolvedDonor && (
+            <>
+                {donor ? (
                     <>
                         <a className={styles.donorLink} href={`edit.php?post_type=give_forms&page=give-donors&view=overview&id=${donor.id}`}>
                             {donor.name}
@@ -94,9 +64,10 @@ function DonorCardContent({donorId}: {donorId: number}) {
                     </>
                 ) : (
                     <p>{__('No donor associated with this donation', 'give')}</p>
-                )
-            }
-        </>
+                )}
+            </>
+         )}
+        </GridCard>
     );
 }
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -19,14 +19,11 @@ export type DonationSummaryGridProps = {
 };
 
 /**
- * @unreleased Refactored to only try to load campaign when we have a valid campaignId from the donation
  * @since 4.8.0 export function for SubscriptionSummaryGrid & add GridCard component
  * @since 4.6.0
  */
 export function CampaignCard({donation}: {donation: Donation}) {
-    const {campaign, hasResolved: hasResolvedCampaign} = donation?.campaignId
-        ? useCampaignEntityRecord(donation?.campaignId)
-        : {campaign: null, hasResolved: false};
+    const {campaign, hasResolved: hasResolvedCampaign} = useCampaignEntityRecord(donation?.campaignId);
 
     return (
         <GridCard heading={__('Campaign name', 'give')} headingId="campaign-name">

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -440,7 +440,7 @@ class SubscriptionRepository
      */
    public function createRenewal(Subscription $subscription, array $attributes = []): Donation
    {
-       $initialDonation = $subscription->initialDonation();
+        $initialDonation = $subscription->initialDonation();
 
         $donation = Donation::create(
             array_merge([

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -440,7 +440,7 @@ class SubscriptionRepository
      */
    public function createRenewal(Subscription $subscription, array $attributes = []): Donation
    {
-        $initialDonation = $subscription->initialDonation();
+       $initialDonation = $subscription->initialDonation();
 
         $donation = Donation::create(
             array_merge([

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -433,6 +433,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased Remove campaignId from the attributes array since it is auto-generated based on the subscription's form.
      * @since 4.8.0 Add campaignId support.
      * @since 3.20.0
      * @throws Exception
@@ -440,11 +441,6 @@ class SubscriptionRepository
    public function createRenewal(Subscription $subscription, array $attributes = []): Donation
    {
        $initialDonation = $subscription->initialDonation();
-       $campaignId = $initialDonation->campaignId;
-
-        if (is_null($campaignId) && $campaign = give()->campaigns->getByFormId($subscription->donationFormId)) {
-            $campaignId = $campaign->id;
-        }
 
         $donation = Donation::create(
             array_merge([
@@ -470,7 +466,6 @@ class SubscriptionRepository
                 'formTitle' => $initialDonation->formTitle,
                 'mode' => $subscription->mode->isLive() ? DonationMode::LIVE() : DonationMode::TEST(),
                 'donorIp' => $initialDonation->donorIp,
-                'campaignId' => $campaignId,
             ], $attributes)
         );
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/index.tsx
@@ -8,6 +8,7 @@ import SubscriptionSummary from '@givewp/subscriptions/admin/components/Subscrip
 import { getSubscriptionOptionsWindowData, useSubscriptionEntityRecord } from "@givewp/subscriptions/utils";
 import SubscriptionAnnualProjection from "./SubscriptionAnnualProjection";
 import styles from "./styles.module.scss";
+import { Spinner } from "@givewp/admin/components";
 
 /**
  * @since 4.8.0
@@ -17,6 +18,11 @@ export default function SubscriptionDetailsPageOverviewTab() {
     const { record: subscription, hasResolved: subscriptionsResolved, isResolving: subscriptionLoading } = useSubscriptionEntityRecord();
     const { intendedAmount } = useSubscriptionAmounts(subscription);
     const { records: donations, hasResolved: donationsResolved, isResolving: donationsLoading } = useDonationsBySubscription(subscription?.id, mode);
+
+    if (!subscriptionsResolved || !donationsResolved || !subscription || !donations) {
+        // TODO: Add loading state
+        return <Spinner />;
+    }
 
     return (
         <div className={styles.overview}>

--- a/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
@@ -53,6 +53,7 @@ class DonationRouteUpdateTest extends RestApiTestCase
     }
 
     /**
+     * @unreleased Remove campaignId from the test since it has been removed from the nonEditableFields property.
      * @since 4.6.0
      */
     public function testUpdateDonationShouldNotUpdateNonEditableFields()
@@ -64,7 +65,6 @@ class DonationRouteUpdateTest extends RestApiTestCase
         $originalDonorIp = $donation->donorIp;
         $originalMode = $donation->mode->getValue();
         $originalType = $donation->type->getValue();
-        $originalCampaignId = $donation->campaignId;
 
         $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id;
         $request = $this->createRequest('PUT', $route, [], 'administrator');
@@ -73,7 +73,6 @@ class DonationRouteUpdateTest extends RestApiTestCase
             'donorIp' => '192.168.1.1',
             'mode' => 'live',
             'type' => 'renewal',
-            'campaignId' => 123,
         ]);
 
         $response = $this->dispatchRequest($request);
@@ -87,7 +86,6 @@ class DonationRouteUpdateTest extends RestApiTestCase
         $this->assertEquals($originalDonorIp, $data['donorIp']);
         $this->assertEquals($originalMode, $data['mode']);
         $this->assertEquals($originalType, $data['type']);
-        $this->assertEquals($originalCampaignId, $data['campaignId']);
     }
 
     /**


### PR DESCRIPTION
Resolves [GIVE-2870]

## Description

This hotfix addresses an issue where a donation could not be updated through the details screen after the campaign field was changed. Changes in this PR include:
	•	Removed `campaignId` from the `nonEditableFields` property in the donations API endpoint, allowing it to be updated.
	•	Moved the fallback logic for `campaignId` assignment to `getCoreDonationMetaForDatabase` to centralize it, removing redundant logic from the `insert` method in the donations repository and the `createRenewal` method in the subscriptions repository.

## Affects
Donation Details and Subscription Details

## Visuals

https://github.com/user-attachments/assets/bf6c936d-b3bb-4611-8efb-920f658a7b6b

_We can now update a donation after removing `campaignId` from the `nonEditableFields` list._

https://github.com/user-attachments/assets/fb59552a-9eb1-40eb-b4b6-1f7ee1a8d3e1

_Showing that we can still create a renewal after refactoring the `campaignId` logic._

https://github.com/user-attachments/assets/2656d1a1-b852-4157-8a85-bfb78d521189

_Throttling my connection to show that campaign data loads only after the donation data._

## Testing Instructions
1.	Update the campaign and form in a donation using the Donation Details screen.
2.	Create a renewal from the Subscription Details screen.
3.	Verify that there are no 404 responses from any API requests on the Subscription Details screen.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

[GIVE-2870]: https://stellarwp.atlassian.net/browse/GIVE-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ