### PR TITLE
Release 4.15.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "stellarwp/admin-notices": "^2.0.1",
         "stellarwp/arrays": "^1.3",
         "moneyphp/money": "^3.3.3",
-        "stellarwp/harbor": "^1.1"
+        "stellarwp/harbor": "^1.2"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -829,12 +829,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "c9519c36168f40aebb4210b033235eceda3e6366"
+                "reference": "f22783d0d79597d5b1acf6cce73e6f3ddb701334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/c9519c36168f40aebb4210b033235eceda3e6366",
-                "reference": "c9519c36168f40aebb4210b033235eceda3e6366",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/f22783d0d79597d5b1acf6cce73e6f3ddb701334",
+                "reference": "f22783d0d79597d5b1acf6cce73e6f3ddb701334",
                 "shasum": ""
             },
             "require": {
@@ -891,7 +891,7 @@
                 "issues": "https://github.com/stellarwp/harbor/issues",
                 "source": "https://github.com/stellarwp/harbor/tree/v1.2.0"
             },
-            "time": "2026-05-13T22:44:25+00:00"
+            "time": "2026-05-14T00:04:41+00:00"
         },
         {
             "name": "stellarwp/licensing-api-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9c5538ff55e0afff337cad772b85810",
+    "content-hash": "e6f529331a0ff4257f85f367f12859ad",
     "packages": [
         {
             "name": "composer/installers",
@@ -825,16 +825,16 @@
         },
         {
             "name": "stellarwp/harbor",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "97c3a17758b03f90980c34c661a7dd119c6c307f"
+                "reference": "c9519c36168f40aebb4210b033235eceda3e6366"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/97c3a17758b03f90980c34c661a7dd119c6c307f",
-                "reference": "97c3a17758b03f90980c34c661a7dd119c6c307f",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/c9519c36168f40aebb4210b033235eceda3e6366",
+                "reference": "c9519c36168f40aebb4210b033235eceda3e6366",
                 "shasum": ""
             },
             "require": {
@@ -889,9 +889,9 @@
             "description": "A library that integrates a WordPress product with the Liquid Web licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/harbor/issues",
-                "source": "https://github.com/stellarwp/harbor/tree/v1.1.0"
+                "source": "https://github.com/stellarwp/harbor/tree/v1.2.0"
             },
-            "time": "2026-05-12T19:52:22+00:00"
+            "time": "2026-05-13T22:44:25+00:00"
         },
         {
             "name": "stellarwp/licensing-api-client",
@@ -8750,5 +8750,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/give.php
+++ b/give.php
@@ -6,7 +6,7 @@
  * Description: The most robust, flexible, and intuitive way to accept donations on WordPress.
  * Author: GiveWP
  * Author URI: https://givewp.com/
- * Version: 4.15.1
+ * Version: 4.15.2
  * Requires at least: 6.6
  * Requires PHP: 7.4
  * Text Domain: give
@@ -426,7 +426,7 @@ final class Give
     {
         // Plugin version.
         if (!defined('GIVE_VERSION')) {
-            define('GIVE_VERSION', '4.15.1');
+            define('GIVE_VERSION', '4.15.2');
         }
 
         // Plugin Root File.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: donation, donate, recurring donations, fundraising, crowdfunding
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 4.15.1
+Stable tag: 4.15.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -273,6 +273,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 10. Use almost any payment gateway integration with GiveWP through our add-ons or by creating your own add-on.
 
 == Changelog ==
+= 4.15.2: May 13th, 2026 =
+* Tweak: Update Harbor to 1.2.0, removing the Liquid Web Products page when there are no premium plugins present.
+
 = 4.15.1: May 12th, 2026 =
 * Tweak: Moved the Liquid Web menu item to Settings -> Liquid Web Products.
 * Tweak: The Settings -> Liquid Web Products page now requires a opt-in to communicate with external servers.

--- a/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
+++ b/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\VendorOverrides\Harbor\Actions;
+
+/**
+ * Return true if another brand already has premium presence or if any GiveWP premium add-on is active.
+ *
+ * Hooked into the `lw_harbor/premium_plugin_exists` filter.
+ *
+ * @unreleased
+ */
+class HasActivePremiumAddons
+{
+    /**
+     * @unreleased
+     */
+    public function __invoke(?bool $otherBrandsExistence): bool
+    {
+        if ($otherBrandsExistence) {
+            return true;
+        }
+
+        $premiumAddons = give_get_plugins(['only_premium_add_ons' => true]);
+
+        foreach ($premiumAddons as $addon) {
+            if ($addon['Status'] === 'active') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
+++ b/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
@@ -16,7 +16,7 @@ class HasActivePremiumAddons
     /**
      * @unreleased
      */
-    public function __invoke(?bool $otherBrandsExistence): bool
+    public function __invoke(bool $otherBrandsExistence): bool
     {
         if ($otherBrandsExistence) {
             return true;

--- a/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
+++ b/src/VendorOverrides/Harbor/Actions/HasActivePremiumAddons.php
@@ -9,12 +9,12 @@ namespace Give\VendorOverrides\Harbor\Actions;
  *
  * Hooked into the `lw_harbor/premium_plugin_exists` filter.
  *
- * @unreleased
+ * @since 4.15.2
  */
 class HasActivePremiumAddons
 {
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function __invoke(bool $otherBrandsExistence): bool
     {

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -17,6 +17,7 @@ use Give\Vendors\LiquidWeb\Harbor\Harbor;
 class HarborServiceProvider implements ServiceProviderContract
 {
     /**
+     * @unreleased Register lw_harbor/premium_plugin_exists filter
      * @since 4.15.0
      *
      * @inheritDoc
@@ -26,11 +27,13 @@ class HarborServiceProvider implements ServiceProviderContract
         Config::set_plugin_basename(GIVE_PLUGIN_BASENAME);
         Config::set_container(give()->getContainer());
 
+        // reports whether any GiveWP premium add-on is active to Harbor
+        Hooks::addFilter('lw_harbor/premium_plugin_exists', HasActivePremiumAddons::class);
+
         Harbor::init();
     }
 
     /**
-     * @unreleased Register lw_harbor/premium_plugin_exists filter
      * @since 4.15.0
      *
      * @inheritDoc
@@ -39,9 +42,6 @@ class HarborServiceProvider implements ServiceProviderContract
     {
         // reports legacy licenses to Harbor
         Hooks::addFilter('stellarwp/harbor/legacy_licenses', ReportLegacyLicences::class);
-
-        // reports whether any GiveWP premium add-on is active to Harbor
-        Hooks::addFilter('lw_harbor/premium_plugin_exists', HasActivePremiumAddons::class);
 
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -6,6 +6,7 @@ namespace Give\VendorOverrides\Harbor;
 
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
+use Give\VendorOverrides\Harbor\Actions\HasActivePremiumAddons;
 use Give\VendorOverrides\Harbor\Actions\ReportLegacyLicences;
 use Give\Vendors\LiquidWeb\Harbor\Config;
 use Give\Vendors\LiquidWeb\Harbor\Harbor;
@@ -29,6 +30,7 @@ class HarborServiceProvider implements ServiceProviderContract
     }
 
     /**
+     * @unreleased Register lw_harbor/premium_plugin_exists filter
      * @since 4.15.0
      *
      * @inheritDoc
@@ -37,6 +39,9 @@ class HarborServiceProvider implements ServiceProviderContract
     {
         // reports legacy licenses to Harbor
         Hooks::addFilter('stellarwp/harbor/legacy_licenses', ReportLegacyLicences::class);
+
+        // reports whether any GiveWP premium add-on is active to Harbor
+        Hooks::addFilter('lw_harbor/premium_plugin_exists', HasActivePremiumAddons::class);
 
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -17,7 +17,7 @@ use Give\Vendors\LiquidWeb\Harbor\Harbor;
 class HarborServiceProvider implements ServiceProviderContract
 {
     /**
-     * @unreleased Register lw_harbor/premium_plugin_exists filter
+     * @since 4.15.2 Register lw_harbor/premium_plugin_exists filter
      * @since 4.15.0
      *
      * @inheritDoc

--- a/tests/Unit/VendorOverrides/Harbor/Actions/TestHasActivePremiumAddons.php
+++ b/tests/Unit/VendorOverrides/Harbor/Actions/TestHasActivePremiumAddons.php
@@ -12,7 +12,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 /**
- * @unreleased
+ * @since 4.15.2
  * @coversDefaultClass \Give\VendorOverrides\Harbor\Actions\HasActivePremiumAddons
  */
 class TestHasActivePremiumAddons extends TestCase
@@ -24,7 +24,7 @@ class TestHasActivePremiumAddons extends TestCase
     private HasActivePremiumAddons $action;
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function setUp(): void
     {
@@ -37,7 +37,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function tearDown(): void
     {
@@ -47,7 +47,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function testReturnsTrueWhenOtherBrandsAlreadyHavePremiumPresence(): void
     {
@@ -55,7 +55,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function testReturnsFalseWhenNoPremiumAddOnsMatch(): void
     {
@@ -65,7 +65,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function testReturnsFalseWhenPremiumAddOnExistsButIsInactive(): void
     {
@@ -75,7 +75,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     public function testReturnsTrueWhenPremiumAddOnIsActive(): void
     {
@@ -86,7 +86,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function installPremiumAddonFixture(): void
     {
@@ -99,7 +99,7 @@ class TestHasActivePremiumAddons extends TestCase
      * Bypasses the remote products API by seeding the cached premium add-on slug list directly.
      * The container rebind clears the per-request memoized list inside PremiumAddonsListManager.
      *
-     * @unreleased
+     * @since 4.15.2
      */
     private function registerPremiumSlugs(array $slugs): void
     {
@@ -108,7 +108,7 @@ class TestHasActivePremiumAddons extends TestCase
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function writePluginFixture(): void
     {
@@ -138,7 +138,7 @@ PHP;
      * from setUp before anything has been installed, and from tearDown after a test
      * has fully or partially run.
      *
-     * @unreleased
+     * @since 4.15.2
      */
     private function resetState(): void
     {
@@ -154,7 +154,7 @@ PHP;
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function removePluginFixture(): void
     {
@@ -179,7 +179,7 @@ PHP;
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function requirePluginApi(): void
     {
@@ -189,7 +189,7 @@ PHP;
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function pluginDir(): string
     {
@@ -197,7 +197,7 @@ PHP;
     }
 
     /**
-     * @unreleased
+     * @since 4.15.2
      */
     private function pluginFile(): string
     {

--- a/tests/Unit/VendorOverrides/Harbor/Actions/TestHasActivePremiumAddons.php
+++ b/tests/Unit/VendorOverrides/Harbor/Actions/TestHasActivePremiumAddons.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\VendorOverrides\Harbor\Actions;
+
+use FilesystemIterator;
+use Give\License\PremiumAddonsListManager;
+use Give\Tests\TestCase;
+use Give\VendorOverrides\Harbor\Actions\HasActivePremiumAddons;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * @unreleased
+ * @coversDefaultClass \Give\VendorOverrides\Harbor\Actions\HasActivePremiumAddons
+ */
+class TestHasActivePremiumAddons extends TestCase
+{
+    private const ADDON_SLUG = 'give-harbor-test-add-on';
+
+    private const PREMIUM_ADDONS_TRANSIENT = 'give_premium_addons_ids';
+
+    private HasActivePremiumAddons $action;
+
+    /**
+     * @unreleased
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requirePluginApi();
+        $this->resetState();
+
+        $this->action = new HasActivePremiumAddons();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function tearDown(): void
+    {
+        $this->resetState();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsTrueWhenOtherBrandsAlreadyHavePremiumPresence(): void
+    {
+        $this->assertTrue(($this->action)(true));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsFalseWhenNoPremiumAddOnsMatch(): void
+    {
+        $this->registerPremiumSlugs([]);
+
+        $this->assertFalse(($this->action)(false));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsFalseWhenPremiumAddOnExistsButIsInactive(): void
+    {
+        $this->installPremiumAddonFixture();
+
+        $this->assertFalse(($this->action)(false));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function testReturnsTrueWhenPremiumAddOnIsActive(): void
+    {
+        $this->installPremiumAddonFixture();
+        activate_plugin($this->pluginFile(), '', false, true);
+
+        $this->assertTrue(($this->action)(false));
+    }
+
+    /**
+     * @unreleased
+     */
+    private function installPremiumAddonFixture(): void
+    {
+        $this->registerPremiumSlugs([self::ADDON_SLUG]);
+        $this->writePluginFixture();
+        wp_clean_plugins_cache(true);
+    }
+
+    /**
+     * Bypasses the remote products API by seeding the cached premium add-on slug list directly.
+     * The container rebind clears the per-request memoized list inside PremiumAddonsListManager.
+     *
+     * @unreleased
+     */
+    private function registerPremiumSlugs(array $slugs): void
+    {
+        give()->instance(PremiumAddonsListManager::class, new PremiumAddonsListManager());
+        set_transient(self::PREMIUM_ADDONS_TRANSIENT, $slugs, HOUR_IN_SECONDS);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function writePluginFixture(): void
+    {
+        $dir = $this->pluginDir();
+
+        if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+            self::fail("Could not create test plugin directory: {$dir}");
+        }
+
+        $pluginPhp = <<<'PHP'
+<?php
+/**
+ * Plugin Name: Give Harbor Test Add-on
+ * Plugin URI: https://givewp.com/downloads/plugins/give-harbor-test-add-on
+ * Description: Test fixture for Harbor premium add-on detection.
+ * Version: 1.0.0
+ * Author: GiveWP
+ */
+PHP;
+
+        $bytes = file_put_contents($dir . '/' . self::ADDON_SLUG . '.php', $pluginPhp);
+        self::assertNotFalse($bytes, 'Failed to write test plugin fixture.');
+    }
+
+    /**
+     * Returns every piece of touched state to its baseline. Idempotent: safe to call
+     * from setUp before anything has been installed, and from tearDown after a test
+     * has fully or partially run.
+     *
+     * @unreleased
+     */
+    private function resetState(): void
+    {
+        if (function_exists('is_plugin_active') && is_plugin_active($this->pluginFile())) {
+            deactivate_plugins($this->pluginFile(), true);
+        }
+
+        $this->removePluginFixture();
+
+        give()->instance(PremiumAddonsListManager::class, new PremiumAddonsListManager());
+        delete_transient(self::PREMIUM_ADDONS_TRANSIENT);
+        wp_clean_plugins_cache(true);
+    }
+
+    /**
+     * @unreleased
+     */
+    private function removePluginFixture(): void
+    {
+        $dir = $this->pluginDir();
+
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $path = $item->getPathname();
+            $removed = $item->isDir() ? rmdir($path) : unlink($path);
+            self::assertTrue($removed, "Failed to remove test fixture entry: {$path}");
+        }
+
+        self::assertTrue(rmdir($dir), "Failed to remove test plugin directory: {$dir}");
+    }
+
+    /**
+     * @unreleased
+     */
+    private function requirePluginApi(): void
+    {
+        if (!function_exists('activate_plugin')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+    }
+
+    /**
+     * @unreleased
+     */
+    private function pluginDir(): string
+    {
+        return WP_PLUGIN_DIR . '/' . self::ADDON_SLUG;
+    }
+
+    /**
+     * @unreleased
+     */
+    private function pluginFile(): string
+    {
+        return self::ADDON_SLUG . '/' . self::ADDON_SLUG . '.php';
+    }
+}


### PR DESCRIPTION
## Summary

This change set prepares GiveWP for StellarWP Harbor 1.2 by bumping the `stellarwp/harbor` Composer constraint to `^1.2`, and wiring Harbor’s new `lw_harbor/premium_plugin_exists` boolean filter.

https://github.com/user-attachments/assets/74a7aae5-8f64-463e-a372-d8177d43fa3b

## Changes

- **Composer:** require `stellarwp/harbor` `^1.2` (Harbor 1.2 must be available before `composer install` succeeds).
- **`HasActivePremiumAddons`:** invokable action that returns `true` when another brand already reports premium presence, or when any GiveWP premium add-on is active; otherwise `false`.
- **`HarborServiceProvider`:** registers the action on `lw_harbor/premium_plugin_exists`.
- **Tests:** unit coverage for the other-brands short-circuit, empty premium list, inactive fixture add-on, and active fixture add-on.