### PR TITLE
chore: sync changelog.txt with readme.txt and update releasing doc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ This document outlines the process for releasing new versions of GiveWP.
 
 Releases are prepared continuously as features and fixes are merged:
 
-* **Changelog entries** — every PR adds an entry with `composer run changelog:add`, which drops a YAML file into `./changelog`. These are compiled into `readme.txt` at release time.
+* **Changelog entries** — every PR adds an entry with `composer run changelog:add`, which drops a YAML file into `./changelog`. These are compiled into `readme.txt` and `changelog.txt` at release time.  WordPress [recommends](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#file-size) keeping the latest version's changelog in `readme.txt` and the full history in `changelog.txt`. For Give, this means we reset the `readme.txt` changelog during major version releases.
 * **Docblocks** — new or changed code uses `@since TBD`, which is replaced with the real version number at release time.
 
 ## Preparing a release
@@ -24,7 +24,7 @@ Normal releases follow a [gitflow](https://nvie.com/posts/a-successful-git-branc
    This runs the full version-bump pipeline:
    1. Updates all version strings — `GIVE_VERSION` and the `Version:` plugin header in `give.php`, and `Stable tag:` in `readme.txt`
    2. Replaces all `@since TBD` / `@deprecated TBD` placeholders with the new version
-   3. Compiles the pending entries in `./changelog` into the `readme.txt` changelog
+   3. Compiles the pending entries in `./changelog` into the `readme.txt` and `changelog.txt` changelog
 
    Options: `--date <date>` sets the changelog date (defaults to today); `--dry-run` previews without writing.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,240 @@
 == Changelog ==
 
+= 4.15.4: Jun 15th, 2026 =
+* Security: Added additional protection to the email notification settings.
+
+= 4.15.3: May 28th, 2026 =
+* Fix: Resolved a user role permission conflict with The Events Calendar Pro
+* Fix: Resolved an issue when using multiple Stripe accounts, recurring donations, and webhook API 2026-02-25.clover
+
+= 4.15.2: May 13th, 2026 =
+* Tweak: Update Harbor to 1.2.0, removing the Liquid Web Products page when there are no premium plugins present.
+
+= 4.15.1: May 12th, 2026 =
+* Tweak: Moved the Liquid Web menu item to Settings -> Liquid Web Products.
+* Tweak: The Settings -> Liquid Web Products page now requires a opt-in to communicate with external servers.
+
+= 4.15.0: May 11th, 2026 =
+* Feature: Integrate with Nexcess Licensing and Portal.
+* Tweak: Updated branding references from StellarWP to Nexcess.
+* Fix: Resolved issue with separator style for title on donation-form thanks message.
+
+= 4.14.6: April 22nd, 2026 =
+* Security: Added additional sanitization to the Donation Form.
+* Security: Added additional access control checks to the REST API.
+
+= 4.14.5: April 8th, 2026 =
+* Security: Added additional escaping to the Donation Form Block attributes.
+* Fix: Resolved an issue with donation level labels not displaying correctly for multi-currency donations.
+
+= 4.14.4: April 2nd, 2026 =
+* Security: Added additional validation to PayPal Commerce requests.
+
+= 4.14.3: March 11th, 2026 =
+* Security: Added additional sanitization to the Donation Form.
+
+= 4.14.2: February 25th, 2026 =
+* Enhancement: Added form migration and campaign compatibility for P2P.
+* Fix: Resolved an accessibility issue with the Form Grid Block where screen readers announced all nested content as a single links
+* Fix: Resolved an accessibility issue with buttons on the View Subscription screen on Donor Dashboard page
+* Fix: Resolved an issue with the Donation Form modal when opened in a mobile device
+* Fix: Resolved an issue with emailTags not being assigned to block fields
+* Fix: Resolved an issue with the Donor Confirmation header and description colors on changing text
+* Fix: Resolved an issue where campaign default form title didn’t match campaign name
+
+= 4.14.1: February 11th, 2026 =
+* Fix: Resolved an issue with the Stripe refunded webhook
+* Fix: Resolved an issue with importing Subscriptions without a donor_id
+* Fix: Resolved an issue when using additional Stripe accounts and recurring donations
+* Fix: Resolved an issue with custom visibility conditions on donation forms when initially rendering
+* Fix: Resolved several PHP deprecated warnings on the donor dashboard
+
+= 4.14.0: January 28th, 2026 =
+* New: Added failed donation email notifications to keep you informed when donations don't go through
+* New: Added default country field setting for the billing address block to streamline the donation process
+* Enhancement: Improved compatibility with legacy user roles for sites upgrading from older versions of GiveWP
+* Fix: Resolved a conflict with the Paid Membership Subscriptions plugin
+* Fix: Resolved inconsistencies with the currency switcher display and functionality
+* Fix: Resolved an issue where revenue entries were not being properly removed when donations were deleted
+* Fix: Resolved schema mismatches for donors and donor subresources in the REST API V3
+* Fix: Resolved an issue with the admin fee recovery upgrade notice display
+
+= 4.13.2: December 8th, 2025 =
+* Fix: Resolved block compatibility with WordPress 6.9
+* Security: Added additional sanitization to the donor wall and campaign blocks (CVE-2025-66533)
+* Security: Added additional CSRF protection to PayPal onboarding settings (CVE-2025-67467)
+
+= 4.13.1: November 18th, 2025 =
+* Enhancement: Added Caribbean guilder (XCG) as a currency option
+* Enhancement: Added Curaçao as a country option (open-source contribution by @Genevieve-K)
+* Security: Added additional escaping to the donor wall (CVE-2025-13206)
+* Fix: Resolved a validation issue with some custom form fields using conditional logic
+* Fix: Resolved an issue that was causing REST API console log errors in the browser for not being logged in
+* Fix: Resolved an issue with Donor REST API and sorting by totalAmountDonated
+* Fix: Resolved an issue with merging campaigns and cached campaign goal data
+
+= 4.13.0: November 5th, 2025 =
+* Enhancement: Updated the date and time formatting throughout the new admin screens to respect WordPress settings for timezone, date format, and time format
+* Fix: Resolved an issue with form field manager checkboxes and conditional logic
+* Fix: Resolved an issue with the legacy future status of donations
+* Fix: Resolved a compatibility issue with the Divi color pickers default palette setting
+* Fix: Resolved an issue with Loco Translate that was preventing custom translation files from being loaded properly
+* Dev: Updated the schema for Campaigns and Donations in the v3 REST API
+* Dev: Updated MCP server to be compatible with Angie 1.0.2
+
+= 4.12.0: October 29th, 2025 =
+* New: The admin subscription list table has been upgraded to a new design with additional sorting, filters and statistics
+* New: Updated the new admin donor list table with additional filters and sorting
+* New: Updated the new admin donation list table with additional filters
+* Fix: Subscriptions that were transferred to a form using the visual form builder are now referencing the correct form ID
+* Fix: Resolved an issue with sorting by revenue on the Campaigns list table
+* Fix: Resolved MCP server console errors with Angie v1.0.1
+* Fix: Resolved a migration issue that was causing the cache campaign data migration to be incomplete in some cases
+
+= 4.11.0: October 16th, 2025 =
+* New: Added a new csv subscriptions importer tool for the ability to import recurring donations into GiveWP
+* New: The admin donor list table now displays quick stats
+* New: The new admin subscription details screen now has record fields for status, gateway subscription ID, campaign, form, and associated donor
+* Fix: Resolved conflict from composer with some plugins like KestrelWP
+
+= 4.10.1: October 2nd, 2025 =
+* Security: Improved REST endpoint permissions for campaigns and forms (CVE-2025-11227, CVE-2025-11228)
+
+= 4.10.0: October 1st, 2025 =
+* New: The admin list tables have been upgraded to a new design with various enhancements!
+* New: The admin donations list table now displays quick stats
+* Enhancement: Improved the currency validation for donation forms
+* Fix: Resolved an issue where editing an option-based form was resetting various settings
+* Fix: Resolved various issues with deactiving and deleting GiveWP
+* Fix: Resolved occasional 404 console log errors in the new subscription detail screen
+* Dev: Added a sidebar slot fill to the donor details screen
+
+= 4.9.0: September 17th, 2025 =
+* New: Added MCP server integration with compatibility for Angie by Elementor
+* Enhancement: Updated GiveWP for PHP 8.3 compatibility
+* Fix: Updated various strings that were missing translations (open-source contribution by @DAnn2012)
+* Fix: Resolved schema registration issues in V3 REST endpoints
+
+
+= 4.8.1: September 15th, 2025 =
+* Fix: Resolved an issue with the campaign field in the new donation detail screen not saving properly
+
+= 4.8.0: September 10th, 2025 =
+* New: The subscription admin details screen has been upgraded to a new design and experience!
+* Enhancement: Improved the loading performance of the campaign list table and grid
+* Enhancement: Added Stripe webhook compatibility with their latest version 2025-03-31.basil
+* Enhancement: Improved the performance and experience of the associated donor field in the donation details screen
+* Fix: Resolved an issue with some campaign blocks not rendering option-based forms
+
+= 4.7.1: September 4th, 2025 =
+* Fix: Resolved an issue with the legacy form widget for Elementor not displaying a preview in the builder
+* Fix: Resolved an issue with the Elementor GiveWP category not showing up as intended
+
+= 4.7.0: August 20th, 2025 =
+* New: Elementor support for widgets and campaign landing pages have been added to GiveWP without the need for a separate add-on
+* Enhancement: Stripe Payment Element and PayPal Donations have been updated to support refunding
+* Fix: Resolved an issue with donation form goal progress when using custom date ranges
+* Fix: Resolved an issue with some campaign shortcodes not loading properly
+* Dev: Added support for custom REST API fields for donation and donor endpoints
+
+= 4.6.1: July 29th, 2025 =
+* Security: Addressed an issue with donor information visibility (CVE-2025-47444)
+
+= 4.6.0: July 23rd, 2025 =
+* New: The donation admin details screen has been upgraded to a new design and experience!
+* Fix: Resolved an issue with the bulk actions selector on the campaign forms list
+* Fix: Resolved an issue with PayPal donations and zero decimal currencies like Japanese Yen
+* Fix: Resolved an issue with some form migrations using different goal formats and PHP 8.1+
+* Security: Added additional sanitization and escaping to donor notes (CVE-2025-7205)
+* Security: Added additional auth checks for certain Give user roles (CVE-2025-7221)
+* Security: Removed PayPal donations client token when not being used
+
+= 4.5.0: July 9th, 2025 =
+* New: Added a new PayPal setting to optionally accept credit cards when using Smart Buttons
+* New: Added shortcodes for givewp_campaign_donations, givewp_campaign_donors, and givewp_campaign_comments
+* New: Added support for the gateway transaction ID to the donation importer
+* Enhancement: Added core Stripe gateway support for customers in countries BR, IN, MY, MX, SG, TH
+* Fix: Resolved a Divi compatibility issue
+* Fix: Ensure campaign overview and goal statistics are calculated in the base currency
+* Fix: Resolved a style issue causing a double border around the custom amount field
+* Fix: Resolved an issue with translations that use ajax (Open-source contribution  @Genevieve-K)
+* Fix: Resolved PHP 8.1+ compatibility issues with Form Goal Settings
+* Fix: Resolved an issue with the global css form setting where some characters were being encoded
+* Fix: Resolved an issue with the terms and conditions modal not working properly in Firefox
+* Dev: Added API for gateway webhook events
+
+= 4.4.0: June 18th, 2025 =
+* New: The donor admin details screen has been upgraded to a new design and experience!
+* Enhancement: When using the the visual form builder with recurring donations, the gateway options will now only display the ones that support recurring donations
+* Fix: Resolved an issue with recurring donation email templates in the visual form builder settings
+* Fix: Resolved an issue with the campaign page donate button and option-based forms
+
+
+= 4.3.2: June 11th, 2025 =
+* Enhancement: Improved accessibility across form modal and new tab display styles
+* Enhancement: Added focus border to donation confirmation donor-dashboard link
+* Enhancement: Added aria-support to donation confirmation secure badge
+* Enhancement: Replaced definition list tags in donation confirmation field lists for better semantic structure
+* Fix: Resolved an issue with additional keyboard focus on new donor wall items
+* Fix: Resolved accessibility issues with event ticket elements
+* Fix: Resolved an issue with aria labels in form-grid progress bar
+* Fix: Resolved an issue with campaign colors for grid and block goal progress
+* Fix: Resolved backwards compatibility issues for campaign_id in legacy objects and gateways
+* Fix: Resolved an issue where the Campaign Grid block does not show any Campaigns when the Campaign filter is used
+* Fix: Resolved an issue with the visual form builder route user roles
+* Fix: Resolved an issue with error focus on Date and File fields
+* Fix: Resolved an issue where some servers were experiencing a "Missing PayPal webhook header" error
+* Fix: Resolved a conflict with custom text fields that use the same name as the billing address block field names
+
+= 4.3.1: May 30th, 2025 =
+* Fix: Resolved an issue with the Donor wall when filtering by multiple form IDs
+* Security: Updated permissions for various endpoints (CVE-2025-4571)
+
+= 4.3.0: May 21st, 2025 =
+* New: Added a new Campaign form block and shortcode
+* Enhancement: Improved the performance of the campaign form list table
+* Enhancement: Updated the donation list table to include it's associated Campaign
+* Enhancement: Recurring donation renewals using Stripe will now include meta data
+* Enhancement: Made various improvements to the accessiblity of our donation forms
+* Enhancement: Updated our advanced migration system to offer the ability to rollback a failed migration
+* Enhancement: Updated the campaign admin screen with a sticky header UI
+* Fix: Updated the form to campaign migration to take into account the possibility of multiple upgraded forms which would sometimes cause it to fail
+* Fix: Resolved remaining WP 6.8 _load_textdomain_just_in_time notice for GiveWP core
+* Fix: Updated campaigns admin screen to be translatable
+* Fix: Resolved an issue with sites in subdirectories that are using visual form builder forms were producing an error
+* Fix: Resolved an issue where some custom fields were not showing up on the donor dashboard
+
+= 4.2.1: May 7th, 2025 =
+* Fix: Resolved an issue with PayPal Donations and Fee Recovery when using the global option for donor forced opt-in
+
+= 4.2.0: April 30th, 2025 =
+* New: Added shortcodes for the Campaign Block and Campaign Grid Block
+* New: Added the ability to associate orphaned campaign forms to a campaign
+* New: Added the ability to duplicate a campaign
+* Enhancement: Improved the campaign archiving functionality
+* Fix: Resolved an issue with goal progress amounts not calculating correctly throughout Campaigns and Forms
+* Fix: Resolved an issue with the Stripe Credit Card gateway and utm tags
+* Fix: Resolved an issue with Stripe Payment Element not showing accurate total amount when using Fee Recovery and Apple/Google Pay
+* Fix: Resolved an issue where some donations were not storing currency exchange rates correctly
+
+= 4.1.0: April 16th, 2025 =
+* New: Added the ability for donation forms to inherit Campaign goals and colors
+* New: Added a campaign filter to the donation list table
+* New: Added a global setting to apply custom css to all donation forms
+* New: Added a notice to the campaigns overview that lets your know when the landing page is in draft
+* New: Added the ability to update the associated campaign for a donation within the donation details screen
+* Enhancement: Updated the PayPal Donations gateway to use the new PayPal Card Fields API
+* Enhancement: Improved the donation form modal experience
+* Fix: Fixed an issue where a Form Field Manager upgrade notice was still showing with an active license
+* Fix: Resolved an issue with the cancel/pause subscription modal in the donor dashboard
+
+= 4.0.0: March 31st, 2025 =
+* New: Introducing Campaigns! Manage all of your fundraising efforts seamlessly.
+* New: The Campaign overview dashboard provides donation data and goal progress monitoring for all forms under the same fundraising campaign.
+* New: Campaign pages give you a landing page for each campaign to tell your story and engage with donors.
+* New: All donation forms belong to a campaign, and each campaign can have multiple forms.
+* Enhancement: Improved the processing of PayPal donations to be more reliable on forms using the visual form builder
+
 = 3.22.2: March 19th, 2025 =
 * Fix: Resolved an issue with PayPal hiding the donate button when hosted fields are available
 * Security: Improved the permission check for a GiveWP reporting request (CVE-2025-2331)


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

WordPress [recommends](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/#file-size) truncating changelog in `readme.txt` in favor of `changelog.txt`.  Our `changelog.txt` was out of sync and this PR updates it to the latest version.  

Since we are using changelogger with our release-prep commands now, it will automatically write to both `readme.txt` and `changelog.txt`.  The only time we need to reset `readme.txt` again is during a major version update or if we happen to hit the WP limit again.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

N/A

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

N/A

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

N/A

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

