### PR TITLE
Fix: subscription details form link

### DIFF
--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/index.tsx
@@ -128,7 +128,7 @@ export default function DonationSummaryGrid({
                                 target="_blank"
                                 rel="noopener noreferrer"
                             >
-                                {__('View details', 'give')}
+                                {__('View subscription', 'give')}
                                 <ExternalLinkIcon />
                             </a>
                         )}

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionSummary/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Overview/SubscriptionSummary/index.tsx
@@ -78,6 +78,7 @@ interface SummaryProps {
 }
 
 /**
+ * @unreleased fix form link
  * @since 4.10.0 removed donation from props
  * @since 4.8.0
  */
@@ -100,7 +101,7 @@ export default function Summary({subscription, adminUrl, intendedAmount, isLoadi
             value: subscription?.donationFormId ? (
                 <a
                     className={styles.link}
-                    href={`${adminUrl}edit.php?post_type=give_forms&page=givewp-form-builder&donationFormID=${subscription?.donationFormId}`}
+                    href={`${adminUrl}post.php?post=${subscription?.donationFormId}&action=edit`}
                     target="_blank"
                     rel="noopener noreferrer"
                 >


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The subscription details form link was hard-coded to the visual form builder.  This did not account for v2 forms so the link was updated to the standard edit url which already has logic in place to redirect when it's a v3 form.

Also, _view details_ was changed to _view subscription_ in the donation details screen.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The subscription form link

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Create a subscription with a v2 form
- Create another one with a v3 form
- Make sure the link to the form works for both subscriptions

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

