### PR TITLE
fix: Remove extra separators rendering multiple times

### DIFF
--- a/src/DonationForms/resources/styles/components/_receipt.scss
+++ b/src/DonationForms/resources/styles/components/_receipt.scss
@@ -318,6 +318,10 @@
     &-heading {
         margin-block-end: 1rem;
 
+        > br {
+            display: none;
+        }
+
         &::after {
             position: absolute;
             content: '';

--- a/src/DonationForms/resources/styles/components/_receipt.scss
+++ b/src/DonationForms/resources/styles/components/_receipt.scss
@@ -322,7 +322,7 @@
             display: none;
         }
 
-        &::after {
+        &:not(:empty)::after {
             position: absolute;
             content: '';
             display: block;

--- a/src/DonationForms/resources/styles/components/_receipt.scss
+++ b/src/DonationForms/resources/styles/components/_receipt.scss
@@ -304,7 +304,6 @@
 
     &-heading, &-heading * {
         position: relative;
-        margin-block-end: 1rem;
         font-size: 1.75rem;
         font-weight: 600;
         line-height: 1.2;
@@ -314,8 +313,12 @@
         > * {
             color: currentColor;
         }
+    }
 
-        &:not(:empty)::after {
+    &-heading {
+        margin-block-end: 1rem;
+
+        &::after {
             position: absolute;
             content: '';
             display: block;
@@ -327,10 +330,6 @@
             inset-block-start: calc(100% + 1.25rem);
             transform: translate(-50%);
         }
-    }
-
-    &-heading:has(*) {
-        margin-block-end: 0;
     }
 
     &-description, &-description * {


### PR DESCRIPTION
Resolves #[SMTNC-212](https://linear.app/nexcess/issue/SMTNC-212/an-extra-separator-should-not-be-rendered-when-the-donation)

## Description

Some change (that I couldn't track) inserted a regression fixed by https://github.com/impress-org/givewp/pull/8222. The fix was to not render divisors when ::after had some content in it, but later line breaks introduced a space (&nbsp) which IS content.
New fix was to add divisor only as `::after` of `receipt-header-heading`

## Affects

Style from the header of Confirmation page

## Visuals

<img width="1161" height="1320" alt="image" src="https://github.com/user-attachments/assets/a32a458e-f86c-4988-a041-701b8be43239" />

<img width="2129" height="1023" alt="image" src="https://github.com/user-attachments/assets/c5efe633-78ad-4266-936f-0c0a2771582d" />

https://www.loom.com/share/5df59d73048b49bfa861780bf212f405

## Testing Instructions

*Admin Panel > GiveWP > Campaings > (Create a new or go to "Forms" inside a campaing) > Edit >"Settings" tab > Donation Confirmation > Header*

Edit header, put lines breaks, try to mess with it.

Only one divisor should exist

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

