### PR TITLE
Feature: Add campaign ID to subscriptions

### DIFF
--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Give_Subscription
  *
+ * @unreleased add campaign_id
  * @since 2.19.0 - migrated from give-recurring
  * @since 1.0
  */
@@ -112,7 +113,6 @@ class Give_Subscription {
 	public $donor;
 
     /**
-     * @unreleased
      * @var int
      */
     public $campaign_id = 0;

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -240,6 +240,7 @@ class Give_Subscription {
 	/**
 	 * Creates a subscription.
 	 *
+     * @unreleased add campaign_id
 	 * @since  1.0
 	 *
 	 * @param  array $data Array of attributes for a subscription
@@ -266,6 +267,7 @@ class Give_Subscription {
 			'expiration'           => '',
 			'status'               => '',
 			'profile_id'           => '',
+            'campaign_id'          => 0,
 		);
 
 		$args = wp_parse_args( $data, $defaults );
@@ -290,6 +292,15 @@ class Give_Subscription {
 		if ( ! empty( $args['donor_id'] ) ) {
 			$args['customer_id'] = $args['donor_id'];
 		}
+
+        if (
+            $args['form_id']
+            && ! $args['campaign_id']
+        ) {
+            if ($campaign = give()->campaigns->getByFormId($args['form_id'])) {
+                $args['campaign_id'] = $campaign->id;
+            }
+        }
 
 		$id = $this->subs_db->create( $args );
 

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -294,10 +294,10 @@ class Give_Subscription {
 		}
 
         if (
-            $args['form_id']
+            $args['product_id']
             && ! $args['campaign_id']
         ) {
-            if ($campaign = give()->campaigns->getByFormId($args['form_id'])) {
+            if ($campaign = give()->campaigns->getByFormId($args['product_id'])) {
                 $args['campaign_id'] = $campaign->id;
             }
         }

--- a/src/LegacySubscriptions/includes/give-subscription.php
+++ b/src/LegacySubscriptions/includes/give-subscription.php
@@ -111,6 +111,12 @@ class Give_Subscription {
 	 */
 	public $donor;
 
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $campaign_id = 0;
+
 	/**
 	 * @var int (backward compatibility - maps to donor_id)
 	 */

--- a/src/LegacySubscriptions/includes/give-subscriptions-db.php
+++ b/src/LegacySubscriptions/includes/give-subscriptions-db.php
@@ -45,6 +45,7 @@ class Give_Subscriptions_DB extends Give_DB
      *
      * @access  public
      *
+     * @unreleased add campaign_id column
      * @since 2.24.0 add payment_mode column
      * @since   1.0
      */
@@ -68,6 +69,7 @@ class Give_Subscriptions_DB extends Give_DB
             'status' => '%s',
             'notes' => '%s',
             'profile_id' => '%s',
+            'campaign_id' => '%d',
         ];
     }
 
@@ -76,6 +78,8 @@ class Give_Subscriptions_DB extends Give_DB
      * Get default column values
      *
      * @access  public
+     *
+     * @unreleased add campaign_id column
      * @since   1.0
      */
     public function get_column_defaults()
@@ -96,6 +100,7 @@ class Give_Subscriptions_DB extends Give_DB
             'status' => '',
             'notes' => '',
             'profile_id' => '',
+            'campaign_id' => 0,
         ];
     }
 

--- a/src/Subscriptions/DataTransferObjects/SubscriptionQueryData.php
+++ b/src/Subscriptions/DataTransferObjects/SubscriptionQueryData.php
@@ -13,6 +13,7 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 /**
  * Class SubscriptionObjectData
  *
+ * @unreleased add campaign_id prop
  * @since 2.19.6
  */
 final class SubscriptionQueryData
@@ -78,7 +79,6 @@ final class SubscriptionQueryData
      */
     public $donationFormId;
     /**
-     * @unreleased
      * @var int
      */
     public $campaignId;

--- a/src/Subscriptions/DataTransferObjects/SubscriptionQueryData.php
+++ b/src/Subscriptions/DataTransferObjects/SubscriptionQueryData.php
@@ -77,6 +77,11 @@ final class SubscriptionQueryData
      * @var int
      */
     public $donationFormId;
