### PR TITLE
Add license activation UI to GiveWP onboarding

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
+++ b/assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js
@@ -14,6 +14,7 @@ import {generateFormPreviewWithOnboardingAPI} from '../../../utils';
 import Card from '../../../components/card';
 import GiveLogo from '../../../components/give-logo';
 import ContinueButton from '../../../components/continue-button';
+import ActivateLicenseLink from '../../../components/activate-license-link';
 import DismissLink from '../../../components/dismiss-link';
 
 const Introduction = () => {
@@ -44,6 +45,7 @@ const Introduction = () => {
                         label={__('Start Setup', 'give')}
                         testId="intro-continue-button"
                     />
+                    <ActivateLicenseLink />
                 </div>
             </Card>
             <DismissLink />

--- a/assets/src/js/admin/onboarding-wizard/components/activate-license-link/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/activate-license-link/index.js
@@ -26,7 +26,7 @@ const ActivateLicenseLink = () => {
 			href={ activationUrl }
 			data-givewp-test="activate-license-link"
 		>
-			{ __( 'Activate your license', 'give' ) }
+			{ __( 'Activate license for your add-ons', 'give' ) }
 		</a>
 	);
 };

--- a/assets/src/js/admin/onboarding-wizard/components/activate-license-link/index.js
+++ b/assets/src/js/admin/onboarding-wizard/components/activate-license-link/index.js
@@ -1,0 +1,34 @@
+// Import vendor dependencies
+import { __ } from '@wordpress/i18n';
+
+// Import utilities
+import { getWindowData } from '../../utils';
+
+// Import styles
+import './style.scss';
+
+/**
+ * Sends the user to the Liquid Web portal to activate their license, returning
+ * them to the setup page afterwards. Renders nothing when there is no URL to
+ * offer: the loaded Harbor predates the activation API, or the site is already
+ * activated. The URL is prepared server-side in the wizard's localized data.
+ */
+const ActivateLicenseLink = () => {
+	const activationUrl = getWindowData( 'activationUrl' );
+
+	if ( ! activationUrl ) {
+		return null;
+	}
+
+	return (
+		<a
+			className="give-obw-activate-license-link"
+			href={ activationUrl }
+			data-givewp-test="activate-license-link"
+		>
+			{ __( 'Activate your license', 'give' ) }
+		</a>
+	);
+};
+
+export default ActivateLicenseLink;

--- a/assets/src/js/admin/onboarding-wizard/components/activate-license-link/style.scss
+++ b/assets/src/js/admin/onboarding-wizard/components/activate-license-link/style.scss
@@ -1,0 +1,20 @@
+.give-obw-activate-license-link {
+	font-family: 'Open Sans', Arial, Helvetica, sans-serif;
+	color: #4fa651;
+	font-weight: 600;
+	font-size: 16px;
+	line-height: 22px;
+	margin-top: 24px;
+	padding: 6px;
+	border-radius: 3px;
+
+	&:hover,
+	&:focus {
+		color: #4fa651;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 2px #7ec980, 0 0 0 3px #4fa651;
+		outline: none;
+	}
+}

--- a/src/Onboarding/LicenseData.php
+++ b/src/Onboarding/LicenseData.php
@@ -43,16 +43,47 @@ class LicenseData
     }
 
     /**
+     * Whether this site runs any active GiveWP premium add-on.
+     *
+     * GiveWP is free, and a license only unlocks premium add-ons and their updates.
+     * A site running none of them has nothing to activate, so putting activation UI
+     * in front of that user would imply a license is needed to fundraise at all.
+     * Onboarding asks this first and stays silent when the answer is no.
+     *
+     * @since TBD
+     */
+    public function hasActivePremiumAddons(): bool
+    {
+        // give_get_plugins() leans on get_plugins(), which only ships with the admin.
+        if (!function_exists('get_plugins')) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        foreach (give_get_plugins(['only_premium_add_ons' => true]) as $addon) {
+            if ($addon['Status'] === 'active') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Get the URL that sends a user to the portal to activate a license, for
      * callers that only want one while the user still has something to do.
      *
-     * Empty when there is nothing to be done: the loaded Harbor predates the API,
-     * or the site already holds a valid activated license.
+     * Empty when there is nothing to be done: this site runs no premium add-on a
+     * license would unlock, the loaded Harbor predates the API, or the site already
+     * holds a valid activated license.
      *
      * @since TBD
      */
     public function getActivationUrl(string $returnUrl): string
     {
+        if (!$this->hasActivePremiumAddons()) {
+            return '';
+        }
+
         if (!$this->canBuildActivationUrl()) {
             return '';
         }

--- a/src/Onboarding/LicenseData.php
+++ b/src/Onboarding/LicenseData.php
@@ -2,10 +2,6 @@
 
 namespace Give\Onboarding;
 
-use Give\Vendors\LiquidWeb\Harbor\Licensing\Product_Collection;
-use Give\Vendors\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
-use Give\Vendors\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
-
 /**
  * Answers the licensing questions GiveWP's onboarding UI asks: whether this site
  * has activated GiveWP, and where to send a user who still has something to do
@@ -38,8 +34,7 @@ class LicenseData
      */
     public function canBuildActivationUrl(): bool
     {
-        return function_exists('lw_harbor_get_activation_base_url')
-            && function_exists('lw_harbor_get_product_activation_url');
+        return function_exists('lw_harbor_get_product_activation_url');
     }
 
     /**
@@ -96,9 +91,12 @@ class LicenseData
     }
 
     /**
-     * Build the activation URL whatever this site's activation state. When the
-     * stored license already covers GiveWP the URL is scoped to the product and
-     * tier so the portal pre-selects the right subscription.
+     * Build the activation URL whatever this site's activation state. The URL is
+     * scoped to the tier when Harbor names one, so the portal pre-selects the
+     * right subscription. When it cannot — the key does not cover GiveWP, or
+     * covers it at several tiers — the tier is null and the portal shows its own
+     * picker, still limited to this domain. That is the right screen for a
+     * genuine choice, and better than guessing on the user's behalf.
      *
      * Harbor returns null when it has no URL to give; that is folded into the
      * empty string this returns, because both mean the same thing here — there
@@ -110,24 +108,15 @@ class LicenseData
     {
         // Guarded inline (not only via canBuildActivationUrl()) so static analysis
         // can see the functions are called only when they exist.
-        if (
-            !function_exists('lw_harbor_get_activation_base_url')
-            || !function_exists('lw_harbor_get_product_activation_url')
-        ) {
+        if (!function_exists('lw_harbor_get_product_activation_url')) {
             return '';
         }
 
-        $entitlement = $this->getLicensedEntry();
+        $tier = function_exists('lw_harbor_get_product_tier')
+            ? lw_harbor_get_product_tier(self::PRODUCT_SLUG)
+            : null;
 
-        if (!$entitlement instanceof Product_Entry) {
-            return lw_harbor_get_activation_base_url($returnUrl) ?? '';
-        }
-
-        return lw_harbor_get_product_activation_url(
-            $entitlement->get_product_slug(),
-            $entitlement->get_tier(),
-            $returnUrl
-        ) ?? '';
+        return lw_harbor_get_product_activation_url(self::PRODUCT_SLUG, $tier, $returnUrl) ?? '';
     }
 
     /**
@@ -155,52 +144,7 @@ class LicenseData
      */
     public function isActivated(): bool
     {
-        $products = $this->getProducts();
-
-        if (!$products instanceof Product_Collection) {
-            return false;
-        }
-
-        $entry = $products->get_activated_entry(self::PRODUCT_SLUG);
-
-        return $entry instanceof Product_Entry && $entry->is_valid();
-    }
-
-    /**
-     * Get the licensed entry for GiveWP, whatever its activation state. Used to
-     * scope the activation URL: the tier is known as soon as the key covers the
-     * product, well before activation, so this deliberately does not filter on it.
-     *
-     * @since TBD
-     */
-    protected function getLicensedEntry(): ?Product_Entry
-    {
-        $products = $this->getProducts();
-
-        if (!$products instanceof Product_Collection) {
-            return null;
-        }
-
-        $entries = $products->get_all_by_slug(self::PRODUCT_SLUG);
-
-        return $entries ? reset($entries) : null;
-    }
-
-    /**
-     * Get the licensed products Harbor holds for this site. Harbor returns a
-     * WP_Error when its last fetch failed and null when it has never fetched; both
-     * are flattened to null here and read by callers as "no license".
-     *
-     * @since TBD
-     */
-    protected function getProducts(): ?Product_Collection
-    {
-        if (!class_exists(License_Repository::class)) {
-            return null;
-        }
-
-        $products = give(License_Repository::class)->get_products();
-
-        return $products instanceof Product_Collection ? $products : null;
+        return function_exists('lw_harbor_is_product_license_active')
+            && lw_harbor_is_product_license_active(self::PRODUCT_SLUG);
     }
 }

--- a/src/Onboarding/LicenseData.php
+++ b/src/Onboarding/LicenseData.php
@@ -38,7 +38,7 @@ class LicenseData
      */
     public function canBuildActivationUrl(): bool
     {
-        return function_exists('lw_harbor_get_activation_url')
+        return function_exists('lw_harbor_get_activation_base_url')
             && function_exists('lw_harbor_get_product_activation_url');
     }
 
@@ -107,7 +107,7 @@ class LicenseData
         // Guarded inline (not only via canBuildActivationUrl()) so static analysis
         // can see the functions are called only when they exist.
         if (
-            !function_exists('lw_harbor_get_activation_url')
+            !function_exists('lw_harbor_get_activation_base_url')
             || !function_exists('lw_harbor_get_product_activation_url')
         ) {
             return '';
@@ -116,7 +116,7 @@ class LicenseData
         $entitlement = $this->getLicensedEntry();
 
         if (!$entitlement instanceof Product_Entry) {
-            return lw_harbor_get_activation_url($returnUrl);
+            return lw_harbor_get_activation_base_url($returnUrl);
         }
 
         return lw_harbor_get_product_activation_url(

--- a/src/Onboarding/LicenseData.php
+++ b/src/Onboarding/LicenseData.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Give\Onboarding;
+
+use Give\Vendors\LiquidWeb\Harbor\Licensing\Product_Collection;
+use Give\Vendors\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
+use Give\Vendors\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
+
+/**
+ * Answers the licensing questions GiveWP's onboarding UI asks: whether this site
+ * has activated GiveWP, and where to send a user who still has something to do
+ * about it. Keeps the onboarding screens about rendering rather than about Harbor.
+ *
+ * The plugin reaches Harbor through its stable lw_harbor_* global functions rather
+ * than resolving Harbor's classes directly: the functions always resolve to the
+ * loaded, highest-version Harbor copy, so onboarding is never tied to whichever
+ * version this plugin happens to bundle. Every method degrades to "nothing to
+ * offer" — false, null or an empty string — when the loaded Harbor is older than
+ * the API it needs, so callers can treat that as "hide the UI".
+ *
+ * @since TBD
+ */
+class LicenseData
+{
+    /**
+     * The product slug GiveWP is licensed under in the Liquid Web catalog.
+     *
+     * @since TBD
+     */
+    private const PRODUCT_SLUG = 'give';
+
+    /**
+     * Whether the loaded Harbor can build an activation URL at all. Older copies
+     * predate the activation URL API; callers guard on this so they can skip work
+     * they would only discard, or hide UI they cannot drive.
+     *
+     * @since TBD
+     */
+    public function canBuildActivationUrl(): bool
+    {
+        return function_exists('lw_harbor_get_activation_url')
+            && function_exists('lw_harbor_get_product_activation_url');
+    }
+
+    /**
+     * Get the URL that sends a user to the portal to activate a license, for
+     * callers that only want one while the user still has something to do.
+     *
+     * Empty when there is nothing to be done: the loaded Harbor predates the API,
+     * or the site already holds a valid activated license.
+     *
+     * @since TBD
+     */
+    public function getActivationUrl(string $returnUrl): string
+    {
+        if (!$this->canBuildActivationUrl()) {
+            return '';
+        }
+
+        if ($this->isActivated()) {
+            return '';
+        }
+
+        return $this->buildActivationUrl($returnUrl);
+    }
+
+    /**
+     * Build the activation URL whatever this site's activation state. When the
+     * stored license already covers GiveWP the URL is scoped to the product and
+     * tier so the portal pre-selects the right subscription.
+     *
+     * @since TBD
+     */
+    public function buildActivationUrl(string $returnUrl): string
+    {
+        // Guarded inline (not only via canBuildActivationUrl()) so static analysis
+        // can see the functions are called only when they exist.
+        if (
+            !function_exists('lw_harbor_get_activation_url')
+            || !function_exists('lw_harbor_get_product_activation_url')
+        ) {
+            return '';
+        }
+
+        $entitlement = $this->getLicensedEntry();
+
+        if (!$entitlement instanceof Product_Entry) {
+            return lw_harbor_get_activation_url($returnUrl);
+        }
+
+        return lw_harbor_get_product_activation_url(
+            $entitlement->get_product_slug(),
+            $entitlement->get_tier(),
+            $returnUrl
+        );
+    }
+
+    /**
+     * Get the URL of the in-WP page where a user manages their Liquid Web licenses.
+     * This is the Software Manager settings page Harbor registers, not the external
+     * portal: an activated user manages their products without leaving the site.
+     *
+     * @since TBD
+     */
+    public function getManagementUrl(): string
+    {
+        if (!function_exists('lw_harbor_get_license_page_url')) {
+            return '';
+        }
+
+        return lw_harbor_get_license_page_url();
+    }
+
+    /**
+     * Whether this site already holds a valid, activated license for GiveWP.
+     * Mirrors Harbor's own license UI: an entry counts only when it is activated
+     * against this domain and its entitlement is currently valid.
+     *
+     * @since TBD
+     */
+    public function isActivated(): bool
+    {
+        $products = $this->getProducts();
+
+        if (!$products instanceof Product_Collection) {
+            return false;
+        }
+
+        $entry = $products->get_activated_entry(self::PRODUCT_SLUG);
+
+        return $entry instanceof Product_Entry && $entry->is_valid();
+    }
+
+    /**
+     * Get the licensed entry for GiveWP, whatever its activation state. Used to
+     * scope the activation URL: the tier is known as soon as the key covers the
+     * product, well before activation, so this deliberately does not filter on it.
+     *
+     * @since TBD
+     */
+    protected function getLicensedEntry(): ?Product_Entry
+    {
+        $products = $this->getProducts();
+
+        if (!$products instanceof Product_Collection) {
+            return null;
+        }
+
+        $entries = $products->get_all_by_slug(self::PRODUCT_SLUG);
+
+        return $entries ? reset($entries) : null;
+    }
+
+    /**
+     * Get the licensed products Harbor holds for this site. Harbor returns a
+     * WP_Error when its last fetch failed and null when it has never fetched; both
+     * are flattened to null here and read by callers as "no license".
+     *
+     * @since TBD
+     */
+    protected function getProducts(): ?Product_Collection
+    {
+        if (!class_exists(License_Repository::class)) {
+            return null;
+        }
+
+        $products = give(License_Repository::class)->get_products();
+
+        return $products instanceof Product_Collection ? $products : null;
+    }
+}

--- a/src/Onboarding/LicenseData.php
+++ b/src/Onboarding/LicenseData.php
@@ -100,6 +100,10 @@ class LicenseData
      * stored license already covers GiveWP the URL is scoped to the product and
      * tier so the portal pre-selects the right subscription.
      *
+     * Harbor returns null when it has no URL to give; that is folded into the
+     * empty string this returns, because both mean the same thing here — there
+     * is nothing to link to.
+     *
      * @since TBD
      */
     public function buildActivationUrl(string $returnUrl): string
@@ -116,14 +120,14 @@ class LicenseData
         $entitlement = $this->getLicensedEntry();
 
         if (!$entitlement instanceof Product_Entry) {
-            return lw_harbor_get_activation_base_url($returnUrl);
+            return lw_harbor_get_activation_base_url($returnUrl) ?? '';
         }
 
         return lw_harbor_get_product_activation_url(
             $entitlement->get_product_slug(),
             $entitlement->get_tier(),
             $returnUrl
-        );
+        ) ?? '';
     }
 
     /**

--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -13,6 +13,7 @@ defined('ABSPATH') || exit;
 use Give\Framework\Http\ConnectServer\Client\ConnectClient;
 use Give\Helpers\Gateways\Stripe;
 use Give\Onboarding\FormRepository;
+use Give\Onboarding\LicenseData;
 use Give\PaymentGateways\PayPalCommerce\Repositories\MerchantDetails;
 
 /**
@@ -152,5 +153,41 @@ class PageView
             ],
             esc_url_raw($this->connectClient->getApiUrl('stripe/connect.php'))
         );
+    }
+
+    /**
+     * Whether to show the unified Liquid Web license step — i.e. the loaded Harbor
+     * is new enough to build an activation URL. Omitted entirely otherwise.
+     *
+     * @since TBD
+     */
+    public function isLicenseStepAvailable(): bool
+    {
+        return give(LicenseData::class)->canBuildActivationUrl();
+    }
+
+    /**
+     * Whether this site already holds a valid, activated Liquid Web license.
+     *
+     * @since TBD
+     */
+    public function isLicenseActivated(): bool
+    {
+        return give(LicenseData::class)->isActivated();
+    }
+
+    /**
+     * The destination for the license step's button: the in-WP license manager
+     * once activated, otherwise the portal to activate (returning here afterwards).
+     *
+     * @since TBD
+     */
+    public function licenseStepUrl(): string
+    {
+        $licenseData = give(LicenseData::class);
+
+        return $licenseData->isActivated()
+            ? $licenseData->getManagementUrl()
+            : $licenseData->buildActivationUrl(menu_page_url('give-setup', false));
     }
 }

--- a/src/Onboarding/Setup/PageView.php
+++ b/src/Onboarding/Setup/PageView.php
@@ -156,14 +156,19 @@ class PageView
     }
 
     /**
-     * Whether to show the unified Liquid Web license step — i.e. the loaded Harbor
-     * is new enough to build an activation URL. Omitted entirely otherwise.
+     * Whether to show the unified Liquid Web license step. It earns its place only
+     * on a site running a premium add-on a license would unlock, and only when the
+     * loaded Harbor is new enough to build an activation URL. Omitted entirely
+     * otherwise, so setup never reads as though a license were a prerequisite.
      *
      * @since TBD
      */
