### PR TITLE
Fix: enforce @wordpress/element import standard (#6988)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+# Mirrors the @wordpress/scripts default ignore set plus generated assets.
+# @unreleased
+build
+node_modules
+vendor
+assets/build
+dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,35 @@
+/**
+ * ESLint configuration for GiveWP.
+ *
+ * The project does not ship a full @wordpress/eslint-plugin recommended preset;
+ * those plugins resolve only under @wordpress/scripts' nested node_modules and
+ * cannot be referenced from a root config without hoisting the whole tree.
+ * This config intentionally scopes ESLint to the single coding standard that
+ * needs enforcing today: React runtime APIs must be imported from
+ * "@wordpress/element", not "react". Type-only imports remain allowed for the
+ * React types @wordpress/element does not re-export (ReactNode, FC, ...).
+ *
+ * @unreleased
+ * @see https://github.com/impress-org/givewp/issues/6988
+ */
+module.exports = {
+	root: true,
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaVersion: 'latest',
+		sourceType: 'module',
+		ecmaFeatures: { jsx: true },
+	},
+	plugins: [ '@typescript-eslint' ],
+	rules: {
+		'@typescript-eslint/no-restricted-imports': [ 'error', {
+			paths: [
+				{
+					name: 'react',
+					message: 'Import React runtime APIs (hooks, components) from "@wordpress/element" instead. Type-only imports (import type {...} from \'react\') are allowed for types @wordpress/element does not re-export, such as ReactNode, FC, CSSProperties, and ChangeEvent.',
+					allowTypeImports: true,
+				},
+			],
+		} ],
+	},
+};

--- a/assets/src/js/admin/onboarding-wizard/app/store/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/store/index.js
@@ -1,5 +1,5 @@
 // Import vendor dependencies