+    /**
+     * @unreleased
+     * @var int
+     */
+    public $campaignId;
 
     /**
      * Convert data from Subscription Object to Subscription Model
@@ -105,6 +110,7 @@ final class SubscriptionQueryData
         $self->gatewayId = $subscriptionQueryObject->gatewayId;
         $self->gatewaySubscriptionId = $subscriptionQueryObject->gatewaySubscriptionId;
         $self->donationFormId = (int)$subscriptionQueryObject->donationFormId;
+        $self->campaignId = (int)$subscriptionQueryObject->campaignId;
 
         return $self;
     }

--- a/src/Subscriptions/Migrations/AddCampaignId.php
+++ b/src/Subscriptions/Migrations/AddCampaignId.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Give\Subscriptions\Migrations;
+
+use Give\Donations\ValueObjects\DonationMetaKeys;
+use Give\Framework\Database\DB;
+use Give\Framework\Database\Exceptions\DatabaseQueryException;
+use Give\Framework\Migrations\Contracts\Migration;
+use Give\Framework\Migrations\Contracts\ReversibleMigration;
+use Give\Framework\Migrations\Exceptions\DatabaseMigrationException;
+
+/**
+ * @unreleased
+ */
+class AddCampaignId extends Migration implements ReversibleMigration
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'add_campaign_id_to_subscriptions';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function title(): string
+    {
+        return 'Add campaign id to subscriptions';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp(): string
+    {
+        return strtotime('2025-10-02 00:00:00');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws DatabaseMigrationException
+     */
+    public function run()
+    {
+        try {
+            $query = <<<SQL
+                UPDATE %s AS subscriptions
+                JOIN %s donations
+                    ON subscriptions.parent_payment_id = donations.ID
+                SET subscriptions.campaign_id = (SELECT meta_value FROM %s WHERE donation_id = donations.ID AND meta_key = '%s' LIMIT 1)
+            SQL;
+
+            DB::query(sprintf(
+                $query,
+                DB::prefix('give_subscriptions'),
+                DB::prefix('posts'),
+                DB::prefix('give_donationmeta'),
+                DonationMetaKeys::CAMPAIGN_ID
+            ));
+        } catch (DatabaseQueryException $exception) {
+            throw new DatabaseMigrationException("An error occurred while adding campaign ID to the give_subscriptions table",
+                0, $exception);
+        }
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function reverse(): void
+    {
+        DB::table('give_subscriptions')->update(['campaign_id' => null]);
+    }
+}

--- a/src/Subscriptions/Migrations/AddCampaignId.php
+++ b/src/Subscriptions/Migrations/AddCampaignId.php
@@ -48,17 +48,15 @@ class AddCampaignId extends Migration implements ReversibleMigration
         try {
             $query = <<<SQL
                 UPDATE %s AS subscriptions
-                JOIN %s donations
-                    ON subscriptions.parent_payment_id = donations.ID
-                SET subscriptions.campaign_id = (SELECT meta_value FROM %s WHERE donation_id = donations.ID AND meta_key = '%s' LIMIT 1)
+                JOIN %s campaignForms
+                    ON subscriptions.product_id = campaignForms.form_id
+                SET subscriptions.campaign_id = campaignForms.campaign_id
             SQL;
 
             DB::query(sprintf(
                 $query,
                 DB::prefix('give_subscriptions'),
-                DB::prefix('posts'),
-                DB::prefix('give_donationmeta'),
-                DonationMetaKeys::CAMPAIGN_ID
+                DB::prefix('give_campaign_forms')
             ));
         } catch (DatabaseQueryException $exception) {
             throw new DatabaseMigrationException("An error occurred while adding campaign ID to the give_subscriptions table",

--- a/src/Subscriptions/Migrations/AddCampaignIdColumn.php
+++ b/src/Subscriptions/Migrations/AddCampaignIdColumn.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Give\Subscriptions\Migrations;
+
+use Give\Framework\Database\DB;
+use Give\Framework\Migrations\Contracts\Migration;
+use Give\Framework\Migrations\Exceptions\DatabaseMigrationException;
+
+/**
+ * @unreleased
+ */
+class AddCampaignIdColumn extends Migration
+{
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'add_campaign_id_to_subscriptions_table';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function title(): string
+    {
+        return 'Add Campaign ID to subscriptions table';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function timestamp(): string
+    {
+        return strtotime('2025-10-01 00:00:00');
+    }
+
+    /**
+     * @inheritDoc
+     * @throws DatabaseMigrationException
+     */
+    public function run()
+    {
+        $table = DB::prefix('give_subscriptions');
+        $columnAdded = maybe_add_column($table, 'campaign_id', "ALTER TABLE $table ADD COLUMN campaign_id INT UNSIGNED NULL");
+
+        if ( ! $columnAdded) {
+            throw new DatabaseMigrationException("An error occurred while updating the $table table");
+        }
+    }
+}

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -26,12 +26,14 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 /**
  * Class Subscription
  *
+ * @unreleased added campaign ID property
  * @since 4.10.0 added campaign relationship
  * @since 2.23.0 added the renewsAt property
  * @since 2.19.6
  *
  * @property int $id
  * @property int $donationFormId
+ * @property int $campaignId
  * @property DateTime $createdAt
  * @property DateTime $renewsAt The date the subscription will renew next
  * @property int $donorId
@@ -58,6 +60,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     protected $properties = [
         'id' => 'int',
         'donationFormId' => 'int',
+        'campaignId' => 'int',
         'createdAt' => DateTime::class,
         'renewsAt' => DateTime::class,
         'donorId' => 'int',
@@ -367,7 +370,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * @since 4.10.0
      *
-     * @return ModelQueryBuilder<Campaign>
+     * @return ModelQueryBuilder<Campaign
      */
     public function campaign(): ModelQueryBuilder
     {

--- a/src/Subscriptions/Models/Subscription.php
+++ b/src/Subscriptions/Models/Subscription.php
@@ -370,7 +370,7 @@ class Subscription extends Model implements ModelCrud, ModelHasFactory
     /**
      * @since 4.10.0
      *
-     * @return ModelQueryBuilder<Campaign
+     * @return ModelQueryBuilder<Campaign>
      */
     public function campaign(): ModelQueryBuilder
     {

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -161,6 +161,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add campaign_id column to insert
      * @since 2.24.0 add payment_mode column to insert
      * @since 2.21.0 replace actions with givewp_subscription_creating and givewp_subscription_created
      * @since 2.19.6
@@ -226,6 +227,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add campaign_id column to update
      * @since 3.17.0 add expiration column to update
      * @since 2.24.0 add payment_mode column to update
      * @since 2.21.0 replace actions with givewp_subscription_updating and givewp_subscription_updated
@@ -515,6 +517,7 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased add campaign_id column to select
      * @since 2.19.6
      *
      * @return ModelQueryBuilder<Subscription>

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -121,6 +121,19 @@ class SubscriptionRepository
     }
 
     /**
+     * @unreleased
+     *
+     * @param int $campaignId
+     *
+     * @return ModelQueryBuilder<Subscription>
+     */
+    public function queryByCampaignId(int $campaignId): ModelQueryBuilder
+    {
+        return $this->prepareQuery()
+            ->where('campaign_id', $campaignId);
+    }
+
+    /**
      * @deprecated Use give()->subscriptions->notes()->queryBySubscriptionId()->getAll() instead.
      * @since 2.19.6
      *
@@ -185,6 +198,7 @@ class SubscriptionRepository
                 'bill_times' => $subscription->installments,
                 'transaction_id' => $subscription->transactionId ?? '',
                 'product_id' => $subscription->donationFormId,
+                'campaign_id' => $subscription->campaignId,
                 'payment_mode' => $subscription->mode->getValue(),
             ]);
         } catch (Exception $exception) {
@@ -243,6 +257,7 @@ class SubscriptionRepository
                     'bill_times' => $subscription->installments,
                     'transaction_id' => $subscription->transactionId ?? '',
                     'product_id' => $subscription->donationFormId,
+                    'campaign_id' => $subscription->campaignId,
                     'payment_mode' => $subscription->mode->getValue(),
                 ]);
         } catch (Exception $exception) {
@@ -517,7 +532,8 @@ class SubscriptionRepository
                 ['recurring_fee_amount', 'feeAmount'],
                 'status',
                 ['profile_id', 'gatewaySubscriptionId'],
-                ['product_id', 'donationFormId']
+                ['product_id', 'donationFormId'],
+                ['campaign_id', 'campaignId']
             )
             ->attachMeta(
                 'give_donationmeta',

--- a/src/Subscriptions/Repositories/SubscriptionRepository.php
+++ b/src/Subscriptions/Repositories/SubscriptionRepository.php
@@ -176,6 +176,12 @@ class SubscriptionRepository
             $subscription->bumpRenewalDate();
         }
 
+        // If the subscription is not associated with a campaign, try to find the campaign ID by the form ID
+        if (!$subscription->campaignId) {
+            $campaign = give()->campaigns->getByFormId($subscription->donationFormId);
+            $subscription->campaignId = $campaign ? $campaign->id : null;
+        }
+
         Hooks::doAction('givewp_subscription_creating', $subscription);
 
         $dateCreated = Temporal::withoutMicroseconds($subscription->createdAt ?: Temporal::getCurrentDateTime());

--- a/src/Subscriptions/ServiceProvider.php
+++ b/src/Subscriptions/ServiceProvider.php
@@ -10,6 +10,8 @@ use Give\Subscriptions\Actions\RegisterSubscriptionEntity;
 use Give\Subscriptions\LegacyListeners\DispatchGiveSubscriptionPostCreate;
 use Give\Subscriptions\LegacyListeners\DispatchGiveSubscriptionPreCreate;
 use Give\Subscriptions\ListTable\SubscriptionsListTable;
+use Give\Subscriptions\Migrations\AddCampaignId;
+use Give\Subscriptions\Migrations\AddCampaignIdColumn;
 use Give\Subscriptions\Migrations\AddPaymentModeToSubscriptionTable;
 use Give\Subscriptions\Migrations\BackfillMissingCampaignIdForDonations;
 use Give\Subscriptions\Migrations\CreateSubscriptionTables;
@@ -69,6 +71,7 @@ class ServiceProvider implements ServiceProviderInterface
     /**
      * Registers database migrations with the MigrationsRunner
      *
+     * @unreleased add AddCampaignIdColumn and AddCampaignId migrations
      * @since 2.24.0
      */
     private function registerMigrations()
@@ -79,6 +82,8 @@ class ServiceProvider implements ServiceProviderInterface
             CreateSubscriptionTables::class,
             AddPaymentModeToSubscriptionTable::class,
             BackfillMissingCampaignIdForDonations::class,
+            AddCampaignIdColumn::class,
+            AddCampaignId::class
         ]);
     }
 


### PR DESCRIPTION

## Description

This pull request introduces two new database migrations to support the addition of a `campaign_id` field to the `give_subscriptions` table, and setting the `campaign_id` for each subscription. 


## Affects

`give_subscriptions` table

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

