### PR TITLE
Fix: GiveWP misses stripe resumed and updated webhook events

### DIFF
--- a/changelog/smtnc-1630-givewp-misses-stripe-resumed-and-updated-webhook-events.yaml
+++ b/changelog/smtnc-1630-givewp-misses-stripe-resumed-and-updated-webhook-events.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where paused or failing Stripe Payment Element
+  subscriptions remained stuck when the donor updated their payment method or
+  the subscription was resumed in Stripe.
+timestamp: 2026-07-28T14:24:47.811Z

--- a/src/PaymentGateways/Gateways/ServiceProvider.php
+++ b/src/PaymentGateways/Gateways/ServiceProvider.php
@@ -125,7 +125,7 @@ class ServiceProvider implements ServiceProviderInterface
         );
 
         Hooks::addAction(
-            'give_stripe_event_customer.subscription.resumed',
+            'give_recurring_stripe_processing_customer_subscription_resumed',
             CustomerSubscriptionResumed::class
         );
     }

--- a/src/PaymentGateways/Gateways/ServiceProvider.php
+++ b/src/PaymentGateways/Gateways/ServiceProvider.php
@@ -20,6 +20,8 @@ use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePayme
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\ChargeRefunded;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionCreated;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionDeleted;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionResumed;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionUpdated;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\InvoicePaymentFailed;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\InvoicePaymentSucceeded;
 use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\PaymentIntentPaymentFailed;
