### PR TITLE
Feature: add release-prep commands

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@
 /.cursor
 
 /bin
+/changelog
 /tests
 /node_modules
 /assets/src

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 # Bin files
 /bin/*
 !/bin/strauss-installar.sh
+!/bin/release-utils.php
+!/bin/update-versions.php
+!/bin/replace-since-tags.php
+!/bin/write-changelog.sh
+!/bin/release-prep.sh
 
 # Numerous always-ignore extensions
 .diff

--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,11 @@
 # Bin files
 /bin/*
 !/bin/strauss-installar.sh
-!/bin/release-utils.php
 !/bin/update-versions.php
 !/bin/replace-since-tags.php
 !/bin/write-changelog.sh
 !/bin/release-prep.sh
+!/bin/lib/
 
 # Numerous always-ignore extensions
 .diff

--- a/bin/lib/changelog-strategy.js
+++ b/bin/lib/changelog-strategy.js
@@ -1,0 +1,98 @@
+/**
+ * Custom @stellarwp/changelogger writing strategy that reproduces GiveWP's
+ * legacy WordPress changelog format:
+ *
+ *   = 4.16.0: June 2nd, 2026 =
+ *   * Feature: Added a sample donation widget
+ *   * Fix: Resolved a rounding issue in donation totals
+ *
+ * Referenced from package.json -> changelogger.files[].strategy as a path.
+ * The changelogger loads any strategy whose name ends in .js/.ts (resolved from
+ * the current working directory) and validates that it exports formatChanges,
+ * formatVersionHeader, versionHeaderMatcher and changelogHeaderMatcher.
+ */
+
+const MONTHS = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+];
+
+// feature -> Feature, fix -> Fix, ... matches the labels configured in
+// package.json (each label is just the capitalized type key).
+function typeLabel(type) {
+    return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function ordinalSuffix(day) {
+    const mod100 = day % 100;
+    if (mod100 >= 11 && mod100 <= 13) {
+        return "th";
+    }
+    switch (day % 10) {
+        case 1: return "st";
+        case 2: return "nd";
+        case 3: return "rd";
+        default: return "th";
+    }
+}
+
+// "2026-06-02" -> "June 2nd, 2026". Falls back to the raw value if it is not a
+// plain ISO date (changelogger normalizes --date to YYYY-MM-DD).
+function formatLegacyDate(date) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(date));
+    if (!match) {
+        return String(date);
+    }
+    const [, year, month, day] = match;
+    const dayNum = parseInt(day, 10);
+    return `${MONTHS[parseInt(month, 10) - 1]} ${dayNum}${ordinalSuffix(dayNum)}, ${year}`;
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+module.exports = {
+    // Group entries by type and render "* <Label>: <entry>" lines.
+    formatChanges(version, changes) {
+        const grouped = changes.reduce((acc, change) => {
+            (acc[change.type] = acc[change.type] || []).push(change.entry);
+            return acc;
+        }, {});
+
+        return Object.entries(grouped)
+            .map(([type, entries]) =>
+                entries.map((entry) => `* ${typeLabel(type)}: ${entry}`).join("\n")
+            )
+            .filter((section) => section.length > 0)
+            .join("\n");
+    },
+
+    // Leading/trailing newlines are trimmed by the writer; a single trailing
+    // newline keeps the bullets flush under the header (no blank line between).
+    formatVersionHeader(version, date) {
+        return `\n= ${version}: ${formatLegacyDate(date)} =\n`;
+    },
+
+    formatVersionLink() {
+        return "";
+    },
+
+    // Detect an existing block for this version (so re-runs replace it).
+    versionHeaderMatcher(content, version) {
+        const re = new RegExp(`^(= ${escapeRegExp(version)}: [^=]+ =)$`, "m");
+        const match = content.match(re);
+        return match ? match[1].trim() : undefined;
+    },
+
+    // Insert before the first existing version block, or right after the
+    // "== Changelog ==" heading when there are none yet.
+    changelogHeaderMatcher(content) {
+        const firstVersion = content.match(/^= [^:]+: [^=]+ =$/m);
+        if (!firstVersion) {
+            const mainHeader = content.match(/^== Changelog ==$/m);
+            return mainHeader ? mainHeader.index + mainHeader[0].length + 1 : 0;
+        }
+        return firstVersion.index;
+    },
+};

--- a/bin/lib/release-utils.php
+++ b/bin/lib/release-utils.php
@@ -6,11 +6,11 @@
 declare(strict_types=1);
 
 /**
- * Absolute path to the project root (the directory containing bin/).
+ * Absolute path to the project root (this file lives in bin/lib/).
  */
 function release_project_root(): string
 {
-    return dirname(__DIR__);
+    return dirname(__DIR__, 2);
 }
 
 /**

--- a/bin/release-prep.sh
+++ b/bin/release-prep.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Release prep: run the full version-bump pipeline in order.
+#
+#   1. Bump every version declared in .puprc -> paths.versions
+#   2. Replace @unreleased / @since TBD docblock tags with @since <version>
+#   3. Compile pending changelog entries into readme.txt / changelog.txt
+#
+# Usage:
+#   bin/release-prep.sh <version> [--date <date>] [--dry-run]
+#   composer run release:prep 4.16.0
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+shift || true
+
+if [ -z "$VERSION" ]; then
+  echo "Error: a version number is required." >&2
+  echo "Usage: bin/release-prep.sh <version> [--date <date>] [--dry-run]" >&2
+  exit 1
+fi
+
+# --dry-run is forwarded to every step; any other flags (e.g. --date) apply to
+# the changelog step, which receives the full remaining argument list ("$@").
+DRY_RUN=
+case " $* " in
+  *" --dry-run "*) DRY_RUN=1 ;;
+esac
+
+echo "=== 1/3: Updating version strings ==="
+php bin/update-versions.php "$VERSION" ${DRY_RUN:+--dry-run}
+
+echo ""
+echo "=== 2/3: Replacing @unreleased / @since TBD tags ==="
+php bin/replace-since-tags.php "$VERSION" ${DRY_RUN:+--dry-run}
+
+echo ""
+echo "=== 3/3: Writing changelog ==="
+bin/write-changelog.sh "$VERSION" "$@"
+
+echo ""
+echo "✓ Release prep complete for $VERSION"

--- a/bin/release-utils.php
+++ b/bin/release-utils.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Shared helpers for the release-prep CLI scripts.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Absolute path to the project root (the directory containing bin/).
+ */
+function release_project_root(): string
+{
+    return dirname(__DIR__);
+}
+
+/**
+ * Parse a "<version> [--dry-run]" argument list.
+ *
+ * Prints the usage line and exits(1) when the version is missing or is not a
+ * semantic version. Returns [string $version, bool $dryRun] on success.
+ */
+function release_parse_args(array $argv, string $usage): array
+{
+    $dryRun = false;
+    $version = null;
+
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--dry-run') {
+            $dryRun = true;
+            continue;
+        }
+        if ($version === null) {
+            $version = $arg;
+        }
+    }
+
+    if ($version === null || $version === '') {
+        fwrite(STDERR, "Error: a version number is required.\n$usage\n");
+        exit(1);
+    }
+
+    if (!preg_match('/^\d+\.\d+\.\d+(?:[-+].+)?$/', $version)) {
+        fwrite(STDERR, "Error: \"$version\" does not look like a semantic version (e.g. 4.16.0).\n");
+        exit(1);
+    }
+
+    return [$version, $dryRun];
+}