-    public function isLicenseStepAvailable(): bool
+    public function shouldShowLicenseStep(): bool
     {
-        return give(LicenseData::class)->canBuildActivationUrl();
+        $licenseData = give(LicenseData::class);
+
+        return $licenseData->hasActivePremiumAddons()
+            && $licenseData->canBuildActivationUrl();
     }
 
     /**

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -42,39 +42,6 @@
 
     <?php $step = 0; ?>
 
-    <!-- License activation (unified Liquid Web) -->
-    <?php
-    if ($this->shouldShowLicenseStep()) {
-        echo $this->render_template(
-            'section',
-            [
-                'class' => $this->isLicenseActivated() ? '' : 'current-step',
-                'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Activate license for your add-ons', 'give')),
-                'badge' => ($this->isLicenseActivated()
-                    ? $this->render_template('badge', [
-                        'class' => 'completed',
-                        'text' => esc_html__('Completed', 'give'),
-                    ])
-                    : $this->render_template('badge', [
-                        'class' => 'not-completed',
-                        'text' => esc_html__('Not Completed', 'give'),
-                    ])
-                ),
-                'button' => $this->render_template('action-button', [
-                    'href' => esc_url($this->licenseStepUrl()),
-                    'text' => $this->isLicenseActivated()
-                        ? esc_html__('Manage license', 'give')
-                        : esc_html__('Activate license', 'give'),
-                    'target' => '',
-                ]),
-                'contents' => $this->render_template('sub-header', [
-                    'text' => esc_html__('Receive updates and support for the premium add-ons you\'re using with GiveWP.', 'give'),
-                ]),
-            ]
-        );
-    }
-    ?>
-
     <!-- Configuration -->
     <?php
     if ($this->isFormConfigured()) {
@@ -429,6 +396,39 @@
             ],
         ]
     );
+    ?>
+
+    <!-- License activation (unified Liquid Web) -->
+    <?php
+    if ($this->shouldShowLicenseStep()) {
+        echo $this->render_template(
+            'section',
+            [
+                'class' => '',
+                'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Activate license for your add-ons', 'give')),
+                'badge' => ($this->isLicenseActivated()
+                    ? $this->render_template('badge', [
+                        'class' => 'completed',
+                        'text' => esc_html__('Completed', 'give'),
+                    ])
+                    : $this->render_template('badge', [
+                        'class' => 'not-completed',
+                        'text' => esc_html__('Not Completed', 'give'),
+                    ])
+                ),
+                'button' => $this->render_template('action-button', [
+                    'href' => esc_url($this->licenseStepUrl()),
+                    'text' => $this->isLicenseActivated()
+                        ? esc_html__('Manage license', 'give')
+                        : esc_html__('Activate license', 'give'),
+                    'target' => '',
+                ]),
+                'contents' => $this->render_template('sub-header', [
+                    'text' => esc_html__('Receive updates and support for the premium add-ons you\'re using with GiveWP.', 'give'),
+                ]),
+            ]
+        );
+    }
     ?>
 
     <?php

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -40,6 +40,41 @@
     do_action('give_setup_page_before_sections');
     ?>
 
+    <?php $step = 0; ?>
+
+    <!-- License activation (unified Liquid Web) -->
+    <?php
+    if ($this->isLicenseStepAvailable()) {
+        echo $this->render_template(
+            'section',
+            [
+                'class' => $this->isLicenseActivated() ? '' : 'current-step',
+                'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Activate your license', 'give')),
+                'badge' => ($this->isLicenseActivated()
+                    ? $this->render_template('badge', [
+                        'class' => 'completed',
+                        'text' => esc_html__('Completed', 'give'),
+                    ])
+                    : $this->render_template('badge', [
+                        'class' => 'not-completed',
+                        'text' => esc_html__('Not Completed', 'give'),
+                    ])
+                ),
+                'button' => $this->render_template('action-button', [
+                    'href' => esc_url($this->licenseStepUrl()),
+                    'text' => $this->isLicenseActivated()
+                        ? esc_html__('Manage license', 'give')
+                        : esc_html__('Activate license', 'give'),
+                    'target' => '',
+                ]),
+                'contents' => $this->render_template('sub-header', [
+                    'text' => esc_html__('Unlock updates and support for your Liquid Web products.', 'give'),
+                ]),
+            ]
+        );
+    }
+    ?>
+
     <!-- Configuration -->
     <?php
     if ($this->isFormConfigured()) {
@@ -54,7 +89,7 @@
         'section',
         [
             'class' => !$this->isFormConfigured() ? 'current-step' : '',
-            'title' => sprintf('%s 1: %s', __('Step', 'give'), __('Create your first campaign', 'give')),
+            'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Create your first campaign', 'give')),
             'badge' => ($this->isFormConfigured()
                 ? $this->render_template('badge', [
                     'class' => 'completed',
@@ -87,7 +122,7 @@
         'section',
         [
             'class' => ($this->isFormConfigured() && !($this->isStripeSetup() || $this->isPayPalSetup())) ? 'current-step' : '',
-            'title' => sprintf('%s 2: %s', __('Step', 'give'), __('Connect a payment gateway', 'give')),
+            'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Connect a payment gateway', 'give')),
             'badge' => (($this->isStripeSetup() || $this->isPayPalSetup())
                 ? $this->render_template('badge', [
                     'class' => 'completed',
@@ -211,7 +246,7 @@
     echo $this->render_template(
         'section',
         [
-            'title' => sprintf('%s 3: %s', __('Step', 'give'), __('Get more from your fundraising campaign with add-ons', 'give')),
+            'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Get more from your fundraising campaign with add-ons', 'give')),
             'badge' => $this->render_template('badge', [
                 'class' => 'optional',
                 'text' => esc_html__('Optional', 'give'),

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -49,7 +49,7 @@
             'section',
             [
                 'class' => $this->isLicenseActivated() ? '' : 'current-step',
-                'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Activate your license', 'give')),
+                'title' => sprintf('%s %d: %s', __('Step', 'give'), ++$step, __('Activate license for your add-ons', 'give')),
                 'badge' => ($this->isLicenseActivated()
                     ? $this->render_template('badge', [
                         'class' => 'completed',
@@ -68,7 +68,7 @@
                     'target' => '',
                 ]),
                 'contents' => $this->render_template('sub-header', [
-                    'text' => esc_html__('Unlock updates and support for your Liquid Web products.', 'give'),
+                    'text' => esc_html__('Unlock updates and support for the premium add-ons you\'re using with GiveWP.', 'give'),
                 ]),
             ]
         );

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -44,7 +44,7 @@
 
     <!-- License activation (unified Liquid Web) -->
     <?php
-    if ($this->isLicenseStepAvailable()) {
+    if ($this->shouldShowLicenseStep()) {
         echo $this->render_template(
             'section',
             [

--- a/src/Onboarding/Setup/templates/index.html.php
+++ b/src/Onboarding/Setup/templates/index.html.php
@@ -68,7 +68,7 @@
                     'target' => '',
                 ]),
                 'contents' => $this->render_template('sub-header', [
-                    'text' => esc_html__('Unlock updates and support for the premium add-ons you\'re using with GiveWP.', 'give'),
+                    'text' => esc_html__('Receive updates and support for the premium add-ons you\'re using with GiveWP.', 'give'),
                 ]),
             ]
         );

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -71,6 +71,20 @@ class Page
     }
 
     /**
+     * The wizard's own admin URL.
+     *
+     * Used as the address the Liquid Web portal returns a user to after they
+     * activate, so they come back to the wizard they left rather than to
+     * another screen. Derived from the page slug so the two cannot drift apart.
+     *
+     * @since TBD
+     */
+    public function getReturnUrl(): string
+    {
+        return add_query_arg('page', $this->slug, admin_url());
+    }
+
+    /**
      * Conditionally renders Onboarding Wizard
      *
      * If the current page query matches the onboarding wizard's slug, method renders the onboarding wizard.
@@ -175,9 +189,7 @@ class Page
             'addons' => $this->onboardingSettingsRepository->get('addons') ?: [],
             // Empty when the loaded Harbor cannot build a URL or the site is already
             // activated; the intro screen hides the Activate button in that case.
-            'activationUrl' => give(LicenseData::class)->getActivationUrl(
-                admin_url('edit.php?post_type=give_forms&page=give-setup')
-            ),
+            'activationUrl' => give(LicenseData::class)->getActivationUrl($this->getReturnUrl()),
         ];
 
         EnqueueScript::make(

--- a/src/Onboarding/Wizard/Page.php
+++ b/src/Onboarding/Wizard/Page.php
@@ -9,6 +9,7 @@ use Give\Helpers\EnqueueScript;
 use Give\Onboarding\FormRepository;
 use Give\Onboarding\Helpers\FormatList;
 use Give\Onboarding\Helpers\LocationList;
+use Give\Onboarding\LicenseData;
 use Give\Onboarding\LocaleCollection;
 use Give\Onboarding\SettingsRepository;
 use Give\Onboarding\SettingsRepositoryFactory;
@@ -172,6 +173,11 @@ class Page
             'websiteUrl' => get_bloginfo('url'),
             'websiteName' => get_bloginfo('sitename'),
             'addons' => $this->onboardingSettingsRepository->get('addons') ?: [],
+            // Empty when the loaded Harbor cannot build a URL or the site is already
+            // activated; the intro screen hides the Activate button in that case.
+            'activationUrl' => give(LicenseData::class)->getActivationUrl(
+                admin_url('edit.php?post_type=give_forms&page=give-setup')
+            ),
         ];
 
         EnqueueScript::make(

--- a/tests/Unit/Onboarding/LicenseDataTest.php
+++ b/tests/Unit/Onboarding/LicenseDataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Give\Tests\Unit\Onboarding;
 
+use Faker\Factory;
 use Give\Onboarding\LicenseData;
 use Give\Tests\TestCase;
 
@@ -23,6 +24,8 @@ final class LicenseDataTest extends TestCase
      */
     public function testGetActivationUrlIsEmptyWhenHarborCannotBuildOne(): void
     {
+        $faker = Factory::create();
+
         $licenseData = $this->getMockBuilder(LicenseData::class)
             ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
             ->getMock();
@@ -30,7 +33,7 @@ final class LicenseDataTest extends TestCase
         $licenseData->method('canBuildActivationUrl')->willReturn(false);
         $licenseData->expects($this->never())->method('buildActivationUrl');
 
-        $this->assertSame('', $licenseData->getActivationUrl('https://example.test/return'));
+        $this->assertSame('', $licenseData->getActivationUrl($faker->url()));
     }
 
     /**
@@ -38,6 +41,8 @@ final class LicenseDataTest extends TestCase
      */
     public function testGetActivationUrlIsEmptyWhenAlreadyActivated(): void
     {
+        $faker = Factory::create();
+
         $licenseData = $this->getMockBuilder(LicenseData::class)
             ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
             ->getMock();
@@ -46,7 +51,7 @@ final class LicenseDataTest extends TestCase
         $licenseData->method('isActivated')->willReturn(true);
         $licenseData->expects($this->never())->method('buildActivationUrl');
 
-        $this->assertSame('', $licenseData->getActivationUrl('https://example.test/return'));
+        $this->assertSame('', $licenseData->getActivationUrl($faker->url()));
     }
 
     /**
@@ -54,8 +59,10 @@ final class LicenseDataTest extends TestCase
      */
     public function testGetActivationUrlReturnsBuiltUrlWhenActionableAndNotActivated(): void
     {
-        $returnUrl = 'https://example.test/return';
-        $expectedUrl = 'https://portal.example.test/activate';
+        $faker = Factory::create();
+
+        $returnUrl = $faker->url();
+        $expectedUrl = $faker->url();
 
         $licenseData = $this->getMockBuilder(LicenseData::class)
             ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])

