### PR TITLE
feat(webhooks): add $donationId param to webhook event handlers

### DIFF
--- a/src/Framework/PaymentGateways/Actions/GenerateGatewayRouteUrl.php
+++ b/src/Framework/PaymentGateways/Actions/GenerateGatewayRouteUrl.php
@@ -5,14 +5,15 @@ namespace Give\Framework\PaymentGateways\Actions;
 class GenerateGatewayRouteUrl
 {
     /**
-     * @param  string  $gatewayId
+     * @unreleased Add GIVEWP_GATEWAY_ROUTE_BASE_URL constant
+     * @since      2.19.0 remove $donationId param in favor of args
+     * @since      2.18.0
+     *
+     * @param array|null $args
+     * @param string     $gatewayId
      * @param  string  $gatewayMethod
-     * @param  array|null  $args
+     *
      * @return string
-     * @since 2.18.0
-     *
-     * @since 2.19.0 remove $donationId param in favor of args
-     *
      */
     public function __invoke(string $gatewayId, string $gatewayMethod, array $args = []): string
     {
@@ -28,7 +29,7 @@ class GenerateGatewayRouteUrl
 
         return esc_url_raw(add_query_arg(
             $queryArgs,
-            home_url()
+            defined('GIVEWP_GATEWAY_ROUTE_BASE_URL') ? GIVEWP_GATEWAY_ROUTE_BASE_URL : home_url()
         ));
     }
 }

--- a/src/Framework/PaymentGateways/ServiceProvider.php
+++ b/src/Framework/PaymentGateways/ServiceProvider.php
@@ -84,13 +84,17 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     private function addSubscriptionFirstDonationEventHandler(string $gatewayId)
     {
         Hooks::addAction(
             sprintf('givewp_%s_webhook_event_subscription_first_donation', $gatewayId),
-            SubscriptionFirstDonationCompleted::class, '__invoke', 10, 5
+            SubscriptionFirstDonationCompleted::class,
+            '__invoke',
+            10,
+            6
         );
     }
 

--- a/src/Framework/PaymentGateways/ServiceProvider.php
+++ b/src/Framework/PaymentGateways/ServiceProvider.php
@@ -49,6 +49,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     private function addDonationStatusEventHandlers(string $gatewayId)
@@ -57,7 +58,10 @@ class ServiceProvider implements ServiceProviderInterface
             if ($eventHandlerClass = (new GetEventHandlerClassByDonationStatus())($status)) {
                 Hooks::addAction(
                     sprintf('givewp_%s_webhook_event_donation_status_%s', $gatewayId, $status->getValue()),
-                    $eventHandlerClass, '__invoke', 10, 3
+                    $eventHandlerClass,
+                    '__invoke',
+                    10,
+                    4
                 );
             }
         }

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/Actions/UpdateSubscriptionStatus.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/Actions/UpdateSubscriptionStatus.php
@@ -5,6 +5,7 @@ namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions;
 use Exception;
 use Give\Framework\PaymentGateways\Log\PaymentGatewayLog;
 use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\Models\SubscriptionNote;
 use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 
 /**
@@ -13,6 +14,7 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 class UpdateSubscriptionStatus
 {
     /**
+     * @unreleased Add note to subscription
      * @since 3.6.0
      *
      * @throws Exception
@@ -28,6 +30,15 @@ class UpdateSubscriptionStatus
         if (empty($message)) {
             $message = $this->getMessageFromStatus($status);
         }
+
+        SubscriptionNote::create([
+            'subscriptionId' => $subscription->id,
+            'content' => $message . ' ' . sprintf(
+                    __('%s subscription ID: %s', 'give'),
+                    $subscription->initialDonation()->gateway()->getName(),
+                    $subscription->gatewaySubscriptionId
+                ),
+        ]);
 
         PaymentGatewayLog::info(
             $message . ' ' . sprintf('Subscription ID: %s.', $subscription->id),

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationAbandoned.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationAbandoned.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,12 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationAbandoned
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isAbandoned()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCancelled.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCancelled.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,13 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationCancelled
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
-     *
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isCancelled()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCompleted.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCompleted.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,12 +13,26 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationCompleted
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
-    {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+    public function __invoke(
+        string $gatewayTransactionId,
+        string $message = '',
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
+    ) {
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isComplete()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationFailed.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationFailed.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,13 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationFailed
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
-     *
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isFailed()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPending.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPending.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,13 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationPending
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
-     *
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isPending()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPreapproval.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPreapproval.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,12 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationPreapproval
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isPreapproval()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationProcessing.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationProcessing.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,12 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationProcessing
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isProcessing()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRefunded.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRefunded.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,13 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationRefunded
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
-     *
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isRefunded()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRevoked.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRevoked.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonationStatus;
 
@@ -12,12 +13,22 @@ use Give\Framework\PaymentGateways\Webhooks\EventHandlers\Actions\UpdateDonation
 class DonationRevoked
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 3.6.0
      * @throws Exception
      */