--- a/bin/replace-since-tags.php
+++ b/bin/replace-since-tags.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Release prep: replace placeholder docblock tags with the release version.
+ *
+ *   "@unreleased"        ->  "@since <version>"   (any trailing description is preserved)
+ *   "@since TBD"         ->  "@since <version>"
+ *
+ * Scans the plugin source (php, js, jsx, ts, tsx) and skips build/vendor dirs.
+ *
+ * Usage:
+ *   php bin/replace-since-tags.php <version> [--dry-run]
+ *   composer run release:replace-since-tags 4.16.0
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/release-utils.php';
+
+[$version, $dryRun] = release_parse_args(
+    $argv,
+    'Usage: php bin/replace-since-tags.php <version> [--dry-run]'
+);
+
+$root = release_project_root();
+
+// Directories we never want to touch.
+$excludedDirs = [
+    '.git',
+    'node_modules',
+    'vendor',
+    'bin',
+    'assets/dist',
+    'build',
+];
+
+$extensions = ['php', 'js', 'jsx', 'ts', 'tsx'];
+
+// "@unreleased" (optionally followed by description) and "@since TBD".
+$patterns = [
+    '/@unreleased\b/'        => '@since ' . $version,
+    '/@since\s+TBD\b/'       => '@since ' . $version,
+];
+
+$excludedAbsolute = array_map(static function ($dir) use ($root) {
+    return $root . '/' . $dir;
+}, $excludedDirs);
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveCallbackFilterIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        static function ($current) use ($excludedAbsolute) {
+            $path = $current->getPathname();
+            foreach ($excludedAbsolute as $excluded) {
+                if ($path === $excluded || strpos($path, $excluded . '/') === 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    )
+);
+
+$filesChanged = 0;
+$totalReplacements = 0;
+
+foreach ($iterator as $file) {
+    if (!$file->isFile()) {
+        continue;
+    }
+
+    $ext = strtolower($file->getExtension());
+    if (!in_array($ext, $extensions, true)) {
+        continue;
+    }
+
+    $contents = file_get_contents($file->getPathname());
+
+    // Cheap pre-filter: skip the regex work unless a placeholder token is present.
+    if (strpos($contents, '@unreleased') === false && strpos($contents, 'TBD') === false) {
+        continue;
+    }
+
+    $fileReplacements = 0;
+    $updated = $contents;
+
+    foreach ($patterns as $pattern => $replacement) {
+        $updated = preg_replace($pattern, $replacement, $updated, -1, $count);
+        $fileReplacements += $count;
+    }
+
+    if ($fileReplacements === 0) {
+        continue;
+    }
+
+    $relative = substr($file->getPathname(), strlen($root) + 1);
+    echo "  ✓ $relative ($fileReplacements)\n";
+
+    if (!$dryRun) {
+        file_put_contents($file->getPathname(), $updated);
+    }
+
+    $filesChanged++;
+    $totalReplacements += $fileReplacements;
+}
+
+echo ($dryRun ? "[dry run] " : "")
+    . "Replaced $totalReplacements placeholder tag(s) with @since $version across $filesChanged file(s).\n";
+
+exit(0);

--- a/bin/replace-since-tags.php
+++ b/bin/replace-since-tags.php
@@ -14,7 +14,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/release-utils.php';
+require __DIR__ . '/lib/release-utils.php';
 
 [$version, $dryRun] = release_parse_args(
     $argv,

--- a/bin/update-versions.php
+++ b/bin/update-versions.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Release prep: update every version string declared in .puprc -> paths.versions.
+ *
+ * Each entry in paths.versions has a "file" and a "regex" with two capture groups:
+ *   group 1 = the literal prefix to keep (e.g. "Version: ")
+ *   group 2 = the version to replace
+ *
+ * Usage:
+ *   php bin/update-versions.php <version> [--dry-run]
+ *   composer run release:bump-versions 4.16.0
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/release-utils.php';
+
+[$version, $dryRun] = release_parse_args(
+    $argv,
+    'Usage: php bin/update-versions.php <version> [--dry-run]'
+);
+
+$root = release_project_root();
+$puprcPath = $root . '/.puprc';
+
+if (!is_file($puprcPath)) {
+    fwrite(STDERR, "Error: .puprc not found at $puprcPath\n");
+    exit(1);
+}
+
+$puprc = json_decode(file_get_contents($puprcPath), true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    fwrite(STDERR, "Error: could not parse .puprc: " . json_last_error_msg() . "\n");
+    exit(1);
+}
+
+$versionFiles = $puprc['paths']['versions'] ?? [];
+
+if (empty($versionFiles)) {
+    fwrite(STDERR, "Error: no entries found under paths.versions in .puprc\n");
+    exit(1);
+}
+
+echo ($dryRun ? "[dry run] " : "") . "Setting version to $version in " . count($versionFiles) . " location(s):\n";
+
+$hadError = false;
+
+foreach ($versionFiles as $entry) {
+    $file = $entry['file'] ?? null;
+    $regex = $entry['regex'] ?? null;
+
+    if (!$file || !$regex) {
+        fwrite(STDERR, "  ! skipping malformed entry: " . json_encode($entry) . "\n");
+        $hadError = true;
+        continue;
+    }
+
+    $path = $root . '/' . $file;
+
+    if (!is_file($path)) {
+        fwrite(STDERR, "  ! $file not found, skipping\n");
+        $hadError = true;
+        continue;
+    }
+
+    $contents = file_get_contents($path);
+    $pattern = '~' . $regex . '~';
+
+    $updated = preg_replace_callback(
+        $pattern,
+        static function ($matches) use ($version) {
+            // Keep capture group 1 (the prefix), swap group 2 (the version).
+            return $matches[1] . $version;
+        },
+        $contents,
+        -1,
+        $count
+    );
+
+    if ($updated === null) {
+        fwrite(STDERR, "  ! invalid regex for $file: $regex\n");
+        $hadError = true;
+        continue;
+    }
+
+    if ($count === 0) {
+        fwrite(STDERR, "  ! no match in $file for regex: $regex\n");
+        $hadError = true;
+        continue;
+    }
+
+    if ($updated === $contents) {
+        echo "  = $file already at $version ($regex)\n";
+        continue;
+    }
+
+    if (!$dryRun) {
+        file_put_contents($path, $updated);
+    }
+
+    echo "  ✓ $file ($count replacement" . ($count === 1 ? '' : 's') . ")\n";
+}
+
+exit($hadError ? 1 : 0);

--- a/bin/update-versions.php
+++ b/bin/update-versions.php
@@ -13,7 +13,7 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/release-utils.php';
+require __DIR__ . '/lib/release-utils.php';
 
 [$version, $dryRun] = release_parse_args(
     $argv,

--- a/bin/write-changelog.sh
+++ b/bin/write-changelog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Release prep: compile pending changelog entries into readme.txt / changelog.txt
+# using @stellarwp/changelogger.
+#
+# Authors add entries during development with:
+#   npx changelogger add
+# (or `composer run release:changelog-add`), which drops a YAML file into ./changelog.
+# This command rolls them up under the release version.
+#
+# Usage:
+#   bin/write-changelog.sh <version> [--date <date>] [--dry-run]
+#   composer run release:write-changelog 4.16.0
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+shift || true
+
+if [ -z "$VERSION" ]; then
+  echo "Error: a version number is required." >&2
+  echo "Usage: bin/write-changelog.sh <version> [--date <date>] [--dry-run]" >&2
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "Error: npx (Node.js) is required to run @stellarwp/changelogger." >&2
+  exit 1
+fi
+
+if [ ! -x "node_modules/.bin/changelogger" ]; then
+  echo "Error: @stellarwp/changelogger is not installed. Run \`npm install\` first." >&2
+  exit 1
+fi
+
+echo "Writing changelog for $VERSION..."
+exec npx --no-install changelogger write --overwrite-version "$VERSION" "$@"

--- a/bin/write-changelog.sh
+++ b/bin/write-changelog.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 #
-# Release prep: compile pending changelog entries into readme.txt / changelog.txt
-# using @stellarwp/changelogger.
+# Compile pending changelog entries into readme.txt / changelog.txt using
+# @stellarwp/changelogger (and the custom legacy-format strategy).
 #
 # Authors add entries during development with:
-#   npx changelogger add
-# (or `composer run release:changelog-add`), which drops a YAML file into ./changelog.
-# This command rolls them up under the release version.
+#   composer run changelog:add
+# which drops a YAML file into ./changelog. This command rolls them up.
+#
+# A version is required. changelogger's own auto-versioning is NOT used: it
+# only reads bracketed "= [x.y.z]" headers, which the legacy GiveWP format
+# (= x.y.z: date =) doesn't use, so it would fall back to 0.1.0. The release
+# version is supplied explicitly (release:prep passes it through).
 #
 # Usage:
 #   bin/write-changelog.sh <version> [--date <date>] [--dry-run]
-#   composer run release:write-changelog 4.16.0
+#   composer run changelog:write -- 4.16.0
 #
 set -euo pipefail
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,4 @@
 == Changelog ==
-= TBD: DATE TBD =
-* Tweak: Updated branding references from StellarWP to Nexcess.
 
 = 3.22.2: March 19th, 2025 =
 * Fix: Resolved an issue with PayPal hiding the donate button when hosted fields are available
@@ -14,7 +12,7 @@
 * Fix: Resolved a validation issue with PayPal donations when using Akismet
 * Fix: Resolved an issue with the custom amount block input behaving unexpectedly with some currencies and languages
 * Fix: Prevent recording donation status change if no modification (Open-source contribution by @yiedpozi)
-* Fix: Provide message for the donor when card is declined via Stripe (Open-source contribution by @Genevieve-K)  
+* Fix: Provide message for the donor when card is declined via Stripe (Open-source contribution by @Genevieve-K)
 
 = 3.21.1: February 14th, 2025 =
 * Fix: Resolved an issue that was preventing WordPress plugins from being updated
@@ -22,9 +20,9 @@
 = 3.21.0: February 13th, 2025 =
 * Enhancement: Added support for the future ability to bundle and auto-activate add-on licenses for maximum convenience
 * Enhancement: Added title attribute to Donation Form block to improve accessibility
-* Fix: Added missing form ID to multistep form design template 
+* Fix: Added missing form ID to multistep form design template
 
-= 3.20.0: February 3rd, 2025 = 
+= 3.20.0: February 3rd, 2025 =
 * Enhancement: Updated Event list table to truncate long event descriptions
 * Enhancement: Updated Event description field with placeholder text
 * Enhancement: Updated Events block to display a “sold out” message when all tickets have been sold
@@ -58,18 +56,18 @@
 
 = 3.19.1: December 17th, 2024 =
 * Fix: Resolved an issue with PayPal where some fields were not being validated properly before processing the donation
-* Fix: Resolved an issue with PayPal and emails with a plus sign trying to connect to GiveWP 
-* Fix: Updated the format of the donation count in the multi form goal progress stats 
-* Change: Updated subdivision ISO code for Odisha, India to OD (Open source submission by @sorensd) 
+* Fix: Resolved an issue with PayPal and emails with a plus sign trying to connect to GiveWP
+* Fix: Updated the format of the donation count in the multi form goal progress stats
+* Change: Updated subdivision ISO code for Odisha, India to OD (Open source submission by @sorensd)
 
 = 3.19.0: December 5th, 2024 =
 * New: Added support to the donor dashboard for managing recurring donations from our Blink Payment Gateway add-on
 * Fix: Resolved a compatability issue with loading translations on WordPress 6.7
-* Security: Added sanitization to the manual migrations parameters  
+* Security: Added sanitization to the manual migrations parameters
 
 
 = 3.18.0: November 20th, 2024 =
-* New: Added support to our form migration process for our upcoming Constant Contact add-on 3.0.0 version 
+* New: Added support to our form migration process for our upcoming Constant Contact add-on 3.0.0 version
 * New: The donor wall now shows the donor's uploaded image avatar when available
 * New: Added a global setting to enable or disable the Option-Based Form Editor and settings.
 * Fix: Resolved an issue with multi-step form designs growing extra space outside the form
@@ -82,9 +80,9 @@
 * Fix: Resolved an issue with the Donor Wall shortcode and block filtering by only_comments
 * Fix: Resolved a WordPress 6.7 styling compatibility issue with the visual form builder
 * Fix: Resolved an issue where Stripe Payment Element was causing an error when donation amount is zero
-* Security: Removed Faker PHP library from production to prevent malicious direct access 
+* Security: Removed Faker PHP library from production to prevent malicious direct access
 * Security: Further improved our data sanitization and validation across all of GiveWP to prevent malicious serialized data
-* Dev: Resolved php 8.1 compatibility warnings for Give_Addon_Activation_Banner, Give_License, and CurrencySwitcherSetting classes 
+* Dev: Resolved php 8.1 compatibility warnings for Give_Addon_Activation_Banner, Give_License, and CurrencySwitcherSetting classes
 
 = 3.17.1: October 22nd, 2024 =
 * Fix: Resolved an issue with PayPal donation buttons where clicking the GiveWP donate button was causing an error.
@@ -94,9 +92,9 @@
 
 = 3.17.0: October 16th, 2024 =
 * New: Added new security tab with option to enable a honeypot field for visual builder forms
-* Fix: Resolved an issue with the donor name prefix block not saving correctly 
+* Fix: Resolved an issue with the donor name prefix block not saving correctly
 * Dev: Resolved php 8.1 compatability conflict with MyCLabs\Enum\Enum::jsonSerialize()
-* Dev: Added gateway api updates for pausing subscriptions 
+* Dev: Added gateway api updates for pausing subscriptions
 
 = 3.16.5: October 15th, 2024 =
 * Fix: Resolved a PHP v8+ fatal error on option-based forms when the Tributes add-on was enabled
@@ -112,8 +110,8 @@
 * Enhancement: Updated the visual builder header description field to use the rich text editor
 * Enhancement: Updated the strings in the form builder onboarding buttons to be translatable (Open source submission by @DAnn2012)
 * Enhancement: Updated strings in give settings to be translatable (Open source submission by @DAnn2012)
-* Security: Added additional prevention for serialized data in the option-based donation form request 
-* Security: Added additional security measures to the legacy donor list table request (CVE-2024-9130) 
+* Security: Added additional prevention for serialized data in the option-based donation form request
+* Security: Added additional security measures to the legacy donor list table request (CVE-2024-9130)
 * Fix: Resolved a styling issue with some text fields not respecting error border styling
 * Fix: Resolved a styling issue with the anonymous block for WP 6.6 compatibility
 * Dev: Removed defaultProps in favor of ES6 default parameters for React 19 compatibility
@@ -123,12 +121,12 @@
 
 = 3.16.0: Aug 28th, 2024 =
 * New: Added support for form taxonomy tags and categories in the visual form builder settings
-* New: Added a setting to the visual form builder to enable redirecting to an individual donation confirmation page 
+* New: Added a setting to the visual form builder to enable redirecting to an individual donation confirmation page
 * Enhancement: Multi-step form designs now scroll to the top of the form on step change
-* Enhancement: Added individual form migration links to the donation form list table 
+* Enhancement: Added individual form migration links to the donation form list table
 * Enhancement: Updated various strings throughout GiveWP to be translatable (Open-source contribution by @DAnn2012)
 * Security: Resolved security issues related to file paths and permissions (CVE-2024-6551)
-* Security: Resolved security issue related to the PayPal disconnect button  
+* Security: Resolved security issue related to the PayPal disconnect button
 * Fix: Added prevention of subscription renewals with gateway transaction IDs already used previously
 * Fix: Resolved an issue where the donation form list table and form grid not loading properly on sites with a large number of forms and donations
 * Fix: Resolved an issue with the form grid not showing header images and link previews
@@ -144,7 +142,7 @@
 * Fix: Resolved an issue with Give Subscribers accessing their donor dashboard history
 
 = 3.14.2: Aug 7th, 2024 =
-* Security: Added additional security measures to the option-based donation form and the donor dashboard (CVE-2024-37099) 
+* Security: Added additional security measures to the option-based donation form and the donor dashboard (CVE-2024-37099)
 
 = 3.14.1: July 24th, 2024 =
 * Fix: Resolved an error with the give_totals shortcode when using multiple form IDs
@@ -165,7 +163,7 @@
 * Fix: Resolved an issue when exporting donations that use Razorpay gateway
 * Fix: Resolved an issue in the form builder where recurring donations descriptions were not always matching frequency selection
 * Fix: Resolved an issue with custom donor columns in csv exports and revive filter give_export_donors_get_default_columns
-* Security: Resolved various security issues related to user permissions 
+* Security: Resolved various security issues related to user permissions
 
 = 3.13.0: June 26th, 2024 =
 * New: Added option to PayPal settings to keep webhooks when disconnecting account
@@ -206,11 +204,11 @@
 
 = 3.9.0: April 24th, 2024 =
 * New: Added a donor phone number block to the form builder to collect donor phone numbers on donation forms
-* Enhancement: Updated form field inputs to have a single border color when selected 
+* Enhancement: Updated form field inputs to have a single border color when selected
 
 = 3.8.0: April 17th, 2024 =
 * New: Added pre-requisite form builder compatibility for upcoming double the donation add-on release
-* Enhancement: Updated the form builder tour to highlight where to find the guided tour again 
+* Enhancement: Updated the form builder tour to highlight where to find the guided tour again
 * Dev: Added BlockType api for easier block to field conversion
 
 = 3.7.0: April 10th, 2024 =
@@ -232,7 +230,7 @@
 * New: Added a new form builder layout called "Two Panel" that offers a side-by-side appearance and a multi-step donation experience.
 * New: Added a new setting in the form builder styles tab for the header image overlay
 * Fix: Resolved several styling issues with the donation form modal
-* Fix: Resolved styling conflicts with native WordPress UI components  
+* Fix: Resolved styling conflicts with native WordPress UI components
 
 = 3.5.1: March 6th, 2024 =
 * Fix: Resolved an issue with PayPal that was preventing the ability to connect a PayPal account to GiveWP.
@@ -244,10 +242,10 @@
 * Fix: Resolved a PayPal Donations issue where the donation buttons didn't show up in the modal view of an Option-Based Form Editor form
 
 = 3.4.2: February 19th, 2024 =
-* Fix: Resolved an issue with PayPal donations that ensures the correct donation amount will be used after filling out payment details and modifying the original amount.  
+* Fix: Resolved an issue with PayPal donations that ensures the correct donation amount will be used after filling out payment details and modifying the original amount.
 
 = 3.4.1: February 13th, 2024 =
-* Fix: Resolved an issue with the default email block that ensures it is always a required field in the donation form. 
+* Fix: Resolved an issue with the default email block that ensures it is always a required field in the donation form.
 
 = 3.4.0: February 8th, 2024 =
 * Fix: Resolved several issues with the billing address block including dynamically requiring certain fields and allowing state/county field input
@@ -268,7 +266,7 @@
 * Enhancement: Made several improvements to the give importer for third-parties and admin
 
 = 3.3.1: January 23rd, 2024 =
-* Fix: Resolved an issue checking for the GiveWP Funds and Designations add-on information during form migrations  
+* Fix: Resolved an issue checking for the GiveWP Funds and Designations add-on information during form migrations
 
 = 3.3.0: January 10th, 2024 =
 * Happy new year!

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,12 @@
             "@strauss"
         ],
         "copy-fonts": "rm -rf vendor/tecnickcom/tcpdf/fonts/* && cp assets/src/tcpdf-fonts/* vendor/tecnickcom/tcpdf/fonts/",
+        "release:bump-versions": "@php bin/update-versions.php",
+        "release:replace-since-tags": "@php bin/replace-since-tags.php",
+        "release:changelog-add": "npx --no-install changelogger add",
+        "release:write-changelog": "bin/write-changelog.sh",
+        "release:prep": "bin/release-prep.sh",
+        "release:test": "npx --no-install bats tests/bats",
         "pup": [
             "sh -c 'test -f ./bin/pup.phar || curl -o bin/pup.phar -L -C - https://github.com/stellarwp/pup/releases/download/1.3.9/pup.phar'",
             "sh -c 'PATH=$(echo \"$PATH\" | tr \":\" \"\\n\" | grep -v \"/vendor/bin$\" | paste -sd: -) exec php ./bin/pup.phar \"$@\"' --"

--- a/composer.json
+++ b/composer.json
@@ -60,10 +60,10 @@
             "@strauss"
         ],
         "copy-fonts": "rm -rf vendor/tecnickcom/tcpdf/fonts/* && cp assets/src/tcpdf-fonts/* vendor/tecnickcom/tcpdf/fonts/",
+        "changelog:add": "npx --no-install changelogger add --auto-filename",
+        "changelog:write": "bin/write-changelog.sh",
         "release:bump-versions": "@php bin/update-versions.php",
         "release:replace-since-tags": "@php bin/replace-since-tags.php",
-        "release:changelog-add": "npx --no-install changelogger add",
-        "release:write-changelog": "bin/write-changelog.sh",
         "release:prep": "bin/release-prep.sh",
         "release:test": "npx --no-install bats tests/bats",
         "pup": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
                 "vhtml": "^2.2.0"
             },
             "devDependencies": {
+                "@stellarwp/changelogger": "^0.10.0",
                 "@types/lodash": "^4.14.199",
                 "@types/react": "^18.0.38",
                 "@types/react-datepicker": "^4.15.0",
@@ -107,6 +108,9 @@
                 "@types/wordpress__components": "^23.0.1",
                 "@wordpress/env": "^11.4.0",
                 "@wordpress/scripts": "^26.19.0",
+                "bats": "^1.13.0",
+                "bats-assert": "^2.2.4",
+                "bats-support": "^0.3.0",
                 "copy-webpack-plugin": "^13.0.0",
                 "fork-ts-checker-webpack-plugin": "^9.0.2",
                 "jest": "^29.6.2",
@@ -175,6 +179,61 @@
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/exec": "^1.1.1",
+                "@actions/http-client": "^2.0.1"
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/io": "^1.0.1"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+            "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/http-client": "^2.2.0",
+                "@octokit/core": "^5.0.1",
+                "@octokit/plugin-paginate-rest": "^9.2.2",
+                "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "undici": "^5.28.5"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+            "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tunnel": "^0.0.6",
+                "undici": "^5.25.4"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@adobe/css-tools": {
             "version": "4.3.3",
@@ -2518,6 +2577,16 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@floating-ui/core": {
@@ -8608,6 +8677,96 @@
             },
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/@stellarwp/changelogger": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@stellarwp/changelogger/-/changelogger-0.10.0.tgz",
+            "integrity": "sha512-+sIK6M+91sZt3udWrQW6Kfpc153HjoW/JP+TTJNwjuD98UizIuNE9W1ziePU/507FAtVHtoUUfqUlQQkffLReg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@actions/core": "^1.10.1",
+                "@actions/github": "^6.0.0",
+                "commander": "^12.0.0",
+                "inquirer": "^8.2.6",
+                "locutus": "^2.0.16",
+                "lodash": "^4.17.21",
+                "minimatch": "^9.0.3",
+                "semver": "^7.6.0",
+                "yaml": "^2.4.1"
+            },
+            "bin": {
+                "changelogger": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=9.0.0"
+            }
+        },
+        "node_modules/@stellarwp/changelogger/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@stellarwp/changelogger/node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@stellarwp/changelogger/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@stellarwp/changelogger/node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@stellarwp/changelogger/node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/@stellarwp/mcp-api-fetch": {
@@ -17509,6 +17668,37 @@
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
             "dev": true
         },