@@ -115,6 +117,16 @@ class ServiceProvider implements ServiceProviderInterface
         Hooks::addAction(
             'give_recurring_stripe_processing_customer_subscription_deleted',
             CustomerSubscriptionDeleted::class
+        );
+
+        Hooks::addAction(
+            'give_recurring_stripe_processing_customer_subscription_updated',
+            CustomerSubscriptionUpdated::class
+        );
+
+        Hooks::addAction(
+            'give_stripe_event_customer.subscription.resumed',
+            CustomerSubscriptionResumed::class
         );
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionResumed.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionResumed.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners;
+
+use Exception;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
+use Stripe\Event;
+use Stripe\Subscription as StripeSubscription;
+
+/**
+ * @since TBD
+ */
+class CustomerSubscriptionResumed
+{
+    use StripeWebhookListenerRepository;
+
+    /**
+     * Processes customer.subscription.resumed event.
+     *
+     * Occurs whenever a subscription is no longer paused. Only applies when a subscription is
+     * resumed after being paused, which can follow the donor updating their payment method.
+     *
+     * @see https://stripe.com/docs/api/events/types#event_types-customer.subscription.resumed
+     *
+     * @since TBD
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function __invoke(Event $event)
+    {
+        try {
+            if ($this->processEvent($event)) {
+                exit;
+            }
+        } catch (Exception $exception) {
+            $this->logWebhookError($event, $exception);
+        }
+    }
+
+    /**
+     * @since TBD
+     * @throws Exception
+     */
+    public function processEvent(Event $event): bool
+    {
+        /* @var StripeSubscription $stripeSubscription */
+        $stripeSubscription = $event->data->object;
+
+        $subscription = give()->subscriptions->queryByGatewaySubscriptionId($stripeSubscription->id)->get();
+
+        // only use this for next gen for now
+        if (!$subscription || !$this->shouldProcessSubscription($subscription)) {
+            return false;
+        }
+
+        if ($subscription->status->isFailing() || $subscription->status->isPaused()) {
+            $subscription->status = SubscriptionStatus::ACTIVE();
+            $subscription->save();
+        }
+
+        return true;
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionResumed.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionResumed.php
@@ -24,10 +24,12 @@ class CustomerSubscriptionResumed
      *
      * @since TBD
      *
+     * @param Event $event
+     *
      * @return void
      * @throws Exception
      */
-    public function __invoke(Event $event)
+    public function __invoke($event)
     {
         try {
             if ($this->processEvent($event)) {

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionUpdated.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionUpdated.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners;
+
+use Exception;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
+use Stripe\Event;
+use Stripe\Subscription as StripeSubscription;
+
+/**
+ * @since TBD
+ */
+class CustomerSubscriptionUpdated
+{
+    use StripeWebhookListenerRepository;
+
+    /**
+     * Processes customer.subscription.updated event.
+     *
+     * Occurs whenever a subscription changes (e.g. switching plans, updating quantity, or
+     * recovering from a failed payment once the donor updates their payment method).
+     *
+     * This listener runs on the give_recurring_stripe_processing_customer_subscription_updated
+     * hook dispatched by the Give Recurring add-on. For next-gen (Stripe Payment Element)
+     * subscriptions it short-circuits the add-on's legacy handling, so it must also cover the
+     * legacy paused -> active recovery in addition to the failing -> active recovery.
+     *
+     * @see https://stripe.com/docs/api/events/types#event_types-customer.subscription.updated
+     *
+     * @since TBD
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function __invoke(Event $event)
+    {
+        try {
+            if ($this->processEvent($event)) {
+                exit;
+            }
+        } catch (Exception $exception) {
+            $this->logWebhookError($event, $exception);
+        }
+    }
+
+    /**
+     * @since TBD
+     * @throws Exception
+     */
+    public function processEvent(Event $event): bool
+    {
+        /* @var StripeSubscription $stripeSubscription */
+        $stripeSubscription = $event->data->object;
+
+        $subscription = give()->subscriptions->queryByGatewaySubscriptionId($stripeSubscription->id)->get();
+
+        // only use this for next gen for now
+        if (!$subscription || !$this->shouldProcessSubscription($subscription)) {
+            return false;
+        }
+
+        // When Stripe reports the subscription as active but GiveWP still has it as failing or
+        // paused, the subscription was recovered (e.g. the donor updated their payment method).
+        if (
+            $stripeSubscription->status === 'active' &&
+            ($subscription->status->isFailing() || $subscription->status->isPaused())
+        ) {
+            $subscription->status = SubscriptionStatus::ACTIVE();
+            $subscription->save();
+        }
+
+        return true;
+    }
+}

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionUpdated.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/Webhooks/Listeners/CustomerSubscriptionUpdated.php
@@ -29,10 +29,12 @@ class CustomerSubscriptionUpdated
      *
      * @since TBD
      *
+     * @param Event $event
+     *
      * @return void
      * @throws Exception
      */
-    public function __invoke(Event $event)
+    public function __invoke($event)
     {
         try {
             if ($this->processEvent($event)) {

--- a/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/CustomerSubscriptionResumedTest.php
+++ b/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/CustomerSubscriptionResumedTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Give\Tests\Feature\Gateways\Stripe\StripePaymentElement\Webhooks\Listeners;
+
+use Exception;
+use Give\Donations\Models\Donation;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionResumed;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionPeriod;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
+use Give\Tests\Feature\Gateways\Stripe\TestTraits\HasMockStripeAccounts;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Stripe\Event;
+
+/**
+ * @since TBD
+ */
+class CustomerSubscriptionResumedTest extends TestCase
+{
+    use RefreshDatabase, HasMockStripeAccounts;
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldUpdateFailingSubscriptionStatusToActive()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::FAILING(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionResumed();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isActive());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldUpdatePausedSubscriptionStatusToActive()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::PAUSED(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionResumed();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isActive());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldNotUpdateActiveSubscriptionStatus()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::ACTIVE(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionResumed();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isActive());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldNotProcessNonStripePaymentElementSubscriptions()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::FAILING(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => 'other_gateway',
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionResumed();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isFailing());
+    }
+}

--- a/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/CustomerSubscriptionUpdatedTest.php
+++ b/tests/Feature/Gateways/Stripe/StripePaymentElement/Webhooks/Listeners/CustomerSubscriptionUpdatedTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Give\Tests\Feature\Gateways\Stripe\StripePaymentElement\Webhooks\Listeners;
+
+use Exception;
+use Give\Donations\Models\Donation;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\Webhooks\Listeners\CustomerSubscriptionUpdated;
+use Give\Subscriptions\Models\Subscription;
+use Give\Subscriptions\ValueObjects\SubscriptionPeriod;
+use Give\Subscriptions\ValueObjects\SubscriptionStatus;
+use Give\Tests\Feature\Gateways\Stripe\TestTraits\HasMockStripeAccounts;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use Stripe\Event;
+
+/**
+ * @since TBD
+ */
+class CustomerSubscriptionUpdatedTest extends TestCase
+{
+    use RefreshDatabase, HasMockStripeAccounts;
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldUpdateFailingSubscriptionStatusToActiveWhenStripeReportsActive()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::FAILING(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+            'status' => 'active',
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionUpdated();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isActive());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldUpdatePausedSubscriptionStatusToActiveWhenStripeReportsActive()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::PAUSED(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+            'status' => 'active',
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionUpdated();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isActive());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldNotUpdateFailingSubscriptionWhenStripeReportsNonActive()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::FAILING(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => StripePaymentElementGateway::id(),
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+            'status' => 'past_due',
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionUpdated();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isFailing());
+    }
+
+    /**
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldNotProcessNonStripePaymentElementSubscriptions()
+    {
+        $this->addMockStripeAccounts();
+
+        $subscription = Subscription::factory()->createWithDonation([
+            'status' => SubscriptionStatus::FAILING(),
+            'installments' => 0,
+            'frequency' => 1,
+            'period' => SubscriptionPeriod::MONTH(),
+            'gatewaySubscriptionId' => 'stripe-subscription-id',
+            'gatewayId' => 'other_gateway',
+        ]);
+
+        $donation = $subscription->initialDonation();
+        $donation->gatewayTransactionId = 'stripe-payment-intent-id';
+        $donation->save();
+
+        //refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+        //refresh donation model
+        $donation = Donation::find($donation->id);
+
+        $stripeSubscription = \Stripe\Subscription::constructFrom([
+            'id' => $subscription->gatewaySubscriptionId,
+            'status' => 'active',
+        ]);
+
+        $mockEvent = Event::constructFrom([
+            'data' => [
+                'object' => $stripeSubscription
+            ]
+        ]);
+
+        $listener = new CustomerSubscriptionUpdated();
+
+        $listener->processEvent($mockEvent);
+
+        // Refresh subscription model
+        $subscription = Subscription::find($subscription->id);
+
+        $this->assertTrue($subscription->status->isFailing());
+    }
+}


### PR DESCRIPTION
Resolves #[SMTNC-1630](https://linear.app/nexcess/issue/SMTNC-1630/givewp-misses-stripe-resumed-and-updated-webhook-events)

## Description

GiveWP was not handling \`customer.subscription.resumed\` or \`customer.subscription.updated\` Stripe webhook events for next-gen (Stripe Payment Element) subscriptions.
This meant that when a donor updated their payment method after a failed payment, or when a paused subscription was resumed in Stripe, the GiveWP subscription status remained stuck in \`failing\` or \`paused\` indefinitely.

This PR adds two new webhook listeners for the Stripe Payment Element gateway:

- **`CustomerSubscriptionResumed`— handles `customer.subscription.resumed`**. When Stripe fires this event (subscription is no longer paused), updates the GiveWP subscription status from `failing` or `paused` → `active`.
- **`CustomerSubscriptionUpdated` — handles `customer.subscription.updated`**. When Stripe reports the subscription as `active` but GiveWP still has it as `failing` or `paused` (e.g. donor updated their payment method), updates the status to `active`.

> [!NOTE]
> Depends on [give-recurring#1236](https://github.com/impress-org/give-recurring/pull/1236) which adds the `customer.subscription.resumed` event dispatch.

## Affects

- Stripe Payment Element (next-gen) recurring donations
- Subscription recovery after failed payment + donor payment method update
- Subscription recovery after pause/resume via Stripe

## Visuals

No UI changes — webhook processing only.

## Testing Instructions

**Prerequisites:** Have stripe, webhooks and both PR's setup in your local.

1. Create a subscription (by creating a campaing and form).
2. In the GiveWP admin, manually set the subscription status to \`Failing\`.
3. Here you can use the stripe-cli only for the `customer.subscription.updated` event. `customer.subscription.resume` you need to test manually because it don't support that.
4. Manually set the subscription status back to \`Paused\`.
5. Trigger the event and verify the GiveWP subscription status changes to **Active**.

## Pre-review Checklist

- [x] Acceptance criteria satisfied and marked in related issue
- [x] Relevant \`@unreleased\` tags included in DocBlocks
- [x] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed