### PR TITLE
Refactor: Only display "Resend Receipt" for completed donations

### DIFF
--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/index.tsx
@@ -36,9 +36,9 @@ export default function DonationReceipt({ donation }: { donation: Donation }) {
           </div>
         </div>
 
-        <nav className={styles.actions} aria-label={__('Receipt actions', 'give')}>
+        {donation?.status === 'publish' && <div className={styles.actions} aria-label={__('Receipt actions', 'give')}>
           <ReceiptActions />
-        </nav>
+        </div>}
       </aside>
     </OverviewPanel>
   );


### PR DESCRIPTION
Resolves [GIVE-2773]

## Description
The resend receipt button on the Donation Details page should only be visible when a donation is completed.

## Affects
Donation Details Admin Page

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