+        "node_modules/bats": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+            "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "bats": "bin/bats"
+            }
+        },
+        "node_modules/bats-assert": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.2.4.tgz",
+            "integrity": "sha512-EcaY4Z+Tbz1c7pnC1SrVSq0epr7tLwFpz6qt7KUW9K8uSw8V12DTfH9d2HxZWvBEATaCuMsZ7KoZMFiSQPRoXw==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "peerDependencies": {
+                "bats": "0.4 || ^1",
+                "bats-support": "^0.3"
+            }
+        },
+        "node_modules/bats-support": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/bats-support/-/bats-support-0.3.0.tgz",
+            "integrity": "sha512-z+2WzXbI4OZgLnynydqH8GpI3+DcOtepO66PlK47SfEzTkiuV9hxn9eIQX+uLVFbt2Oqoc7Ky3TJ/N83lqD+cg==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "peerDependencies": {
+                "bats": "0.4 || ^1"
+            }
+        },
         "node_modules/before-after-hook": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -21362,6 +21552,22 @@
                 "pend": "~1.2.0"
             }
         },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -23207,6 +23413,151 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
             "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
             "dev": true
+        },
+        "node_modules/inquirer": {
+            "version": "8.2.7",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+            "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/external-editor": "^1.0.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.5.5",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6",
+                "wrap-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/inquirer/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/inquirer/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -26620,6 +26971,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/locutus": {
+            "version": "2.0.39",
+            "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.39.tgz",
+            "integrity": "sha512-v2iub44UtGpbIv+pFkkYhZ+JsbIM0bJsQcQ1+VayUNGVA/YhM8+CkBiRACcpuuE9Q0xI1pgNzGNwzZDCp1MCww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10",
+                "yarn": ">= 1"
             }
         },
         "node_modules/lodash": {
@@ -31409,6 +31771,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/run-con": {
             "version": "1.2.12",
             "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.12.tgz",
@@ -31472,6 +31844,16 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
             "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw=="
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
         },
         "node_modules/safe-array-concat": {
             "version": "1.1.3",
@@ -33718,6 +34100,16 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/turbo-combine-reducers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
@@ -33971,6 +34363,19 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
             "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         },
         "node_modules/undici-types": {
             "version": "7.19.2",
@@ -34456,15 +34861,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/wait-on/node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.1.0"
             }
         },
         "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,30 @@
         "url": "https://github.com/impress-org/give/issues"
     },
     "homepage": "https://github.com/impress-org/give#readme",
