### PR TITLE
Fix: Cannot refund donation when using per form stripe account

### DIFF
--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -165,6 +165,19 @@ class DonationController extends WP_REST_Controller
                         'type' => 'integer',
                         'required' => true,
                     ],
+                    'includeSensitiveData' => [
+                        'type' => 'boolean',
+                        'default' => false,
+                    ],
+                    'anonymousDonations' => [
+                        'type' => 'string',
+                        'default' => 'exclude',
+                        'enum' => [
+                            'exclude',
+                            'include',
+                            'redact',
+                        ],
+                    ],
                 ],
             ],
             'schema' => [$this, 'get_public_item_schema'],
@@ -410,9 +423,12 @@ class DonationController extends WP_REST_Controller
                 $handler->handle($donation);
             }
 
+            $includeSensitiveData = $request->get_param('includeSensitiveData');
+            $donationAnonymousMode = new DonationAnonymousMode($request->get_param('anonymousDonations'));
+
             $item = (new DonationViewModel($donation))
-                ->includeSensitiveData(true)
-                ->anonymousMode(new DonationAnonymousMode('include'))
+                ->includeSensitiveData($includeSensitiveData)
+                ->anonymousMode($donationAnonymousMode)
                 ->exports();
 
             $response = $this->prepare_item_for_response($item, $request);

--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -410,7 +410,12 @@ class DonationController extends WP_REST_Controller
                 $handler->handle($donation);
             }
 
