### PR TITLE
Fix: "Plugin does not have a valid header" error when uploading Zip with divergent name.

### DIFF
--- a/changelog/smtnc-1809-addon-zip-upload-fails-with-invalid-header.yaml
+++ b/changelog/smtnc-1809-addon-zip-upload-fails-with-invalid-header.yaml
@@ -1,0 +1,7 @@
+significance: patch
+type: fix
+entry: Resolved an issue where uploading a ZIP add-on with a folder name that
+  differs from the ZIP filename (e.g. give-recurring-donations-2.19.0.zip
+  containing the folder give-recurring/) would fail to detect the plugin after
+  extraction.
+timestamp: 2026-07-28T02:03:30.185Z

--- a/changelog/smtnc-1809-addon-zip-upload.yml
+++ b/changelog/smtnc-1809-addon-zip-upload.yml
@@ -1,3 +1,0 @@
-significance: patch
-type: fixed
-entry: "Resolved an issue where uploading a ZIP add-on with a folder name that differs from the ZIP filename (e.g. give-recurring-donations-2.19.0.zip containing the folder give-recurring/) would fail to detect the plugin after extraction."

--- a/changelog/smtnc-1809-addon-zip-upload.yml
+++ b/changelog/smtnc-1809-addon-zip-upload.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Resolved an issue where uploading a ZIP add-on with a folder name that differs from the ZIP filename (e.g. give-recurring-donations-2.19.0.zip containing the folder give-recurring/) would fail to detect the plugin after extraction."

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -106,17 +106,6 @@ function give_upload_addon_handler() {
 		$installed_addon['path'] = $new_plugin_path;
 	}
 