-import { createContext, useContext, useReducer } from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
 
 /**
  * Using existing React Hooks as a lightweight solution for Redux-like state management.

--- a/assets/src/js/admin/onboarding-wizard/components/card-input/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/card-input/index.js
@@ -1,5 +1,5 @@
+import { Children } from '@wordpress/element';
 // Import vendor dependencies
-import React from 'react';
 import PropTypes from 'prop-types';
 
 // Import styles
@@ -51,7 +51,7 @@ CardInput.propTypes = {
         const prop = props[propName];
 
         let error = null;
-        React.Children.forEach(prop, function (child) {
+        Children.forEach(prop, function (child) {
             if (child.type !== Card && typeof child.props.value === undefined) {
                 error = new Error('`' + componentName + '` children should be of type `Card` with a `value` prop.');
             }

--- a/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/donation-form/index.js
@@ -1,5 +1,5 @@
 // Import vendor dependencies
-import {useEffect, useRef, useState} from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import IframeResizer from 'iframe-resizer-react';
 

--- a/assets/src/js/admin/onboarding-wizard/components/step-navigation/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/step-navigation/index.js
@@ -1,5 +1,5 @@
+import { Children } from '@wordpress/element';
 // Import vendor dependencies
-import React from 'react';
 import PropTypes from 'prop-types';
 
 // Import components
@@ -28,7 +28,7 @@ StepNavigation.propTypes = {
         const prop = props[propName];
 
         let error = null;
-        React.Children.forEach(prop, function (child) {
+        Children.forEach(prop, function (child) {
             if (child.type !== Step) {
                 error = new Error('`' + componentName + '` children should be of type `Step`.');
             }

--- a/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/wizard/index.js
@@ -1,5 +1,5 @@
+import { Children, useRef, useEffect } from '@wordpress/element';
 // Import vendor dependencies
-import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 // Import store dependencies
@@ -53,7 +53,7 @@ Wizard.propTypes = {
 		const prop = props[ propName ];
 
 		let error = null;
-		React.Children.forEach( prop, function( child ) {
+		Children.forEach( prop, function( child ) {
 			if ( child.type !== Step ) {
 				error = new Error( '`' + componentName + '` children should be of type `Step`.' );
 			}

--- a/assets/src/js/admin/onboarding-wizard/index.js
+++ b/assets/src/js/admin/onboarding-wizard/index.js
@@ -3,7 +3,6 @@
 // Entry point for Onboarind Wizard app
 
 // Vendor dependencies
-import React from 'react';
 import {createRoot} from 'react-dom/client';
 
 // Onboarding Wizard app

--- a/assets/src/js/admin/reports/app.js
+++ b/assets/src/js/admin/reports/app.js
@@ -2,7 +2,6 @@
 
 // Vendor dependencies
 import { HashRouter as Router } from 'react-router-dom';
-import React from 'react';
 import {createRoot} from 'react-dom/client';
 
 // Reports app

--- a/assets/src/js/admin/reports/app/pages/overview-page/index.js
+++ b/assets/src/js/admin/reports/app/pages/overview-page/index.js
@@ -4,7 +4,7 @@
 
 // Vendor dependencies
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 
 // Store-related dependencies
 import { useStoreValue } from '../../../store';

--- a/assets/src/js/admin/reports/components/ProductRecommendation/index.tsx
+++ b/assets/src/js/admin/reports/components/ProductRecommendation/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {createInterpolateElement} from '@wordpress/element';
 import {getWindowData} from '../../utils';

--- a/assets/src/js/admin/reports/components/chart/index.js
+++ b/assets/src/js/admin/reports/components/chart/index.js
@@ -1,6 +1,6 @@
 // Dependencies
 import ChartJS from 'chart.js';
-import { useEffect, useState, createRef, Fragment } from 'react';
+import { useEffect, useState, createRef, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import './style.scss';
 

--- a/assets/src/js/admin/reports/components/legend/index.js
+++ b/assets/src/js/admin/reports/components/legend/index.js
@@ -1,6 +1,6 @@
 // Dependencies
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 // Utilities
 import { getColor } from './utils';

--- a/assets/src/js/admin/reports/components/list/index.js
+++ b/assets/src/js/admin/reports/components/list/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useEffect, createRef, Fragment } from 'react';
+import { useEffect, createRef, Fragment } from '@wordpress/element';
 import './style.scss';
 
 const List = ( { title, onScrollEnd, children } ) => {

--- a/assets/src/js/admin/reports/components/mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/mini-chart/index.js
@@ -1,4 +1,4 @@
-import { createRef, useEffect, useLayoutEffect, useState, Fragment } from 'react';
+import { createRef, useEffect, useLayoutEffect, useState, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 //Import ChartJS dependencies

--- a/assets/src/js/admin/reports/components/no-data-notice/index.js
+++ b/assets/src/js/admin/reports/components/no-data-notice/index.js
@@ -1,5 +1,5 @@
 // Dependencies
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {getWindowData} from '../../utils';
 

--- a/assets/src/js/admin/reports/components/period-selector/index.js
+++ b/assets/src/js/admin/reports/components/period-selector/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import moment from 'moment';
 
 // react-dates dependencies

--- a/assets/src/js/admin/reports/components/rest-chart/index.js
+++ b/assets/src/js/admin/reports/components/rest-chart/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 // Store-related dependencies

--- a/assets/src/js/admin/reports/components/rest-list/index.js
+++ b/assets/src/js/admin/reports/components/rest-list/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n'
 

--- a/assets/src/js/admin/reports/components/rest-mini-chart/index.js
+++ b/assets/src/js/admin/reports/components/rest-mini-chart/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 // Components

--- a/assets/src/js/admin/reports/components/rest-table/index.js
+++ b/assets/src/js/admin/reports/components/rest-table/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 // Components

--- a/assets/src/js/admin/reports/components/settings-toggle/index.js
+++ b/assets/src/js/admin/reports/components/settings-toggle/index.js
@@ -4,7 +4,7 @@ import Toggle from '../toggle';
 import { toggleSettingsPanel, setCurrency, toggleTestMode } from '../../store/actions';
 import { useStoreValue } from '../../store';
 import './style.scss';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Utils

--- a/assets/src/js/admin/reports/components/table/index.js
+++ b/assets/src/js/admin/reports/components/table/index.js
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import ExportCSV from '../export-csv';
 
 import './style.scss';

--- a/assets/src/js/admin/reports/store/index.js
+++ b/assets/src/js/admin/reports/store/index.js
@@ -1,4 +1,4 @@
-import {createContext, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
 
 export const StoreContext = createContext();
 

--- a/assets/src/js/admin/reports/utils/index.js
+++ b/assets/src/js/admin/reports/utils/index.js
@@ -1,5 +1,5 @@
 import { useStoreValue } from '../store';
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import axios from 'axios';
 import { setGiveStatus, setPageLoaded } from '../store/actions';
 import { getSampleData } from './sample';

--- a/changelog/fix-6988-enforce-element-imports.yaml
+++ b/changelog/fix-6988-enforce-element-imports.yaml
@@ -1,0 +1,4 @@
+significance: minor
+type: dev
+entry: Enforced the `@wordpress/element` import standard for React runtime APIs via ESLint. Added `.eslintrc.js`, `.eslintignore`, and `lint:js` / `lint:js:fix` npm scripts. Migrated 271 files to import hooks, components, and shared types from `@wordpress/element`, keeping `import type` for React types that `@wordpress/element` does not re-export.
+timestamp: 2026-07-19T00:00:00.000Z

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,8 @@
                 "@types/react-dom": "^18.0.11",
                 "@types/wordpress__blocks": "^12.5.0",
                 "@types/wordpress__components": "^23.0.1",
+                "@typescript-eslint/eslint-plugin": "^6.21.0",
+                "@typescript-eslint/parser": "^6.21.0",
                 "@wordpress/env": "^11.4.0",
                 "@wordpress/scripts": "^26.19.0",
                 "bats": "^1.13.0",
@@ -122,43 +124,6 @@
                 "webpack-cli": "^6.0.1",
                 "wp-pot": "^1.10.2",
                 "wp-textdomain": "^1.0.1"
-            }
-        },
-        "../../givewp-mcp-server": {
-            "name": "@impress-org/mcp-server",
-            "version": "1.0.0",
-            "extraneous": true,
-            "license": "ISC",
-            "devDependencies": {
-                "@eslint/js": "^9.33.0",
-                "@types/bun": "^1.2.20",
-                "@types/node": "^24.3.0",
-                "@vitest/coverage-istanbul": "^3.2.4",
-                "@vitest/ui": "^3.2.4",
-                "del-cli": "^6.0.0",
-                "eslint": "^9.33.0",
-                "open-cli": "^8.0.0",
-                "prettier-plugin-organize-imports": "^4.2.0",
-                "typescript": "^5.9.2",
-                "typescript-eslint": "^8.39.1",
-                "vitest": "^3.2.4"
-            },
-            "workspaces": {
-                "packages": [
-                    "packages/*"
-                ],
-                "catalog": {
-                    "@modelcontextprotocol/sdk": "^1.17.2",
-                    "@wordpress/api-fetch": "^7.28.0",
-                    "@wordpress/url": "^4.28.0"
-                },
-                "catalogs": {
-                    "testing": {
-                        "@vitest/coverage-istanbul": "^3.2.4",
-                        "@vitest/ui": "^3.2.4",
-                        "vitest": "^3.2.4"
-                    }
-                }
             }
         },
         "../../givewp-mcp-server/packages/test-server": {
@@ -9997,6 +9962,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
             "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
                 "@typescript-eslint/scope-manager": "6.21.0",
@@ -10044,6 +10010,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
         "watch": "wp-scripts start",
         "env": "wp-env",
         "env:start": "wp-env start --auto-port",
+        "lint:js": "wp-scripts lint-js",
+        "lint:js:fix": "wp-scripts lint-js --fix",
         "packages-update": "wp-scripts packages-update",
         "plugin-zip": "wp-scripts plugin-zip"
     },
@@ -64,6 +66,8 @@
         "@types/react-dom": "^18.0.11",
         "@types/wordpress__blocks": "^12.5.0",
         "@types/wordpress__components": "^23.0.1",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
         "@wordpress/env": "^11.4.0",
         "@wordpress/scripts": "^26.19.0",
         "bats": "^1.13.0",

--- a/src/Admin/components/Charts/TimeSeriesChart.tsx
+++ b/src/Admin/components/Charts/TimeSeriesChart.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import Chart from 'react-apexcharts';
 import {ApexOptions} from 'apexcharts';
 import apiFetch from '@wordpress/api-fetch';

--- a/src/Admin/components/Header/index.tsx
+++ b/src/Admin/components/Header/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import styles from './styles.module.scss';
 
 /**
  * @since 4.4.0
  */
 type HeaderProps = {
-    children?: React.ReactNode;
+    children?: ReactNode;
     title: string;
     subtitle?: string;
     href?: string;
@@ -40,13 +40,13 @@ export default function Header({title, subtitle, href, actionText, actionOnClick
 /**
  * @since 4.4.0
  */
-export function HeaderText({children}: {children: React.ReactNode}) {
+export function HeaderText({children}: {children: ReactNode}) {
     return <h2 className={styles.headerText}>{children}</h2>;
 }
 
 /**
  * @since 4.4.0
  */
-export function SubHeaderText({children}: {children: React.ReactNode}) {
+export function SubHeaderText({children}: {children: ReactNode}) {
     return <p className={styles.subHeaderText}>{children}</p>;
 }

--- a/src/Admin/components/OverviewPanel/index.tsx
+++ b/src/Admin/components/OverviewPanel/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import styles from './styles.module.scss';
 
 /**
  * @since 4.5.0
  */
 interface OverviewPanelProps {
-    children: React.ReactNode;
+    children: ReactNode;
     className?: string;
 }
 

--- a/src/Admin/components/PrivateNotes/index.tsx
+++ b/src/Admin/components/PrivateNotes/index.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import cx from 'classnames';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import useSWR from 'swr';
 import Spinner from '../Spinner';
 import { ConfirmationDialogIcon, DeleteIcon, DotsMenuIcon, EditIcon, NotesIcon } from './Icons';

--- a/src/Admin/components/SummaryTable/index.tsx
+++ b/src/Admin/components/SummaryTable/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import classnames from 'classnames';
 import Spinner from '@givewp/src/Admin/components/Spinner';
 import styles from './styles.module.scss';
@@ -9,7 +9,7 @@ import styles from './styles.module.scss';
  */
 export type SummaryItem = {
   label: string;
-  value: string | React.ReactNode;
+  value: string | ReactNode;
   isPill?: boolean;
 };
 

--- a/src/Admin/fields/CampaignFormGroup/index.tsx
+++ b/src/Admin/fields/CampaignFormGroup/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 import { FieldError, useFormContext, useFormState } from 'react-hook-form';
 
 /**

--- a/src/Admin/fields/CampaignFormGroup/useFormAsyncSelectOptions.ts
+++ b/src/Admin/fields/CampaignFormGroup/useFormAsyncSelectOptions.ts
@@ -1,6 +1,6 @@
 import { useAsyncSelectOptions } from "@givewp/admin/hooks/useAsyncSelectOption";
 import apiFetch from "@wordpress/api-fetch";
-import { useEffect, useState } from "react";
+import { useEffect, useState } from '@wordpress/element';
 
 export default function useFormAsyncSelectOptions(formId: number, campaignId: number, queryParams?: {}) {
     const [selectedForm, setSelectedForm] = useState<any>(null);

--- a/src/Admin/hooks/useAsyncSelectOption.ts
+++ b/src/Admin/hooks/useAsyncSelectOption.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {UseAsyncSelectOptionReturn} from '@givewp/admin/types';
 

--- a/src/Admin/providers/EmotionStylesProvider/index.tsx
+++ b/src/Admin/providers/EmotionStylesProvider/index.tsx
@@ -1,4 +1,5 @@
-import {useMemo, useRef, useState, useEffect, ReactNode} from 'react';
+import { useMemo, useRef, useState, useEffect } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import {CacheProvider} from '@emotion/react';
 import createCache from '@emotion/cache';
 

--- a/src/Campaigns/Blocks/Campaign/edit.tsx
+++ b/src/Campaigns/Blocks/Campaign/edit.tsx
@@ -1,5 +1,6 @@
 import {__} from '@wordpress/i18n';
-import React, {CSSProperties, useState} from 'react';
+import { useState } from '@wordpress/element';
+import type { CSSProperties } from 'react';
 import {InspectorControls, useBlockProps} from '@wordpress/block-editor';
 import {BlockEditProps} from '@wordpress/blocks';
 import {PanelBody, ToggleControl} from '@wordpress/components';

--- a/src/Campaigns/Blocks/CampaignComments/resources/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignComments/resources/edit.tsx
@@ -5,7 +5,7 @@ import {__} from '@wordpress/i18n';
 import CampaignComments from './shared/components/CampaignComments';
 import useCampaign from '../../shared/hooks/useCampaign';
 import CampaignSelector from '../../shared/components/CampaignSelector';
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import {Attributes} from './types';
 
 export default function Edit({attributes, setAttributes, clientId}: BlockEditProps<Attributes>) {

--- a/src/Campaigns/Blocks/CampaignComments/resources/shared/components/CommentCard/index.tsx
+++ b/src/Campaigns/Blocks/CampaignComments/resources/shared/components/CommentCard/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {Attributes, CommentData} from '../../../types';
 import './styles.scss';

--- a/src/Campaigns/Blocks/CampaignComments/resources/shared/components/EmptyState/index.tsx
+++ b/src/Campaigns/Blocks/CampaignComments/resources/shared/components/EmptyState/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {__} from '@wordpress/i18n';
 import './styles.scss';
 

--- a/src/Campaigns/Blocks/CampaignForm/resources/edit.tsx
+++ b/src/Campaigns/Blocks/CampaignForm/resources/edit.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import {useBlockProps} from '@wordpress/block-editor';
 import {BlockEditProps} from '@wordpress/blocks';
 import {__} from '@wordpress/i18n';

--- a/src/Campaigns/Blocks/CampaignGrid/types.ts
+++ b/src/Campaigns/Blocks/CampaignGrid/types.ts
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import type { MouseEventHandler } from 'react';
 
 export interface TokenItem {
     /**

--- a/src/Campaigns/Blocks/shared/components/CampaignSelector/Selector.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignSelector/Selector.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {Campaign} from '@givewp/campaigns/admin/components/types';
 import ReactSelect from 'react-select';

--- a/src/Campaigns/Blocks/shared/components/CampaignSelector/index.tsx
+++ b/src/Campaigns/Blocks/shared/components/CampaignSelector/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import Inspector from './Inspector';
 import useCampaigns from '../../hooks/useCampaigns';
 import Selector from './Selector';

--- a/src/Campaigns/Blocks/shared/components/EntitySelector/EntitySelector.tsx
+++ b/src/Campaigns/Blocks/shared/components/EntitySelector/EntitySelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ReactSelect from 'react-select';
 import logo from './givewp-logo.svg';

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/CampaignStats/index.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import RevenueChart from '../RevenueChart';
 import GoalProgressChart from '../GoalProgressChart';
 import apiFetch from '@wordpress/api-fetch';

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/ColorControl/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import {useCallback, useState} from 'react';
+import { useCallback, useState } from '@wordpress/element';
 import {Controller, useFormContext} from 'react-hook-form';
 
 /**

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/GoalProgressChart/index.tsx
@@ -1,6 +1,5 @@
 import {__} from '@wordpress/i18n';
 import Chart from 'react-apexcharts';
-import React from 'react';
 
 import styles from './styles.module.scss';
 import {amountFormatter, getCampaignOptionsWindowData} from '@givewp/campaigns/utils';

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/RevenueChart.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import Chart from 'react-apexcharts';
 import apiFetch from '@wordpress/api-fetch';
 import {addQueryArgs} from '@wordpress/url';

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/Components/TextareaControl/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import {TextareaHTMLAttributes} from 'react';
+import type { TextareaHTMLAttributes } from 'react';
 import {Controller, useFormContext} from 'react-hook-form';
 
 /**

--- a/src/Campaigns/resources/admin/components/CampaignDetailsPage/types.ts
+++ b/src/Campaigns/resources/admin/components/CampaignDetailsPage/types.ts
@@ -1,4 +1,4 @@
-import {FC} from 'react';
+import type { FC } from 'react';
 
 export interface GiveCampaignDetails {
     adminUrl: string;

--- a/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignFormModal/index.tsx
@@ -4,7 +4,7 @@ import styles from './CampaignFormModal.module.scss';
 import FormModal from '../FormModal';
 import CampaignsApi from '../api';
 import {CampaignFormInputs, CampaignModalProps, GoalTypeOption as GoalTypeOptionType} from './types';
-import {useRef, useState} from 'react';
+import { useRef, useState } from '@wordpress/element';
 import {Currency, Upload} from '../Inputs';
 import {
     AmountFromSubscriptionsIcon,

--- a/src/Campaigns/resources/admin/components/CampaignsListTable/CampaignsRowActions.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignsListTable/CampaignsRowActions.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {useSWRConfig} from 'swr';
 import {__, sprintf} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';

--- a/src/Campaigns/resources/admin/components/CampaignsListTable/index.tsx
+++ b/src/Campaigns/resources/admin/components/CampaignsListTable/index.tsx
@@ -6,7 +6,7 @@ import {CampaignsRowActions} from './CampaignsRowActions';
 import styles from './CampaignsListTable.module.scss';
 import {GiveCampaignsListTable} from './types';
 import CreateCampaignModal from '../CreateCampaignModal';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import MergeCampaignModal from '../MergeCampaign/Modal';
 import ExistingUserIntroModal from '@givewp/campaigns/admin/components/ExistingUserIntroModal';
 import {getCampaignOptionsWindowData} from '@givewp/campaigns/utils';

--- a/src/Campaigns/resources/admin/components/ExistingUserIntroModal/index.tsx
+++ b/src/Campaigns/resources/admin/components/ExistingUserIntroModal/index.tsx
@@ -1,5 +1,5 @@
 import ModalDialog from '@givewp/components/AdminUI/ModalDialog';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {DismissIcon, StarIcon} from './icons';
 import {getGiveCampaignsListTableWindowData} from '@givewp/campaigns/admin/components/CampaignsListTable';
 import {__} from '@wordpress/i18n';

--- a/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
+++ b/src/Campaigns/resources/admin/components/Inputs/Upload/index.tsx
@@ -3,7 +3,6 @@
  * @link https://wordpress.stackexchange.com/a/382291
  */
 
-import React from 'react';
 import _ from 'lodash';
 import {__, sprintf} from '@wordpress/i18n';
 import classnames from 'classnames';

--- a/src/Campaigns/resources/admin/components/MergeCampaign/Form/index.tsx
+++ b/src/Campaigns/resources/admin/components/MergeCampaign/Form/index.tsx
@@ -3,7 +3,7 @@ import {__} from '@wordpress/i18n';
 import styles from './Form.module.scss';
 import FormModal from '../../FormModal';
 import {MergeCampaignFormInputs, MergeCampaignFormProps} from './types';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {addQueryArgs} from '@wordpress/url';
 import {getGiveCampaignsListTableWindowData} from '../../CampaignsListTable';

--- a/src/Campaigns/resources/hooks/index.tsx
+++ b/src/Campaigns/resources/hooks/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {getCampaignOptionsWindowData, handleTooltipDismiss} from '@givewp/campaigns/utils';
 
 type NoticeId = 'givewp_campaign_form_notice' | 'givewp_campaign_settings_notice' | 'givewp_campaign_listtable_notice';

--- a/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
+++ b/src/DonationForms/Blocks/DonationFormBlock/resources/editor/Edit.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {useBlockProps} from '@wordpress/block-editor';
 import {BlockEditProps} from '@wordpress/blocks';
 import ServerSideRender from '@wordpress/server-side-render';

--- a/src/DonationForms/OrphanedForms/resources/app.tsx
+++ b/src/DonationForms/OrphanedForms/resources/app.tsx
@@ -1,5 +1,5 @@
 import {__, _x} from '@wordpress/i18n';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import {Button, Card, Modal, Notice, Pagination as ListTablePagination, Spinner, Table} from '@givewp/components';
 import {useForms} from '../../resources/utils';

--- a/src/DonationForms/V2/resources/add-v2form.tsx
+++ b/src/DonationForms/V2/resources/add-v2form.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import './colors.scss';
 import AddForm from './components/Onboarding/Components/AddForm';

--- a/src/DonationForms/V2/resources/admin-donation-forms.tsx
+++ b/src/DonationForms/V2/resources/admin-donation-forms.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import DonationFormsListTable from './components/DonationFormsListTable';
 import './colors.scss';

--- a/src/DonationForms/V2/resources/components/AddCampaignFormModal/index.tsx
+++ b/src/DonationForms/V2/resources/components/AddCampaignFormModal/index.tsx
@@ -1,7 +1,7 @@
 import ModalDialog from '@givewp/components/AdminUI/ModalDialog';
 import styles from './AddCampaignFormModal.module.scss';
 import {__} from '@wordpress/i18n';
-import {useRef, useState} from 'react';
+import { useRef, useState } from '@wordpress/element';
 
 export type EditorTypeOptionProps = {
     editorType: string;

--- a/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsListTable.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {ListTableApi, ListTablePage} from '@givewp/components';
 import {DonationFormsRowActions} from './DonationFormsRowActions';

--- a/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
+++ b/src/DonationForms/V2/resources/components/DonationFormsRowActions.tsx
@@ -2,7 +2,7 @@ import {__, sprintf} from '@wordpress/i18n';
 import {useSWRConfig} from 'swr';
 import RowAction from '@givewp/components/ListTable/RowAction';
 import ListTableApi from '@givewp/components/ListTable/api';
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {Interweave} from 'interweave';
 import {UpgradeModalContent} from './Migration';

--- a/src/DonationForms/V2/resources/components/Onboarding/Components/AddForm.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Components/AddForm.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import FormBuilderButtonPortal from './FormBuilderButtonPortal';
 
 export default function AddForm() {

--- a/src/DonationForms/V2/resources/components/Onboarding/Components/Banner.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Components/Banner.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {ExitIcon, StarsIcon} from '@givewp/components/AdminUI/Icons';
 import {OnboardingContext} from '../index';

--- a/src/DonationForms/V2/resources/components/Onboarding/Components/EditForm.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Components/EditForm.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import FormBuilderButtonPortal from './FormBuilderButtonPortal';
 import Button from '@givewp/components/AdminUI/Button';

--- a/src/DonationForms/V2/resources/components/Onboarding/Components/FormBuilderButtonPortal.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/Components/FormBuilderButtonPortal.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import {createPortal} from 'react-dom';
 import {FeatureNoticeDialog} from '../Dialogs';
 import styles from '../style.module.scss';

--- a/src/DonationForms/V2/resources/components/Onboarding/index.tsx
+++ b/src/DonationForms/V2/resources/components/Onboarding/index.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext} from 'react';
+import { createContext, useContext } from '@wordpress/element';
 import {FeatureNoticeDialog} from './Dialogs';
 
 export const OnboardingContext = createContext([]);

--- a/src/DonationForms/V2/resources/edit-v2form.tsx
+++ b/src/DonationForms/V2/resources/edit-v2form.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import EditForm from './components/Onboarding/Components/EditForm';
 import './colors.scss';

--- a/src/DonationForms/resources/app/DonationFormApp.tsx
+++ b/src/DonationForms/resources/app/DonationFormApp.tsx
@@ -1,4 +1,4 @@
-import {createRoot} from '@wordpress/element';
+import {createRoot} from 'react-dom/client';
 import getDefaultValuesFromSections from './utilities/getDefaultValuesFromSections';
 import Form from './form/Form';
 import {DonationFormStateProvider} from './store';
@@ -13,7 +13,7 @@ import MultiStepForm from '@givewp/forms/app/form/MultiStepForm';
 import getDonationFormNodeSettings from '@givewp/forms/app/utilities/getDonationFormNodeSettings';
 import {DonationFormSettingsProvider} from '@givewp/forms/app/store/form-settings';
 import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPubSub';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import type {Form as DonationForm} from '@givewp/forms/types';
 
 const formTemplates = window.givewp.form.templates;

--- a/src/DonationForms/resources/app/form/Form.tsx
+++ b/src/DonationForms/resources/app/form/Form.tsx
@@ -5,7 +5,7 @@ import getWindowData from '../utilities/getWindowData';
 import {useDonationFormState} from '../store';
 import {Section} from '@givewp/forms/types';
 import {withTemplateWrapper} from '../templates';
-import {useCallback} from 'react';
+import { useCallback } from '@wordpress/element';
 import FormSection from './Section';
 
 import {ObjectSchema} from 'joi';

--- a/src/DonationForms/resources/app/form/Header.tsx
+++ b/src/DonationForms/resources/app/form/Header.tsx
@@ -2,7 +2,7 @@ import DonationFormErrorBoundary from '@givewp/forms/app/errors/boundaries/Donat
 import amountFormatter from '@givewp/forms/app/utilities/amountFormatter';
 import type { GoalType } from '@givewp/forms/propTypes';
 import type { Form as DonationForm } from '@givewp/forms/types';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from '@wordpress/element';
 import { withTemplateWrapper } from '../templates';
 
 const formTemplates = window.givewp.form.templates;

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/NextButton.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/NextButton.tsx
@@ -2,7 +2,7 @@ import {useDonationFormMultiStepState} from '@givewp/forms/app/form/MultiStepFor
 import useSetNextStep from '@givewp/forms/app/form/MultiStepForm/hooks/useSetNextStep';
 import {useFormContext} from 'react-hook-form';
 import {__} from '@wordpress/i18n';
-import {useMemo, useState} from 'react';
+import { useMemo, useState } from '@wordpress/element';
 import handleValidationRequest from '@givewp/forms/app/utilities/handleValidationRequest';
 import getWindowData from '@givewp/forms/app/utilities/getWindowData';
 import useGetGatewayById from '@givewp/forms/app/form/MultiStepForm/hooks/useGetGatewayById';

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/PreviousButton.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/PreviousButton.tsx
@@ -1,6 +1,6 @@
 import useSetPreviousStep from '@givewp/forms/app/form/MultiStepForm/hooks/useSetPreviousStep';
 import {useDonationFormMultiStepState} from '@givewp/forms/app/form/MultiStepForm/store';
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 
 /**
  * @since 3.0.0

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepForm.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepForm.tsx
@@ -1,6 +1,6 @@
 import {FormProvider, useForm, useFormState} from 'react-hook-form';
 import {joiResolver} from '@hookform/resolvers/joi';
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import DonationFormErrorBoundary from '@givewp/forms/app/errors/boundaries/DonationFormErrorBoundary';
 import handleSubmitRequest from '@givewp/forms/app/utilities/handleFormSubmitRequest';
 import {useDonationFormState} from '@givewp/forms/app/store';

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/Steps.tsx
@@ -3,7 +3,7 @@ import {useDonationFormMultiStepState} from "@givewp/forms/app/form/MultiStepFor
 import usePrevious from "@givewp/forms/app/form/MultiStepForm/hooks/usePreviousValue";
 import classNames from "classnames";
 import StepsWrapper from "@givewp/forms/app/form/MultiStepForm/components/StepsWrapper";
-import { useEffect } from "react";
+import { useEffect } from '@wordpress/element';
 
 /**
  * @since 3.0.0

--- a/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/components/StepsWrapper.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import PreviousButton from '@givewp/forms/app/form/MultiStepForm/components/PreviousButton';
 import {__, sprintf} from '@wordpress/i18n';
 import {useDonationFormMultiStepState} from '@givewp/forms/app/form/MultiStepForm/store';

--- a/src/DonationForms/resources/app/form/MultiStepForm/hooks/useGetGatewayById.ts
+++ b/src/DonationForms/resources/app/form/MultiStepForm/hooks/useGetGatewayById.ts
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import { useCallback } from '@wordpress/element';
 import {useDonationFormState} from '@givewp/forms/app/store';
 
 /**

--- a/src/DonationForms/resources/app/form/MultiStepForm/hooks/useSetNextStep.ts
+++ b/src/DonationForms/resources/app/form/MultiStepForm/hooks/useSetNextStep.ts
@@ -3,7 +3,7 @@ import {setNextStep} from '@givewp/forms/app/form/MultiStepForm/store/reducer';
 import {useDonationFormStateDispatch} from '@givewp/forms/app/store';
 import {setFormDefaultValues} from '@givewp/forms/app/store/reducer';
 import {FieldValues} from 'react-hook-form';
-import {useCallback} from 'react';
+import { useCallback } from '@wordpress/element';
 
 /**
  * @since 3.0.0

--- a/src/DonationForms/resources/app/form/MultiStepForm/hooks/useSetPreviousStep.ts
+++ b/src/DonationForms/resources/app/form/MultiStepForm/hooks/useSetPreviousStep.ts
@@ -1,6 +1,6 @@
 import {useDonationFormMultiStepStateDispatch} from '@givewp/forms/app/form/MultiStepForm/store';
 import {setCurrentStep} from '@givewp/forms/app/form/MultiStepForm/store/reducer';
-import {useCallback} from 'react';
+import { useCallback } from '@wordpress/element';
 
 /**
  * @since 3.0.0

--- a/src/DonationForms/resources/app/form/MultiStepForm/store/index.tsx
+++ b/src/DonationForms/resources/app/form/MultiStepForm/store/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactNode, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import reducer from './reducer';
 import {StepObject} from '@givewp/forms/app/form/MultiStepForm/types';
 

--- a/src/DonationForms/resources/app/hooks/useCurrencyFormatter.ts
+++ b/src/DonationForms/resources/app/hooks/useCurrencyFormatter.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
 import amountFormatter from '@givewp/forms/app/utilities/amountFormatter';
 
 /**

--- a/src/DonationForms/resources/app/hooks/useVisibilityCondition.ts
+++ b/src/DonationForms/resources/app/hooks/useVisibilityCondition.ts
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
 import {useFormContext} from 'react-hook-form';
 import {FieldCondition} from '@givewp/forms/types';
 import conditionOperatorFunctions from '@givewp/forms/app/utilities/conditionOperatorFunctions';

--- a/src/DonationForms/resources/app/store/donation-summary/index.tsx
+++ b/src/DonationForms/resources/app/store/donation-summary/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactElement, ReactNode, useContext} from 'react';
+import { createContext, useContext } from '@wordpress/element';
+import type { ReactElement, ReactNode } from 'react';
 import {useImmerReducer} from 'use-immer';
 import reducer from './reducer';
 

--- a/src/DonationForms/resources/app/store/form-settings/index.tsx
+++ b/src/DonationForms/resources/app/store/form-settings/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactNode, useContext} from 'react';
+import { createContext, useContext } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import {CurrencySwitcherSetting} from '@givewp/forms/types';
 
 const StoreContext = createContext(null);

--- a/src/DonationForms/resources/app/store/index.tsx
+++ b/src/DonationForms/resources/app/store/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactNode, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import type {Gateway} from '@givewp/forms/types';
 import reducer from '@givewp/forms/app/store/reducer';
 import {ObjectSchema} from 'joi';

--- a/src/DonationForms/resources/app/templates/index.tsx
+++ b/src/DonationForms/resources/app/templates/index.tsx
@@ -1,5 +1,5 @@
 import type {FC, ReactNode} from 'react';
-import {useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
 import {Element, Field, Group} from '@givewp/forms/types';
 
 /**

--- a/src/DonationForms/resources/app/utilities/useDonationFormPubSub.ts
+++ b/src/DonationForms/resources/app/utilities/useDonationFormPubSub.ts
@@ -1,4 +1,4 @@
-import {RefObject, useEffect} from 'react';
+import { RefObject, useEffect } from '@wordpress/element';
 import {iframeRef} from '@givewp/form-builder/components/canvas/DesignPreview';
 import {FormSettings} from '@givewp/form-builder/types';
 import {FormColors, FormGoal, RequireAtLeastOne} from '@givewp/forms/types';

--- a/src/DonationForms/resources/propTypes.ts
+++ b/src/DonationForms/resources/propTypes.ts
@@ -1,6 +1,6 @@
 import {Element, Field, Gateway, Group, ReceiptDetail, Section as SectionType, SelectOption} from '@givewp/forms/types';
 import {FieldErrors, UseFormRegisterReturn} from 'react-hook-form';
-import {FC, FormHTMLAttributes, ReactNode} from 'react';
+import type { FC, FormHTMLAttributes, ReactNode } from 'react';
 
 export interface FieldProps extends Field {
     inputProps: UseFormRegisterReturn;

--- a/src/DonationForms/resources/registrars/templates/elements/DonationSummary.tsx
+++ b/src/DonationForms/resources/registrars/templates/elements/DonationSummary.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {isSubscriptionPeriod, SubscriptionPeriod} from '../groups/DonationAmount/subscriptionPeriod';
 import {createInterpolateElement} from '@wordpress/element';

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/CurrencySwitcher.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/CurrencySwitcher.tsx
@@ -1,5 +1,6 @@
 import {CurrencySwitcherSetting} from '@givewp/forms/types';
-import {ChangeEvent, useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
+import type { ChangeEvent } from 'react';
 import amountFormatter from '@givewp/forms/app/utilities/amountFormatter';
 
 /**

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/CustomAmount.tsx
@@ -3,7 +3,7 @@ import {__} from '@wordpress/i18n';
 import CurrencyInput from 'react-currency-input-field';
 import {CurrencyInputOnChangeValues} from 'react-currency-input-field/dist/components/CurrencyInputProps';
 
-import {useEffect, useRef} from "react";
+import { useEffect, useRef } from '@wordpress/element';
 /**
  * @since 3.0.0
  */

--- a/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Amount/index.tsx
@@ -1,7 +1,7 @@
 import {useCallback} from '@wordpress/element';
 import type {AmountProps} from '@givewp/forms/propTypes';
 import CustomAmount from './CustomAmount';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {getAmountLevelsWithCurrencySettings, getDefaultAmountWithCurrencySettings} from './withCurrencySettings';
 import DonationAmountCurrency from './DonationAmountCurrency';
 import DonationAmountLevels from './DonationAmountLevels';

--- a/src/DonationForms/resources/registrars/templates/fields/Consent/createIframePortal.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Consent/createIframePortal.tsx
@@ -1,6 +1,6 @@
 import {createPortal} from 'react-dom';
 import {createRoot} from 'react-dom/client';
-import {useEffect, useRef} from 'react';
+import { useEffect, useRef } from '@wordpress/element';
 
 import './styles.scss';
 

--- a/src/DonationForms/resources/registrars/templates/fields/Date.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Date.tsx
@@ -4,7 +4,7 @@ import {format, parse} from 'date-fns';
 import {DateProps} from '@givewp/forms/propTypes';
 import 'react-datepicker/dist/react-datepicker.css';
 import styles from '../styles.module.scss';
-import {useEffect, useRef} from "react";
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * @since 4.3.2 manually focus the visible input when error is present.

--- a/src/DonationForms/resources/registrars/templates/fields/File.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/File.tsx
@@ -1,6 +1,6 @@
 import {FileProps} from '@givewp/forms/propTypes';
 import {__, sprintf} from '@wordpress/i18n';
-import {useEffect, useRef} from "react";
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * @since 4.3.2 manually focus the visible input when error is present.

--- a/src/DonationForms/resources/registrars/templates/fields/Honeypot.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Honeypot.tsx
@@ -1,5 +1,5 @@
 import {FieldHasDescriptionProps} from '@givewp/forms/propTypes';
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 
 /**

--- a/src/DonationForms/resources/registrars/templates/fields/Phone.tsx
+++ b/src/DonationForms/resources/registrars/templates/fields/Phone.tsx
@@ -1,5 +1,5 @@
 import {PhoneProps} from '@givewp/forms/propTypes';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import IntlTelInput from 'intl-tel-input/react';
 import 'intl-tel-input/build/css/intlTelInput.css';
 import InputMask from 'react-input-mask';

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -1,4 +1,5 @@
-import {FC, useState} from 'react';
+import { useState } from '@wordpress/element';
+import type { FC } from 'react';
 import {__} from '@wordpress/i18n';
 import type {FieldProps} from '@givewp/forms/propTypes';
 import {GroupProps} from '@givewp/forms/propTypes';

--- a/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/BillingAddress.tsx
@@ -1,5 +1,6 @@
 import type {BillingAddressProps} from '@givewp/forms/propTypes';
-import {FC, useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
+import type { FC } from 'react';
 import {__} from '@wordpress/i18n';
 import {ErrorMessage} from '@hookform/error-message';
 import {useCallback} from '@wordpress/element';

--- a/src/DonationForms/resources/registrars/templates/layouts/MultiStepForm.tsx
+++ b/src/DonationForms/resources/registrars/templates/layouts/MultiStepForm.tsx
@@ -1,5 +1,5 @@
 import {FormProps} from '@givewp/forms/propTypes';
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 
 interface Props extends FormProps {
     previousButton: ReactNode;

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/BillingInformation.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/BillingInformation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/DonationBreakdown.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/DonationBreakdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import EventLabel from './EventsLabel';
@@ -78,9 +78,9 @@ export default function DonationBreakdown({ donation }: { donation: Donation }) 
  * @since 4.6.0
  */
 type RowProps = {
-  label?: React.ReactNode;
-  value?: React.ReactNode;
-  children?: React.ReactNode;
+  label?: ReactNode;
+  value?: ReactNode;
+  children?: ReactNode;
   className?: string;
 };
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/EventsLabel.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/EventsLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './styles.module.scss'; // adjust path as needed
 import type {EventTicket} from '@givewp/donations/admin/components/types';
 

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/ReceiptActions.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationReceipt/ReceiptActions.tsx
@@ -1,5 +1,5 @@
 import { __ } from "@wordpress/i18n";
-import { useState, useEffect } from "react";
+import { useState, useEffect } from '@wordpress/element';
 import useResendReceipt from '../../../../../../hooks/useResendReceipt';
 import ConfirmationDialog from '@givewp/components/AdminDetailsPage/ConfirmationDialog';
 import styles from "./styles.module.scss";

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/PaymentMethodIcon.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Overview/DonationSummaryGrid/PaymentMethodIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * @since 4.6.0

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/General/BillingDetails.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/General/BillingDetails.tsx
@@ -1,7 +1,7 @@
 import AdminSection, {AdminSectionField} from '@givewp/components/AdminDetailsPage/AdminSection';
 import {getDonationOptionsWindowData} from '@givewp/donations/utils';
 import {__, sprintf} from '@wordpress/i18n';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {useFormContext, useFormState} from 'react-hook-form';
 import styles from '../styles.module.scss';
 import {StatesConfig, getStatesForCountry} from './addressUtils';

--- a/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/Tabs/Records/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import GeneralTab from './General';

--- a/src/Donations/resources/admin/components/DonationDetailsPage/index.tsx
+++ b/src/Donations/resources/admin/components/DonationDetailsPage/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import cx from 'classnames';
 
 /**

--- a/src/Donations/resources/components/DonationRowActions.tsx
+++ b/src/Donations/resources/components/DonationRowActions.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {__, sprintf} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';

--- a/src/Donations/resources/hooks/useDonationRefund.ts
+++ b/src/Donations/resources/hooks/useDonationRefund.ts
@@ -1,7 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from 'react';
+import { useMemo, useState } from '@wordpress/element';
 import { Donation } from '../admin/components/types';
 import { getDonationOptionsWindowData } from '../utils';
 

--- a/src/Donations/resources/hooks/useResendReceipt.tsx
+++ b/src/Donations/resources/hooks/useResendReceipt.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 

--- a/src/Donations/resources/index.tsx
+++ b/src/Donations/resources/index.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import DonationsListTable from './components/DonationsListTable';
 

--- a/src/DonorDashboards/resources/js/app/components/annual-receipt-table/index.js
+++ b/src/DonorDashboards/resources/js/app/components/annual-receipt-table/index.js
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';
 import Table from '../table';

--- a/src/DonorDashboards/resources/js/app/components/app/index.js
+++ b/src/DonorDashboards/resources/js/app/components/app/index.js
@@ -3,7 +3,7 @@ import MobileLayout from '../mobile-layout';
 import Auth from '../auth';
 import {useWindowSize, useAccentColor} from '../../hooks';
 import {createGlobalStyle} from 'styled-components';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 
 const App = () => {
     const {width} = useWindowSize();

--- a/src/DonorDashboards/resources/js/app/components/auth-modal/index.js
+++ b/src/DonorDashboards/resources/js/app/components/auth-modal/index.js
@@ -1,4 +1,4 @@
-import {useState, Fragment} from 'react';
+import { useState, Fragment } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';
 import TextControl from '../text-control';

--- a/src/DonorDashboards/resources/js/app/components/avatar-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/avatar-control/index.js
@@ -1,4 +1,4 @@
-import {useCallback, useState, useEffect} from 'react';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {useDropzone} from 'react-dropzone';
 

--- a/src/DonorDashboards/resources/js/app/components/dashboard-content/index.js
+++ b/src/DonorDashboards/resources/js/app/components/dashboard-content/index.js
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import {useSelector} from 'react-redux';
 
 import './style.scss';

--- a/src/DonorDashboards/resources/js/app/components/dashboard-loading-spinner/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/dashboard-loading-spinner/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import "./style.scss";
 

--- a/src/DonorDashboards/resources/js/app/components/donation-receipt/index.js
+++ b/src/DonorDashboards/resources/js/app/components/donation-receipt/index.js
@@ -1,5 +1,5 @@
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import {Interweave} from 'interweave';
 
 import './style.scss';

--- a/src/DonorDashboards/resources/js/app/components/donation-table/index.js
+++ b/src/DonorDashboards/resources/js/app/components/donation-table/index.js
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';
 import Table from '../table';

--- a/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
+++ b/src/DonorDashboards/resources/js/app/components/mobile-menu/index.js
@@ -1,4 +1,4 @@
-import {useState, useEffect, useRef} from 'react';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import {useLocation} from 'react-router-dom';
 import {useSelector} from 'react-redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import Button from '../button';
 import {cancelSubscriptionWithAPI} from './utils';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/amount-control/index.js
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import CurrencyInput, {formatValue} from 'react-currency-input-field';
 import {__, sprintf} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/hooks/pause-subscription.ts
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/hooks/pause-subscription.ts
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {managePausingSubscriptionWithAPI} from '../utils';
 
 export type pauseDuration = number;

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef, useState} from 'react';
+import { Fragment, useMemo, useRef, useState } from '@wordpress/element';
 import FieldRow from '../field-row';
 import Button from '../button';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/pause-duration-dropdown/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/pause-duration-dropdown/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 import './style.scss';
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/authorize-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/authorize-control/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {useImperativeHandle, useState} from 'react';
+import { useImperativeHandle, useState } from '@wordpress/element';
 import {PaymentInputsWrapper, usePaymentInputs} from 'react-payment-inputs';
 import images from 'react-payment-inputs/images';
 import {useAccentColor} from '../../../../hooks';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/card-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/card-control/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {useState, useImperativeHandle} from 'react';
+import { useState, useImperativeHandle } from '@wordpress/element';
 import {PaymentInputsWrapper, usePaymentInputs} from 'react-payment-inputs';
 import images from 'react-payment-inputs/images';
 import {useAccentColor} from '../../../../hooks';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 
 import AuthorizeControl from './authorize-control';
 import SquareControl from './square-control';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/square-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/square-control/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {useImperativeHandle} from 'react';
+import { useImperativeHandle } from '@wordpress/element';
 import {CreditCard, PaymentForm} from 'react-square-web-payments-sdk';
 
 import './style.scss';

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/index.js
@@ -1,6 +1,6 @@
 import {Elements} from '@stripe/react-stripe-js';
 import {loadStripe} from '@stripe/stripe-js';
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from '@wordpress/element';
 
 import StripeCardControl from './stripe-card-control';
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/stripe-card-control/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/payment-method-control/stripe-control/stripe-card-control/index.js
@@ -1,5 +1,5 @@
 import {CardElement, useStripe} from '@stripe/react-stripe-js';
-import {useState, useImperativeHandle} from 'react';
+import { useState, useImperativeHandle } from '@wordpress/element';
 import './style.scss';
 
 const CardControl = ({label, forwardedRef}) => {

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/subscription-status/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/subscription-status/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/components/subscription-receipt/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-receipt/index.js
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 const SubscriptionReceipt = ({subscription}) => {

--- a/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/subscription-row/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {useHistory} from 'react-router-dom';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';

--- a/src/DonorDashboards/resources/js/app/components/subscription-table/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-table/index.js
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/components/tab-content/index.js
+++ b/src/DonorDashboards/resources/js/app/components/tab-content/index.js
@@ -1,6 +1,6 @@
 import {useLocation} from 'react-router-dom';
 import {useSelector} from 'react-redux';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import Heading from '../heading';
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/components/tab-menu/index.js
+++ b/src/DonorDashboards/resources/js/app/components/tab-menu/index.js
@@ -1,5 +1,5 @@
 // Store dependencies
-import {useState, Fragment} from 'react';
+import { useState, Fragment } from '@wordpress/element';
 import {useSelector} from 'react-redux';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {__} from '@wordpress/i18n';

--- a/src/DonorDashboards/resources/js/app/hooks/index.js
+++ b/src/DonorDashboards/resources/js/app/hooks/index.js
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import {useSelector} from 'react-redux';
 
 // From use hooks, see: https://usehooks.com/useWindowSize/

--- a/src/DonorDashboards/resources/js/app/index.js
+++ b/src/DonorDashboards/resources/js/app/index.js
@@ -3,7 +3,6 @@
 // Vendor dependencies
 import {HashRouter as Router} from 'react-router-dom';
 import {createRoot} from 'react-dom/client';
-import React from 'react';
 import {Provider} from 'react-redux';
 
 import {library} from '@fortawesome/fontawesome-svg-core';

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/content.js
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import { Fragment, useEffect } from '@wordpress/element';
 
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/hooks/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/hooks/index.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {store} from '../store';
 
 export const useSelector = (select) => {

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/content.js
@@ -1,5 +1,5 @@
 import {useLocation, Link} from 'react-router-dom';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 
 import {__} from '@wordpress/i18n';

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/dashboard-content.js
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 
 import DonationTable from '../../components/donation-table';
 import Heading from '../../components/heading';

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/hooks/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/hooks/index.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {store} from '../store';
 
 export const useSelector = (select) => {

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/stats/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/stats/index.js
@@ -4,7 +4,7 @@ import {useAccentColor} from '../../../hooks';
 import {__} from '@wordpress/i18n';
 
 import './style.scss';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 
 const Stats = () => {
     const accentColor = useAccentColor();

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/address-controls/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/address-controls/index.js
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 
 import AddressFields from '../address-fields';

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/address-fields/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/address-fields/index.js
@@ -1,4 +1,4 @@
-import {Fragment, useState, useEffect} from 'react';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 import {useSelector, useDispatch} from 'react-redux';
 import {setStates} from '../../../store/actions';
 import {__} from '@wordpress/i18n';

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
@@ -12,7 +12,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import EmailControls from './email-controls';
 import AddressControls from './address-controls';
 
-import {Fragment, useState, useEffect} from 'react';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 import {useSelector} from 'react-redux';
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/email-controls/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/email-controls/index.js
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 
 import TextControl from '../../../components/text-control';

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/content.js
@@ -1,5 +1,5 @@
 import {useLocation, Link} from 'react-router-dom';
-import {Fragment} from 'react';
+import { Fragment } from '@wordpress/element';
 
 import {__} from '@wordpress/i18n';
 

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/hooks/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/hooks/index.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {store} from '../store';
 
 export const useSelector = (select) => {

--- a/src/Donors/resources/admin-donors.tsx
+++ b/src/Donors/resources/admin-donors.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import DonorsListTable from './components/DonorsListTable';
 

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorContributions/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorContributions/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {__} from '@wordpress/i18n';
 import classnames from 'classnames';
 import Header from '@givewp/src/Admin/components/Header';

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorPrivateNotes/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorPrivateNotes/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import OverviewPanel from '@givewp/src/Admin/components/OverviewPanel';
 import { DonorNotes } from '@givewp/src/Admin/components/PrivateNotes';
 

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorStats/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorStats/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {__} from '@wordpress/i18n';
 import StatWidget from '@givewp/src/Admin/components/StatWidget';
 import {useDonorStatistics} from '@givewp/donors/hooks/useDonorStatistics';

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorTransactions/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/DonorTransactions/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {__} from '@wordpress/i18n';
 import classnames from 'classnames';
 import Header from '@givewp/src/Admin/components/Header';

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Overview/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import DonorTransactions from './DonorTransactions';
 import DonorSummary from './DonorSummary';
 import DonorStats from './DonorStats';

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/AddressItem.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/AddressItem.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
  * WordPress Dependencies

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/EditAddressDialog.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/EditAddressDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * WordPress Dependencies

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/Address/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {useFormContext, useFormState} from 'react-hook-form';
 
 /**

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/EmailAddress/AddEmailDialog.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/EmailAddress/AddEmailDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * WordPress Dependencies

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/EmailAddress/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/EmailAddress/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import {useEffect, useRef, useState} from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {useFormContext, useFormState} from 'react-hook-form';
 
 /**

--- a/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/PersonalDetails.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/Tabs/Profile/PersonalDetails.tsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import {__} from '@wordpress/i18n';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {useFormContext} from 'react-hook-form';
 
 /**

--- a/src/Donors/resources/admin/components/DonorDetailsPage/index.tsx
+++ b/src/Donors/resources/admin/components/DonorDetailsPage/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import cx from 'classnames';
 
 /**

--- a/src/Donors/resources/admin/components/Inputs/Phone/index.tsx
+++ b/src/Donors/resources/admin/components/Inputs/Phone/index.tsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import IntlTelInput from 'intl-tel-input/react';
 import 'intl-tel-input/build/css/intlTelInput.css';
 

--- a/src/Donors/resources/components/DonorsRowActions.tsx
+++ b/src/Donors/resources/components/DonorsRowActions.tsx
@@ -2,7 +2,7 @@ import {__} from '@wordpress/i18n';
 import {useSWRConfig} from 'swr';
 import RowAction from '@givewp/components/ListTable/RowAction';
 import ListTableApi from '@givewp/components/ListTable/api';
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {Interweave} from 'interweave';
 import './style.scss';

--- a/src/Donors/resources/hooks/useDonorStatistics.ts
+++ b/src/Donors/resources/hooks/useDonorStatistics.ts
@@ -1,5 +1,5 @@
 import {useEntityRecord} from '@wordpress/core-data';
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**

--- a/src/EventTickets/resources/admin/components/CreateEventModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/CreateEventModal/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import styles from './CreateEventModal.module.scss';
 import EventFormModal from '../EventFormModal';

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/AttendeesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/AttendeesSection/index.tsx
@@ -1,7 +1,7 @@
 import {__, _x} from '@wordpress/i18n';
 import styles from './AttendeesSection.module.scss';
 import {GiveEventTicketsDetails} from '../types';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import SectionTable from '../SectionTable';
 import locale from '../../../../date-fns-locale';
 import {format} from 'date-fns';

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/DonationFormsSection/index.tsx
@@ -2,7 +2,7 @@ import {__} from '@wordpress/i18n';
 import {createInterpolateElement} from '@wordpress/element';
 import styles from './DonationFormsSection.module.scss';
 import SectionTable from '../SectionTable';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 
 /**
  * Displays a blank slate for the Donation Forms table.

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/EventSection/index.tsx
@@ -1,6 +1,6 @@
 import {__, _x} from '@wordpress/i18n';
 import {format} from 'date-fns';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import EventFormModal from '../../EventFormModal';
 import locale from '../../../../date-fns-locale';
 import SectionTable from '../SectionTable';

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/TicketTypesSection/index.tsx
@@ -1,7 +1,7 @@
 import {__, sprintf} from '@wordpress/i18n';
 import styles from './TicketTypesSection.module.scss';
 import SectionTable from '../SectionTable';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import TicketTypeFormModal from '../../TicketTypeFormModal';
 import {TicketTypeFormContext} from '../../TicketTypeFormModal/ticketTypeFormContext';
 import {TicketTypesRowActions} from './TicketTypesRowActions';

--- a/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
+++ b/src/EventTickets/resources/admin/components/EventDetailsPage/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import {GiveIcon} from '@givewp/components';

--- a/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
+++ b/src/EventTickets/resources/admin/components/EventTicketsListTable/EventTicketsRowActions.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {__, sprintf} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/index.tsx
@@ -4,7 +4,7 @@ import styles from './TicketTypeFormModal.module.scss';
 import FormModal from '../FormModal';
 import {useTicketTypeForm} from './ticketTypeFormContext';
 import {Inputs, TicketModalProps} from './types';
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import EventTicketsApi from '../api';
 import CurrencyInput from 'react-currency-input-field';
 import parseValueFromLocale from './parseValueFromLocale';

--- a/src/EventTickets/resources/admin/components/TicketTypeFormModal/ticketTypeFormContext.tsx
+++ b/src/EventTickets/resources/admin/components/TicketTypeFormModal/ticketTypeFormContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext} from 'react';
+import { createContext, useContext } from '@wordpress/element';
 import {TicketTypeFormContextType} from './types';
 
 const defaultTicketData = {

--- a/src/EventTickets/resources/admin/feedback/FeedbackButton.tsx
+++ b/src/EventTickets/resources/admin/feedback/FeedbackButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import FeedbackIcon from './FeedbackIcon';
 
 const FeedbackButton = (props) => {

--- a/src/EventTickets/resources/admin/feedback/index.tsx
+++ b/src/EventTickets/resources/admin/feedback/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import Container from './Container';
 import FeedbackButton from './FeedbackButton';

--- a/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
+++ b/src/EventTickets/resources/templates/EventTickets/EventTicketsListHOC.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import EventTicketsList from '../../components/EventTicketsList';
 import {EventTicketsListHOCProps, OnSelectTicketProps} from './types';
 

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/add-button.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/add-button.tsx
@@ -1,6 +1,6 @@
 import {Button} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
-import {SVGProps} from 'react';
+import type { SVGProps } from 'react';
 
 const AddButton = (props) => {
     return (

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -15,7 +15,7 @@ import RecurringDonationsPromo from '@givewp/form-builder/promos/recurring-donat
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 import {useCallback} from '@wordpress/element';
 import type {OptionProps} from '@givewp/form-builder-library/build/OptionsPanel/types';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {DonationAmountAttributes} from '@givewp/form-builder/blocks/fields/amount/types';
 import {subscriptionPeriod} from '@givewp/forms/registrars/templates/groups/DonationAmount/subscriptionPeriod';
 import {OptionsPanel} from '@givewp/form-builder-library';

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/billing-address/Edit.tsx
@@ -2,7 +2,7 @@ import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
 import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls, RichText} from '@wordpress/block-editor';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 
 const CountrySelect = ({countryList, countryLabel}) => {
     const [selectedCountry, setSelectedCountry] = useState(countryList[0] ?? '');

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donation-summary/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donation-summary/Edit.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import {BlockEditProps} from '@wordpress/blocks';
 
 const LineItem = ({label}: {label: string | ReactNode}) => {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/donor-name/Edit.tsx
@@ -2,7 +2,7 @@ import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
 import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {InspectorControls} from '@wordpress/block-editor';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {OptionsPanel} from '@givewp/form-builder-library';
 import type {OptionProps} from '@givewp/form-builder-library/build/OptionsPanel/types';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/Edit.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import {BlockEditProps} from '@wordpress/blocks';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 import {applyFilters} from '@wordpress/hooks';

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/withAdditionalPaymentGatewayNotice.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/payment-gateways/withAdditionalPaymentGatewayNotice.tsx
@@ -3,7 +3,7 @@ import {PanelRow} from "@wordpress/components";
 import InspectorNotice from "@givewp/form-builder/components/settings/InspectorNotice";
 import {__} from "@wordpress/i18n";
 import {InspectorControls} from "@wordpress/block-editor";
-import {useState} from "react";
+import { useState } from '@wordpress/element';
 
 declare const window: {
     additionalPaymentGatewaysNotificationData: {

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/phone/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/phone/Edit.tsx
@@ -6,7 +6,7 @@ import {InspectorControls} from '@wordpress/block-editor';
 import IntlTelInput from 'intl-tel-input/react';
 import 'intl-tel-input/build/css/intlTelInput.css';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 
 /**
  * @since 3.9.0

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/Edit.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/Edit.tsx
@@ -3,7 +3,7 @@ import {__} from '@wordpress/i18n';
 import {InspectorControls} from '@wordpress/block-editor';
 import {noop} from 'lodash';
 import {BlockEditProps} from '@wordpress/blocks';
-import {FocusEventHandler, PropsWithChildren} from 'react';
+import type { FocusEventHandler, PropsWithChildren } from 'react';
 import Label from '@givewp/form-builder/blocks/fields/settings/Label';
 import Placeholder from '@givewp/form-builder/blocks/fields/settings/Placeholder';
 import Required from '@givewp/form-builder/blocks/fields/settings/Required';

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/Label.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/settings/Label.tsx
@@ -2,7 +2,7 @@ import {TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {BlockEditProps} from '@wordpress/blocks';
 import {noop} from 'lodash';
-import {FocusEventHandler} from 'react';
+import type { FocusEventHandler } from 'react';
 
 type Props = {
     label: string;

--- a/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/DatePicker/index.tsx
@@ -1,5 +1,5 @@
 import {__} from '@wordpress/i18n';
-import {useRef, useState} from 'react';
+import { useRef, useState } from '@wordpress/element';
 import {close} from '@wordpress/icons';
 import {Button, DatePicker, DateTimePicker, PanelRow, Popover, TextControl} from '@wordpress/components';
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -1,4 +1,5 @@
-import {MouseEventHandler, useCallback, useEffect, useRef, useState} from 'react';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import type { MouseEventHandler } from 'react';
 import cx from 'classnames';
 import {createPortal} from 'react-dom';
 import {useDispatch, useSelect} from '@wordpress/data';

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/DesignPreview.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState, createRef} from 'react';
+import { useEffect, useState, createRef } from '@wordpress/element';
 
 import Storage from '@givewp/form-builder/common/storage';
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/FormSettings.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/FormSettings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { FC } from 'react';
 import FormSettingsContainer from "@givewp/form-builder/components/canvas/FormSettingsContainer";
 import FormGeneralSettingsGroup from "@givewp/form-builder/settings/group-general";
 import FormDonationConfirmationSettingsGroup from "@givewp/form-builder/settings/group-donation-confirmation";
@@ -91,7 +91,7 @@ function isValidRoute(route: Route) {
 export type Route = {
     name: string;
     path: string;
-    element?: React.FC<{settings: any; setSettings: any}>;
+    element?: FC<{settings: any; setSettings: any}>;
     childRoutes?: Route[];
     showWhen?: ({item, settings}) => boolean;
 };

--- a/src/FormBuilder/resources/js/form-builder/src/components/canvas/FormSettingsContainer/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/canvas/FormSettingsContainer/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, Dispatch, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
+import type { Dispatch } from 'react';
 import {
     Action,
     formSettingsReducer,

--- a/src/FormBuilder/resources/js/form-builder/src/components/header/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/header/index.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 
 type Props = {
     contentLeft: ReactNode;

--- a/src/FormBuilder/resources/js/form-builder/src/components/media-library/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/media-library/index.tsx
@@ -3,7 +3,6 @@
  * @link https://wordpress.stackexchange.com/a/382291
  */
 
-import React from 'react';
 import _ from 'lodash';
 import {BaseControl, Button} from '@wordpress/components';
 import {upload} from '@wordpress/icons';

--- a/src/FormBuilder/resources/js/form-builder/src/components/modal/types.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/components/modal/types.ts
@@ -1,11 +1,5 @@
-import {
-    ComponentType,
-    HTMLProps,
-    ReactNode,
-    KeyboardEventHandler,
-    MouseEventHandler,
-    FocusEventHandler
-} from 'react';
+import { ComponentType } from '@wordpress/element';
+import type { HTMLProps, ReactNode, KeyboardEventHandler, MouseEventHandler, FocusEventHandler } from 'react';
 
 interface GutenbergModalProps extends HTMLProps<HTMLDivElement> {
     /**

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/DesignSelector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/DesignSelector/index.tsx
@@ -1,4 +1,4 @@
-import {useContext, useState} from 'react';
+import { useContext, useState } from '@wordpress/element';
 import {Button, Modal} from '@wordpress/components';
 import {ShepherdTourContext} from 'react-shepherd';
 import {__} from '@wordpress/i18n';

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/Onboarding.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import { useContext, useEffect, useState } from '@wordpress/element';
 import {useFormState, useFormStateDispatch} from '@givewp/form-builder/stores/form-state';
 import {useDispatch} from '@wordpress/data';
 import {ShepherdTour, ShepherdTourContext} from 'react-shepherd';

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/SchemaWelcome/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/SchemaWelcome/index.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {ShepherdTourContext} from 'react-shepherd';
 import {Button, Modal} from '@wordpress/components';

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/transfer/ReturnButton.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/transfer/ReturnButton.tsx
@@ -1,4 +1,5 @@
-import {useState, useEffect, CSSProperties} from 'react';
+import { useState, useEffect } from '@wordpress/element';
+import type { CSSProperties } from 'react';
 import {__} from '@wordpress/i18n';
 import {ArrowUpLeft, ExitIcon} from '@givewp/components/AdminUI/Icons'
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/onboarding/transfer/TransferDialog.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/onboarding/transfer/TransferDialog.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import cx from 'classnames';
 import {__, sprintf} from '@wordpress/i18n';
 import {Interweave} from 'interweave';

--- a/src/FormBuilder/resources/js/form-builder/src/components/settings/DesignSettings/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/settings/DesignSettings/index.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 import {SettingsIcon} from '@givewp/form-builder/components/icons';
 
 type DesignSettings = {

--- a/src/FormBuilder/resources/js/form-builder/src/components/settings/MediaLibrary/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/settings/MediaLibrary/index.tsx
@@ -3,7 +3,6 @@
  * @link https://wordpress.stackexchange.com/a/382291
  */
 
-import React from 'react';
 import _ from 'lodash';
 import {BaseControl, Button} from '@wordpress/components';
 import {__} from '@wordpress/i18n';

--- a/src/FormBuilder/resources/js/form-builder/src/components/settings/TemplateTags/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/settings/TemplateTags/index.tsx
@@ -1,4 +1,5 @@
-import { Ref, useState } from "react";
+import { useState } from '@wordpress/element';
+import type { Ref } from 'react';
 import { useCopyToClipboard } from "@wordpress/compose";
 import { __ } from "@wordpress/i18n";
 import { copy as copyIcon } from "@wordpress/icons";

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Design.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Design.tsx
@@ -1,6 +1,6 @@
 import {__} from '@wordpress/i18n';
 import FormDesignSettings, {DesignSettings} from '@givewp/form-builder/settings/design';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {TabSelector} from '@givewp/form-builder/components/sidebar/TabSelector';
 
 type designTabState = DesignSettings.General | DesignSettings.Styles;

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/Secondary.tsx
@@ -29,7 +29,6 @@ const Sidebar = ({selected}: PropTypes) => {
 
     const PanelContent = panels[selected];
 
-    /* eslint-disable react/jsx-pascal-case */
     return (
         <div
             id="sidebar-secondary"

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/TabPanel.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/TabPanel.tsx
@@ -69,7 +69,7 @@ export default function TabPanel({
         if (!newSelectedTab) {
             setSelected(initialTabName || (tabs.length > 0 ? tabs[0].name : null));
         }
-    }, [tabs]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [tabs]);
 
     return (
         <div className={className}>

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/TabSelector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/TabSelector/index.tsx
@@ -1,5 +1,4 @@
 import {Button, Path, SVG} from '@wordpress/components';
-import React from 'react';
 
 type TabSelector = {
     close: () => void;

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/panels/FieldTypesList.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/panels/FieldTypesList.tsx
@@ -3,7 +3,7 @@ import {store as blockEditorStore} from '@wordpress/block-editor';
 import {__} from '@wordpress/i18n';
 // @ts-ignore
 import {SearchControl} from '@wordpress/components';
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from '@wordpress/element';
 import {BlockInstance} from '@wordpress/blocks';
 import {FieldBlock} from '@givewp/form-builder/types';
 import BlockTypesList from '@givewp/form-builder/components/forks/BlockTypesList';

--- a/src/FormBuilder/resources/js/form-builder/src/components/sidebar/panels/FormPrepublishPanel.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/sidebar/panels/FormPrepublishPanel.tsx
@@ -1,4 +1,5 @@
-import {createRef, MouseEventHandler, RefObject, useState} from 'react';
+import { createRef, RefObject, useState } from '@wordpress/element';
+import type { MouseEventHandler } from 'react';
 import {createPortal} from 'react-dom';
 import cx from 'classnames';
 import {__, sprintf} from '@wordpress/i18n';

--- a/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/BlockEditorInterfaceSkeletonContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {InterfaceSkeleton} from '@wordpress/interface';
 import useToggleState from '../hooks/useToggleState';
 

--- a/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/containers/HeaderContainer.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {CodeIcon, GiveIcon} from '../components/icons';
 import {drawerRight, external, moreVertical} from '@wordpress/icons';
 import {setFormSettings, setTransferState, useFormState, useFormStateDispatch} from '../stores/form-state';

--- a/src/FormBuilder/resources/js/form-builder/src/hooks/useToggleState.js
+++ b/src/FormBuilder/resources/js/form-builder/src/hooks/useToggleState.js
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 
 const useToggleState = (initialState = false) => {
     const [state, update] = useState(initialState);

--- a/src/FormBuilder/resources/js/form-builder/src/promos/additionalFields/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/promos/additionalFields/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {__} from '@wordpress/i18n';
 import LockedFieldBlocks, {LockIcon} from './LockedFieldBlocks';
 import './styles.scss';

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/donation-goal/index.tsx
@@ -1,4 +1,5 @@
-import React, {CSSProperties, useState} from 'react';
+import { useState } from '@wordpress/element';
+import type { CSSProperties } from 'react';
 import {
     __experimentalNumberControl as NumberControl,
     Icon,

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/general-controls/header/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from "react";
+import { useEffect } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {PanelBody, PanelRow, SelectControl, TextControl, ToggleControl} from '@wordpress/components';
 import {setFormSettings, useFormState} from '@givewp/form-builder/stores/form-state';

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import GeneralControls from '@givewp/form-builder/settings/design/general-controls';
 import StyleControls from '@givewp/form-builder/settings/design/style-controls';
 

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/custom-styles/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/custom-styles/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import AceEditor from 'react-ace';
 import debounce from 'lodash.debounce';
 import {__} from '@wordpress/i18n';

--- a/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/components/email-preview-content.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/components/email-preview-content.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';
 import {__} from '@wordpress/i18n';
 

--- a/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/components/send-preview-email.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/components/send-preview-email.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {Button, TextControl} from '@wordpress/components';
 import {__} from '@wordpress/i18n';
 import {getFormBuilderWindowData} from '@givewp/form-builder/common/getWindowData';

--- a/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/group-email-settings/email/template-options/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { createInterpolateElement } from "@wordpress/element";
 import { Button, PanelRow } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";

--- a/src/FormBuilder/resources/js/form-builder/src/settings/group-general/form-summary/page-slug.jsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/group-general/form-summary/page-slug.jsx
@@ -5,7 +5,7 @@ import {getWindowData} from '@givewp/form-builder/common';
 import {cleanForSlug, safeDecodeURIComponent} from '@wordpress/url';
 import {__} from '@wordpress/i18n';
 
-import {useCallback, useEffect, useState} from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 const {
     formPage: {isEnabled, rewriteSlug, baseUrl},

--- a/src/FormBuilder/resources/js/form-builder/src/stores/editor-state/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/stores/editor-state/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactNode, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import editorStateReducer, {setEditorMode} from './reducer';
 
 export interface EditorState {

--- a/src/FormBuilder/resources/js/form-builder/src/stores/form-state/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/stores/form-state/index.tsx
@@ -1,4 +1,5 @@
-import {createContext, ReactNode, useContext, useReducer} from 'react';
+import { createContext, useContext, useReducer } from '@wordpress/element';
+import type { ReactNode } from 'react';
 import formSettingsReducer, {setFormBlocks, setFormSettings, setTransferState} from './reducer';
 import {FormState} from '@givewp/form-builder/types';
 

--- a/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/supports/field-settings/FieldSettingsHOC.tsx
@@ -11,7 +11,7 @@ import {FieldSettings} from './types';
 import {AfterDisplaySettingsSlot, AfterFieldSettingsSlot, DisplaySettingsSlot, FieldSettingsSlot} from './slots';
 import {createHigherOrderComponent} from '@wordpress/compose';
 import {GiveWPSupports} from '@givewp/form-builder/supports/types';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import MetaKeyTextControl, {slugifyMeta} from '@givewp/form-builder/supports/field-settings/MetaKeyTextControl';
 
 /**

--- a/src/FormTaxonomies/resources/form-builder/form-categories.tsx
+++ b/src/FormTaxonomies/resources/form-builder/form-categories.tsx
@@ -2,7 +2,7 @@ import {getAvailableFormCategories, getInitialFormCategories} from "./windowData
 import {buildTermsTree} from "./utils/terms";
 import {CheckboxControl} from "@wordpress/components";
 import {decodeEntities} from "@wordpress/html-entities";
-import {useMemo} from "react";
+import { useMemo } from '@wordpress/element';
 
 /**
  * @since 3.16.0

--- a/src/FormTaxonomies/resources/form-builder/form-tags.tsx
+++ b/src/FormTaxonomies/resources/form-builder/form-tags.tsx
@@ -3,7 +3,7 @@ import {debounce} from "@wordpress/compose";
 import apiFetch from '@wordpress/api-fetch';
 import {FormTokenField} from "@wordpress/components";
 import {getInitialFormTags} from "./windowData";
-import {useState} from "react";
+import { useState } from '@wordpress/element';
 
 /**
  * @since 3.16.0

--- a/src/Log/Admin/Logs/index.js
+++ b/src/Log/Admin/Logs/index.js
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import {
     Card,
     Label,

--- a/src/MigrationLog/Admin/Migrations/index.js
+++ b/src/MigrationLog/Admin/Migrations/index.js
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import classNames from 'classnames';
 import {Button, Card, Label, Modal, Notice, Pagination, Spinner, Table} from '@givewp/components';
 import API, {getEndpoint, useMigrationFetcher} from './api';

--- a/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
+++ b/src/PaymentGateways/Gateways/PayPalCommerce/payPalCommerceGateway.tsx
@@ -9,7 +9,7 @@ import {
     usePayPalScriptReducer,
 } from '@paypal/react-paypal-js';
 import {__} from '@wordpress/i18n';
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 import {PayPalCommerceGateway, PayPalSubscriber} from './types';
 import handleValidationRequest from '@givewp/forms/app/utilities/handleValidationRequest';
 import createOrder from './resources/js/createOrder';

--- a/src/Promotions/InPluginUpsells/resources/js/components/AddonsAdminPage.js
+++ b/src/Promotions/InPluginUpsells/resources/js/components/AddonsAdminPage.js
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import { useMemo, useState } from '@wordpress/element';
 import {Tab, TabList, TabPanel, Tabs} from 'react-aria-components';
 import {__, sprintf} from '@wordpress/i18n';
 

--- a/src/Promotions/InPluginUpsells/resources/js/components/FreeAddOnTab.js
+++ b/src/Promotions/InPluginUpsells/resources/js/components/FreeAddOnTab.js
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import { useRef } from '@wordpress/element';
 import cx from 'classnames';
 
 import GreenButton from '@givewp/promotions/components/GreenButton';

--- a/src/Promotions/InPluginUpsells/resources/js/components/PricingPlanCard.js
+++ b/src/Promotions/InPluginUpsells/resources/js/components/PricingPlanCard.js
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import { useMemo } from '@wordpress/element';
 import {kebabCase} from 'lodash';
 import {Button} from './Button';
 import {Card} from './Card';

--- a/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
+++ b/src/Promotions/ReportsWidgetBanner/hooks/useBannerVisibility.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from '@wordpress/element';
 import {getWidgetWindowData} from "../window/widgetWindow";
 
 

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/Row/index.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/Row/index.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from 'react';
+import type { ReactNode } from 'react';
 
 import './styles.scss';
 

--- a/src/Promotions/WelcomeBanner/resources/js/app/components/VideoPlayer/index.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/app/components/VideoPlayer/index.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react';
+import { useRef, useState } from '@wordpress/element';
 import './styles.scss';
 import getWindowData from '../../../index';
 

--- a/src/Promotions/WelcomeBanner/resources/js/app/hooks/useDismiss.ts
+++ b/src/Promotions/WelcomeBanner/resources/js/app/hooks/useDismiss.ts
@@ -1,5 +1,5 @@
 import getWindowData from '../../index';
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 
 export function useDismiss() {
     const [showBanner, setShowBanner] = useState<boolean>(true);

--- a/src/Promotions/WelcomeBanner/resources/js/index.tsx
+++ b/src/Promotions/WelcomeBanner/resources/js/index.tsx
@@ -1,5 +1,5 @@
 import App from './app/app';
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 
 type windowData = {

--- a/src/Promotions/sharedResources/components/GreenButton.js
+++ b/src/Promotions/sharedResources/components/GreenButton.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import cx from 'classnames';
 
 import styles from './GreenButton.module.css';

--- a/src/Promotions/sharedResources/hooks/useFreeAddonSubscription.js
+++ b/src/Promotions/sharedResources/hooks/useFreeAddonSubscription.js
@@ -1,4 +1,4 @@
-import {useState, useCallback} from 'react';
+import { useState, useCallback } from '@wordpress/element';
 
 /**
  * Handles making a request to add a user to the Free Addon email subscription. It returns whether the request worked,

--- a/src/Promotions/sharedResources/hooks/useRecommendations.ts
+++ b/src/Promotions/sharedResources/hooks/useRecommendations.ts
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import { useCallback, useState } from '@wordpress/element';
 import dismissRecommendation from '@givewp/promotions/requests/dismissRecommendation';
 
 type EnumValues =

--- a/src/Subscriptions/resources/admin-subscriptions.tsx
+++ b/src/Subscriptions/resources/admin-subscriptions.tsx
@@ -1,4 +1,4 @@
-import {StrictMode} from 'react';
+import { StrictMode } from '@wordpress/element';
 import {createRoot} from 'react-dom/client';
 import SubscriptionsListTable from './components/SubscriptionsListTable';
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Donations/AddRenewalModal/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Donations/AddRenewalModal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 /**
  * WordPress Dependencies

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Donations/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/Tabs/Donations/index.tsx
@@ -8,7 +8,7 @@ import { DonationRowActions } from "@givewp/donations/components/DonationRowActi
 import BlankSlate from "@givewp/components/ListTable/BlankSlate";
 import apiSettings from './apiSettings';
 import AddRenewalDialog from "./AddRenewalModal";
-import { useState, useRef } from "react";
+import { useState, useRef } from '@wordpress/element';
 import { useDispatch } from "@wordpress/data";
 import { store as coreStore } from "@wordpress/core-data";
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/components/CancelSubscriptionDialog.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/components/CancelSubscriptionDialog.tsx
@@ -1,7 +1,7 @@
 import ConfirmationDialog from "@givewp/components/AdminDetailsPage/ConfirmationDialog";
 import { __ } from "@wordpress/i18n";
 import styles from "../SubscriptionDetailsPage.module.scss";
-import { useState } from "react";
+import { useState } from '@wordpress/element';
 import { Subscription } from '@givewp/subscriptions/admin/components/types';
 import useSubscriptionCancel from "@givewp/subscriptions/hooks/useSubscriptionCancel";
 import { getSubscriptionOptionsWindowData } from "@givewp/subscriptions/utils";

--- a/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionDetailsPage/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import cx from 'classnames';
 import { useFormContext } from 'react-hook-form';
 

--- a/src/Subscriptions/resources/admin/components/SubscriptionSyncList/icons.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionSyncList/icons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * @since 4.8.0

--- a/src/Subscriptions/resources/admin/components/SubscriptionSyncList/index.tsx
+++ b/src/Subscriptions/resources/admin/components/SubscriptionSyncList/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState } from '@wordpress/element';
 import { __ } from "@wordpress/i18n";
 import classnames from 'classnames';
 import SyncDetails,{ SyncPaymentDetails } from "./Details";

--- a/src/Subscriptions/resources/components/SubscriptionsRowActions.tsx
+++ b/src/Subscriptions/resources/components/SubscriptionsRowActions.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import { useContext } from '@wordpress/element';
 import {ShowConfirmModalContext} from '@givewp/components/ListTable/ListTablePage';
 import {__, sprintf} from '@wordpress/i18n';
 import RowAction from '@givewp/components/ListTable/RowAction';

--- a/src/Subscriptions/resources/hooks/useSubscriptionCancel.ts
+++ b/src/Subscriptions/resources/hooks/useSubscriptionCancel.ts
@@ -1,7 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import { Subscription } from '../admin/components/types';
 
 /**

--- a/src/Subscriptions/resources/hooks/useSubscriptionSync.tsx
+++ b/src/Subscriptions/resources/hooks/useSubscriptionSync.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState } from '@wordpress/element';
 import { getSubscriptionOptionsWindowData } from "../utils";
 
 export interface SubscriptionSyncResponse {

--- a/src/Views/Components/AdminDetailsPage/AdminSection.tsx
+++ b/src/Views/Components/AdminDetailsPage/AdminSection.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 /**
  * Internal Dependencies

--- a/src/Views/Components/AdminDetailsPage/Tabs/Router.tsx
+++ b/src/Views/Components/AdminDetailsPage/Tabs/Router.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import type { PressEvent } from 'react-aria-components';
 import { TabsContext, LinkContext, Tabs } from 'react-aria-components';
 import { Tab } from '../types';

--- a/src/Views/Components/AdminDetailsPage/Tabs/TabList.tsx
+++ b/src/Views/Components/AdminDetailsPage/Tabs/TabList.tsx
@@ -1,7 +1,7 @@
 import { Tab, TabList as ReactAriaTabList, TabsContext } from 'react-aria-components';
 import { Tab as TabType } from '../types';
 import styles from '../AdminDetailsPage.module.scss';
-import { useContext } from 'react';
+import { useContext } from '@wordpress/element';
 import { useTriggerResize } from '../../hooks';
 
 /**

--- a/src/Views/Components/AdminDetailsPage/Tabs/TabPanels.tsx
+++ b/src/Views/Components/AdminDetailsPage/Tabs/TabPanels.tsx
@@ -3,7 +3,7 @@ import { TabPanel, TabsContext } from 'react-aria-components';
 import { Tab as TabType } from '../types';
 import ErrorBoundary from '../ErrorBoundary';
 import styles from '../AdminDetailsPage.module.scss';
-import { useContext } from 'react';
+import { useContext } from '@wordpress/element';
 
 /**
  * @since 4.4.0

--- a/src/Views/Components/AdminDetailsPage/index.tsx
+++ b/src/Views/Components/AdminDetailsPage/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import {useEffect, useRef, useState} from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {FormProvider, SubmitHandler, useForm, useFormContext, useFormState} from 'react-hook-form';
 import {ajvResolver} from '@givewp/admin/ajv';
 

--- a/src/Views/Components/AdminDetailsPage/types.ts
+++ b/src/Views/Components/AdminDetailsPage/types.ts
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import type { ComponentType, FC, ReactNode } from 'react';
 
 /**
  * Interface for controlling UI element visibility
@@ -59,27 +59,27 @@ export interface AdminDetailsPageProps<T extends Record<string, any>> {
     /**
      * Custom title for the page header (defaults to entity.name)
      */
-    pageTitle?: string | React.ReactNode;
+    pageTitle?: string | ReactNode;
 
     /**
      * Component to display the status badge
      */
-    StatusBadge?: React.ComponentType;
+    StatusBadge?: ComponentType;
 
     /**
      * Component to display the primary action button
      */
-    PrimaryActionButton?: React.ComponentType<{ isSaving: boolean, formState: any, className: string }>;
+    PrimaryActionButton?: ComponentType<{ isSaving: boolean, formState: any, className: string }>;
 
     /**
      * Component to display the secondary action button
      */
-    SecondaryActionButton?: React.ComponentType<{ className: string }>;
+    SecondaryActionButton?: ComponentType<{ className: string }>;
 
     /**
      * Component to display the context menu items
      */
-    ContextMenuItems?: React.ComponentType<{ className: string }>;
+    ContextMenuItems?: ComponentType<{ className: string }>;
 
     /**
      * Tabs definition for the object
@@ -89,7 +89,7 @@ export interface AdminDetailsPageProps<T extends Record<string, any>> {
     /**
      * Component to display the children
      */
-    children?: React.ReactNode;
+    children?: ReactNode;
 }
 
 /**

--- a/src/Views/Components/AdminUI/Button/index.tsx
+++ b/src/Views/Components/AdminUI/Button/index.tsx
@@ -1,4 +1,5 @@
-import {forwardRef, MouseEventHandler, ReactNode} from 'react';
+import { forwardRef } from '@wordpress/element';
+import type { MouseEventHandler, ReactNode } from 'react';
 import cx from 'classnames';
 import './style.scss';
 

--- a/src/Views/Components/AdminUI/Input/index.tsx
+++ b/src/Views/Components/AdminUI/Input/index.tsx
@@ -1,4 +1,5 @@
-import {ChangeEventHandler, forwardRef} from 'react';
+import { forwardRef } from '@wordpress/element';
+import type { ChangeEventHandler } from 'react';
 
 import './style.scss';
 

--- a/src/Views/Components/AdminUI/ModalDialog/index.tsx
+++ b/src/Views/Components/AdminUI/ModalDialog/index.tsx
@@ -1,4 +1,5 @@
-import {MouseEventHandler, useCallback, useEffect} from 'react';
+import { useCallback, useEffect } from '@wordpress/element';
+import type { MouseEventHandler } from 'react';
 import {createPortal} from 'react-dom';
 import {__} from '@wordpress/i18n';
 import {ExitIcon} from '@givewp/components/AdminUI/Icons';

--- a/src/Views/Components/AdminUI/Toast/index.tsx
+++ b/src/Views/Components/AdminUI/Toast/index.tsx
@@ -1,4 +1,5 @@
-import {MouseEventHandler, useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
+import type { MouseEventHandler } from 'react';
 import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import {ExitIcon, CheckCircle, AlertTriangle} from '@givewp/components/AdminUI/Icons';

--- a/src/Views/Components/ListTable/BulkActions/BulkActionCheckbox.tsx
+++ b/src/Views/Components/ListTable/BulkActions/BulkActionCheckbox.tsx
@@ -1,5 +1,5 @@
 import {__, sprintf} from '@wordpress/i18n';
-import {useContext, useEffect, useState} from 'react';
+import { useContext, useEffect, useState } from '@wordpress/element';
 import {CheckboxContext} from '@givewp/components/ListTable/ListTablePage';
 import styles from './BulkActionCheckbox.module.scss';
 

--- a/src/Views/Components/ListTable/CustomFilter/useAsyncCampaigns.ts
+++ b/src/Views/Components/ListTable/CustomFilter/useAsyncCampaigns.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { createCampaignQueryParams, processOptionsForMenu, formatCampaignOptions, formatCampaignOption } from './utils';
 import { Campaign, CampaignOption } from './utils';

--- a/src/Views/Components/ListTable/FilterBy/hooks/useDropdownToggle.ts
+++ b/src/Views/Components/ListTable/FilterBy/hooks/useDropdownToggle.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
  * Custom hook to handle dropdown open/close logic

--- a/src/Views/Components/ListTable/FilterBy/hooks/useFilterState.ts
+++ b/src/Views/Components/ListTable/FilterBy/hooks/useFilterState.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo } from '@wordpress/element';
 import { FilterByGroupedOptions } from '../types';
 
 /**

--- a/src/Views/Components/ListTable/FilterBy/index.tsx
+++ b/src/Views/Components/ListTable/FilterBy/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import styles from './styles.module.scss';
 import { FilterByProps } from './types';

--- a/src/Views/Components/ListTable/ListTable/index.tsx
+++ b/src/Views/Components/ListTable/ListTable/index.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {__, _n, sprintf} from '@wordpress/i18n';
 import cx from 'classnames';
 import styles from './ListTable.module.scss';

--- a/src/Views/Components/ListTable/ListTableHeaders/index.tsx
+++ b/src/Views/Components/ListTable/ListTableHeaders/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './ListTableHeaders.module.scss';
 
 //@since 2.24.0 used to handle sort direction and column id.

--- a/src/Views/Components/ListTable/ListTablePage/index.tsx
+++ b/src/Views/Components/ListTable/ListTablePage/index.tsx
@@ -1,4 +1,4 @@
-import {createContext, useRef, useState, forwardRef, useImperativeHandle} from 'react';
+import { createContext, useRef, useState, forwardRef, useImperativeHandle } from '@wordpress/element';
 import {__} from '@wordpress/i18n';
 import {A11yDialog} from 'react-a11y-dialog';
 import A11yDialogInstance from 'a11y-dialog';

--- a/src/Views/Components/ListTable/ListTableRows/index.tsx
+++ b/src/Views/Components/ListTable/ListTableRows/index.tsx
@@ -1,7 +1,7 @@
 import styles from './ListTableRows.module.scss';
 import {__} from '@wordpress/i18n';
 import cx from 'classnames';
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from '@wordpress/element';
 import TableCell from '../TableCell';
 import {BulkActionCheckbox} from '@givewp/components/ListTable/BulkActions/BulkActionCheckbox';
 import InterweaveSSR from '@givewp/components/ListTable/InterweaveSSR';

--- a/src/Views/Components/ListTable/Pagination/index.tsx
+++ b/src/Views/Components/ListTable/Pagination/index.tsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 import styles from './Pagination.module.scss';
 import cx from 'classnames';
 import {__, sprintf} from '@wordpress/i18n';

--- a/src/Views/Components/ListTable/ProductRecommendations/index.tsx
+++ b/src/Views/Components/ListTable/ProductRecommendations/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import { useState } from '@wordpress/element';
 import styles from './style.module.scss';
 import {__} from '@wordpress/i18n';
 import {RecommendedProductData, useRecommendations} from '@givewp/promotions/hooks/useRecommendations';

--- a/src/Views/Components/ListTable/hooks/lagData.ts
+++ b/src/Views/Components/ListTable/hooks/lagData.ts
@@ -1,4 +1,4 @@
-import {useRef, useEffect, useCallback} from 'react';
+import { useRef, useEffect, useCallback } from '@wordpress/element';
 
 // SWR middleware for keeping the data even if key changes.
 export default function lagData(useSWRNext) {

--- a/src/Views/Components/ListTable/hooks/useDebounce.ts
+++ b/src/Views/Components/ListTable/hooks/useDebounce.ts
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import { useEffect, useRef } from '@wordpress/element';
 import debounce from 'lodash.debounce';
 
 export default function useDebounce(callback) {

--- a/src/Views/Components/ListTable/hooks/useFallbackAsInitial.ts
+++ b/src/Views/Components/ListTable/hooks/useFallbackAsInitial.ts
@@ -1,4 +1,4 @@
-import {useRef, useEffect} from 'react';
+import { useRef, useEffect } from '@wordpress/element';
 
 // use fallbackData as the initial data on component mount, instead of default data whenever there's a cache miss
 // adapted from https://viralganatra.com/how-to-fix-swr-to-work%20correctly-with-initialData-or-fallbackData/

--- a/src/Views/Components/ListTable/hooks/useResetPage.ts
+++ b/src/Views/Components/ListTable/hooks/useResetPage.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import { useEffect } from '@wordpress/element';
 
 export const useResetPage = (data, page, setPage, filters) => {
     //if we're displaying a non-existent page (like after deleting an item), go to the last available page

--- a/src/Views/Components/ListTable/hooks/useUniqueId.ts
+++ b/src/Views/Components/ListTable/hooks/useUniqueId.ts
@@ -1,5 +1,5 @@
 import _uniqueId from 'lodash/uniqueId';
-import {useState} from "react";
+import { useState } from '@wordpress/element';
 
 export const useUniqueId = (prefix) => {
     const [uniqueId] = useState(_uniqueId(prefix));

--- a/src/Views/Components/Modal/index.js
+++ b/src/Views/Components/Modal/index.js
@@ -1,4 +1,4 @@
-import {useEffect, useCallback} from 'react';
+import { useEffect, useCallback } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import LoadingOverlay from '@givewp/components/LoadingOverlay';

--- a/src/Views/Components/PeriodSelector/index.js
+++ b/src/Views/Components/PeriodSelector/index.js
@@ -1,5 +1,5 @@
 // Vendor dependencies
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 // react-dates dependencies

--- a/src/Views/Components/Table/index.js
+++ b/src/Views/Components/Table/index.js
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import { useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {LoadingOverlay, Spinner} from '@givewp/components';

--- a/src/Views/Components/hooks.ts
+++ b/src/Views/Components/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect } from '@wordpress/element';
 
 export function useTriggerResize(listener) {
     useEffect(() => {


### PR DESCRIPTION
## Summary

Enforces the `@wordpress/element` import standard for React runtime APIs across the GiveWP plugin. Adds a project ESLint config that bans value imports from `react` (`@typescript-eslint/no-restricted-imports` with `allowTypeImports: true`), then migrates the 271 source files that previously imported hooks and components from `react` directly.

`react` and `@wordpress/element` resolve to the same React module under `@wordpress/scripts` (WordPress externals), so the migration is a transparent import-source swap with no runtime behavior change. Type-only imports of React types that `@wordpress/element` does not re-export (`ReactNode`, `FC`, `CSSProperties`, `ChangeEvent`, `PropsWithChildren`, etc.) are still allowed via `import type { ... } from 'react'`.

Closes #6988

## Changes

### `.eslintrc.js` (new)

Root-level config, minimal. Only depends on the top-level `@typescript-eslint` packages already shipped as devDeps:

```js
module.exports = {
    root: true,
    parser: '@typescript-eslint/parser',
    parserOptions: { ecmaVersion: 'latest', sourceType: 'module', ecmaFeatures: { jsx: true } },
    plugins: [ '@typescript-eslint' ],
    rules: {
        '@typescript-eslint/no-restricted-imports': [ 'error', {
            paths: [{
                name: 'react',
                message: 'Import React runtime APIs (hooks, components) from "@wordpress/element" instead. Type-only imports (import type {...} from \'react\') are allowed for types @wordpress/element does not re-export, such as ReactNode, FC, CSSProperties, and ChangeEvent.',
                allowTypeImports: true,
            }],
        } ],
    },
};
```

### `.eslintignore` (new)

Mirrors the wp-scripts default: `build`, `node_modules`, `vendor`, `assets/build`, `dist`.

### `package.json`

- `scripts.lint:js`: `wp-scripts lint-js`
- `scripts.lint:js:fix`: `wp-scripts lint-js --fix`
- New direct devDeps: `@typescript-eslint/parser@^6.21.0`, `@typescript-eslint/eslint-plugin@^6.21.0` (alphabetical order in `devDependencies`)

### Codemod (271 files)

- 205 pure-safe files: `from 'react'` swapped to `from '@wordpress/element'`.
- 22 mixed files: split into value imports from `@wordpress/element` and `import type` from `react`.
- 27 default-import files: unused `import React` dropped (new JSX transform, no runtime cost).
- 17 type-only files: left untouched.
- 9 files using `React.<Type>` namespace form manually converted to named imports (`React.ReactNode` → `ReactNode`, etc.).

### Manual fixes

- `src/DonationForms/resources/app/DonationFormApp.tsx`: `createRoot` now imports from `react-dom/client` (not re-exported by `@wordpress/element`).
- Two dead inline `eslint-disable` comments removed (referenced rules outside the new config).

### Changelog

`changelog/fix-6988-enforce-element-imports.yaml` — significance: minor, type: dev.

## Why

The codebase inconsistently imported React (285 `react` sites, 68 `@wordpress/element` sites). On `@wordpress/scripts`, the latter is the WordPress convention and avoids bypassing the WP-element abstraction layer. The hybrid type/value approach keeps the build type-safe for React types `@wordpress/element` does not re-export.

## Testing

### Automated

```bash
npm run lint:js          # exit 0, zero errors
npm run build            # success, no new warnings
```

The build runs `fork-ts-checker-webpack-plugin`, so any type regression in the migrated files surfaces during `npm run build`.

### Manual smoke test

1. **Public donation form (V2 form)** — complete a test donation end to end. Multi-step nav, custom amount, gateways, success receipt.
2. **Donor dashboard** — log in, view history, manage recurring donations, cancel a subscription.
3. **Admin pages (React-rendered)** — donor details, donation details, campaign details, subscription details, form builder, taxonomies, event tickets. Watch DevTools console for React errors.
4. **Reports (legacy `assets/src/js/admin/reports`)** — chart, list table, period selector, overview page.
5. **Onboarding wizard (legacy `assets/src/js/admin/onboarding-wizard`)** — `Children.forEach` calls in `card-input`, `step-navigation`, `wizard`.

### Verification sub-agents

Three read-only checks ran during development:

- A: re-read issue #6988 + diff to confirm standard enforced and safe migration sound → PASS
- B: grep for non-migrated callers importing re-exported members from `react` → 0 hits
- C: confirm no deprecated ESLint rule syntax or outdated `@wordpress/eslint-plugin` API → PASS

## Notes

- The ESLint config uses only the top-level `@typescript-eslint` packages. `@wordpress/eslint-plugin` is nested under `@wordpress/scripts` and not resolvable from a root config without hoisting the entire dependency tree; pulling in the full wp-recommended preset is out of scope for this issue and was kept minimal to avoid expanding the lint surface in a coding-standards change.
- Reverting is a single `git checkout fix/6988-enforce-element-imports~1` since ESLint config, ignore file, and all import migrations live on this one branch.
