### PR TITLE
Fix: Redirect new users to the Campaigns page after onboarding

### DIFF
--- a/src/Campaigns/CampaignsAdminPage.php
+++ b/src/Campaigns/CampaignsAdminPage.php
@@ -54,4 +54,12 @@ class CampaignsAdminPage
     {
         return isset($_GET['id'], $_GET['page']) && 'give-campaigns' === $_GET['page'];
     }
+
+    /**
+     * @unreleased
+     */
+    public static function getUrl()
+    {
+        return admin_url('edit.php?post_type=give_forms&page=give-campaigns');
+    }
 }

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -26,6 +26,7 @@ class Page
     /**
      * Dismiss the Setup Page.
      *
+     * @unreleased redirect to campaigns page
      * @since 2.8.0
      */
     public function dismissSetupPage()

--- a/src/Onboarding/Setup/Page.php
+++ b/src/Onboarding/Setup/Page.php
@@ -8,7 +8,7 @@
 
 namespace Give\Onboarding\Setup;
 
-use Give\DonationForms\V2\DonationFormsAdminPage;
+use Give\Campaigns\CampaignsAdminPage;
 
 defined('ABSPATH') || exit;
 
@@ -33,7 +33,7 @@ class Page
         if (wp_verify_nonce($_GET['_wpnonce'], 'dismiss_setup_page')) {
             give_update_option('setup_page_enabled', self::DISABLED);
 
-            wp_redirect(DonationFormsAdminPage::getUrl());
+            wp_redirect(CampaignsAdminPage::getUrl());
             exit;
         }
     }


### PR DESCRIPTION
Resolves: https://lw.slack.com/archives/C02RH0J92HK/p1758278748670199

## Description
This redirects new users to the Campaigns page when they click on the "Dismiss Setup Screen" button while on the Onboarding screen.

## Affects
New Users Onboarding

## Visuals
<img width="1900" height="1076" alt="image" src="https://github.com/user-attachments/assets/ff3c65f0-af18-4ec2-91bd-8561e5677b3f" />


## Testing Instructions
- Go through the Onboarding Flow
- Click the "Dismiss Setup Screen" button
- Verify that you are redirected to the Campaigns page

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

