### PR TITLE
Changed: Filter read-only fields from admin detail forms

### DIFF
--- a/src/API/REST/V3/Routes/Donors/DonorController.php
+++ b/src/API/REST/V3/Routes/Donors/DonorController.php
@@ -449,6 +449,26 @@ class DonorController extends WP_REST_Controller
                         ],
                     ],
                 ],
+                'customFields' => [
+                    'type' => 'array',
+                    'readonly' => true,
+                    'description' => esc_html__('Custom fields (sensitive data)', 'give'),
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'label' => [
+                                'type' => 'string',
+                                'description' => esc_html__('Field label', 'give'),
+                                'format' => 'text-field',
+                            ],
+                            'value' => [
+                                'type' => 'string',
+                                'description' => esc_html__('Field value', 'give'),
+                                'format' => 'text-field',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/AdditionalInfo/CustomFields/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/AdditionalInfo/CustomFields/index.tsx
@@ -1,18 +1,13 @@
 import { __ } from "@wordpress/i18n";
-import { useFormContext } from "react-hook-form";
 import { Interweave } from 'interweave';
 import AdminSection, { AdminSectionField } from '@givewp/components/AdminDetailsPage/AdminSection';
 import BlankSlate from './BlankSlate';
 import styles from './styles.module.scss';
-
-interface CustomField {
-    label: string;
-    value: string;
-}
+import { useDonationEntityRecord } from "@givewp/donations/utils";
 
 export default function CustomFields() {
-    const { getValues } = useFormContext();
-    const customFields: CustomField[] = getValues('customFields') || [];
+    const { record: donation } = useDonationEntityRecord();
+    const customFields = donation?.customFields || [];
 
     return (
         <AdminSection

--- a/src/Donations/resources/admin/components/types.ts
+++ b/src/Donations/resources/admin/components/types.ts
@@ -58,6 +58,12 @@ export type Donation = {
   };
   eventTickets: EventTicket[];
   gateway: PaymentGateway;
+  customFields: CustomField[];
+};
+
+export type CustomField = {
+    label: string;
+    value: string;
 };
 
 export type Event = {

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/CustomFields/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/CustomFields/index.tsx
@@ -1,26 +1,20 @@
-import AdminSection, {AdminSectionField} from '@givewp/components/AdminDetailsPage/AdminSection';
-import {__} from '@wordpress/i18n';
-import {Interweave} from 'interweave';
-import {useFormContext, useFormState} from 'react-hook-form';
+import AdminSection, { AdminSectionField } from '@givewp/components/AdminDetailsPage/AdminSection';
+import { __ } from '@wordpress/i18n';
+import { Interweave } from 'interweave';
 import BlankSlate from './BlankSlate';
 import styles from './styles.module.scss';
-
-interface CustomField {
-    label: string;
-    value: string;
-}
+import { useDonorEntityRecord } from '@givewp/donors/utils';
 
 /**
  * @since 4.9.0 Add error prop to all AdminSectionField components
  */
 export default function CustomFields() {
-    const {getValues} = useFormContext();
-    const {errors} = useFormState();
-    const customFields: CustomField[] = getValues('customFields') || [];
+    const { record: donor } = useDonorEntityRecord();
+    const customFields = donor?.customFields || [];
 
     return (
         <AdminSection title={__('Custom Fields', 'give')} description={__('Custom fields filled by the donor', 'give')}>
-            <AdminSectionField error={errors.customFields?.message as string}>
+            <AdminSectionField>
                 {!customFields.length ? (
                     <BlankSlate />
                 ) : (

--- a/src/Donors/resources/admin/components/types.ts
+++ b/src/Donors/resources/admin/components/types.ts
@@ -23,12 +23,21 @@ export type Donor = {
   totalNumberOfDonations: number;
   wpUserPermalink: string;
   status: DonorStatus;
+  customFields: CustomField[];
 };
 
 /**
  * @since 4.4.0
  */
 export type DonorStatus = 'current' | 'prospective' | 'retained' | 'lapsed' | 'new' | 'recaptured' | 'recurring';
+
+/**
+ * @unreleased
+ */
+export type CustomField = {
+    label: string;
+    value: string;
+};
 
 /**
  * @since 4.4.0

--- a/src/Views/Components/AdminDetailsPage/types.ts
+++ b/src/Views/Components/AdminDetailsPage/types.ts
@@ -42,11 +42,6 @@ export interface AdminDetailsPageProps<T extends Record<string, any>> {
     };
 
     /**
-     * Function to reset the form
-     */
-    resetForm?: (reset: () => void) => void;
-
-    /**
      * Function to determine if the form should be saved
      */
     shouldSaveForm?: (isDirty: boolean, data: T) => boolean;
@@ -120,6 +115,17 @@ export type Notification = {
     autoHide?: boolean;
     onDismiss?: () => void;
     duration?: number,
+}
+
+/**
+ * Schema property interface for filtering read-only fields
+ *
+ * @unreleased
+ */
+export interface SchemaProperty {
+    readOnly?: boolean;
+    properties?: Record<string, SchemaProperty>;
+    [key: string]: any;
 }
 
 /**

--- a/src/Views/Components/AdminDetailsPage/utils.ts
+++ b/src/Views/Components/AdminDetailsPage/utils.ts
@@ -1,3 +1,5 @@
+import { SchemaProperty } from "./types";
+
 /**
  * @since 4.4.0
  */
@@ -41,4 +43,39 @@ export function formatDateLocal(dateString: string) {
     const day = String(date.getDate()).padStart(2, '0');
 
     return `${year}-${month}-${day}`;
+}
+
+/**
+ * @unreleased
+ */
+export function filterOutReadOnlyFields(
+    record: Record<string, any>,
+    schemaProperties: Record<string, SchemaProperty>
+): Record<string, any> {
+    const processValue = (value: any, schema: SchemaProperty): any => {
+        // Handle nested objects
+        if (schema.properties && typeof value === "object" && value !== null && !Array.isArray(value)) {
+            return filterOutReadOnlyFields(value, schema.properties as Record<string, SchemaProperty>);
+        }
+
+        // Handle arrays of objects
+        if (schema.type === "array" && schema.items && Array.isArray(value)) {
+            return value.map(item =>
+                typeof item === "object" && item !== null
+                    ? filterOutReadOnlyFields(item, (schema.items as any).properties ?? {})
+                    : item
+            );
+        }
+
+        return value;
+    };
+
+    return Object.fromEntries(
+        Object.entries(record)
+            .filter(([key]) => !schemaProperties[key]?.readOnly && !schemaProperties[key]?.readonly)
+            .map(([key, value]) => [
+                key,
+                schemaProperties[key] ? processValue(value, schemaProperties[key]) : value
+            ])
+    );
 }


### PR DESCRIPTION
## Description

This PR refactors the admin detail page forms to properly filter out read-only fields from React Hook Form (RHF) initialization and updates CustomFields components to use entity values instead of form field values.

**HOW this solves the problem:**
- Implements a recursive  utility function that removes read-only fields from entity records before initializing forms
- Updates CustomFields components to access entity data directly instead of through RHF, preventing issues with read-only fields being included in form state
- Adds proper TypeScript interfaces for schema properties to ensure type safety

**WHY these choices were made:**
- Read-only fields should not be part of form state as they cannot be edited by users
- CustomFields need to display actual entity data, not form data, to show accurate information including read-only fields
- Recursive filtering handles nested objects and arrays properly for complex entity structures

## Affects

- **Admin detail pages**: Donations, Donors, Subscriptions, and Campaigns detail forms
- **CustomFields components**: Now use entity data instead of form data
- **Form initialization**: Read-only fields are filtered out before setting default form values
- **Type safety**: New SchemaProperty interface ensures proper typing

## Visuals

No visual changes - this is an internal refactor that improves data handling without affecting the UI appearance.

## Testing Instructions

1. Navigate to any admin detail page (Donation, Donor, Subscription, or Campaign)
2. Verify that:
   - The form loads correctly without read-only fields in the form state
   - CustomFields sections display accurate data
   - Read-only fields like gateway info, projected revenue, etc. are not editable
   - Nested objects (like amount, fund info) are handled properly
   - Form submission works as expected

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] Self Review of code and UX completed