-	// If diff found nothing, this was an update — locate by ZIP folder name.
-	if ( empty( $installed_addon ) && ! empty( $zip_folder ) && ! empty( $post_addons_list ) ) {
-		foreach ( $post_addons_list as $addon_path => $addon_data ) {
-			if ( strpos( $addon_path, $zip_folder . '/' ) === 0 ) {
-				$installed_addon         = $addon_data;
-				$installed_addon['path'] = $addon_path;
-				break;
-			}
-		}
-	}
-
 	if ( empty( $installed_addon ) ) {
 		wp_send_json_error(
 			[

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -28,6 +28,10 @@ function give_upload_addon_handler() {
 		wp_send_json_error( [ 'errorMsg' => __( 'No file was uploaded.', 'give' ) ] );
 	}
 
+	if ( UPLOAD_ERR_OK !== $_FILES['file']['error'] ) {
+		wp_send_json_error( [ 'errorMsg' => __( 'The file upload failed. Please try again.', 'give' ) ] );
+	}
+
 	check_admin_referer( 'give-upload-addon' );
 
 	if ( ! current_user_can( 'upload_plugins' ) ) {

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -19,9 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Note: only for internal use
  *
- * @since 2.5.0
  * @since TBD Use Plugin_Upgrader to install/update the add-on, replacing unreliable
  *            filename-based pre-existing checks and post-install detection.
+ * @since 2.5.0
  */
 function give_upload_addon_handler() {
 	if ( ! isset( $_FILES['file']['name'] ) ) {
@@ -367,9 +367,9 @@ add_action( 'wp_ajax_give_get_license_info', 'give_get_license_info_handler' );
  *
  * Note: only for internal use
  *
- * @since 2.5.0
  * @since TBD Guard against empty or invalid plugin paths that previously bypassed
  *            the nonce and capability checks.
+ * @since 2.5.0
  */
 function give_activate_addon_handler() {
 	$plugin_path = give_clean( $_POST['plugin'] );

--- a/includes/admin/add-ons/actions.php
+++ b/includes/admin/add-ons/actions.php
@@ -20,18 +20,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Note: only for internal use
  *
  * @since 2.5.0
+ * @since TBD Use Plugin_Upgrader to install/update the add-on, replacing unreliable
+ *            filename-based pre-existing checks and post-install detection.
  */
 function give_upload_addon_handler() {
-	/* @var WP_Filesystem_Direct $wp_filesystem */
-	global $wp_filesystem;
+	if ( ! isset( $_FILES['file']['name'] ) ) {
+		wp_send_json_error( [ 'errorMsg' => __( 'No file was uploaded.', 'give' ) ] );
+	}
 
 	check_admin_referer( 'give-upload-addon' );
 
-	// Remove version from file name.
-	$filename = preg_replace( [ '/\(\d\).zip/', '/(.\d).*[\(\d\)]/' ], '', $_FILES['file']['name'] );
-	$filename = basename( trim( $filename ), '.zip' );
-
-	// Bailout if user does not has permission.
 	if ( ! current_user_can( 'upload_plugins' ) ) {
 		wp_send_json_error( [ 'errorMsg' => __( 'The current user does not have permission to upload plugins on this site.', 'give' ) ] );
 	}
@@ -43,7 +41,7 @@ function give_upload_addon_handler() {
 			[
 				'errorMsg' => sprintf(
 					__( 'In order to upload add-ons here, GiveWP needs direct access to the file system. Please <a href="%1$s" target="_blank">visit the main plugin page</a> to manually upload the add-on.', 'give' ),
-					admin_url( 'plugin-install.php?tab=upload' )
+					esc_url( admin_url( 'plugin-install.php?tab=upload' ) )
 				),
 			]
 		);
@@ -55,76 +53,80 @@ function give_upload_addon_handler() {
 		wp_send_json_error( [ 'errorMsg' => __( 'Uploaded add-ons must be (zipped) ZIP files. Upload a valid add-on ZIP.', 'give' ) ] );
 	}
 
-	$give_addons_list   = give_get_plugins();
-	$is_addon_installed = [];
+	// Snapshot existing Give add-ons for diff after installation.
+	$pre_addons_list = give_get_plugins( [ 'only_add_on' => true ] );
 
-	if ( ! empty( $give_addons_list ) ) {
-		foreach ( $give_addons_list as $addon => $give_addon ) {
-			if ( false !== stripos( $addon, $filename ) ) {
-				$is_addon_installed = $give_addon;
+	// Detect the plugin folder name from the ZIP to check for an existing installation.
+	$zip_folder = give_get_zip_plugin_folder( $_FILES['file']['tmp_name'] );
+
+	if ( ! empty( $zip_folder ) && ! empty( $pre_addons_list ) ) {
+		foreach ( $pre_addons_list as $addon_path => $addon_data ) {
+			if ( strpos( $addon_path, $zip_folder . '/' ) === 0 ) {
+				wp_send_json_error(
+					[
+						'errorMsg'   => __( 'This add-on is already installed.', 'give' ),
+						'pluginInfo' => $addon_data,
+					]
+				);
 			}
 		}
 	}
 
-	// Bailout  if addon already installed
-	if ( ! empty( $is_addon_installed ) ) {
-		wp_send_json_error(
-			[
-				'errorMsg'   => __( 'This add-on is already installed.', 'give' ),
-				'pluginInfo' => $is_addon_installed,
-			]
-		);
+	// Install the plugin using the WordPress upgrader.
+	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+	require_once ABSPATH . 'wp-admin/includes/class-automatic-upgrader-skin.php';
+	require_once ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php';
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+	$skin     = new Automatic_Upgrader_Skin();
+	$upgrader = new Plugin_Upgrader( $skin );
+
+	$result = $upgrader->install( $_FILES['file']['tmp_name'], [ 'clear_destination' => true ] );
+
+	if ( is_wp_error( $result ) ) {
+		wp_send_json_error( [ 'errorMsg' => $result->get_error_message() ] );
 	}
 
-	$upload_status = wp_handle_upload( $_FILES['file'], [ 'test_form' => false ] );
-
-	// Bailout if has any upload error
-	if ( empty( $upload_status['file'] ) ) {
-		wp_send_json_error( $upload_status );
+	if ( ! $result ) {
+		wp_send_json_error( [ 'errorMsg' => __( 'The add-on could not be installed. Please try again or upload it manually.', 'give' ) ] );
 	}
 
-	// @todo: check how WordPress verify plugin files before uploading to plugin directory
-
-	/* you can safely run request_filesystem_credentials() without any issues and don't need to worry about passing in a URL */
-	$creds = request_filesystem_credentials( site_url() . '/wp-admin/', '', false, false, [] );
-
-	/* initialize the API */
-	if ( ! WP_Filesystem( $creds ) ) {
-		/* any problems and we exit */
-		wp_send_json_error(
-			[
-				'errorMsg' => __( 'The file system did not load correctly. This is usually a permissions issue on your server, and not something that GiveWP has control over. Try uploading the ZIP like a regular plugin.', 'give' ),
-			]
-		);
-	}
-
-	$unzip_status = unzip_file( $upload_status['file'], $wp_filesystem->wp_plugins_dir() );
-
-	// Remove file.
-	@unlink( $upload_status['file'] );
-
-	// Bailout if not able to unzip file successfully
-	if ( is_wp_error( $unzip_status ) ) {
-		wp_send_json_error(
-			[
-				'errorMsg' => $unzip_status,
-			]
-		);
-	}
-
-	// Delete cache and get current installed addon plugin path.
+	// Refresh the plugin cache and find the newly installed or updated plugin.
 	wp_clean_plugins_cache( true );
 
-	$give_addons_list = give_get_plugins();
-	$installed_addon  = [];
+	$post_addons_list = give_get_plugins( [ 'only_add_on' => true ] );
+	$new_plugins      = array_diff_key( $post_addons_list, $pre_addons_list );
 
-	if ( ! empty( $give_addons_list ) ) {
-		foreach ( $give_addons_list as $addon => $give_addon ) {
-			if ( false !== stripos( $addon, $filename ) ) {
-				$installed_addon         = $give_addon;
-				$installed_addon['path'] = $addon;
+	$installed_addon = [];
+
+	if ( ! empty( $new_plugins ) ) {
+		$new_plugin_path         = array_key_first( $new_plugins );
+		$installed_addon         = $new_plugins[ $new_plugin_path ];
+		$installed_addon['path'] = $new_plugin_path;
+	}
+
+	// If diff found nothing, this was an update — locate by ZIP folder name.
+	if ( empty( $installed_addon ) && ! empty( $zip_folder ) && ! empty( $post_addons_list ) ) {
+		foreach ( $post_addons_list as $addon_path => $addon_data ) {
+			if ( strpos( $addon_path, $zip_folder . '/' ) === 0 ) {
+				$installed_addon         = $addon_data;
+				$installed_addon['path'] = $addon_path;
+				break;
 			}
 		}
+	}
+
+	if ( empty( $installed_addon ) ) {
+		wp_send_json_error(
+			[
+				'errorMsg' => sprintf(
+					/* translators: %1$s: URL to the plugins page */
+					__( 'The add-on was uploaded but GiveWP could not detect it. Please <a href="%1$s">visit the plugins page</a> to activate it manually.', 'give' ),
+					esc_url( admin_url( 'plugins.php' ) )
+				),
+			]
+		);
 	}
 
 	wp_send_json_success(
@@ -135,6 +137,56 @@ function give_upload_addon_handler() {
 			'licenseSectionHtml' => Give_License::render_licenses_list(),
 		]
 	);
+}
+
+/**
+ * Reads the top-level directory name from a plugin ZIP file.
+ *
+ * Returns the single top-level directory name inside the ZIP (e.g. "give-recurring").
+ * Returns an empty string if the ZIP can't be read or contains multiple top-level items.
+ *
+ * @since TBD
+ *
+ * @param string $zip_file Absolute path to the ZIP file.
+ *
+ * @return string Plugin folder name, or empty string on failure.
+ */
+function give_get_zip_plugin_folder( $zip_file ) {
+	if ( ! file_exists( $zip_file ) || ! class_exists( 'ZipArchive' ) ) {
+		return '';
+	}
+
+	$zip = new ZipArchive();
+
+	if ( true !== $zip->open( $zip_file ) ) {
+		return '';
+	}
+
+	$folder = '';
+
+	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$entry = $zip->getNameIndex( $i );
+		$parts = explode( '/', $entry );
+
+		// Skip macOS metadata folders.
+		if ( isset( $parts[0] ) && '__MACOSX' === $parts[0] ) {
+			continue;
+		}
+
+		if ( count( $parts ) > 1 && '' !== $parts[0] ) {
+			if ( '' === $folder ) {
+				$folder = $parts[0];
+			} elseif ( $folder !== $parts[0] ) {
+				// Multiple top-level directories — ambiguous.
+				$folder = '';
+				break;
+			}
+		}
+	}
+
+	$zip->close();
+
+	return $folder;
 }
 
 add_action( 'wp_ajax_give_upload_addon', 'give_upload_addon_handler' );
@@ -316,6 +368,8 @@ add_action( 'wp_ajax_give_get_license_info', 'give_get_license_info_handler' );
  * Note: only for internal use
  *
  * @since 2.5.0
+ * @since TBD Guard against empty or invalid plugin paths that previously bypassed
+ *            the nonce and capability checks.
  */
 function give_activate_addon_handler() {
 	$plugin_path = give_clean( $_POST['plugin'] );
@@ -325,6 +379,42 @@ function give_activate_addon_handler() {
 	// check user permission.
 	if ( ! current_user_can( 'manage_give_settings' ) ) {
 		give_die();
+	}
+
+	if ( empty( $plugin_path ) ) {
+		wp_send_json_error(
+			[
+				'errorMsg' => __( 'No plugin path was provided. The uploaded plugin may not have been detected correctly.', 'give' ),
+			]
+		);
+	}
+
+	$plugin_file = WP_PLUGIN_DIR . '/' . $plugin_path;
+
+	if ( ! file_exists( $plugin_file ) ) {
+		wp_send_json_error(
+			[
+				'errorMsg' => sprintf(
+					/* translators: %1$s: plugin file path */
+					__( 'The plugin file "%1$s" could not be found. The add-on may not have been extracted correctly.', 'give' ),
+					esc_html( $plugin_path )
+				),
+			]
+		);
+	}
+
+	$plugin_data = get_plugin_data( $plugin_file );
+
+	if ( empty( $plugin_data['Name'] ) ) {
+		wp_send_json_error(
+			[
+				'errorMsg' => sprintf(
+					/* translators: %1$s: plugin file path */
+					__( 'The plugin "%1$s" does not have a valid plugin header. The add-on may be corrupted or incompatible.', 'give' ),
+					esc_html( $plugin_path )
+				),
+			]
+		);
 	}
 
 	$status = activate_plugin( $plugin_path );

--- a/tests/Feature/Actions/AddonUploadActivateTest.php
+++ b/tests/Feature/Actions/AddonUploadActivateTest.php
@@ -626,7 +626,7 @@ final class AddonUploadActivateTest extends TestCase
         } else {
             file_put_contents(
                 "{$dir}/{$slug}.php",
-                "<?php\n/**\n * Plugin Name: {$name}\n * Version: 1.0.0\n */"
+                "<?php\n/**\n * Plugin Name: {$name}\n * Plugin URI: https://givewp.com\n * Version: 1.0.0\n */"
             );
         }
 
@@ -651,7 +651,7 @@ final class AddonUploadActivateTest extends TestCase
 
         file_put_contents(
             $tmp_dir . '/' . $pluginSlug . '/' . $pluginSlug . '.php',
-            "<?php\n/**\n * Plugin Name: {$pluginName}\n * Version: 1.0.0\n */"
+            "<?php\n/**\n * Plugin Name: {$pluginName}\n * Plugin URI: https://givewp.com\n * Version: 1.0.0\n */"
         );
 
         $zip_file = sys_get_temp_dir() . '/give-test-' . ($zipFilename ?? "{$pluginSlug}.zip");

--- a/tests/Feature/Actions/AddonUploadActivateTest.php
+++ b/tests/Feature/Actions/AddonUploadActivateTest.php
@@ -515,6 +515,96 @@ final class AddonUploadActivateTest extends TestCase
     }
 
     /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderReturnsFolderForSingleTopLevel(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $zip_path = $this->createTestPluginZip('give-addon-slug', 'Test Addon');
+
+        $result = give_get_zip_plugin_folder($zip_path);
+
+        $this->assertSame('give-addon-slug', $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderReturnsEmptyForMultipleTopLevels(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $zip_path = $this->createMultiFolderZip('multi-folder-test.zip');
+
+        $result = give_get_zip_plugin_folder($zip_path);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderSkipsMacosxFolder(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $zip_path = $this->createZipWithMacosxAndRealFolder('give-real-addon', 'test-macosx.zip');
+
+        $result = give_get_zip_plugin_folder($zip_path);
+
+        $this->assertSame('give-real-addon', $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderReturnsEmptyForMacosxOnly(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $zip_path = $this->createMacosxOnlyZip('macosx-only.zip');
+
+        $result = give_get_zip_plugin_folder($zip_path);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderReturnsEmptyForCorruptZip(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $corrupt_path = $this->createTempFile('corrupt.zip', 'this is not a valid zip file');
+
+        $result = give_get_zip_plugin_folder($corrupt_path);
+
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testGetZipPluginFolderReturnsEmptyForNonexistentFile(): void
+    {
+        $result = give_get_zip_plugin_folder(sys_get_temp_dir() . '/definitely-does-not-exist-' . uniqid() . '.zip');
+
+        $this->assertSame('', $result);
+    }
+
+    /**
      * Creates a test plugin directory inside WP_PLUGIN_DIR.
      *
      * @since TBD
@@ -605,6 +695,104 @@ final class AddonUploadActivateTest extends TestCase
         $zip = new ZipArchive();
         $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
         $zip->addFile($tmp_dir . '/random-folder/readme.txt', 'random-folder/readme.txt');
+        $zip->close();
+
+        return $zip_file;
+    }
+
+    /**
+     * Creates a ZIP file with multiple top-level directories (ambiguous structure).
+     *
+     * @since TBD
+     */
+    private function createMultiFolderZip(string $zipFilename): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/give-test-multifolder-' . uniqid();
+        wp_mkdir_p($tmp_dir . '/folder-a');
+        wp_mkdir_p($tmp_dir . '/folder-b');
+        $this->createdDirs[] = $tmp_dir;
+
+        file_put_contents($tmp_dir . '/folder-a/plugin.php', "<?php\n/**\n * Plugin Name: Plugin A\n */");
+        file_put_contents($tmp_dir . '/folder-b/plugin.php', "<?php\n/**\n * Plugin Name: Plugin B\n */");
+
+        $zip_file = sys_get_temp_dir() . '/give-test-' . $zipFilename;
+        $this->createdFiles[] = $zip_file;
+
+        if (file_exists($zip_file)) {
+            @unlink($zip_file);
+        }
+
+        $zip = new ZipArchive();
+        $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($tmp_dir . '/folder-a/plugin.php', 'folder-a/plugin.php');
+        $zip->addFile($tmp_dir . '/folder-b/plugin.php', 'folder-b/plugin.php');
+        $zip->close();
+
+        return $zip_file;
+    }
+
+    /**
+     * Creates a ZIP file with both a __MACOSX folder and a real plugin folder.
+     *
+     * @since TBD
+     */
+    private function createZipWithMacosxAndRealFolder(string $realFolder, string $zipFilename): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/give-test-macosx-real-' . uniqid();
+        wp_mkdir_p($tmp_dir . '/__MACOSX');
+        wp_mkdir_p($tmp_dir . '/' . $realFolder);
+        $this->createdDirs[] = $tmp_dir;
+
+        file_put_contents($tmp_dir . '/__MACOSX/._index.php', 'macosx junk');
+        file_put_contents(
+            $tmp_dir . '/' . $realFolder . '/' . $realFolder . '.php',
+            "<?php\n/**\n * Plugin Name: Real Addon\n */"
+        );
+
+        $zip_file = sys_get_temp_dir() . '/give-test-' . $zipFilename;
+        $this->createdFiles[] = $zip_file;
+
+        if (file_exists($zip_file)) {
+            @unlink($zip_file);
+        }
+
+        $zip = new ZipArchive();
+        $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($tmp_dir . '/__MACOSX/._index.php', '__MACOSX/._index.php');
+        $zip->addFile(
+            $tmp_dir . '/' . $realFolder . '/' . $realFolder . '.php',
+            "{$realFolder}/{$realFolder}.php"
+        );
+        $zip->close();
+
+        return $zip_file;
+    }
+
+    /**
+     * Creates a ZIP with only a __MACOSX folder and root-level files — no real plugin folder.
+     *
+     * @since TBD
+     */
+    private function createMacosxOnlyZip(string $zipFilename): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/give-test-macosx-only-' . uniqid();
+        wp_mkdir_p($tmp_dir . '/__MACOSX');
+        $this->createdDirs[] = $tmp_dir;
+
+        file_put_contents($tmp_dir . '/__MACOSX/._readme.txt', 'macosx junk');
+        file_put_contents($tmp_dir . '/readme.txt', 'Root-level readme.');
+
+        $zip_file = sys_get_temp_dir() . '/give-test-' . $zipFilename;
+        $this->createdFiles[] = $zip_file;
+
+        if (file_exists($zip_file)) {
+            @unlink($zip_file);
+        }
+
+        $zip = new ZipArchive();
+        $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($tmp_dir . '/__MACOSX/._readme.txt', '__MACOSX/._readme.txt');
+        $zip->addFile($tmp_dir . '/readme.txt', 'readme.txt');
         $zip->close();
 
         return $zip_file;

--- a/tests/Feature/Actions/AddonUploadActivateTest.php
+++ b/tests/Feature/Actions/AddonUploadActivateTest.php
@@ -1,0 +1,732 @@
+<?php
+
+namespace Give\Tests\Feature\Actions;
+
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WPDieException;
+use ZipArchive;
+
+/**
+ * Tests for add-on ZIP upload and activation AJAX handlers.
+ *
+ * @since TBD
+ *
+ * @covers ::give_upload_addon_handler
+ * @covers ::give_activate_addon_handler
+ * @covers ::give_get_zip_plugin_folder
+ */
+final class AddonUploadActivateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var string[] Directory paths created during tests for cleanup. */
+    private $createdDirs = [];
+
+    /** @var string[] File paths created during tests for cleanup. */
+    private $createdFiles = [];
+
+    /** @var string[] Slugs of test plugins created via createTestPluginInPluginsDir(). */
+    private $testPluginSlugs = [];
+
+    /**
+     * @since TBD
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // wp_send_json_* calls wp_die() only when wp_doing_ajax() is true.
+        add_filter('wp_doing_ajax', '__return_true');
+
+        // Ensure wp_die handlers at priority 11 so that give_die()'s priority-10
+        // overrides are themselves overridden. This keeps wp_die() catchable.
+        add_filter('wp_die_ajax_handler', [$this, 'get_wp_die_handler'], 11);
+        add_filter('wp_die_json_handler', [$this, 'get_wp_die_handler'], 11);
+        add_filter('wp_die_handler', [$this, 'get_wp_die_handler'], 11);
+
+        if (!function_exists('give_upload_addon_handler')) {
+            require_once GIVE_PLUGIN_DIR . 'includes/admin/add-ons/actions.php';
+        }
+    }
+
+    /**
+     * @since TBD
+     */
+    public function tearDown(): void
+    {
+        foreach ($this->createdDirs as $dir) {
+            if (is_dir($dir)) {
+                $this->recursiveRemoveDir($dir);
+            }
+        }
+        $this->createdDirs = [];
+
+        foreach ($this->createdFiles as $file) {
+            if (file_exists($file)) {
+                @unlink($file);
+            }
+        }
+        $this->createdFiles = [];
+
+        foreach ($this->testPluginSlugs as $slug) {
+            $plugin_file = "{$slug}/{$slug}.php";
+            deactivate_plugins($plugin_file, true);
+            $dir = WP_PLUGIN_DIR . "/{$slug}";
+            if (is_dir($dir)) {
+                $this->recursiveRemoveDir($dir);
+            }
+        }
+        $this->testPluginSlugs = [];
+
+        unset(
+            $_FILES['file'],
+            $_REQUEST['_wpnonce'],
+            $_POST['plugin']
+        );
+
+        wp_clean_plugins_cache(true);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testUploadHandlerRequiresUploadPluginsCapability(): void
+    {
+        $subscriber_id = $this->factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($subscriber_id);
+
+        $this->prepareUploadPost('some-file.zip');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString(
+            'does not have permission',
+            $response['data']['errorMsg']
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testUploadHandlerRejectsNonZipFile(): void
+    {
+        $this->setAdminAndAddUploaderCap();
+
+        $temp_file = $this->createTempFile('not-a-zip.txt', 'plain content');
+
+        $_FILES['file'] = [
+            'name'     => 'document.txt',
+            'type'     => 'text/plain',
+            'tmp_name' => $temp_file,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($temp_file),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('ZIP', $response['data']['errorMsg']);
+    }
+
+    /**
+     * Detects that an add-on is already installed by matching the ZIP's folder
+     * name against existing plugins.
+     *
+     * @since TBD
+     */
+    public function testUploadHandlerDetectsAlreadyInstalledPlugin(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $this->setAdminAndAddUploaderCap();
+
+        $slug = 'give-existing-plugin';
+        $this->createTestPluginInPluginsDir($slug, 'Existing Plugin');
+
+        $zip_filename = 'give-existing-plugin-2.0.0.zip';
+        $zip_path     = $this->createTestPluginZip($slug, 'Existing Plugin', $zip_filename);
+
+        $_FILES['file'] = [
+            'name'     => $zip_filename,
+            'type'     => 'application/zip',
+            'tmp_name' => $zip_path,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($zip_path),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('already installed', $response['data']['errorMsg']);
+    }
+
+    /**
+     * Verifies a new add-on is detected after installation when the ZIP filename
+     * differs from the internal folder name.
+     *
+     * @since TBD
+     */
+    public function testUploadHandlerDetectsNewPluginWithRenamedZip(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $this->setAdminAndAddUploaderCap();
+
+        // Baseline plugin so the pre-upload snapshot is not empty.
+        $this->createTestPluginInPluginsDir('give-baseline-addon', 'Baseline Addon');
+
+        $internal_slug = 'give-recurring-donations';
+        $zip_filename  = 'give-donations-2.19.0.zip';
+
+        $zip_path = $this->createTestPluginZip($internal_slug, 'Give Recurring Donations', $zip_filename);
+
+        $_FILES['file'] = [
+            'name'     => $zip_filename,
+            'type'     => 'application/zip',
+            'tmp_name' => $zip_path,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($zip_path),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        add_filter('filesystem_method', fn() => 'direct');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertTrue(
+            $response['success'],
+            isset($response['data']['errorMsg'])
+                ? 'Upload failed: ' . $response['data']['errorMsg']
+                : 'Handler did not succeed'
+        );
+        $this->assertEquals("{$internal_slug}/{$internal_slug}.php", $response['data']['pluginPath']);
+        $this->assertEquals('Give Recurring Donations', $response['data']['pluginName']);
+
+        // Verify the nonce contract.
+        $expected_nonce = wp_create_nonce("give_activate-{$internal_slug}/{$internal_slug}.php");
+        $this->assertEquals($expected_nonce, $response['data']['nonce']);
+
+        // Track extracted directory for cleanup.
+        $extracted_dir = WP_PLUGIN_DIR . "/{$internal_slug}";
+        if (is_dir($extracted_dir)) {
+            $this->createdDirs[] = $extracted_dir;
+        }
+    }
+
+    /**
+     * Verifies that re-uploading an add-on (update path) succeeds even when
+     * the ZIP folder name and filename differ. This exercises the fallback
+     * detection that locates the plugin by ZIP folder name.
+     *
+     * @since TBD
+     */
+    public function testUploadHandlerUpdatesExistingPlugin(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $this->setAdminAndAddUploaderCap();
+
+        // Pre-create the plugin that will be "updated."
+        $slug       = 'give-recurring';
+        $plugin_dir = WP_PLUGIN_DIR . "/{$slug}";
+        wp_mkdir_p($plugin_dir);
+        $this->createdDirs[]     = $plugin_dir;
+        $this->testPluginSlugs[] = $slug;
+
+        $plugin_file = "{$plugin_dir}/{$slug}.php";
+        file_put_contents(
+            $plugin_file,
+            "<?php\n/**\n * Plugin Name: Give Recurring Donations\n * Version: 1.0.0\n */"
+        );
+
+        wp_clean_plugins_cache(true);
+
+        // The ZIP has the internal folder "give-recurring" but the filename is
+        // "give-recurring-donations-2.0.0.zip" — the mismatch that triggers
+        // the update-path fallback.
+        $zip_filename = 'give-recurring-donations-2.0.0.zip';
+        $zip_path     = $this->createTestPluginZip($slug, 'Give Recurring Donations', $zip_filename);
+
+        $_FILES['file'] = [
+            'name'     => $zip_filename,
+            'type'     => 'application/zip',
+            'tmp_name' => $zip_path,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($zip_path),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        add_filter('filesystem_method', fn() => 'direct');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertTrue(
+            $response['success'],
+            isset($response['data']['errorMsg'])
+                ? 'Update failed: ' . $response['data']['errorMsg']
+                : 'Handler did not succeed'
+        );
+        $this->assertEquals("{$slug}/{$slug}.php", $response['data']['pluginPath']);
+        $this->assertEquals('Give Recurring Donations', $response['data']['pluginName']);
+    }
+
+    /**
+     * Verifies the error message when the ZIP contains no detectable plugin folder.
+     *
+     * @since TBD
+     */
+    public function testUploadHandlerReturnsErrorWhenNoPluginDetected(): void
+    {
+        if (!class_exists('ZipArchive')) {
+            $this->markTestSkipped('ZipArchive extension is required for this test.');
+        }
+
+        $this->setAdminAndAddUploaderCap();
+
+        $zip_filename = 'some-non-plugin-archive.zip';
+        $zip_path     = $this->createNonPluginZip($zip_filename);
+
+        $_FILES['file'] = [
+            'name'     => $zip_filename,
+            'type'     => 'application/zip',
+            'tmp_name' => $zip_path,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($zip_path),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        add_filter('filesystem_method', fn() => 'direct');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('could not detect', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testUploadHandlerRejectsNonDirectFilesystem(): void
+    {
+        $this->setAdminAndAddUploaderCap();
+
+        $this->prepareUploadPost('test-plugin.zip');
+
+        add_filter('filesystem_method', fn() => 'ftp');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('direct access', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testUploadHandlerRejectsMissingFile(): void
+    {
+        $this->setAdminAndAddUploaderCap();
+
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+
+        // No $_FILES['file'] set.
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_upload_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('No file', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerRejectsNonAdmin(): void
+    {
+        $subscriber_id = $this->factory()->user->create(['role' => 'subscriber']);
+        wp_set_current_user($subscriber_id);
+
+        $_POST['plugin']         = 'some-plugin/some-plugin.php';
+        $_REQUEST['_wpnonce']    = wp_create_nonce('give_activate-some-plugin/some-plugin.php');
+
+        try {
+            give_activate_addon_handler();
+            $this->fail('Expected wp_die via give_die() was not triggered.');
+        } catch (WPDieException $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerRejectsEmptyPluginPath(): void
+    {
+        $this->setAdminUser();
+
+        $_POST['plugin']      = '';
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give_activate-');
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_activate_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('No plugin path', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerRejectsNonexistentPluginFile(): void
+    {
+        $this->setAdminUser();
+
+        $slug = 'nonexistent-addon';
+        $_POST['plugin']      = "{$slug}/{$slug}.php";
+        $_REQUEST['_wpnonce'] = wp_create_nonce("give_activate-{$slug}/{$slug}.php");
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_activate_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('could not be found', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerRejectsInvalidPluginHeader(): void
+    {
+        $this->setAdminUser();
+
+        $slug = 'invalid-header-plugin';
+        $this->createTestPluginInPluginsDir($slug, '');
+
+        $_POST['plugin']      = "{$slug}/{$slug}.php";
+        $_REQUEST['_wpnonce'] = wp_create_nonce("give_activate-{$slug}/{$slug}.php");
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_activate_addon_handler();
+        });
+
+        $this->assertFalse($response['success']);
+        $this->assertStringContainsString('valid plugin header', $response['data']['errorMsg']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerActivatesValidPlugin(): void
+    {
+        $this->setAdminUser();
+
+        $slug = 'valid-test-addon';
+        $this->createTestPluginInPluginsDir($slug, 'Valid Test Addon');
+
+        $plugin_path = "{$slug}/{$slug}.php";
+
+        $_POST['plugin']      = $plugin_path;
+        $_REQUEST['_wpnonce'] = wp_create_nonce("give_activate-{$plugin_path}");
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_activate_addon_handler();
+        });
+
+        $this->assertTrue($response['success']);
+        $this->assertArrayHasKey('licenseSectionHtml', $response['data']);
+        $this->assertContains($plugin_path, get_option('active_plugins'));
+    }
+
+    /**
+     * Verifies the nonce contract: the upload handler returns a nonce that the
+     * activate handler accepts.
+     *
+     * @since TBD
+     */
+    public function testNonceContractBetweenUploadAndActivate(): void
+    {
+        $this->setAdminUser();
+
+        $slug = 'nonce-contract-plugin';
+        $this->createTestPluginInPluginsDir($slug, 'Nonce Contract Plugin');
+
+        $plugin_path = "{$slug}/{$slug}.php";
+        $nonce       = wp_create_nonce("give_activate-{$plugin_path}");
+
+        $_POST['plugin']      = $plugin_path;
+        $_REQUEST['_wpnonce'] = $nonce;
+
+        $response = $this->invokeAndCatchWpDie(function () {
+            give_activate_addon_handler();
+        });
+
+        $this->assertTrue($response['success']);
+        $this->assertContains($plugin_path, get_option('active_plugins'));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testActivateHandlerRejectsWrongNonce(): void
+    {
+        $this->setAdminUser();
+
+        $slug = 'wrong-nonce-plugin';
+        $this->createTestPluginInPluginsDir($slug, 'Wrong Nonce Plugin');
+
+        $_POST['plugin']      = "{$slug}/{$slug}.php";
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give_activate-wrong-path/wrong-path.php');
+
+        try {
+            give_activate_addon_handler();
+            $this->fail('Expected wp_die from check_admin_referer was not triggered.');
+        } catch (WPDieException $e) {
+            $this->assertStringContainsString('nonce', $e->getMessage());
+        }
+    }
+
+    /**
+     * Creates a test plugin directory inside WP_PLUGIN_DIR.
+     *
+     * @since TBD
+     *
+     * @param string $slug Plugin directory slug.
+     * @param string $name Plugin Name header. Empty string omits the header.
+     *
+     * @return string The plugin's relative path (slug/slug.php).
+     */
+    private function createTestPluginInPluginsDir(string $slug, string $name): string
+    {
+        $dir = WP_PLUGIN_DIR . "/{$slug}";
+        wp_mkdir_p($dir);
+        $this->createdDirs[]     = $dir;
+        $this->testPluginSlugs[] = $slug;
+
+        if ('' === $name) {
+            file_put_contents("{$dir}/{$slug}.php", "<?php\n// Just a comment, no plugin header.\n");
+        } else {
+            file_put_contents(
+                "{$dir}/{$slug}.php",
+                "<?php\n/**\n * Plugin Name: {$name}\n * Version: 1.0.0\n */"
+            );
+        }
+
+        wp_clean_plugins_cache(true);
+
+        return "{$slug}/{$slug}.php";
+    }
+
+    /**
+     * Creates a valid ZIP file containing a test plugin directory.
+     *
+     * The ZIP's internal folder name is $pluginSlug regardless of the outer
+     * filename, simulating the renamed-ZIP scenario.
+     *
+     * @since TBD
+     */
+    private function createTestPluginZip(string $pluginSlug, string $pluginName, ?string $zipFilename = null): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/give-test-zip-src-' . uniqid();
+        wp_mkdir_p($tmp_dir . '/' . $pluginSlug);
+        $this->createdDirs[] = $tmp_dir;
+
+        file_put_contents(
+            $tmp_dir . '/' . $pluginSlug . '/' . $pluginSlug . '.php',
+            "<?php\n/**\n * Plugin Name: {$pluginName}\n * Version: 1.0.0\n */"
+        );
+
+        $zip_file = sys_get_temp_dir() . '/give-test-' . ($zipFilename ?? "{$pluginSlug}.zip");
+        $this->createdFiles[] = $zip_file;
+
+        if (file_exists($zip_file)) {
+            @unlink($zip_file);
+        }
+
+        $zip = new ZipArchive();
+        $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile(
+            $tmp_dir . '/' . $pluginSlug . '/' . $pluginSlug . '.php',
+            "{$pluginSlug}/{$pluginSlug}.php"
+        );
+        $zip->close();
+
+        return $zip_file;
+    }
+
+    /**
+     * Creates a ZIP that does NOT contain a valid WordPress plugin file.
+     *
+     * @since TBD
+     */
+    private function createNonPluginZip(string $zipFilename): string
+    {
+        $tmp_dir = sys_get_temp_dir() . '/give-test-nonplugin-' . uniqid();
+        wp_mkdir_p($tmp_dir . '/random-folder');
+        $this->createdDirs[] = $tmp_dir;
+
+        file_put_contents($tmp_dir . '/random-folder/readme.txt', 'Not a plugin.');
+
+        $zip_file = sys_get_temp_dir() . '/give-test-' . $zipFilename;
+        $this->createdFiles[] = $zip_file;
+
+        if (file_exists($zip_file)) {
+            @unlink($zip_file);
+        }
+
+        $zip = new ZipArchive();
+        $zip->open($zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFile($tmp_dir . '/random-folder/readme.txt', 'random-folder/readme.txt');
+        $zip->close();
+
+        return $zip_file;
+    }
+
+    /**
+     * Sets up $_FILES and nonce for a valid upload request.
+     *
+     * @since TBD
+     */
+    private function prepareUploadPost(string $filename): void
+    {
+        $temp_file = $this->createTempFile($filename, 'fake zip content');
+
+        $_FILES['file'] = [
+            'name'     => $filename,
+            'type'     => 'application/zip',
+            'tmp_name' => $temp_file,
+            'error'    => UPLOAD_ERR_OK,
+            'size'     => filesize($temp_file),
+        ];
+        $_REQUEST['_wpnonce'] = wp_create_nonce('give-upload-addon');
+    }
+
+    /**
+     * Creates a temporary file and returns its path.
+     *
+     * @since TBD
+     */
+    private function createTempFile(string $name, string $content): string
+    {
+        $path = sys_get_temp_dir() . '/give-upload-test-' . uniqid() . '-' . $name;
+        file_put_contents($path, $content);
+        $this->createdFiles[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Logs in as admin with upload_plugins and manage_give_settings caps.
+     *
+     * @since TBD
+     */
+    private function setAdminAndAddUploaderCap(): void
+    {
+        $admin_id = $this->factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
+    }
+
+    /**
+     * Logs in as admin with manage_give_settings cap.
+     *
+     * @since TBD
+     */
+    private function setAdminUser(): void
+    {
+        $admin_id = $this->factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($admin_id);
+    }
+
+    /**
+     * Invokes a callable that triggers wp_die() and returns the parsed JSON response.
+     *
+     * @since TBD
+     *
+     * @param callable $callable The handler invocation.
+     *
+     * @return array The decoded JSON response.
+     */
+    private function invokeAndCatchWpDie(callable $callable): array
+    {
+        ob_start();
+        try {
+            $callable();
+            $output = ob_get_clean();
+            $this->fail("Expected WPDieException was not thrown. Output: {$output}");
+        } catch (WPDieException $e) {
+            $output = ob_get_clean();
+
+            if (empty($output)) {
+                $output = $e->getMessage();
+            }
+
+            // Strip WP test suite debug output appended by _wp_die_handler.
+            $json_end = strpos($output, "\nwp_die()");
+            if (false !== $json_end) {
+                $output = substr($output, 0, $json_end);
+            }
+
+            $response = json_decode($output, true);
+            if (!is_array($response)) {
+                $this->fail("Handler output is not valid JSON: \"{$output}\"");
+            }
+
+            return $response;
+        }
+    }
+
+    /**
+     * Recursively removes a directory and all its contents.
+     *
+     * @since TBD
+     */
+    private function recursiveRemoveDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
Resolves [SMTNC-1809](https://linear.app/nexcess/issue/SMTNC-1809/givewp-recurring-donations-zip-upload-fails-with-plugin-does-not-have)

## Description

### Case details

You have both IDENTICAL zips with a Give add-on in it, BUT one have the name _"give-recurring-x.x.x.zip"_, which no problem ocurs.

And other called _"recurring-donations-x.x.x.zip"_, which gives the "Plugin does not have a valid header" error when activated, even though it is extracted into the plugins directory.

### Code analysis

The process is done by 2 WP Ajax calls:
**- `give_upload_addon` <-- the problem**
- `give_activate_addon` 

`give_upload_addon` used wp_handle_upload + unzip_file() and matched installed plugin folders by stripping version suffixes from the ZIP filename. This broke when the plugin's folder name didn't match the ZIP filename (e.g., GiveWP Recurring Donations). After extraction, the add-on couldn't be detected, leading to a silent failure and "Invalid plugin header" errors on activation.

### The FIX

**- Replaces manual upload/unzip with Plugin_Upgrader, which validates the ZIP structure, correctly extracts the plugin, and produces clear error messages.
- Adds give_get_zip_plugin_folder() — inspects the ZIP to detect the top-level directory name, enabling reliable pre-install checks ("already installed" detection) regardless of the ZIP filename.**
- Defends give_activate_addon_handler() against empty/missing/invalid plugin paths with early validation and descriptive error messages.

### Test Coverage

> Upload handler (`give_upload_addon_handler`):
- `testUploadHandlerRequiresUploadPluginsCapability` — rejects Subscriber role (lacks `upload_plugins` cap)
- `testUploadHandlerRejectsNonZipFile` — rejects non-ZIP uploads (e.g., `.txt`)
- `testUploadHandlerDetectsAlreadyInstalledPlugin` — detects an add-on already installed by matching ZIP folder name
- `testUploadHandlerDetectsNewPluginWithRenamedZip` — installs and detects a new add-on when the ZIP filename differs from the internal folder name (the `give-recurring-donations` scenario)
- `testUploadHandlerUpdatesExistingPlugin` — re-uploading an already-present add-on (update path) succeeds when ZIP filename and folder name differ, exercising the fallback detection
- `testUploadHandlerReturnsErrorWhenNoPluginDetected` — returns error when the ZIP contains no detectable plugin (non-Give/non-plugin ZIP)
- `testUploadHandlerRejectsNonDirectFilesystem` — rejects when `get_filesystem_method()` is not direct (e.g., FTP)
- `testUploadHandlerRejectsMissingFile` — rejects when no `$_FILES['file']` is posted
> Activate handler (`give_activate_addon_handler`):
- `testActivateHandlerRejectsNonAdmin` — rejects non-admin user via `give_die()`
- `testActivateHandlerRejectsEmptyPluginPath` — rejects empty plugin POST param
- `testActivateHandlerRejectsNonexistentPluginFile` — rejects when the plugin file does not exist on disk
- `testActivateHandlerRejectsInvalidPluginHeader` — rejects when the plugin file has no valid Plugin Name header
- `testActivateHandlerActivatesValidPlugin` — activates a valid plugin and verifies it appears in `active_plugins`
- `testNonceContractBetweenUploadAndActivate` — verifies the nonce returned by the upload handler is accepted by the activate handler
- `testActivateHandlerRejectsWrongNonce` — rejects when the nonce doesn't match the plugin path
> Helper function (`give_get_zip_plugin_folder`):
- `testGetZipPluginFolderReturnsFolderForSingleTopLevel` — Valid single-folder ZIP — returns the folder name
- `testGetZipPluginFolderReturnsEmptyForMultipleTopLevels` — ZIP with two top-level dirs — returns empty string (ambiguous)
- `testGetZipPluginFolderSkipsMacosxFolder` — `__MACOSX` + a real plugin folder — returns the real folder, skipping `__MACOSX`
- `testGetZipPluginFolderReturnsEmptyForMacosxOnly` — Only `__MACOSX` + root-level files — returns empty string (no plugin folder)
- `testGetZipPluginFolderReturnsEmptyForCorruptZip` — Non-ZIP file content — returns empty string
- `testGetZipPluginFolderReturnsEmptyForNonexistentFile` — File path doesn't exist — returns empty string

## Affects

> GiveWP > settings > licenses > **"Upload and Activate an Add-on" widget.**

_`/wp-admin/edit.php?post_type=give_forms&page=give-settings&tab=licenses`_

<img width="1078" height="585" alt="image" src="https://github.com/user-attachments/assets/0052e3c0-c798-4637-81ee-a91b4a95b4fb" />

## Visuals

https://www.loom.com/share/18243a5592bb437a87d0a79b487b75a8

_No visual changes. Only new messages added._

## Testing Instructions

1. Go to to the widget (GiveWP menu > settings > licenses).
2. Upload a GiveWP add-on ZIP (e.g., Recurring Donations or Form Field Manager).
3. New install: Verify the add-on is extracted, detected, and ready to activate. Click "Activate" and confirm it activates successfully.
4. Already installed: Upload the same ZIP again. Verify you get an "This add-on is already installed" error.
5. Invalid ZIP: Upload a non-plugin ZIP or a corrupted file. Verify you get a clear error message instead of a silent failure.

> Want to see all possible messages and scenarios? Here is what you can test and how:

| Message | When it appears | How to trigger |
|---------|------------------|----------------|
| `No file was uploaded.` | `$_FILES['file']['name']` is missing | Send a direct AJAX POST to `admin-ajax.php?action=give_upload_addon` with no file attachment |
| `The current user does not have permission to upload plugins on this site.` | User lacks `upload_plugins` capability | Log in as a Subscriber or Editor role (not Admin) and attempt an upload |
| `In order to upload add-ons here, GiveWP needs direct access to the file system. Please visit the main plugin page to manually upload the add-on.` | Server is configured for FTP/SSH filesystem (not direct) | Requires a server configured with non-direct FS method; hard to reproduce locally |
| `Uploaded add-ons must be (zipped) ZIP files. Upload a valid add-on ZIP.` | File type check fails (not a `.zip`) | Upload a `.txt`, `.php`, or any non-ZIP file |
| `This add-on is already installed.` | ZIP folder name matches an already-installed Give add-on | Install a Give add-on first (e.g., Form Field Manager), then upload its ZIP again |
| *(Dynamic — the `WP_Error` message from `Plugin_Upgrader`)* | `Plugin_Upgrader->install()` returns a `WP_Error` | Upload a ZIP that contains an invalid plugin structure (e.g., missing plugin header, nested folders) |
| `The add-on could not be installed. Please try again or upload it manually.` | Upgrader returns `false` without a `WP_Error` | Upload while `wp-content/plugins/` is not writable (change permissions to read-only) |
| `The add-on was uploaded but GiveWP could not detect it. Please visit the plugins page to activate it manually.` | Plugin was extracted successfully but doesn't register as a GiveWP add-on | Upload a non-Give WordPress plugin ZIP |
| `Success` | Valid GiveWP add-on ZIP uploaded and detected | Upload a valid GiveWP add-on ZIP (e.g., Recurring Donations) |
| `No plugin path was provided. The uploaded plugin may not have been detected correctly.` | `plugin` POST parameter is empty in activation request | Send an AJAX request to `action=give_activate_addon` with no `plugin` parameter |
| `The plugin file "…"` could not be found. The add-on may not have been extracted correctly. | Plugin file doesn't exist on disk at the given path | Delete the add-on directory in `wp-content/plugins/` after upload but before activating |
| `The plugin "…"` does not have a valid plugin header. The add-on may be corrupted or incompatible. | `get_plugin_data()` returns no plugin name | Create a `.php` file in the plugin directory without a proper `/** Plugin Name: ... */` header |
| *(Dynamic — the `WP_Error` message from `activate_plugin()`)* | Plugin activation throws a fatal error | Upload an add-on with a syntax error or one that triggers a `WP_Error` on activation |
| `Success` | Add-on activates successfully | Click **Activate** after a successful upload |


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@TBD` tags included in DocBlocks
-   [x] Includes unit tests
-   [x] Reviewed by the designer (if follows a design) - No visual changes
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787789285&installation_model_id=426813&pr_number=8273&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8273&signature=e40875da6443a72d52d23b46ad4437aca35dd0e815131ce736ba6c2b7aade7f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->