+    "changelogger": {
+        "changesDir": "changelog",
+        "ordering": [
+            "type",
+            "content"
+        ],
+        "types": {
+            "feature": "Feature",
+            "enhancement": "Enhancement",
+            "tweak": "Tweak",
+            "fix": "Fix",
+            "security": "Security"
+        },
+        "files": [
+            {
+                "path": "readme.txt",
+                "strategy": "stellarwp-readme"
+            },
+            {
+                "path": "changelog.txt",
+                "strategy": "stellarwp-readme"
+            }
+        ]
+    },
     "_zipname": "give",
     "_version_files": [
         {
@@ -33,6 +57,7 @@
         }
     ],
     "devDependencies": {
+        "@stellarwp/changelogger": "^0.10.0",
         "@types/lodash": "^4.14.199",
         "@types/react": "^18.0.38",
         "@types/react-datepicker": "^4.15.0",
@@ -41,6 +66,9 @@
         "@types/wordpress__components": "^23.0.1",
         "@wordpress/env": "^11.4.0",
         "@wordpress/scripts": "^26.19.0",
+        "bats": "^1.13.0",
+        "bats-assert": "^2.2.4",
+        "bats-support": "^0.3.0",
         "copy-webpack-plugin": "^13.0.0",
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "jest": "^29.6.2",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
         "files": [
             {
                 "path": "readme.txt",
-                "strategy": "stellarwp-readme"
+                "strategy": "bin/lib/changelog-strategy.js"
             },
             {
                 "path": "changelog.txt",
-                "strategy": "stellarwp-readme"
+                "strategy": "bin/lib/changelog-strategy.js"
             }
         ]
     },