-            $response = $this->prepare_item_for_response($donation->toArray(), $request);
+            $item = (new DonationViewModel($donation))
+                ->includeSensitiveData(true)
+                ->anonymousMode(new DonationAnonymousMode('include'))
+                ->exports();
+
+            $response = $this->prepare_item_for_response($item, $request);
 
             return rest_ensure_response($response);
         } catch (\Exception $exception) {

--- a/src/API/REST/V3/Routes/Donations/DonationController.php
+++ b/src/API/REST/V3/Routes/Donations/DonationController.php
@@ -414,7 +414,11 @@ class DonationController extends WP_REST_Controller
 
             return rest_ensure_response($response);
         } catch (\Exception $exception) {
-            return new WP_REST_Response(__('Failed to refund donation', 'give'), 500);
+            return new WP_REST_Response([
+                'message' => __('Failed to refund donation', 'give'),
+                'error' => $exception->getMessage(),
+                'code' => $exception->getCode(),
+            ], 500);
         }
     }
 

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -173,8 +173,7 @@ class StripePaymentElementGateway extends PaymentGateway implements PaymentGatew
     {
         try {
             $this->setUpStripeAppInfo($donation->formId);
-            $stripeConnectAccountId = give_stripe_get_connected_account_id($donation->formId);
-            $refund = $this->refundStripePayment($donation, $stripeConnectAccountId);
+            $refund = $this->refundStripePayment($donation);
 
             if ($refund->status !== 'succeeded') {
                 throw new Exception(__('Refund failed. Please check the Stripe dashboard for more details.', 'give'));

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementGateway.php
@@ -172,7 +172,9 @@ class StripePaymentElementGateway extends PaymentGateway implements PaymentGatew
     public function refundDonation(Donation $donation): PaymentRefunded
     {
         try {
-            $refund = $this->refundStripePayment($donation);
+            $this->setUpStripeAppInfo($donation->formId);
+            $stripeConnectAccountId = give_stripe_get_connected_account_id($donation->formId);
+            $refund = $this->refundStripePayment($donation, $stripeConnectAccountId);
 
             if ($refund->status !== 'succeeded') {
                 throw new Exception(__('Refund failed. Please check the Stripe dashboard for more details.', 'give'));

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
@@ -37,12 +37,13 @@ trait StripePaymentElementRepository
      * @since 4.7.0
      *
      * @param Donation $donation
-     * @param string   $stripeConnectAccountId
      *
      * @throws ApiErrorException
      */
-    protected function refundStripePayment(Donation $donation, string $stripeConnectAccountId): Refund
+    protected function refundStripePayment(Donation $donation): Refund
     {
+        $stripeConnectAccountId = give_stripe_get_connected_account_id($donation->formId);
+
         $options = [];
         if ($stripeConnectAccountId !== '') {
             $options['stripe_account'] = $stripeConnectAccountId;

--- a/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
+++ b/src/PaymentGateways/Gateways/Stripe/StripePaymentElementGateway/StripePaymentElementRepository.php
@@ -35,13 +35,23 @@ trait StripePaymentElementRepository
 
     /**
      * @since 4.7.0
+     *
+     * @param Donation $donation
+     * @param string   $stripeConnectAccountId
+     *
      * @throws ApiErrorException
      */
-    protected function refundStripePayment(Donation $donation): Refund
+    protected function refundStripePayment(Donation $donation, string $stripeConnectAccountId): Refund
     {
-        return Refund::create([
-            'payment_intent' => $donation->gatewayTransactionId,
-        ]);
+        $options = [];
+        if ($stripeConnectAccountId !== '') {
+            $options['stripe_account'] = $stripeConnectAccountId;
+        }
+
+        return Refund::create(
+            ['payment_intent' => $donation->gatewayTransactionId],
+            $options
+        );
     }
 
     /**

--- a/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/DonationRouteUpdateTest.php
@@ -10,6 +10,7 @@ use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
 use Give\Tests\RestApiTestCase;
 use Give\Tests\TestTraits\RefreshDatabase;
 use Give\Tests\TestTraits\HasDefaultWordPressUsers;
+use Give\Tests\Unit\API\REST\V3\Routes\Donations\ThrowingTestGateway;
 
 /**
  * @since 4.6.0
@@ -352,7 +353,7 @@ class DonationRouteUpdateTest extends RestApiTestCase
         $this->assertNull($data['honorific']);
     }
 
-        /**
+    /**
      * @since 4.6.0
      */
     public function testRefundDonationShouldRefundDonationSuccessfully()
@@ -379,6 +380,17 @@ class DonationRouteUpdateTest extends RestApiTestCase
 
         $this->assertEquals(200, $status);
         $this->assertTrue($data['status']->isRefunded());
+
+        // Verify DonationViewModel shape (regression: switching back to toArray() would miss these keys)
+        $this->assertArrayHasKey('customFields', $data);
+        $this->assertArrayHasKey('eventTicketsAmount', $data);
+        $this->assertArrayHasKey('eventTickets', $data);
+        $this->assertArrayHasKey('gateway', $data);
+
+        // Verify base donation properties are still present
+        $this->assertArrayHasKey('id', $data);
+        $this->assertArrayHasKey('formId', $data);
+        $this->assertArrayHasKey('gatewayId', $data);
     }
 
     /**
@@ -421,5 +433,66 @@ class DonationRouteUpdateTest extends RestApiTestCase
         $status = $response->get_status();
 
         $this->assertEquals(403, $status);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldReturnStructuredErrorOnFailure()
+    {
+        /** @var PaymentGatewayRegister $registrar */
+        $registrar = give(PaymentGatewayRegister::class);
+        if (!$registrar->hasPaymentGateway(ThrowingTestGateway::id())) {
+            $registrar->registerGateway(ThrowingTestGateway::class);
+        }
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => ThrowingTestGateway::id(),
+            'status' => DonationStatus::COMPLETE()
+        ]);
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id . '/refund';
+        $request = $this->createRequest('POST', $route, [], 'administrator');
+
+        $response = $this->dispatchRequest($request);
+
+        $this->assertEquals(500, $response->get_status());
+
+        $data = $response->get_data();
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('message', $data);
+        $this->assertArrayHasKey('error', $data);
+        $this->assertArrayHasKey('code', $data);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationErrorShouldContainExceptionDetails()
+    {
+        /** @var PaymentGatewayRegister $registrar */
+        $registrar = give(PaymentGatewayRegister::class);
+        if (!$registrar->hasPaymentGateway(ThrowingTestGateway::id())) {
+            $registrar->registerGateway(ThrowingTestGateway::class);
+        }
+
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => ThrowingTestGateway::id(),
+            'status' => DonationStatus::COMPLETE()
+        ]);
+
+        $route = '/' . DonationRoute::NAMESPACE . '/' . DonationRoute::BASE . '/' . $donation->id . '/refund';
+        $request = $this->createRequest('POST', $route, [], 'administrator');
+
+        $response = $this->dispatchRequest($request);
+
+        $this->assertEquals(500, $response->get_status());
+
+        $data = $response->get_data();
+        $this->assertEquals('Failed to refund donation', $data['message']);
+        $this->assertEquals('Simulated refund error', $data['error']);
+        $this->assertEquals(42, $data['code']);
     }
 }

--- a/tests/Unit/API/REST/V3/Routes/Donations/ThrowingTestGateway.php
+++ b/tests/Unit/API/REST/V3/Routes/Donations/ThrowingTestGateway.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Give\Tests\Unit\API\REST\V3\Routes\Donations;
+
+use Give\Donations\Models\Donation;
+use Give\Framework\PaymentGateways\Commands\PaymentRefunded;
+use Give\PaymentGateways\Gateways\TestGateway\TestGateway;
+
+class ThrowingTestGateway extends TestGateway
+{
+    public static function id(): string
+    {
+        return 'throwing-test-gateway';
+    }
+
+    public function getId(): string
+    {
+        return self::id();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function refundDonation(Donation $donation): PaymentRefunded
+    {
+        throw new \Exception('Simulated refund error', 42);
+    }
+}

--- a/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
@@ -66,7 +66,7 @@ class StripePaymentElementGatewayTest extends TestCase
         /** @var MockObject $mockGateway */
         $mockGateway->expects($this->once())
             ->method('refundStripePayment')
-            ->with($donation, $this->anything())
+            ->with($donation)
             ->willReturn($mockRefund);
 
         $result = $mockGateway->refundDonation($donation);

--- a/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
@@ -119,13 +119,15 @@ class StripePaymentElementGatewayTest extends TestCase
             ->method('refundStripePayment')
             ->willReturn($mockRefund);
 
+        $noteCountBeforeRefund = Donation::find($donation->id)->notes()->count();
+
         $mockGateway->refundDonation($donation);
 
         $donation = Donation::find($donation->id);
         $notes = $donation->notes()->getAll();
 
-        $this->assertCount(1, $notes);
-        $this->assertStringContainsString('Donation refunded in Stripe', $notes[0]->content);
+        $this->assertCount($noteCountBeforeRefund + 1, $notes);
+        $this->assertStringContainsString('Donation refunded in Stripe', $notes[count($notes) - 1]->content);
     }
 
     /**
@@ -146,6 +148,8 @@ class StripePaymentElementGatewayTest extends TestCase
             ->method('refundStripePayment')
             ->willThrowException(new Exception('Stripe API error'));
 
+        $noteCountBeforeRefund = Donation::find($donation->id)->notes()->count();
+
         try {
             $mockGateway->refundDonation($donation);
         } catch (PaymentGatewayException $e) {
@@ -155,8 +159,8 @@ class StripePaymentElementGatewayTest extends TestCase
         $donation = Donation::find($donation->id);
         $notes = $donation->notes()->getAll();
 
-        $this->assertCount(1, $notes);
-        $this->assertStringContainsString('NOT refunded', $notes[0]->content);
+        $this->assertCount($noteCountBeforeRefund + 1, $notes);
+        $this->assertStringContainsString('NOT refunded', $notes[count($notes) - 1]->content);
     }
 
     /**

--- a/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
@@ -127,7 +127,7 @@ class StripePaymentElementGatewayTest extends TestCase
         $notes = $donation->notes()->getAll();
 
         $this->assertCount($noteCountBeforeRefund + 1, $notes);
-        $this->assertStringContainsString('Donation refunded in Stripe', $notes[count($notes) - 1]->content);
+        $this->assertStringContainsString('Donation refunded in Stripe', $notes[0]->content);
     }
 
     /**
@@ -160,7 +160,7 @@ class StripePaymentElementGatewayTest extends TestCase
         $notes = $donation->notes()->getAll();
 
         $this->assertCount($noteCountBeforeRefund + 1, $notes);
-        $this->assertStringContainsString('NOT refunded', $notes[count($notes) - 1]->content);
+        $this->assertStringContainsString('NOT refunded', $notes[0]->content);
     }
 
     /**

--- a/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
+++ b/tests/Unit/PaymentGateways/Stripe/StripePaymentElementGateway/StripePaymentElementGatewayTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Give\Tests\Unit\PaymentGateways\Stripe\StripePaymentElementGateway;
+
+use Exception;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\PaymentGateways\Commands\PaymentRefunded;
+use Give\Framework\PaymentGateways\Exceptions\PaymentGatewayException;
+use Give\PaymentGateways\Gateways\Stripe\StripePaymentElementGateway\StripePaymentElementGateway;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use Stripe\Refund;
+
+class StripePaymentElementGatewayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldCallSetUpStripeAppInfo()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => StripePaymentElementGateway::id(),
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        $mockRefund = Refund::constructFrom(['status' => 'succeeded']);
+
+        $mockGateway = $this->getMockGateway();
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('setUpStripeAppInfo')
+            ->with($donation->formId);
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('refundStripePayment')
+            ->willReturn($mockRefund);
+
+        $result = $mockGateway->refundDonation($donation);
+
+        $this->assertInstanceOf(PaymentRefunded::class, $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldCallRefundStripePayment()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => StripePaymentElementGateway::id(),
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        $mockRefund = Refund::constructFrom(['status' => 'succeeded']);
+
+        $mockGateway = $this->getMockGateway();
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('refundStripePayment')
+            ->with($donation, $this->anything())
+            ->willReturn($mockRefund);
+
+        $result = $mockGateway->refundDonation($donation);
+
+        $this->assertInstanceOf(PaymentRefunded::class, $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldThrowExceptionWhenStripeApiFails()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => StripePaymentElementGateway::id(),
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        $mockGateway = $this->getMockGateway();
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('refundStripePayment')
+            ->willThrowException(new Exception('Stripe API error'));
+
+        $this->expectException(PaymentGatewayException::class);
+        $this->expectExceptionMessage('Stripe API error: Stripe API error');
+
+        $mockGateway->refundDonation($donation);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldCreateDonationNoteOnSuccess()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => StripePaymentElementGateway::id(),
+            'status' => DonationStatus::COMPLETE(),
+            'gatewayTransactionId' => 'stripe-test-transaction-id',
+        ]);
+
+        $mockRefund = Refund::constructFrom(['status' => 'succeeded']);
+
+        $mockGateway = $this->getMockGateway();
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('refundStripePayment')
+            ->willReturn($mockRefund);
+
+        $mockGateway->refundDonation($donation);
+
+        $donation = Donation::find($donation->id);
+        $notes = $donation->notes()->getAll();
+
+        $this->assertCount(1, $notes);
+        $this->assertStringContainsString('Donation refunded in Stripe', $notes[0]->content);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRefundDonationShouldCreateDonationNoteOnFailure()
+    {
+        /** @var Donation $donation */
+        $donation = Donation::factory()->create([
+            'gatewayId' => StripePaymentElementGateway::id(),
+            'status' => DonationStatus::COMPLETE(),
+        ]);
+
+        $mockGateway = $this->getMockGateway();
+
+        /** @var MockObject $mockGateway */
+        $mockGateway->expects($this->once())
+            ->method('refundStripePayment')
+            ->willThrowException(new Exception('Stripe API error'));
+
+        try {
+            $mockGateway->refundDonation($donation);
+        } catch (PaymentGatewayException $e) {
+            // Expected exception
+        }
+
+        $donation = Donation::find($donation->id);
+        $notes = $donation->notes()->getAll();
+
+        $this->assertCount(1, $notes);
+        $this->assertStringContainsString('NOT refunded', $notes[0]->content);
+    }
+
+    /**
+     * @since TBD
+     */
+    protected function getMockGateway(array $methods = []): MockObject
+    {
+        return $this->createMockWithCallback(
+            StripePaymentElementGateway::class,
+            function (MockBuilder $mockBuilder) use ($methods) {
+                $mockBuilder->setMethods(
+                    array_merge(['refundStripePayment', 'setUpStripeAppInfo'], $methods)
+                );
+
+                return $mockBuilder->getMock();
+            }
+        );
+    }
+}


