### PR TITLE
ci: bypass setup-php github-token to avoid composer auth failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
                     php-version: 7.4
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
+                    github-token: '' # TODO: Remove temporary fix for Composer authentication issue caused by GitHub switching to a ghs_APPID_JWT format that Composer does not support. See https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
 
             -   name: Install composer dependencies
                 uses: php-actions/composer@v5

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -64,6 +64,7 @@ jobs:
                     php-version: 7.4
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
+                    github-token: '' # TODO: Remove temporary fix for Composer authentication issue caused by GitHub switching to a ghs_APPID_JWT format that Composer does not support. See https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
 
             -   name: Install composer dependencies
                 run: composer install --no-progress --no-interaction
@@ -94,6 +95,7 @@ jobs:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
+                    github-token: '' # TODO: Remove temporary fix for Composer authentication issue caused by GitHub switching to a ghs_APPID_JWT format that Composer does not support. See https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/
 
             -   name: Reload Composer autoload
                 run: composer dump-autoload


### PR DESCRIPTION
## Summary

GitHub is rolling out a new `ghs_APPID_JWT` installation token format (see the [GitHub changelog](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)) whose base64url JWT segment can contain hyphens. Composer's `BaseIO` token regex `{^[.A-Za-z0-9_]+$}` rejects hyphens, so any composer command that runs after `shivammathur/setup-php` auto-writes that token into `~/.composer/auth.json` fails with `github oauth token contains invalid characters`.

This is what caused the 4.15.1 `Deploy to WordPress.org` workflow to fail (run [25765762166](https://github.com/impress-org/givewp/actions/runs/25765762166)).

This PR passes an empty `github-token` to every `setup-php` step in the workflows we control so the bad token is never written to `auth.json`. Composer falls back to unauthenticated GitHub API access, which is fine for the volume of metadata fetched here.

### Files patched

- `wordpress.yml` — both `Set Up PHP for build` and `Set Up PHP for testing` steps. This is the workflow `release.yml` calls for tests, so it covers the deploy path.
- `release.yml` — the `Setup PHP` step in the `release` job, since the subsequent `php-actions/composer@v5` install and the direct `composer run copy-fonts` step would otherwise fail the same way.

### Known limitation

Other workflows (`php-compatibility.yml`, `static-analysis.yml`, `pre-release.yml`, `generate-zip.yml`, `close-stale-issues.yml`) call reusable workflows in `impress-org/givewp-github-actions` that we don't patch here. Those will continue to fail intermittently for the same reason. Because the JWT signature segment only contains hyphens probabilistically, individual runs may pass on retry. Fully resolving them requires either a fix in `impress-org/givewp-github-actions` or in upstream Composer.

This is a temporary workaround; once Composer accepts the new token format upstream, the `github-token: ''` overrides should be removed (TODO comments left in place to flag this).