--- a/tests/Unit/Onboarding/LicenseDataTest.php
+++ b/tests/Unit/Onboarding/LicenseDataTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\Onboarding;
+
+use Give\Onboarding\LicenseData;
+use Give\Tests\TestCase;
+
+/**
+ * Covers the decision logic LicenseData owns: when it offers an activation URL and
+ * when it stays quiet. The Harbor-facing calls it wraps (global functions, the
+ * final Product_Collection/Product_Entry classes) are exercised through Harbor's
+ * own suite; these tests fix the branching around them so it holds whatever version
+ * of Harbor a build happens to bundle.
+ *
+ * @since TBD
+ */
+final class LicenseDataTest extends TestCase
+{
+    /**
+     * @since TBD
+     */
+    public function testGetActivationUrlIsEmptyWhenHarborCannotBuildOne(): void
+    {
+        $licenseData = $this->getMockBuilder(LicenseData::class)
+            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->getMock();
+
+        $licenseData->method('canBuildActivationUrl')->willReturn(false);
+        $licenseData->expects($this->never())->method('buildActivationUrl');
+
+        $this->assertSame('', $licenseData->getActivationUrl('https://example.test/return'));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetActivationUrlIsEmptyWhenAlreadyActivated(): void
+    {
+        $licenseData = $this->getMockBuilder(LicenseData::class)
+            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->getMock();
+
+        $licenseData->method('canBuildActivationUrl')->willReturn(true);
+        $licenseData->method('isActivated')->willReturn(true);
+        $licenseData->expects($this->never())->method('buildActivationUrl');
+
+        $this->assertSame('', $licenseData->getActivationUrl('https://example.test/return'));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetActivationUrlReturnsBuiltUrlWhenActionableAndNotActivated(): void
+    {
+        $returnUrl = 'https://example.test/return';
+        $expectedUrl = 'https://portal.example.test/activate';
+
+        $licenseData = $this->getMockBuilder(LicenseData::class)
+            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->getMock();
+
+        $licenseData->method('canBuildActivationUrl')->willReturn(true);
+        $licenseData->method('isActivated')->willReturn(false);
+        $licenseData->expects($this->once())
+            ->method('buildActivationUrl')
+            ->with($returnUrl)
+            ->willReturn($expectedUrl);
+
+        $this->assertSame($expectedUrl, $licenseData->getActivationUrl($returnUrl));
+    }
+}

--- a/tests/Unit/Onboarding/LicenseDataTest.php
+++ b/tests/Unit/Onboarding/LicenseDataTest.php
@@ -22,14 +22,32 @@ final class LicenseDataTest extends TestCase
     /**
      * @since TBD
      */
+    public function testGetActivationUrlIsEmptyWhenNoActivePremiumAddons(): void
+    {
+        $faker = Factory::create();
+
+        $licenseData = $this->getMockBuilder(LicenseData::class)
+            ->onlyMethods(['hasActivePremiumAddons', 'canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->getMock();
+
+        $licenseData->method('hasActivePremiumAddons')->willReturn(false);
+        $licenseData->expects($this->never())->method('buildActivationUrl');
+
+        $this->assertSame('', $licenseData->getActivationUrl($faker->url()));
+    }
+
+    /**
+     * @since TBD
+     */
     public function testGetActivationUrlIsEmptyWhenHarborCannotBuildOne(): void
     {
         $faker = Factory::create();
 
         $licenseData = $this->getMockBuilder(LicenseData::class)
-            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->onlyMethods(['hasActivePremiumAddons', 'canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
             ->getMock();
 
+        $licenseData->method('hasActivePremiumAddons')->willReturn(true);
         $licenseData->method('canBuildActivationUrl')->willReturn(false);
         $licenseData->expects($this->never())->method('buildActivationUrl');
 
@@ -44,9 +62,10 @@ final class LicenseDataTest extends TestCase
         $faker = Factory::create();
 
         $licenseData = $this->getMockBuilder(LicenseData::class)
-            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->onlyMethods(['hasActivePremiumAddons', 'canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
             ->getMock();
 
+        $licenseData->method('hasActivePremiumAddons')->willReturn(true);
         $licenseData->method('canBuildActivationUrl')->willReturn(true);
         $licenseData->method('isActivated')->willReturn(true);
         $licenseData->expects($this->never())->method('buildActivationUrl');
@@ -65,9 +84,10 @@ final class LicenseDataTest extends TestCase
         $expectedUrl = $faker->url();
 
         $licenseData = $this->getMockBuilder(LicenseData::class)
-            ->onlyMethods(['canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
+            ->onlyMethods(['hasActivePremiumAddons', 'canBuildActivationUrl', 'isActivated', 'buildActivationUrl'])
             ->getMock();
 
+        $licenseData->method('hasActivePremiumAddons')->willReturn(true);
         $licenseData->method('canBuildActivationUrl')->willReturn(true);
         $licenseData->method('isActivated')->willReturn(false);
         $licenseData->expects($this->once())

--- a/tests/Unit/Onboarding/Setup/PageViewTest.php
+++ b/tests/Unit/Onboarding/Setup/PageViewTest.php
@@ -4,6 +4,7 @@ namespace Give\Tests\Unit\Onboarding\Setup;
 
 use Give\Framework\Http\ConnectServer\Client\ConnectClient;
 use Give\Onboarding\FormRepository;
+use Give\Onboarding\LicenseData;
 use Give\Onboarding\Setup\PageView;
 use Give\Tests\TestCase;
 
@@ -24,6 +25,93 @@ final class PageViewTest extends TestCase
         $this->assertStringContainsString(
             '<article id="" class="setup-item foo" data-givewp-test="">',
             $pageView->render_template('row-item', ['class' => 'foo'])
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLicenseStepAvailabilityFollowsLicenseData(): void
+    {
+        $this->bindLicenseData(['canBuildActivationUrl' => true]);
+        $this->assertTrue($this->makePageView()->isLicenseStepAvailable());
+
+        $this->bindLicenseData(['canBuildActivationUrl' => false]);
+        $this->assertFalse($this->makePageView()->isLicenseStepAvailable());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLicenseActivationStateFollowsLicenseData(): void
+    {
+        $this->bindLicenseData(['isActivated' => true]);
+        $this->assertTrue($this->makePageView()->isLicenseActivated());
+
+        $this->bindLicenseData(['isActivated' => false]);
+        $this->assertFalse($this->makePageView()->isLicenseActivated());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLicenseStepUrlUsesTheManagerOnceActivated(): void
+    {
+        $this->bindLicenseData([
+            'isActivated' => true,
+            'getManagementUrl' => 'https://example.test/wp-admin/manage',
+        ]);
+
+        $this->assertSame(
+            'https://example.test/wp-admin/manage',
+            $this->makePageView()->licenseStepUrl()
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLicenseStepUrlPointsToActivationWhenNotActivated(): void
+    {
+        $this->bindLicenseData([
+            'isActivated' => false,
+            'buildActivationUrl' => 'https://portal.example.test/activate',
+        ]);
+
+        $this->assertSame(
+            'https://portal.example.test/activate',
+            $this->makePageView()->licenseStepUrl()
+        );
+    }
+
+    /**
+     * Bind a LicenseData test double into the container so PageView resolves it in
+     * place of the real service. Only the passed methods are stubbed; the rest keep
+     * their PHPUnit defaults.
+     *
+     * @since TBD
+     *
+     * @param array<string, mixed> $returns method name => value it should return
+     */
+    private function bindLicenseData(array $returns): void
+    {
+        $licenseData = $this->createMock(LicenseData::class);
+
+        foreach ($returns as $method => $value) {
+            $licenseData->method($method)->willReturn($value);
+        }
+
+        give()->instance(LicenseData::class, $licenseData);
+    }
+
+    /**
+     * @since TBD
+     */
+    private function makePageView(): PageView
+    {
+        return new PageView(
+            $this->createMock(FormRepository::class),
+            give(ConnectClient::class)
         );
     }
 }

--- a/tests/Unit/Onboarding/Setup/PageViewTest.php
+++ b/tests/Unit/Onboarding/Setup/PageViewTest.php
@@ -32,13 +32,35 @@ final class PageViewTest extends TestCase
     /**
      * @since TBD
      */
-    public function testLicenseStepAvailabilityFollowsLicenseData(): void
+    public function testLicenseStepIsShownOnlyWithPremiumAddonsAndACapableHarbor(): void
     {
-        $this->bindLicenseData(['canBuildActivationUrl' => true]);
-        $this->assertTrue($this->makePageView()->isLicenseStepAvailable());
+        $this->bindLicenseData([
+            'hasActivePremiumAddons' => true,
+            'canBuildActivationUrl' => true,
+        ]);
+        $this->assertTrue($this->makePageView()->shouldShowLicenseStep());
 
-        $this->bindLicenseData(['canBuildActivationUrl' => false]);
-        $this->assertFalse($this->makePageView()->isLicenseStepAvailable());
+        $this->bindLicenseData([
+            'hasActivePremiumAddons' => true,
+            'canBuildActivationUrl' => false,
+        ]);
+        $this->assertFalse($this->makePageView()->shouldShowLicenseStep());
+    }
+
+    /**
+     * GiveWP is free, so a site running no premium add-on must not be shown a
+     * license step — even when Harbor is perfectly able to build the URL.
+     *
+     * @since TBD
+     */
+    public function testLicenseStepIsHiddenWithoutActivePremiumAddons(): void
+    {
+        $this->bindLicenseData([
+            'hasActivePremiumAddons' => false,
+            'canBuildActivationUrl' => true,
+        ]);
+
+        $this->assertFalse($this->makePageView()->shouldShowLicenseStep());
     }
 
     /**

--- a/tests/Unit/Onboarding/Setup/PageViewTest.php
+++ b/tests/Unit/Onboarding/Setup/PageViewTest.php
@@ -2,6 +2,7 @@
 
 namespace Give\Tests\Unit\Onboarding\Setup;
 
+use Faker\Factory;
 use Give\Framework\Http\ConnectServer\Client\ConnectClient;
 use Give\Onboarding\FormRepository;
 use Give\Onboarding\LicenseData;
@@ -57,13 +58,15 @@ final class PageViewTest extends TestCase
      */
     public function testLicenseStepUrlUsesTheManagerOnceActivated(): void
     {
+        $managementUrl = Factory::create()->url();
+
         $this->bindLicenseData([
             'isActivated' => true,
-            'getManagementUrl' => 'https://example.test/wp-admin/manage',
+            'getManagementUrl' => $managementUrl,
         ]);
 
         $this->assertSame(
-            'https://example.test/wp-admin/manage',
+            $managementUrl,
             $this->makePageView()->licenseStepUrl()
         );
     }
@@ -73,13 +76,15 @@ final class PageViewTest extends TestCase
      */
     public function testLicenseStepUrlPointsToActivationWhenNotActivated(): void
     {
+        $activationUrl = Factory::create()->url();
+
         $this->bindLicenseData([
             'isActivated' => false,
-            'buildActivationUrl' => 'https://portal.example.test/activate',
+            'buildActivationUrl' => $activationUrl,
         ]);
 
         $this->assertSame(
-            'https://portal.example.test/activate',
+            $activationUrl,
             $this->makePageView()->licenseStepUrl()
         );
     }

--- a/tests/Unit/Onboarding/Wizard/PageTest.php
+++ b/tests/Unit/Onboarding/Wizard/PageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Tests\Unit\Onboarding\Wizard;
+
+use Give\Onboarding\FormRepository;
+use Give\Onboarding\LocaleCollection;
+use Give\Onboarding\SettingsRepositoryFactory;
+use Give\Onboarding\Wizard\Page;
+use Give\Tests\TestCase;
+
+/**
+ * Covers the address the wizard hands the Liquid Web portal to return a user to.
+ *
+ * The portal sends the user back wherever it is told, so the wizard has to name
+ * itself rather than another onboarding screen; a user who leaves the wizard to
+ * activate should come back to the wizard.
+ *
+ * @since TBD
+ */
+final class PageTest extends TestCase
+{
+    /**
+     * @since TBD
+     */
+    public function testGetReturnUrlPointsAtTheWizard(): void
+    {
+        $page = $this->makePage();
+
+        $this->assertSame(
+            add_query_arg('page', 'give-onboarding-wizard', admin_url()),
+            $page->getReturnUrl()
+        );
+    }
+
+    /**
+     * The return URL was previously the setup page, which sent a user who
+     * activated from the wizard to a different screen on the way back.
+     *
+     * @since TBD
+     */
+    public function testGetReturnUrlIsNotTheSetupPage(): void
+    {
+        $returnUrl = $this->makePage()->getReturnUrl();
+
+        $this->assertStringContainsString('page=give-onboarding-wizard', $returnUrl);
+        $this->assertStringNotContainsString('give-setup', $returnUrl);
+    }
+
+    /**
+     * @since TBD
+     */
+    private function makePage(): Page
+    {
+        return new Page(
+            $this->createMock(FormRepository::class),
+            $this->createMock(SettingsRepositoryFactory::class),
+            $this->createMock(LocaleCollection::class)
+        );
+    }
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1836] (parent [SMTNC-1833])

### 🎥 Artifacts

(no audio)
https://www.loom.com/share/9e329110ef8949539bb457efe7d61fbd

<img width="1516" height="1147" alt="Screenshot 2026-07-24 190630" src="https://github.com/user-attachments/assets/1c05b9ae-5223-4202-a392-9f8667a41920" />

<img width="2317" height="1160" alt="Screenshot 2026-07-24 190742" src="https://github.com/user-attachments/assets/3ee119c8-3cca-4d7a-8988-0c698a3065c1" />

<img width="2319" height="1156" alt="Screenshot 2026-07-24 190648" src="https://github.com/user-attachments/assets/9d43c67e-8b22-46c4-8ee2-1f709ce582a5" />

### 🗒️ Description

**New feature.** GiveWP's onboarding had no route to activating a license — a user who had bought GiveWP but not activated it on this site had to find the portal themselves. This adds that route in both places onboarding appears:

- **Setup page** (`edit.php?post_type=give_forms&page=give-setup`) — a license step at the head of the list. Before activation it offers an **Activate license** button (→ the portal, scoped to GiveWP, with a return address); once activated it reads as completed and offers a **Manage license** button (→ the in-WP Liquid Web **Software Manager**, `options-general.php?page=lw-software-manager`).
- **Onboarding wizard** welcome screen — an **Activate license for your add-ons** link beneath "Start Setup", shown only while there is something to activate. The portal returns the user to the wizard they left, not to another onboarding screen.

**Neither surface appears unless the site runs an active premium add-on.** GiveWP is free, and a license only unlocks premium add-ons and their updates — so a site running none of them is never shown licensing UI that would imply otherwise.

This is the GiveWP counterpart of the same work in The Events Calendar and LearnDash (parent SMTNC-1833). **Dependency note:** the feature calls Harbor's activation-URL global functions (`lw_harbor_get_activation_url()` / `lw_harbor_get_product_activation_url()`, SMTNC-1844 / Harbor #181), which GiveWP's **bundled (Strauss-prefixed) Harbor does not ship yet** — so on the current dependency it is inert (`function_exists()` guards hide the UI). It comes alive once the bundled Harbor is bumped to a release that ships those functions, or when another StellarWP plugin loads a newer Harbor in the same install; see Blockers.

#### What changed

| File | Change |
| --- | --- |
| `src/Onboarding/LicenseData.php` | **New** — every licensing question onboarding asks: has-active-premium-add-ons / can-build / is-activated / the portal activation URL / and `getManagementUrl()` (the in-WP Software Manager page) |
| `src/Onboarding/Setup/PageView.php` | Three view methods — `shouldShowLicenseStep()`, `isLicenseActivated()`, `licenseStepUrl()` — delegating to `LicenseData` |
| `src/Onboarding/Setup/templates/index.html.php` | Prepends the license step (state-aware badge + Activate/Manage button); a step counter renumbers the existing steps so the list stays sequential whether or not the license step shows |
| `src/Onboarding/Wizard/Page.php` | Localizes the activation URL into `giveOnboardingWizardData` for the React app, and names the wizard as the portal's return address via `getReturnUrl()` |
| `assets/src/js/admin/onboarding-wizard/components/activate-license-link/` | **New** — the wizard link component; renders nothing when there is no URL to offer |
| `assets/src/js/admin/onboarding-wizard/app/steps/introduction/index.js` | Renders the Activate link beneath the "Start Setup" button |
| `tests/Unit/Onboarding/LicenseDataTest.php` | **New** — the activation-URL decision logic (hidden when no premium add-on is active / Harbor can't build one / already activated / built otherwise) |
| `tests/Unit/Onboarding/Setup/PageViewTest.php` | Delegation tests for the three new view methods, plus that the license step stays hidden without an active premium add-on |
| `tests/Unit/Onboarding/Wizard/PageTest.php` | **New** — pins the portal's return address to the wizard, so activating from it cannot send the user back to a different screen |

No built assets are committed — `build/` is gitignored and rebuilt at release, so this PR is source-only. The React bundle was rebuilt locally to confirm it compiles.

The throwaway URLs in both test files are Faker-generated (`Faker\Factory::create()->url()`), matching how the rest of the suite handles incidental values.

#### Why a new service

The licensing logic lives in `LicenseData` rather than on the setup-page or wizard classes. Those change when the UI changes; Harbor's repository, product collections, entitlement validity and URL formats change for entirely different reasons. Keeping them apart means the onboarding code stays about rendering. (This mirrors the `License_Data` service the TEC and LearnDash PRs settled on.)

#### Review notes

**1. Global functions, not Harbor's classes.** Everything Harbor exposes globally is reached through its stable `lw_harbor_*` functions, not by resolving Harbor's classes from GiveWP's container — so onboarding follows the highest-version Harbor loaded in the install, never whichever copy GiveWP happens to bundle. The one exception is reading the licensed **tier** for URL scoping (note 3), which Harbor has no global accessor for; that goes through the licensing repository, exactly as in TEC/LearnDash.

**2. Three URL methods, on purpose.** `buildActivationUrl()` answers "build a portal URL whatever the state"; `getActivationUrl()` also returns empty once activated, so the wizard link disappears when there's nothing to do; `getManagementUrl()` returns the **in-WP** Software Manager page URL. The setup-page step picks between activate and manage by activation state.

**3. `isActivated()` vs the licensed entry are not redundant.** The first filters on activation; the second doesn't. The second scopes the URL: the tier is known as soon as the key covers the product, well before activation, so `sku=give:<tier>` pre-selects the right subscription in the portal. (Verified locally — a licensed-but-not-activated site produced `…&sku=give:essentials`.)

**4. The setup page is a procedural template, so the step is added inline.** GiveWP's setup page is rendered from `templates/index.html.php` (no steps filter like LearnDash's). The license section is prepended directly, guarded by `shouldShowLicenseStep()`, and a small `$step` counter drives the "Step N:" titles so the existing steps renumber themselves when the license step is present or absent.

**5. The wizard URL is prepared server-side.** `Page::enqueue_scripts()` builds the activation URL once and localizes it; the React link reads it via `getWindowData('activationUrl')` and hides itself when it's empty. No licensing logic in JS.

**6. The premium add-on gate.** GiveWP core is free, and a license only unlocks premium add-ons and their updates — so presenting a license step to a site running none of them would imply activation is a prerequisite for fundraising. `LicenseData::hasActivePremiumAddons()` gates both surfaces: the wizard link via `getActivationUrl()`, the setup step via `shouldShowLicenseStep()`. Detection uses GiveWP's own `give_get_plugins(['only_premium_add_ons' => true])` and requires an **active** add-on, matching the existing `HasActivePremiumAddons` action already wired to Harbor's `lw_harbor/premium_plugin_exists` filter. The gate lives in `LicenseData` rather than at the two call sites so any future surface inherits it instead of having to remember to apply it.

### ⚠️ Blockers

- **Harbor dependency — the real blocker.** The feature calls Harbor's activation-URL global functions (`lw_harbor_get_activation_url()` / `lw_harbor_get_product_activation_url()`, SMTNC-1844 / Harbor #181), which GiveWP's bundled Harbor does not ship yet (it has `lw_harbor_get_license_page_url()` but not the activation pair). Until the bundled Harbor is bumped to a release that ships them — or a newer Harbor is loaded by another StellarWP plugin in the same install — `function_exists()` is false and the UI stays hidden. Merge should either wait for that bump or land knowing the feature is inert until it happens.
- **`@since TBD`.** GiveWP uses real version numbers in docblocks; new symbols here carry `@since TBD` for now and need a concrete version at merge.

### Testing Instructions (QA)

Requires a site with a Liquid Web unified license that covers GiveWP, and a Harbor that ships the activation-URL functions (see Blockers).

- **No premium add-ons active:** neither the setup step nor the wizard link appears, whatever the license state, and the setup page's step numbering stays sequential.
- **Not activated on this domain:** the setup page leads with the license step ("Activate license for your add-ons") showing an **Activate license** button; the wizard welcome screen shows an **Activate license for your add-ons** link. Clicking either lands on the portal's subscriptions screen, scoped to GiveWP (`sku=give:<tier>`), and returns you afterwards.
- **Activated on this domain:** the setup-page card reads as completed and shows a **Manage license** button that opens the in-WP Liquid Web Software Manager (`Settings → Liquid Web Products`); the wizard link is hidden.
- **Older/bundled Harbor without the activation API:** neither the step nor the wizard link appears, and the setup page's step numbering stays sequential.

### ✔️ Checklist

- [x] Code is covered by **NEW** tests. <!-- LicenseDataTest (decision logic), PageViewTest (delegation) -->
- [ ] Changelog item has been added. <!-- GiveWP has no active per-PR changelog tooling (changelog/ holds only .gitkeep); readme.txt changelog is compiled at release. -->
- [x] All CI checks have passed. <!-- Green across the matrix: build/analyse and build/check on PHP 7.4 and 8.3, plus the full test matrix (PHP 7.4 and 8.4 x MySQL 5.7 and 8.0 x WP 6.5 and latest). Also verified locally: php -l on all touched PHP, wp-scripts build (bundle compiles), and a runtime probe via wp eval (functions resolve, container resolves the repository, activation URL comes back sku-scoped). -->
- [x] Have you added Artifacts? <!-- Screenshots of both onboarding surfaces above. -->
- [x] Have you added Testing Instructions for QA?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787506802&installation_model_id=426813&pr_number=8271&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8271&signature=7ebd9e4a3b60c075d39e7cee1d27f9dd0fb46fcb280da5db10350bec4efcc614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->