### PR DESCRIPTION
Resolves [SMTNC-1687](https://linear.app/nexcess/issue/SMTNC-1687/cannot-refund-donation-when-using-per-form-stripe-account)

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

**It searches the payment_intent with the default account, and when we don't use the default account, but a different, it does not pass the account_id.
The solutions is to provide the account_id in the refund flow**

- When testing, I needed to expose more info about the error in [DonationController::refund_item](https://github.com/impress-org/givewp/blob/77fd85d9e65584460af5539a2d246459d981f709/src/API/REST/V3/Routes/Donations/DonationController.php#L417), which gave me this info that helped me find the solution:
```json
{
    "message": "Failed to refund donation",
    "error": "Stripe API error: No such payment_intent: 'pi_***************'",
    "code": 0
}
```
- Used `setUpStripeAppInfo` in `StripePaymentElementGateway::refundDonation` like in other flows to setup the necessary info.
- `DonationController::refund_item` now uses `DonationViewModel` like other classes do, for consistent response shape

- I tested the webhook flow too. For example if I refunded directly from Stripe webhook responded and it worked on Give side.
## Affects

**Refunds behavior**
 
## Visuals

Reproducing the error:
https://www.loom.com/share/c9a71091b56640159de05ad41483ff37

## Testing Instructions

1. In GiveWP Payment settings, connect two different Stripe accounts.
1. In a donation form, select the Stripe account that's not the general default.
1. Make a donation.
1. Try to refund a donation

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design) - **No visual changes**
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed
