### PR TITLE
fix: make react-dates DateRangePicker strings translatable

### DIFF
--- a/assets/src/js/admin/reports/components/period-selector/index.js
+++ b/assets/src/js/admin/reports/components/period-selector/index.js
@@ -1,6 +1,7 @@
 // Vendor dependencies
 import { useState } from 'react';
 import moment from 'moment';
+import { getSettings } from '@wordpress/date';
 
 // react-dates dependencies
 import 'react-dates/initialize';
@@ -11,8 +12,11 @@ import 'react-dates/lib/css/_datepicker.css';
 import { useStoreValue } from '../../store';
 import { setDates, setRange } from '../../store/actions';
 
+import { phpToMomentDateFormat } from '@givewp/src/Admin/common/phpToMomentDateFormat';
 import './style.scss';
 import { __ } from '@wordpress/i18n';
+
+const getDisplayFormat = () => phpToMomentDateFormat( getSettings().formats.date );
 
 const PeriodSelector = () => {
 	// Get 'period' object from the store
@@ -51,6 +55,10 @@ const PeriodSelector = () => {
 					} }
 					isOutsideRange={ day => ( moment().diff( day ) < 0 ) }
 					numberOfMonths={ 1 }
+					startDatePlaceholderText={ __( 'Start Date', 'give' ) }
+					endDatePlaceholderText={ __( 'End Date', 'give' ) }
+					weekDayFormat="ddd"
+					displayFormat={ getDisplayFormat }
 					initialVisibleMonth={
 						() => {
 							if ( focusedInput === 'endDate' ) {

--- a/changelog/fix-7633-translatable-react-dates-strings.yaml
+++ b/changelog/fix-7633-translatable-react-dates-strings.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Made the date range picker placeholders, weekday headers, and selected date format translatable and locale-aware on the Reports and Logs admin pages.
+timestamp: 2026-07-19T00:00:00.000Z

--- a/src/Admin/common/phpToMomentDateFormat.ts
+++ b/src/Admin/common/phpToMomentDateFormat.ts
@@ -1,0 +1,86 @@
+/**
+ * Convert a WordPress (PHP) date format string into a moment.js format string.
+ *
+ * WordPress stores the site date format (`get_option('date_format')`) as a PHP
+ * format string, but react-dates formats the selected date with moment.js. This
+ * maps the common PHP date tokens to their moment equivalents so a picker can
+ * render the date in the site's configured format and locale.
+ *
+ * Tokens not in the map are wrapped as moment bracket literals (`[x]`), which
+ * moment renders verbatim, matching how PHP treats unknown format characters as
+ * literals. Explicitly escaped characters (`\x`) are also emitted as literals so
+ * their text cannot collide with a moment token.
+ *
+ * @since @unreleased
+ */
+export function phpToMomentDateFormat(format: string): string {
+    const tokens: Record<string, string> = {
+        // Day.
+        d: 'DD',
+        D: 'ddd',
+        j: 'D',
+        l: 'dddd',
+        N: 'E',
+        w: 'd',
+        z: 'DDDD',
+        // Week.
+        W: 'WW',
+        // Month.
+        F: 'MMMM',
+        m: 'MM',
+        M: 'MMM',
+        n: 'M',
+        t: '',
+        L: '',
+        // Year.
+        o: 'GGGG',
+        Y: 'YYYY',
+        y: 'YY',
+        // Time.
+        a: 'a',
+        A: 'A',
+        g: 'h',
+        G: 'H',
+        h: 'hh',
+        H: 'HH',
+        i: 'mm',
+        s: 'ss',
+        u: 'SSSSSS',
+        // Timezone.
+        e: 'z',
+        T: 'z',
+        Z: 'ZZ',
+        // Full date/time (best-effort).
+        c: 'YYYY-MM-DDTHH:mm:ssZ',
+        r: 'ddd, DD MMM YYYY HH:mm:ss ZZ',
+        U: 'X',
+    };
+
+    let result = '';
+    for (let i = 0; i < format.length; i++) {
+        const char = format[i];
+        if (char === '\\') {
+            // Escaped literal: render the next character verbatim in moment brackets
+            // so its text cannot be read as a moment token.
+            result += `[${format[i + 1] || ''}]`;
+            i++;
+            continue;
+        }
+        // PHP pairs the day-of-month token `j` with the ordinal suffix `S`, e.g. "jS".
+        // Moment has a single `Do` token for both, so collapse the pair to avoid two
+        // day-of-month tokens rendering as "19th19".
+        if (char === 'j' && format[i + 1] === 'S') {
+            result += 'Do';
+            i++;
+            continue;
+        }
+        if (tokens[char] !== undefined) {
+            result += tokens[char];
+            continue;
+        }
+        // Unknown character: emit verbatim, wrapped so moment treats it as a literal.
+        result += `[${char}]`;
+    }
+
+    return result;
+}

--- a/src/Views/Components/PeriodSelector/index.js
+++ b/src/Views/Components/PeriodSelector/index.js
@@ -2,12 +2,17 @@
 import {useState} from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import {__} from '@wordpress/i18n';
+import {getSettings} from '@wordpress/date';
 // react-dates dependencies
 import 'react-dates/initialize';
 import {DateRangePicker} from 'react-dates';
 import 'react-dates/lib/css/_datepicker.css';
 
+import {phpToMomentDateFormat} from '@givewp/src/Admin/common/phpToMomentDateFormat';
 import styles from './style.module.scss';
+
+const getDisplayFormat = () => phpToMomentDateFormat(getSettings().formats.date);
 
 const PeriodSelector = ({period = {startDate: null, endDate: null}, setDates = () => {}}) => {
     const [focusedInput, setFocusedInput] = useState(null);
@@ -46,6 +51,10 @@ const PeriodSelector = ({period = {startDate: null, endDate: null}, setDates = (
                     }}
                     isOutsideRange={(day) => moment().diff(day) < 0}
                     numberOfMonths={1}
+                    startDatePlaceholderText={__('Start Date', 'give')}
+                    endDatePlaceholderText={__('End Date', 'give')}
+                    weekDayFormat="ddd"
+                    displayFormat={getDisplayFormat}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Summary

The date range picker (`react-dates` `DateRangePicker`) on the Reports and Logs admin pages rendered English-only strings regardless of site language:

- the "Start Date" / "End Date" placeholders
- the calendar month and weekday abbreviations
- the selected date, always shown as MM/DD/YYYY

Reported on `it_IT`: the picker showed English placeholders, English month/weekday names, and the US date format.

Fixes #7633

## Changes

### `assets/src/js/admin/reports/components/period-selector/index.js` (Reports app)
**Before:**
```js
<DateRangePicker
    noBorder={ true }
    startDate={ period.startDate }
    startDateId="givewp-reports-start"
    endDate={ period.endDate }
    hideKeyboardShortcutsPanel={ true }
    endDateId="givewp-reports-end"
    ...
    isOutsideRange={ day => ( moment().diff( day ) < 0 ) }
    numberOfMonths={ 1 }
/>
```
**After:**
```js
<DateRangePicker
    ...
    isOutsideRange={ day => ( moment().diff( day ) < 0 ) }
    numberOfMonths={ 1 }
    startDatePlaceholderText={ __( 'Start Date', 'give' ) }
    endDatePlaceholderText={ __( 'End Date', 'give' ) }
    weekDayFormat="ddd"
    displayFormat={ getDisplayFormat }
    ...
/>
```
**Why:** pass the placeholder strings through `__()` so they follow the `give` text domain; use `weekDayFormat="ddd"` (moment `weekdaysShort`) so the weekday headers localize instead of the built-in English min-abbreviations; derive the selected date format from the site date format. Importing `@wordpress/date` (via `getSettings`) adds the `wp-date` dependency to the `admin-reports` bundle, which makes WordPress core enqueue its inline `moment` locale script on the Reports page so month and weekday names localize too.

### `src/Views/Components/PeriodSelector/index.js` (Logs app)
Same three props added (`startDatePlaceholderText` / `endDatePlaceholderText` via `__()`, `weekDayFormat="ddd"`, `displayFormat={ getDisplayFormat }`), plus the `@wordpress/date` import to make the `wp-date` dependency explicit. The Logs bundle already pulled `wp-date` in transitively.

### `src/Admin/common/phpToMomentDateFormat.ts` (new)
**Why:** WordPress stores the site date format as a PHP string (`get_option('date_format')`, e.g. `F j, Y`), but react-dates formats the selected date with moment.js. This maps PHP date tokens to their moment equivalents (`F` -> `MMMM`, `j` -> `D`, `Y` -> `YYYY`, `jS` -> `Do`, escaped literals `\x` -> moment bracket literals `[x]`, etc.) so the selected date respects both the locale and the configured day/month/year order.

## Testing

**Test 1: Reports and Logs pickers localize on a non-English site**

1. Set site language to a non-English locale (e.g. Italian) at Settings > General > Site Language, and a non-US date format (e.g. `j F Y`).
2. Go to Donations > Reports and open the date range picker.
3. Confirm the placeholders are translated (when a `give` translation is present), the month name is localized (e.g. "luglio"), the weekday row is localized (e.g. "lun mar mer ..."), and selecting a date shows it in the configured format (e.g. "19 luglio 2026").
4. Repeat at Donations > Tools > Logs.

Result: the picker is fully localized on both pages.

**Test 2: English sanity check**

1. Switch the site language back to English (United States) and the date format to the default (`F j, Y`).
2. Open the picker on Reports and Logs.

Result: English placeholders, English month/weekday, and a selected date like "July 19, 2026". No PHP or JS console errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786993878&installation_id=145883177&pr_number=8267&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8267&signature=e4e1b68b144edbbf9b78ba50e81ed344b1a9996b926a6af074cff7157693f17c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->