### PR TITLE
Rebrand to Nexcess | SCON-355

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Tweak: Updated branding references from StellarWP to Liquid Web.
+* Tweak: Updated branding references from StellarWP to Nexcess.
 
 ## New
 -   Allow Fields API fields to be macroable (#5900)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+* Tweak: Updated branding references from StellarWP to Liquid Web.
+
 ## New
 -   Allow Fields API fields to be macroable (#5900)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
 * Tweak: Updated branding references from StellarWP to Liquid Web.
 
 ## New

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 == Changelog ==
 = TBD =
-
 * Tweak: Updated branding references from StellarWP to Liquid Web.
 
 = 3.22.2: March 19th, 2025 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 == Changelog ==
 = TBD: DATE TBD =
-* Tweak: Updated branding references from StellarWP to Liquid Web.
+* Tweak: Updated branding references from StellarWP to Nexcess.
 
 = 3.22.2: March 19th, 2025 =
 * Fix: Resolved an issue with PayPal hiding the donate button when hosted fields are available

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 == Changelog ==
-= TBD =
+= TBD: DATE TBD =
 * Tweak: Updated branding references from StellarWP to Liquid Web.
 
 = 3.22.2: March 19th, 2025 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 == Changelog ==
+= TBD =
+
+* Tweak: Updated branding references from StellarWP to Liquid Web.
+
 = 3.22.2: March 19th, 2025 =
 * Fix: Resolved an issue with PayPal hiding the donate button when hosted fields are available
 * Security: Improved the permission check for a GiveWP reporting request (CVE-2025-2331)

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Are you a developer? GiveWP is built with best practices and easy to extend and 
 
 === 💚 About the GiveWP Team ===
 
-GiveWP is part of Liquid Web, a Liquid Web Family Brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
+GiveWP Give is part of Software by Liquid Web. A Nexcess brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
 
 === 📧 Connect with GiveWP ===
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Are you a developer? GiveWP is built with best practices and easy to extend and 
 
 === 💚 About the GiveWP Team ===
 
-The most downloaded fundraising plugin on WordPress, Give has helped users raise over $350 million since 2009. Behind it is a professional team of WordPress developers who know what serious fundraising operations need: flexible tools, rock-solid reliability, and software that grows with your mission. As part of Liquid Web’s software offerings, Give is backed by decades of experience building and hosting WordPress solutions.
+The most downloaded fundraising plugin on WordPress, Give has helped users raise over $350 million since 2009. Behind it is a professional team of WordPress developers who know what serious fundraising operations need: flexible tools, rock-solid reliability, and software that grows with your mission. As part of Nexcess’s software offerings, Give is backed by decades of experience building and hosting WordPress solutions.
 
 === 📧 Connect with GiveWP ===
 
@@ -274,7 +274,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Changelog ==
 = TBD =
-* Tweak: Updated branding references from StellarWP to Liquid Web.
+* Tweak: Updated branding references from StellarWP to Nexcess.
 
 = 4.14.4: April 2nd, 2026 =
 * Security: Added additional validation to PayPal Commerce requests.

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Are you a developer? GiveWP is built with best practices and easy to extend and 
 
 === 💚 About the GiveWP Team ===
 
-GiveWP is part of Software by Liquid Web. A Nexcess brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
+The most downloaded fundraising plugin on WordPress, Give has helped users raise over $350 million since 2009. Behind it is a professional team of WordPress developers who know what serious fundraising operations need: flexible tools, rock-solid reliability, and software that grows with your mission. As part of Liquid Web’s software offerings, Give is backed by decades of experience building and hosting WordPress solutions.
 
 === 📧 Connect with GiveWP ===
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Are you a developer? GiveWP is built with best practices and easy to extend and 
 
 === 💚 About the GiveWP Team ===
 
-GiveWP is part of StellarWP, a Liquid Web Family Brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
+GiveWP is part of Liquid Web, a Liquid Web Family Brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
 
 === 📧 Connect with GiveWP ===
 
@@ -273,6 +273,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= TBD =
+* Tweak: Updated branding references from StellarWP to Liquid Web.
+
 = 4.14.4: April 2nd, 2026 =
 * Security: Added additional validation to PayPal Commerce requests.
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Are you a developer? GiveWP is built with best practices and easy to extend and 
 
 === 💚 About the GiveWP Team ===
 
-GiveWP Give is part of Software by Liquid Web. A Nexcess brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
+GiveWP is part of Software by Liquid Web. A Nexcess brand. Our donation plugin is backed by a growing team of WordPress developers, support engineers, customer success managers, and marketing professionals who’ve worked with WordPress and nonprofits since 2009. This means GiveWP is made with best practices in mind; extremely extensible and customizable, stable, and reliable. We’ll be here in years to come for you and your nonprofit organization.
 
 === 📧 Connect with GiveWP ===
 

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -41,7 +41,7 @@ class ServiceProvider implements ServiceProviderContract
     /**
      * @since 4.3.0 refactor to add conditional scripts inside admin_enqueue_scripts hook
      * @since 4.0.0 add CampaignWelcomeBanner
-     * @since 3.13.0 add Liquid Web banner.
+     * @since 3.13.0 add Stellar banner.
      * @since 2.27.1 Removed Recurring donations tab app.
      * @since 2.19.0
      *

--- a/src/Promotions/ServiceProvider.php
+++ b/src/Promotions/ServiceProvider.php
@@ -41,7 +41,7 @@ class ServiceProvider implements ServiceProviderContract
     /**
      * @since 4.3.0 refactor to add conditional scripts inside admin_enqueue_scripts hook
      * @since 4.0.0 add CampaignWelcomeBanner
-     * @since 3.13.0 add Stellar banner.
+     * @since 3.13.0 add Liquid Web banner.
      * @since 2.27.1 Removed Recurring donations tab app.
      * @since 2.19.0
      *


### PR DESCRIPTION
:ticket: [SCON-355]


Automated rebrand from StellarWP / Liquid Web to Nexcess.

**Changes made:**
- Added a changelog entry noting the brand update from StellarWP to Nexcess (in `CHANGELOG.md`, `changelog.txt`, and `readme.txt`).
- Updated the `readme.txt` "About the GiveWP Team" paragraph to describe Give as part of Nexcess's software offerings.

**Preserved (not changed):**
- PHP identifiers (class names, function names, variables, namespaces)
- CSS class/ID names
- File and directory names
- Text domains
- Non-brand URLs and email addresses

**Notes:**
- This PR targets `bucket/product-consolidation`, which was created from the repo's default branch. If a more appropriate base branch exists, a reviewer can update the base accordingly.
- Names of Stellar libraries / tools (e.g. StellarWP Telemetry, StellarWP Asset, StellarWP Pipeline, StellarWP DB, StellarWP Admin Notices, SLIC) have had their names preserved to prevent confusion.
- Some services may have had their names updated. We should revert them if it makes sense. Example: "Stellar Sites" is staying as-is per Jack.
- If a change is user-facing, then a changelog entry has been added.

[SCON-355]: https://stellarwp.atlassian.net/browse/SCON-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