-    public function __invoke(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function __invoke(string $gatewayTransactionId, string $message = '', bool $skipRecurringDonations = false, int $donationId = 0)
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
+
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        }
 
         if ( ! $donation || $donation->status->isRevoked()) {
             return;

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompleted.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompleted.php
@@ -3,6 +3,7 @@
 namespace Give\Framework\PaymentGateways\Webhooks\EventHandlers;
 
 use Exception;
+use Give\Donations\Models\Donation;
 use Give\Donations\Models\DonationNote;
 use Give\Donations\ValueObjects\DonationStatus;
 use Give\Framework\PaymentGateways\Log\PaymentGatewayLog;
@@ -16,6 +17,7 @@ use Give\Subscriptions\ValueObjects\SubscriptionStatus;
 class SubscriptionFirstDonationCompleted
 {
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0 Add $setDonationComplete and $gatewaySubscriptionId parameters
      * @since 3.6.0
      */
@@ -24,15 +26,30 @@ class SubscriptionFirstDonationCompleted
         string $message = '',
         bool $setSubscriptionActive = true,
         bool $setDonationComplete = true,
-        string $gatewaySubscriptionId = ''
+        string $gatewaySubscriptionId = '',
+        int $donationId = 0
     )
     {
-        $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+        if ($donationId > 0) {
+            $donation = Donation::find($donationId);
 
-        if (! $donation && ! empty($gatewaySubscriptionId) && $subscription = give()->subscriptions->getByGatewaySubscriptionId($gatewaySubscriptionId)) {
-            $donation = $subscription->initialDonation();
-            $donation->gatewayTransactionId = $gatewayTransactionId;
-            $donation->save();
+            if ($donation) {
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+
+                if ( ! empty($gatewaySubscriptionId) && empty($donation->subscription->gatewaySubscriptionId)) {
+                    $donation->subscription->gatewaySubscriptionId = $gatewaySubscriptionId;
+                    $donation->subscription->save();
+                }
+            }
+        } else {
+            $donation = give()->donations->getByGatewayTransactionId($gatewayTransactionId);
+
+            if (! $donation && ! empty($gatewaySubscriptionId) && $subscription = give()->subscriptions->getByGatewaySubscriptionId($gatewaySubscriptionId)) {
+                $donation = $subscription->initialDonation();
+                $donation->gatewayTransactionId = $gatewayTransactionId;
+                $donation->save();
+            }
         }
 
         if ( ! $donation || ! $donation->type->isSubscription() || $donation->id !== $donation->subscription->initialDonation()->id) {

--- a/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompleted.php
+++ b/src/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompleted.php
@@ -33,7 +33,7 @@ class SubscriptionFirstDonationCompleted
         if ($donationId > 0) {
             $donation = Donation::find($donationId);
 
-            if ($donation) {
+            if ($donation && $donation->subscription) {
                 $donation->gatewayTransactionId = $gatewayTransactionId;
                 $donation->save();
 

--- a/src/Framework/PaymentGateways/Webhooks/WebhookEvents.php
+++ b/src/Framework/PaymentGateways/Webhooks/WebhookEvents.php
@@ -25,93 +25,178 @@ class WebhookEvents
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     public function donationAbandoned(
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     ) {
-        $this->setDonationStatus(DonationStatus::ABANDONED(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::ABANDONED(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     public function donationCancelled(
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     ) {
-        $this->setDonationStatus(DonationStatus::CANCELLED(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::CANCELLED(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     public function donationCompleted(
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     ) {
-        $this->setDonationStatus(DonationStatus::COMPLETE(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::COMPLETE(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
-    public function donationFailed(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function donationFailed(
+        string $gatewayTransactionId,
+        string $message = '',
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
+    )
     {
-        $this->setDonationStatus(DonationStatus::FAILED(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::FAILED(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
-    public function donationPending(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function donationPending(
+        string $gatewayTransactionId,
+        string $message = '',
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
+    )
     {
-        $this->setDonationStatus(DonationStatus::PENDING(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::PENDING(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     public function donationPreapproval(
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     ) {
-        $this->setDonationStatus(DonationStatus::PREAPPROVAL(), $gatewayTransactionId, $message,
-            $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::PREAPPROVAL(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
     public function donationProcessing(
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
+    ) {
+        $this->setDonationStatus(
+            DonationStatus::PROCESSING(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
+    }
+
+    /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
+     * @since 4.5.0
+     */
+    public function donationRefunded(
+        string $gatewayTransactionId,
+        string $message = '',
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     )
     {
-        $this->setDonationStatus(DonationStatus::PROCESSING(), $gatewayTransactionId, $message,
-            $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::REFUNDED(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      */
-    public function donationRefunded(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
+    public function donationRevoked(
+        string $gatewayTransactionId,
+        string $message = '',
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
+    )
     {
-        $this->setDonationStatus(DonationStatus::REFUNDED(), $gatewayTransactionId, $message, $skipRecurringDonations);
-    }
-
-    /**
-     * @since 4.5.0
-     */
-    public function donationRevoked(string $gatewayTransactionId, string $message = '', $skipRecurringDonations = false)
-    {
-        $this->setDonationStatus(DonationStatus::REVOKED(), $gatewayTransactionId, $message, $skipRecurringDonations);
+        $this->setDonationStatus(
+            DonationStatus::REVOKED(),
+            $gatewayTransactionId,
+            $message,
+            $skipRecurringDonations,
+            $donationId
+        );
     }
 
     /**
@@ -220,6 +305,7 @@ class WebhookEvents
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      *
      * @return int The webhook event ID. Zero if there was an error setting the event.
@@ -228,10 +314,11 @@ class WebhookEvents
         DonationStatus $status,
         string $gatewayTransactionId,
         string $message = '',
-        $skipRecurringDonations = false
+        bool $skipRecurringDonations = false,
+        int $donationId = 0
     ): int {
         $hook = sprintf('givewp_%s_webhook_event_donation_status_%s', $this->gatewayId, $status->getValue());
-        $args = [$gatewayTransactionId, $message, $skipRecurringDonations];
+        $args = [$gatewayTransactionId, $message, $skipRecurringDonations, $donationId];
         $group = $this->getGroup();
 
         return AsBackgroundJobs::enqueueAsyncAction($hook, $args, $group);

--- a/src/Framework/PaymentGateways/Webhooks/WebhookEvents.php
+++ b/src/Framework/PaymentGateways/Webhooks/WebhookEvents.php
@@ -269,6 +269,7 @@ class WebhookEvents
     }
 
     /**
+     * @unreleased Add $donationId to support gateways that only receive the transaction ID via webhook (e.g. PayFast).
      * @since 4.5.0
      *
      * @return int The webhook event ID. Zero if there was an error setting the event.
@@ -278,10 +279,18 @@ class WebhookEvents
         string $message = '',
         bool $setSubscriptionActive = true,
         bool $setDonationComplete = true,
-        string $gatewaySubscriptionId = ''
+        string $gatewaySubscriptionId = '',
+        int $donationId = 0
     ): int {
         $hook = sprintf('givewp_%s_webhook_event_subscription_first_donation', $this->gatewayId);
-        $args = [$gatewayTransactionId, $message, $setSubscriptionActive, $setDonationComplete, $gatewaySubscriptionId];
+        $args = [
+            $gatewayTransactionId,
+            $message,
+            $setSubscriptionActive,
+            $setDonationComplete,
+            $gatewaySubscriptionId,
+            $donationId,
+        ];
         $group = $this->getGroup();
 
         return AsBackgroundJobs::enqueueAsyncAction($hook, $args, $group);

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationAbandonedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationAbandonedTest.php
@@ -56,4 +56,25 @@ class DonationAbandonedTest extends TestCase
 
         $this->assertNotTrue($donation->status->isAbandoned());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToAbandonedAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PENDING(),
+        ]);
+
+        give(DonationAbandoned::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isAbandoned());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCancelledTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCancelledTest.php
@@ -56,4 +56,25 @@ class DonationCancelledTest extends TestCase
 
         $this->assertNotTrue($donation->status->isCancelled());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToCancelledAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        give(DonationCancelled::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isCancelled());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCompletedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationCompletedTest.php
@@ -57,4 +57,26 @@ class DonationCompletedTest extends TestCase
 
         $this->assertNotTrue($donation->status->isComplete());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToCompletedAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PENDING(),
+        ]);
+
+        give(DonationCompleted::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isComplete());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
+
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationFailedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationFailedTest.php
@@ -56,4 +56,25 @@ class DonationFailedTest extends TestCase
 
         $this->assertNotTrue($donation->status->isFailed());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToFailedAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PENDING(),
+        ]);
+
+        give(DonationFailed::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isFailed());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPendingTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPendingTest.php
@@ -56,4 +56,25 @@ class DonationPendingTest extends TestCase
 
         $this->assertNotTrue($donation->status->isPending());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToPendingAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PREAPPROVAL(),
+        ]);
+
+        give(DonationPending::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isPending());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPreapprovalTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationPreapprovalTest.php
@@ -56,4 +56,25 @@ class DonationPreapprovalTest extends TestCase
 
         $this->assertNotTrue($donation->status->isPreapproval());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToPreapprovalAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PROCESSING(),
+        ]);
+
+        give(DonationPreapproval::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isPreapproval());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationProcessingTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationProcessingTest.php
@@ -56,4 +56,25 @@ class DonationProcessingTest extends TestCase
 
         $this->assertNotTrue($donation->status->isProcessing());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToProcessingAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PENDING(),
+        ]);
+
+        give(DonationProcessing::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isProcessing());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRefundedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRefundedTest.php
@@ -56,4 +56,25 @@ class DonationRefundedTest extends TestCase
 
         $this->assertNotTrue($donation->status->isRefunded());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToRefundedAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        give(DonationRefunded::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isRefunded());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRevokedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/DonationRevokedTest.php
@@ -56,4 +56,25 @@ class DonationRevokedTest extends TestCase
 
         $this->assertNotTrue($donation->status->isRevoked());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldSetStatusToRevokedAndBindTransactionIdWhenDonationIdIsProvided()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        give(DonationRevoked::class)('gateway-transaction-id', '', false, $donation->id);
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isRevoked());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompletedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompletedTest.php
@@ -69,4 +69,68 @@ class SubscriptionFirstDonationCompletedTest extends TestCase
         $this->assertTrue($subscription->status->isPending());
         $this->assertTrue($donation->status->isComplete());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldUpdateDonationAndSubscriptionStatusesWhenDonationIdIsProvided()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $donation = $subscription->initialDonation();
+
+        $subscription->status = SubscriptionStatus::PENDING();
+        $subscription->save();
+
+        $donation->status = DonationStatus::PENDING();
+        $donation->gatewayTransactionId = null;
+        $donation->save();
+
+        give(SubscriptionFirstDonationCompleted::class)(
+            'gateway-transaction-id',
+            '',
+            true,
+            true,
+            'gateway-subscription-id',
+            $donation->id
+        );
+
+        $subscription = Subscription::find($subscription->id);
+        $donation = Donation::find($donation->id);
+
+        $this->assertTrue($donation->status->isComplete());
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+        $this->assertTrue($subscription->status->isActive());
+        $this->assertSame('gateway-subscription-id', $subscription->gatewaySubscriptionId);
+    }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldBindTransactionIdToExistingDonationWhenDonationIdIsProvided()
+    {
+        $subscription = Subscription::factory()->createWithDonation();
+        $donation = $subscription->initialDonation();
+
+        $donation->status = DonationStatus::PENDING();
+        $donation->gatewayTransactionId = null;
+        $donation->save();
+
+        give(SubscriptionFirstDonationCompleted::class)(
+            'gateway-transaction-id',
+            '',
+            false,
+            true,
+            '',
+            $donation->id
+        );
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
+        $this->assertTrue($donation->status->isComplete());
+    }
 }

--- a/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompletedTest.php
+++ b/tests/Unit/Framework/PaymentGateways/Webhooks/EventHandlers/SubscriptionFirstDonationCompletedTest.php
@@ -133,4 +133,32 @@ class SubscriptionFirstDonationCompletedTest extends TestCase
         $this->assertSame('gateway-transaction-id', $donation->gatewayTransactionId);
         $this->assertTrue($donation->status->isComplete());
     }
+
+    /**
+     * @unreleased
+     *
+     * @throws Exception
+     */
+    public function testShouldNotUpdateDonationWhenDonationIdIsProvidedButHasNoSubscription()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayTransactionId' => null,
+            'status' => DonationStatus::PENDING(),
+        ]);
+
+        give(SubscriptionFirstDonationCompleted::class)(
+            'gateway-transaction-id',
+            '',
+            true,
+            true,
+            'gateway-subscription-id',
+            $donation->id
+        );
+
+        $donation = Donation::find($donation->id);
+
+        $this->assertNull($donation->gatewayTransactionId);
+        $this->assertTrue($donation->status->isPending());
+    }
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [[SMTNC-980](https://linear.app/nexcess/issue/SMTNC-980/payfast-renewals-incorrectly-marked-as-complete)]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

Some payment gateways (e.g. PayFast) generate the transaction ID on their side and only deliver it via webhook (`pf_payment_id`), alongside the original donation ID (`m_payment_id`). Because the donation's `gatewayTransactionId` is `null` at the time the webhook arrives, the existing `getByGatewayTransactionId` lookup returns `null` and the donation status never gets updated.

So, this PR solves it by adding a new $donationsId parameter to the webhook event handlers.

### Add unit tests for the new `$donationId` parameter in webhook event handlers

Added tests to all donation status event handler test classes to cover the new `$donationId` lookup path introduced in this PR. Each test verifies that when a donation ID is provided directly, the handler correctly finds the donation by ID, binds the `gatewayTransactionId`, and updates the status — without relying on `getByGatewayTransactionId`.

`SubscriptionFirstDonationCompletedTest` received two additional tests covering the full scenario: binding `gatewayTransactionId` and `gatewaySubscriptionId` and updating both donation and subscription statuses when a donation ID is passed.


## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

**`src/Framework/PaymentGateways/Webhooks/WebhookEvents.php`**
- Added `int $donationId = 0` to all donation status methods (`donationCompleted`, `donationFailed`, `donationPending`, `donationCancelled`, `donationAbandoned`, `donationPreapproval`, `donationProcessing`, `donationRefunded`, `donationRevoked`) and to `subscriptionFirstDonation`
- Updated `setDonationStatus` to accept and forward `$donationId` in the dispatched args
- Fixed missing `bool` type hint on `$skipRecurringDonations` across all methods

**`src/Framework/PaymentGateways/Webhooks/EventHandlers/Donation*.php`** (all 8 status handlers) and **`SubscriptionFirstDonationCompleted.php`**
- Added `int $donationId = 0` parameter
- When `$donationId > 0`: finds the donation directly via `Donation::find()`, sets `gatewayTransactionId`, and saves — bypassing the `getByGatewayTransactionId` lookup entirely
- `SubscriptionFirstDonationCompleted` additionally sets `subscription->gatewaySubscriptionId` when provided, ensuring future renewal webhooks can locate the subscription

**`src/Framework/PaymentGateways/ServiceProvider.php`**
- Updated `addDonationStatusEventHandlers` accepted args from `3` to `4`
- Updated `addSubscriptionFirstDonationEventHandler` accepted args from `5` to `6`

**`src/Framework/PaymentGateways/Actions/GenerateGatewayRouteUrl.php`**
- Added support for `GIVEWP_GATEWAY_ROUTE_BASE_URL` constant, allowing local development environments to override `home_url()` with a tunnel URL (e.g. expose.dev) without affecting the rest of the WordPress installation


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Check the test instructions here: https://github.com/impress-org/give-recurring/pull/1234

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

