### PR TITLE
Update Harbor to v1.6.0

### DIFF
--- a/changelog/chore-bump-harbor-1-6-0.yaml
+++ b/changelog/chore-bump-harbor-1-6-0.yaml
@@ -1,6 +1,4 @@
 significance: patch
 type: tweak
-entry: Updated Harbor to 1.6.0, split the products list into Installed and
-  Available Features, added an Activate link to the product header, and improved
-  license handling on staging and preview sites.
+entry: Improved the unified licensing page experience.
 timestamp: 2026-07-29T13:21:41.668Z

--- a/changelog/chore-bump-harbor-1-6-0.yaml
+++ b/changelog/chore-bump-harbor-1-6-0.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: tweak
+entry: Updated Harbor to 1.6.0, split the products list into Installed and
+  Available Features, added an Activate link to the product header, and improved
+  license handling on staging and preview sites.
+timestamp: 2026-07-29T13:21:41.668Z

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "stellarwp/admin-notices": "^2.0.1",
         "stellarwp/arrays": "^1.3",
         "moneyphp/money": "^3.3.3",
-        "stellarwp/harbor": "^1.4"
+        "stellarwp/harbor": "^1.6.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "stellarwp/admin-notices": "^2.0.1",
         "stellarwp/arrays": "^1.3",
         "moneyphp/money": "^3.3.3",
-        "stellarwp/harbor": "^1.6.0"
+        "stellarwp/harbor": "^1.6"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -825,16 +825,16 @@
         },
         {
             "name": "stellarwp/harbor",
-            "version": "v1.4.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d"
+                "reference": "e0253fa5512522a50dd73abe990d3591017494fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/0d21b6e6da4352364610168c053ed0ec9d59253d",
-                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/e0253fa5512522a50dd73abe990d3591017494fb",
+                "reference": "e0253fa5512522a50dd73abe990d3591017494fb",
                 "shasum": ""
             },
             "require": {
@@ -889,9 +889,9 @@
             "description": "A library that integrates a WordPress product with the Liquid Web licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/harbor/issues",
-                "source": "https://github.com/stellarwp/harbor/tree/v1.4.0"
+                "source": "https://github.com/stellarwp/harbor/tree/v1.6.0"
             },
-            "time": "2026-05-21T17:13:36+00:00"
+            "time": "2026-07-27T14:52:06+00:00"
         },
         {
             "name": "stellarwp/licensing-api-client",
@@ -8746,9 +8746,9 @@
     "platform": {
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Updates the bundled Harbor library from v1.4.0 to v1.6.0.

Verified with a fresh `composer install` — the Strauss-prefixed copy reports `1.6.0`. Only `composer.lock` changed.

[SMTNC-1873](https://linear.app/nexcess/issue/SMTNC-1873/update-harbor-to-v160-in-givewp)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787858667&installation_model_id=426813&pr_number=8275&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8275&signature=6d8f2d5a79dd414ccfc1f3ca1d1c7927ffe13a0687bcf622a917d061fc30b849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->