--- a/tests/bats/release-prep.bats
+++ b/tests/bats/release-prep.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Tests for bin/release-prep.sh (the combined pipeline)
+
+load test_helper
+
+@test "fails when no version is given" {
+    run "$BIN_DIR/release-prep.sh"
+    assert_failure
+    assert_output --partial "a version number is required"
+}
+
+@test "dry-run runs all three steps in order and completes" {
+    run "$BIN_DIR/release-prep.sh" 9.9.9 --dry-run
+    assert_success
+    assert_output --partial "1/3"
+    assert_output --partial "2/3"
+    assert_output --partial "3/3"
+    assert_output --partial "Release prep complete for 9.9.9"
+}
+
+@test "dry-run leaves the real version files untouched" {
+    run "$BIN_DIR/release-prep.sh" 9.9.9 --dry-run
+    assert_success
+
+    run cat "$REPO_ROOT/give.php"
+    refute_output --partial "9.9.9"
+}

--- a/tests/bats/replace-since-tags.bats
+++ b/tests/bats/replace-since-tags.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+#
+# Tests for bin/replace-since-tags.php
+
+load test_helper
+
+setup() {
+    make_sandbox replace-since-tags.php
+
+    mkdir -p "$SANDBOX/src" "$SANDBOX/vendor"
+
+    cat > "$SANDBOX/src/Foo.php" <<'PHP'
+<?php
+/**
+ * @unreleased
+ * @unreleased Added a new thing
+ * @since TBD changed behavior
+ * @since 1.0.0 original
+ */
+class Foo {}
+PHP
+
+    # Excluded directory: should never be touched.
+    cat > "$SANDBOX/vendor/Bar.php" <<'PHP'
+<?php
+/** @unreleased */
+class Bar {}
+PHP
+}
+
+teardown() {
+    cleanup_sandbox
+}
+
+@test "fails when no version is given" {
+    run php "$SANDBOX/bin/replace-since-tags.php"
+    assert_failure
+    assert_output --partial "a version number is required"
+}
+
+@test "rejects a non-semver version" {
+    run php "$SANDBOX/bin/replace-since-tags.php" nope
+    assert_failure
+    assert_output --partial "does not look like a semantic version"
+}
+
+@test "replaces @unreleased and @since TBD, preserving descriptions" {
+    run php "$SANDBOX/bin/replace-since-tags.php" 9.9.9
+    assert_success
+
+    run cat "$SANDBOX/src/Foo.php"
+    assert_output --partial "@since 9.9.9"
+    assert_output --partial "@since 9.9.9 Added a new thing"
+    assert_output --partial "@since 9.9.9 changed behavior"
+    # An existing @since version is left alone.
+    assert_output --partial "@since 1.0.0 original"
+    refute_output --partial "@unreleased"
+    refute_output --partial "@since TBD"
+}
+
+@test "does not touch excluded directories (vendor)" {
+    run php "$SANDBOX/bin/replace-since-tags.php" 9.9.9
+    assert_success
+
+    run cat "$SANDBOX/vendor/Bar.php"
+    assert_output --partial "@unreleased"
+}
+
+@test "dry-run reports changes without writing them" {
+    run php "$SANDBOX/bin/replace-since-tags.php" 9.9.9 --dry-run
+    assert_success
+    assert_output --partial "[dry run]"
+
+    run cat "$SANDBOX/src/Foo.php"
+    assert_output --partial "@unreleased"
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Shared setup for the release-script Bats suite.
+#
+
+TESTS_BATS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_BATS_DIR/../.." && pwd)"
+BIN_DIR="$REPO_ROOT/bin"
+
+export REPO_ROOT BIN_DIR
+
+# Load the assertion helpers installed via npm (node_modules/bats-*).
+export BATS_LIB_PATH="$REPO_ROOT/node_modules:${BATS_LIB_PATH:-}"
+bats_load_library bats-support
+bats_load_library bats-assert
+
+# Create an isolated copy of a bin script so the PHP scripts (which resolve the
+# project root from their own location) operate on fixtures instead of the repo.
+#
+#   make_sandbox <script-name>
+#
+# Sets SANDBOX to a fresh temp dir containing bin/<script-name>.
+make_sandbox() {
+    local script="$1"
+    SANDBOX="$(mktemp -d)"
+    mkdir -p "$SANDBOX/bin"
+    cp "$BIN_DIR/$script" "$SANDBOX/bin/$script"
+    # PHP scripts require this shared helper relative to their own location.
+    if [ -f "$BIN_DIR/release-utils.php" ]; then
+        cp "$BIN_DIR/release-utils.php" "$SANDBOX/bin/release-utils.php"
+    fi
+}
+
+cleanup_sandbox() {
+    if [ -n "${SANDBOX:-}" ] && [ -d "$SANDBOX" ]; then
+        rm -rf "$SANDBOX"
+    fi
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -26,8 +26,9 @@ make_sandbox() {
     mkdir -p "$SANDBOX/bin"
     cp "$BIN_DIR/$script" "$SANDBOX/bin/$script"
     # PHP scripts require this shared helper relative to their own location.
-    if [ -f "$BIN_DIR/release-utils.php" ]; then
-        cp "$BIN_DIR/release-utils.php" "$SANDBOX/bin/release-utils.php"
+    if [ -f "$BIN_DIR/lib/release-utils.php" ]; then
+        mkdir -p "$SANDBOX/bin/lib"
+        cp "$BIN_DIR/lib/release-utils.php" "$SANDBOX/bin/lib/release-utils.php"
     fi
 }
 

--- a/tests/bats/update-versions.bats
+++ b/tests/bats/update-versions.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Tests for bin/update-versions.php
+
+load test_helper
+
+setup() {
+    make_sandbox update-versions.php
+
+    cat > "$SANDBOX/.puprc" <<'JSON'
+{
+    "paths": {
+        "versions": [
+            { "file": "give.php", "regex": "(define\\('GIVE_VERSION', ')([^']+)" },
+            { "file": "give.php", "regex": "(Version: )(.+)" },
+            { "file": "readme.txt", "regex": "(Stable tag: )(.+)" }
+        ]
+    }
+}
+JSON
+
+    cat > "$SANDBOX/give.php" <<'PHP'
+<?php
+/**
+ * Version: 1.0.0
+ */
+if (!defined('GIVE_VERSION')) {
+    define('GIVE_VERSION', '1.0.0');
+}
+PHP
+
+    printf 'Stable tag: 1.0.0\n' > "$SANDBOX/readme.txt"
+}
+
+teardown() {
+    cleanup_sandbox
+}
+
+@test "fails when no version is given" {
+    run php "$SANDBOX/bin/update-versions.php"
+    assert_failure
+    assert_output --partial "a version number is required"
+}
+
+@test "rejects a non-semver version" {
+    run php "$SANDBOX/bin/update-versions.php" not-a-version
+    assert_failure
+    assert_output --partial "does not look like a semantic version"
+}
+
+@test "updates every version declared in .puprc" {
+    run php "$SANDBOX/bin/update-versions.php" 9.9.9
+    assert_success
+
+    run cat "$SANDBOX/give.php"
+    assert_output --partial "define('GIVE_VERSION', '9.9.9')"
+    assert_output --partial "Version: 9.9.9"
+
+    run cat "$SANDBOX/readme.txt"
+    assert_output --partial "Stable tag: 9.9.9"
+}
+
+@test "dry-run reports changes without writing them" {
+    run php "$SANDBOX/bin/update-versions.php" 9.9.9 --dry-run
+    assert_success
+    assert_output --partial "[dry run]"
+
+    run cat "$SANDBOX/give.php"
+    assert_output --partial "1.0.0"
+    refute_output --partial "9.9.9"
+}
+
+@test "errors when a declared version file is missing" {
+    rm "$SANDBOX/readme.txt"
+    run php "$SANDBOX/bin/update-versions.php" 9.9.9
+    assert_failure
+    assert_output --partial "readme.txt not found"
+}

--- a/tests/bats/write-changelog.bats
+++ b/tests/bats/write-changelog.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+#
+# Tests for bin/write-changelog.sh
+
+load test_helper
+
+TMP_ENTRY="$BATS_TMPDIR/_skip"
+
+setup() {
+    # A temporary changelog entry so `write --dry-run` has something to render.
+    TMP_ENTRY="$REPO_ROOT/changelog/zzz-bats-tmp.yaml"
+    cat > "$TMP_ENTRY" <<'YAML'
+significance: patch
+type: fix
+entry: Bats temporary test entry
+YAML
+}
+
+teardown() {
+    rm -f "$TMP_ENTRY"
+    cleanup_sandbox
+}
+
+@test "fails when no version is given" {
+    run "$BIN_DIR/write-changelog.sh"
+    assert_failure
+    assert_output --partial "a version number is required"
+}
+
+@test "errors when changelogger is not installed" {
+    make_sandbox write-changelog.sh
+    run "$SANDBOX/bin/write-changelog.sh" 9.9.9
+    assert_failure
+    assert_output --partial "is not installed"
+}
+
+@test "dry-run renders the new version into both changelog files" {
+    run "$BIN_DIR/write-changelog.sh" 9.9.9 --dry-run
+    assert_success
+    assert_output --partial "= [9.9.9]"
+    assert_output --partial "readme.txt"
+    assert_output --partial "changelog.txt"
+    assert_output --partial "Bats temporary test entry"
+}
+
+@test "dry-run does not modify the real changelog files" {
+    run "$BIN_DIR/write-changelog.sh" 9.9.9 --dry-run
+    assert_success
+
+    run cat "$REPO_ROOT/readme.txt"
+    refute_output --partial "= [9.9.9]"
+}

--- a/tests/bats/write-changelog.bats
+++ b/tests/bats/write-changelog.bats
@@ -34,13 +34,23 @@ teardown() {
     assert_output --partial "is not installed"
 }
 
-@test "dry-run renders the new version into both changelog files" {
+@test "dry-run renders the new version into both changelog files (legacy format)" {
     run "$BIN_DIR/write-changelog.sh" 9.9.9 --dry-run
     assert_success
-    assert_output --partial "= [9.9.9]"
+    # Legacy GiveWP format from bin/lib/changelog-strategy.js: "= <version>: <date> ="
+    # and "* <Label>: <entry>" (not the changelogger-native "= [..]" / "* X - ").
+    assert_output --partial "= 9.9.9:"
+    assert_output --partial "* Fix: Bats temporary test entry"
+    refute_output --partial "= [9.9.9]"
+    refute_output --partial "* Fix - "
     assert_output --partial "readme.txt"
     assert_output --partial "changelog.txt"
-    assert_output --partial "Bats temporary test entry"
+}
+
+@test "formats the release date with an ordinal day (legacy style)" {
+    run "$BIN_DIR/write-changelog.sh" 9.9.9 --dry-run --date 2026-07-15
+    assert_success
+    assert_output --partial "= 9.9.9: July 15th, 2026 ="
 }
 
 @test "dry-run does not modify the real changelog files" {
@@ -48,5 +58,5 @@ teardown() {
     assert_success
 
     run cat "$REPO_ROOT/readme.txt"
-    refute_output --partial "= [9.9.9]"
+    refute_output --partial "= 9.9.9:"
 }


### PR DESCRIPTION
## Summary

This adds release-prep commands/scripts instead of having to do this manually. The idea is when you're prepping a release you can simply run composer run `release:prep 4.16.0` with whatever version number and it will handle all/most of the prep needed.


### Details
Adds Composer-invoked release tooling so version bumps, `@since` tag replacement, and changelog generation are scripted and tested instead of manual.

Two namespaces split the developer-facing changelog commands from the release-manager commands:

| Command | Purpose |
|---|---|
| `composer run changelog:add` | Author a changelog entry (auto-names the file from the branch via `--auto-filename`) — run this in each PR |
| `composer run changelog:write -- 4.16.0` | Compile pending entries into `readme.txt` + `changelog.txt` |
| `composer run release:bump-versions 4.16.0` | Update every version declared in `.puprc` → `paths.versions` (`give.php` ×2, `readme.txt`) |
| `composer run release:replace-since-tags 4.16.0` | Replace `@unreleased` / `@since TBD` with `@since 4.16.0` across `.php/.js/.jsx/.ts/.tsx` (descriptions preserved) |
| `composer run release:prep 4.16.0` | Run bump-versions → replace-since-tags → changelog write in order |
| `composer run release:test` | Run the Bats suite |

All commands accept `--dry-run`; `release:prep` / `changelog:write` also forward `--date`.

### Workflow

- **Per PR:** author writes `@unreleased` / `@since TBD` in code, and runs `composer run changelog:add`. The entry YAML is committed with the PR (branch-named, so no conflicts).
- **At release:** `composer run release:prep <version>` bumps versions, resolves the `@since` markers, and folds all pending `changelog/*.yaml` entries into the changelog files.

### Implementation notes

- **Layout:** CLI entrypoints in `bin/`; non-executable helpers in `bin/lib/` (`release-utils.php` for shared arg parsing/semver, `changelog-strategy.js` for the changelog format).
- **Changelog format:** `@stellarwp/changelogger` (dev dependency) loads a custom writing strategy from `bin/lib/changelog-strategy.js`, producing GiveWP's established WordPress format — `= 4.16.0: June 2nd, 2026 =` with `* Fix: …` — rather than the tool's native `= [4.16.0] 2026-06-02 =` / `* Fix - …`.
- **Versioning:** `changelog:write` requires an explicit version. changelogger's native auto-versioning only reads bracketed `= [x.y.z]` headers, so it would mis-detect against the legacy format; the chosen version is always passed explicitly.
- **Bash wrappers** are portable (`set -euo pipefail`, bash 3.2-safe) and fail gracefully if Node/changelogger is missing.
- `changelog/` holds pending entry files and is excluded from the distributed zip (`.distignore`); `/bin` was already excluded.
- Also retires the stale hand-written `= TBD: DATE TBD =` placeholder in `changelog.txt`.

### Testing

18 Bats tests in `tests/bats/` cover all scripts black-box: validation, real file mutation in sandboxes, dry-run no-write, excluded-dir skipping, legacy changelog header/bullet format, and ordinal date formatting. Run with `composer run release:test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)