### PR TITLE
Fix: Guard block selection when iframe isn’t in Gutenberg

### DIFF
--- a/src/Views/Form/Templates/Sequoia/assets/js/form.js
+++ b/src/Views/Form/Templates/Sequoia/assets/js/form.js
@@ -13,8 +13,17 @@
     // Make donation form block selectable in editor
     if (parentWp && parentWp.data) {
         $container.on('click', function () {
-            const blockId = window.frameElement.closest('.wp-block').getAttribute('data-block');
-            parentWp.data.dispatch('core/block-editor').selectBlock(blockId);
+            const frameElement = window.frameElement;
+            const blockElement = frameElement && frameElement.closest ? frameElement.closest('.wp-block') : null;
+
+            if (!blockElement) {
+                return;
+            }
+
+            const blockId = blockElement.getAttribute('data-block');
+            if (blockId) {
+                parentWp.data.dispatch('core/block-editor').selectBlock(blockId);
+            }
         });
     }
 


### PR DESCRIPTION
When GiveWP’s Sequoia template runs inside an iframe on sites built with WP Bakery, the iframe isn’t wrapped in a Gutenberg .wp-block, so the block selection click handler throws. This PR adds safe checks for the frame element, .closest, and a valid data-block before dispatching block selection. That prevents errors in non-Gutenberg contexts while preserving the editor behavior when the block exists.

Affects
Sequoia template editor click handling for block selection in form.js.

Testing Instructions
Load a Sequoia form inside the block editor; click inside the form and confirm the block still selects.
Load the form on a WP Bakery page (no .wp-block ancestor) and confirm no JS errors.

