### PR TITLE
Warn users away from entering LW unified keys on Give license page

### DIFF
--- a/changelog/smtnc-1845.yaml
+++ b/changelog/smtnc-1845.yaml
@@ -1,0 +1,4 @@
+significance: minor
+type: tweak
+entry: Warn users away from entering LW unified keys on Give license page
+timestamp: 2026-07-23T11:14:06.401Z

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -169,13 +169,7 @@ function give_get_license_info_handler() {
 		);
 
 	} elseif ( 0 === stripos( $license_key, 'LWSW-' ) ) {
-		$license_manager_url = function_exists( 'lw_harbor_get_license_page_url' )
-			? lw_harbor_get_license_page_url()
-			: '';
-
-		if ( empty( $license_manager_url ) ) {
-			$license_manager_url = admin_url( 'options-general.php?page=lw-software-manager' );
-		}
+		$license_manager_url = lw_harbor_get_license_page_url();
 
 		wp_send_json_error(
 			[

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -144,6 +144,7 @@ add_action( 'wp_ajax_give_upload_addon', 'give_upload_addon_handler' );
  *
  * Note: only for internal use
  *
+ * @since TBD Redirect Liquid Web unified license keys (LWSW-) to the Liquid Web License Manager.
  * @since 2.5.0
  */
 function give_get_license_info_handler() {
@@ -164,6 +165,25 @@ function give_get_license_info_handler() {
 		wp_send_json_error(
 			[
 				'errorMsg' => __( 'You entered an invalid key. Confirm your license key on your GiveWP dashboard and try again.', 'give' ),
+			]
+		);
+
+	} elseif ( 0 === stripos( $license_key, 'LWSW-' ) ) {
+		$license_manager_url = function_exists( 'lw_harbor_get_license_page_url' )
+			? lw_harbor_get_license_page_url()
+			: '';
+
+		if ( empty( $license_manager_url ) ) {
+			$license_manager_url = admin_url( 'options-general.php?page=lw-software-manager' );
+		}
+
+		wp_send_json_error(
+			[
+				'errorMsg' => sprintf(
+					/* translators: %s: URL to the Liquid Web License Manager page */
+					__( 'This is a Liquid Web Unified License. To activate it, enter your license in the <a href="%s" target="_blank">Liquid Web License Manager</a> instead.', 'give' ),
+					esc_url( $license_manager_url )
+				),
 			]
 		);
 

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -175,7 +175,7 @@ function give_get_license_info_handler() {
 			[
 				'errorMsg' => sprintf(
 					/* translators: %s: URL to the Liquid Web License Manager page */
-					__( 'This is a Liquid Web Unified License. To activate it, enter your license in the <a href="%s" target="_blank">Liquid Web License Manager</a> instead.', 'give' ),
+					__( 'This is a unified license key. To activate it, enter your license in the <a href="%s" target="_blank">Liquid Web License Manager</a> instead.', 'give' ),
 					esc_url( $license_manager_url )
 				),
 			]

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -175,7 +175,7 @@ function give_get_license_info_handler() {
 			[
 				'errorMsg' => sprintf(
 					/* translators: %s: URL to the Liquid Web License Manager page */
-					__( 'This is a unified license key. To activate it, enter your license in the <a href="%s" target="_blank">Liquid Web License Manager</a> instead.', 'give' ),
+					__( 'This is a unified license key. To activate it, enter your license in the <a href="%s" target="_blank">Unified License Manager</a> instead.', 'give' ),
 					esc_url( $license_manager_url )
 				),
 			]


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [SMTNC-1845](https://linear.app/nexcess/issue/SMTNC-1845/warn-users-away-from-entering-lw-unified-keys-on-give-license-page)

## Description

Guide the user if they try to enter the unified license key in the Give legacy license field.


## Visuals

<img width="1800" height="1295" alt="image" src="https://github.com/user-attachments/assets/020935c3-50bf-4dce-ac63-d972d3afd774" />


## Testing Instructions

1. Enter a unified license to GiveWP > Settings > Licenses
2. Ensure that you receive an error saying "This is a Liquid Web Unified License. To activate it, enter your license in the Liquid Web License Manager instead".

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787313657&installation_model_id=426813&pr_number=8270&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8270&signature=8b8b4c25c68bdd65b3f54a5dc4d98325a1b172414f80ab23e630857d27900a51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->