### PR TITLE
Fix: Update subscription product ID on form data transfer

### DIFF
--- a/src/FormMigration/Actions/TransferDonations.php
+++ b/src/FormMigration/Actions/TransferDonations.php
@@ -42,6 +42,11 @@ class TransferDonations
                 ->where('form_id', $this->sourceId)
                 ->update(['form_id' => $destinationId]);
 
+            // Update subscriptions to use v3 form ID
+            DB::table('give_subscriptions')
+                ->where('product_id', $this->sourceId)
+                ->update(['product_id' => $destinationId]);
+
             give_update_meta(
                 $destinationId,
                 '_give_form_sales',

--- a/src/Session/SessionDonation/SessionObjects/Donation.php
+++ b/src/Session/SessionDonation/SessionObjects/Donation.php
@@ -23,6 +23,7 @@ use Give\ValueObjects\ValueObjects;
  * @property FormEntry $formEntry
  * @property DonorInfo $donorInfo
  */
+#[\AllowDynamicProperties]
 class Donation implements Objects
 {
     /**


### PR DESCRIPTION


## Description

This PR resolves the issue with migrating v2 forms to v3 and transferring data. The initial donation is updated to the new form, but the subscription is still associated with the old form.

**Donation transfer improvements:**

* Updated the `TransferDonations` action to also update the `product_id` in the `give_subscriptions` table when transferring donations, ensuring subscriptions are associated with the correct form after migration.

**Codebase compatibility:**

* Added the `#[\AllowDynamicProperties]` attribute to the `Donation` class to explicitly allow dynamic properties, improving compatibility with PHP 8.2 and above.
* 
## Affects

Form upgrade and data transfer


## Testing Instructions

Create a campaign
Add v2 form
Make recurring donations to that v2 form
Upgrade v2 form
Transfer v2 form data to the new v3 form

Verify that all subscriptions associated with the v2 form are associated with the v3 form after data transfer

<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

