### PR TITLE
Refactor: Conditionally load frontend assets only on pages with Give content

### DIFF
--- a/includes/class-give-scripts.php
+++ b/includes/class-give-scripts.php
@@ -63,7 +63,6 @@ class Give_Scripts {
 			add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_styles' ] );
 			add_action( 'enqueue_block_editor_assets', [ $this, 'gutenberg_admin_scripts' ] );
 			add_action( 'admin_head', [ $this, 'global_admin_head' ] );
-
 		} else {
 			add_action( 'wp_enqueue_scripts', [ $this, 'public_enqueue_styles' ] );
 			add_action( 'wp_enqueue_scripts', [ $this, 'public_enqueue_scripts' ] );
@@ -88,9 +87,13 @@ class Give_Scripts {
 	/**
 	 * Registers all plugin styles.
 	 *
+     * @unreleased Prevent loading styles on non-Give pages.
 	 * @since 2.1.0
 	 */
 	public function register_styles() {
+        if (!Give\Helpers\Frontend\Page::hasGiveContent()) {
+            return;
+        }
 
 		// Global WP-admin.
 		wp_register_style( 'give-admin-global-styles', GIVE_PLUGIN_URL . 'build/assets/dist/css/admin-global' . $this->direction . '.css', [], GIVE_VERSION );
@@ -115,9 +118,14 @@ class Give_Scripts {
 	/**
 	 * Registers all plugin scripts.
 	 *
+     * @unreleased Prevent loading scripts on non-Give pages.
 	 * @since 2.1.0
 	 */
 	public function register_scripts() {
+        if (!Give\Helpers\Frontend\Page::hasGiveContent()) {
+            return;
+        }
+
         // WP-Admin.
         EnqueueScript::make(
             'give-admin-scripts',
@@ -454,9 +462,14 @@ class Give_Scripts {
 	/**
 	 * Enqueues public styles.
 	 *
+     * @unreleased Prevent loading styles on non-Give pages.
 	 * @since 2.1.0
 	 */
 	public function public_enqueue_styles() {
+        if (!Give\Helpers\Frontend\Page::hasGiveContent()) {
+            return;
+        }
+
 		wp_enqueue_style( 'give-styles' );
 	}
 
@@ -464,9 +477,14 @@ class Give_Scripts {
 	/**
 	 * Enqueues public scripts.
 	 *
+     * @unreleased Prevent loading scripts on non-Give pages.
 	 * @since 2.1.0
 	 */
 	public function public_enqueue_scripts() {
+        if (!Give\Helpers\Frontend\Page::hasGiveContent()) {
+            return;
+        }
+
 		wp_enqueue_script( 'give' );
 
 		$this->public_localize_scripts();

--- a/includes/gateways/stripe/includes/give-stripe-scripts.php
+++ b/includes/gateways/stripe/includes/give-stripe-scripts.php
@@ -16,11 +16,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Load Frontend javascript
  *
+ * @unreleased Prevent loading scripts on non-Give pages.
  * @since 2.5.0
  *
  * @return void
  */
 function give_stripe_frontend_scripts() {
+    if (!Give\Helpers\Frontend\Page::hasGiveContent()) {
+        return;
+    }
 
 	/**
 	 * Bailout, if Stripe account is not configured.

--- a/src/API/REST/V3/Entities/Actions/RegisterPublicEntities.php
+++ b/src/API/REST/V3/Entities/Actions/RegisterPublicEntities.php
@@ -4,6 +4,7 @@ namespace Give\API\REST\V3\Entities\Actions;
 
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Helpers\Language;
+use Give\Helpers\Frontend\Page;
 
 /**
  * @since 4.13.1
@@ -11,10 +12,15 @@ use Give\Helpers\Language;
 class RegisterPublicEntities
 {
     /**
+     * @unreleased Prevent loading scripts on non-Give pages.
      * @since 4.13.1
      */
     public function __invoke()
     {
+        if (!is_admin() && !Page::hasGiveContent()) {
+            return;
+        }
+
         $handleName = 'givewp-entities-public';
         $scriptAsset = ScriptAsset::get(GIVE_PLUGIN_DIR . 'build/entitiesPublic.asset.php');
 

--- a/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
+++ b/src/Framework/DesignSystem/Actions/RegisterDesignSystemStyles.php
@@ -2,13 +2,20 @@
 
 namespace Give\Framework\DesignSystem\Actions;
 
+use Give\Helpers\Frontend\Page;
+
 class RegisterDesignSystemStyles
 {
     /**
+     * @unreleased Prevent loading styles on non-Give pages.
      * @since 2.26.0
      */
     public function __invoke()
     {
+        if (!is_admin() && !Page::hasGiveContent()) {
+            return;
+        }
+
         $version = file_get_contents(GIVE_PLUGIN_DIR . 'build/assets/dist/css/design-system/version');
 
         wp_register_style(

--- a/src/Helpers/Frontend/Page.php
+++ b/src/Helpers/Frontend/Page.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Give\Helpers\Frontend;
+
+/**
+ * Frontend Page Detection Helper
+ *
+ * Provides utilities for detecting Give content on frontend pages
+ *
+ * @unreleased
+ */
+class Page
+{
+    /**
+     * Check if current page has Give content (forms, blocks, or is a Give page)
+     *
+     * This method checks for:
+     * - Give form post types
+     * - Give success/campaign pages
+     * - Give shortcodes in content
+     * - Give blocks in content
+     *
+     * @unreleased
+     */
+    public static function hasGiveContent(): bool
+    {
+        global $post;
+
+        if (self::isGiveEmbed()) {
+            return true;
+        }
+
+        if (!is_single() && !is_page()) {
+            return false;
+        }
+
+        // Check if it's a Give success page
+        if (give_is_success_page()) {
+            return true;
+        }
+
+        // Check if it's a campaign page
+        if (function_exists('give_is_campaign_page') && give_is_campaign_page()) {
+            return true;
+        }
+
+        // Check if it's a single give_forms post type
+        if (is_singular('give_forms')) {
+            return true;
+        }
+
+        // No post to check
+        if (!$post instanceof \WP_Post) {
+            return apply_filters('give_page_has_give_content', false);
+        }
+
+        // Check for Give shortcodes
+        if (self::hasGiveShortcode($post->post_content)) {
+            return true;
+        }
+
+        // Check for Give blocks
+        if (self::hasGiveBlock($post->post_content)) {
+            return true;
+        }
+
+
+        // Allow filtering for custom conditions
+        return apply_filters('give_page_has_give_content', false);
+    }
+
+    /**
+     * Check if content has any Give shortcode
+     *
+     * @unreleased
+     */
+    public static function hasGiveShortcode(string $content): bool
+    {
+        $shortcodes = [
+            'donation_history',
+            'give_form',
+            'give_goal',
+            'give_login',
+            'give_register',
+            'give_receipt',
+            'give_profile_editor',
+            'give_totals',
+            'give_form_grid',
+            'give_donor_wall',
+            'givewp_campaign',
+            'givewp_campaign_grid',
+            'givewp_campaign_form',
+            'givewp_campaign_comments',
+            'givewp_campaign_donors',
+            'givewp_campaign_donations',
+            'givewp_campaign_stats',
+            'givewp_campaign_goal',
+            'give_donor_dashboard',
+            'give_multi_form_goal',
+        ];
+
+        foreach ($shortcodes as $shortcode) {
+            if (has_shortcode($content, $shortcode)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if content has any Give block
+     *
+     * @unreleased
+     */
+    public static function hasGiveBlock(string $content): bool
+    {
+        if (!function_exists('has_block')) {
+            return false;
+        }
+
+        $blocks = [
+            // Core donation form blocks
+            'give/donation-form',
+            'give/donation-form-grid',
+            'givewp/donation-form',
+
+            // Donor blocks
+            'give/donor-dashboard',
+            'give/donor-wall',
+
+            // Multi-form goal blocks
+            'give/multi-form-goal',
+            'give/progress-bar',
+
+            // Campaign blocks
+            'givewp/campaign-block',
+            'givewp/campaign-grid',
+            'givewp/campaign-form',
+            'givewp/campaign-goal',
+            'givewp/campaign-stats-block',
+            'givewp/campaign-comments-block',
+            'givewp/campaign-donors',
+            'givewp/campaign-donations',
+            'givewp/campaign-cover-block',
+            'givewp/campaign-title',
+            'givewp/campaign-donate-button',
+
+            // Event tickets (add-on)
+            'givewp/event-tickets',
+        ];
+
+        foreach ($blocks as $block) {
+            if (has_block($block)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Check if current page is a Give embed
+     *
+     * @unreleased
+     */
+    public static function isGiveEmbed(): bool
+    {
+        $keys = [
+            'give-embed',
+            'givewp-route',
+            'giveDonationFormInIframe',
+        ];
+
+        foreach ($keys as $key) {
+            if (filter_input(INPUT_GET, $key, FILTER_SANITIZE_STRING) !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Resolves [GIVE-2427]

## Description

This PR optimizes frontend performance by implementing conditional loading of Give scripts, styles, and REST API entities. Previously, all Give frontend assets were loaded on every page of the site, regardless of whether Give content was present. This caused unnecessary HTTP requests and increased page load times on pages without any Give forms, blocks, or shortcodes.

The solution introduces a new helper class `Give\Helpers\Frontend\Page` that intelligently detects if the current page contains Give content by checking for:
- Give form post types
- Give success/campaign pages  
- Give shortcodes (donation forms, donor dashboard, etc.)
- Give blocks (donation forms, campaigns, donor wall, etc.)
- Give embed contexts (iframes, routes)

This helper is then used to conditionally enqueue assets only when needed, reducing the frontend footprint on non-Give pages while maintaining full functionality on pages that use Give.

## Affects

- **Frontend Performance**: Pages without Give content will no longer load Give scripts/styles
- **Script Loading**: `give.js`, `give-styles.css`, Stripe scripts, and design system styles now load conditionally
- **REST API Entities**: Public entities registration is now conditional
- **Compatibility**: Maintains backward compatibility with all existing Give features

## Visuals

N/A - This is a performance optimization with no visual changes to the user interface.

## Testing Instructions

### Test 1: Verify assets load on Give pages
1. Create a page with a Give donation form (shortcode or block)
2. View the page source
3. Confirm Give scripts and styles are loaded (search for `give.js`, `give-styles.css`)

### Test 2: Verify assets don't load on non-Give pages
1. Create a regular page without any Give content
2. View the page source
3. Confirm Give scripts and styles are NOT loaded

### Test 3: Test all Give content types
Test that assets load correctly for:
- [ ] Give form shortcode `[give_form id="123"]`
- [ ] Give donation form block
- [ ] Give donor dashboard shortcode/block
- [ ] Give donor wall
- [ ] Campaign pages
- [ ] Campaign blocks
- [ ] Give success page
- [ ] Give form single post type
- [ ] Give embed/iframe contexts

### Test 4: Test Stripe gateway
1. Create a donation form with Stripe gateway enabled
2. Verify Stripe scripts load correctly on the form page
3. Complete a test donation to ensure Stripe functionality works

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant `@unreleased` tags included in DocBlocks
- [ ] Includes unit tests
- [ ] Reviewed by the designer (if follows a design) - N/A
- [x] Self Review of code and UX completed

[GIVE-2427]: https://stellarwp.atlassian.net/browse/GIVE-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