### PR TITLE
[SMTNC-1541] Fix: The donor dashboard reset password should have a validation.

### DIFF
--- a/changelog/smtnc-1541-the-donor-dashboard-should-have-a-validation.yaml
+++ b/changelog/smtnc-1541-the-donor-dashboard-should-have-a-validation.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Added validation to prevent empty password updates in the Donor Dashboard.
+timestamp: 2026-07-29T00:02:59.954Z

--- a/changelog/smtnc-1541-the-donor-dashboard-should-have-a-validation.yaml
+++ b/changelog/smtnc-1541-the-donor-dashboard-should-have-a-validation.yaml
@@ -1,4 +1,4 @@
 significance: patch
-type: fixed
+type: fix
 entry: Added validation to prevent empty password updates in the Donor Dashboard.
 timestamp: 2026-07-29T00:02:59.954Z

--- a/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
+++ b/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
@@ -6,6 +6,7 @@ use Give\DonorDashboards\Helpers\SanitizeProfileData as SanitizeHelper;
 use Give\DonorDashboards\Profile as Profile;
 use Give\DonorDashboards\Tabs\Contracts\Route as RouteAbstract;
 use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * @since 2.10.0
@@ -38,18 +39,32 @@ class PasswordRoute extends RouteAbstract
     /**
      * Handles password update.
      *
+     * @since TBD added password validation
      * @since 3.3.0
      *
      * @param WP_REST_Request $request
      *
-     * @return array
-     *
+     * @return array|WP_REST_Response
      */
     public function handleRequest(WP_REST_Request $request)
     {
+        $newPassword = trim($request->get_param('newPassword'));
+
+        if (empty($newPassword)) {
+            return new WP_REST_Response(
+                [
+                    'status' => 400,
+                    'response' => 'invalid_password',
+                    'body_response' => [
+                        'message' => esc_html__('Please enter a valid password.', 'give'),
+                    ],
+                ]
+            );
+        }
+
         wp_update_user([
             'ID' => wp_get_current_user()->ID,
-            'user_pass' => $request->get_param('newPassword'),
+            'user_pass' => $newPassword,
         ]);
 
         return [

--- a/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
+++ b/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
@@ -2,8 +2,7 @@
 
 namespace Give\DonorDashboards\Tabs\EditProfileTab;
 
-use Give\DonorDashboards\Helpers\SanitizeProfileData as SanitizeHelper;
-use Give\DonorDashboards\Profile as Profile;
+use Give\Donors\Models\Donor;
 use Give\DonorDashboards\Tabs\Contracts\Route as RouteAbstract;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -62,7 +61,23 @@ class PasswordRoute extends RouteAbstract
             );
         }
 
-        wp_set_password($newPassword, wp_get_current_user()->ID);
+        $donorId = give()->donorDashboard->getId();
+
+        $donor = Donor::find($donorId);
+
+        if ( ! $donor || empty($donor->userId)) {
+            return new WP_REST_Response(
+                [
+                    'status' => 400,
+                    'response' => 'no_user_account',
+                    'body_response' => [
+                        'message' => esc_html__('Unable to update password. Contact a site administrator.', 'give'),
+                    ],
+                ]
+            );
+        }
+
+        wp_set_password($newPassword, $donor->userId);
 
         return [
             'success' => true,

--- a/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
+++ b/src/DonorDashboards/Tabs/EditProfileTab/PasswordRoute.php
@@ -62,10 +62,7 @@ class PasswordRoute extends RouteAbstract
             );
         }
 
-        wp_update_user([
-            'ID' => wp_get_current_user()->ID,
-            'user_pass' => $newPassword,
-        ]);
+        wp_set_password($newPassword, wp_get_current_user()->ID);
 
         return [
             'success' => true,

--- a/src/DonorDashboards/resources/js/app/components/button/index.tsx
+++ b/src/DonorDashboards/resources/js/app/components/button/index.tsx
@@ -14,7 +14,7 @@ type ButtonProps = {
     disabled?: boolean;
 };
 
-const Button = ({icon, children, onClick, href, type, variant,classnames, ...rest}: ButtonProps) => {
+const Button = ({icon, children, onClick, href, type, variant, disabled, classnames, ...rest}: ButtonProps) => {
     const handleHrefClick = (e) => {
         e.preventDefault();
         window.parent.location = href;
@@ -40,9 +40,11 @@ const Button = ({icon, children, onClick, href, type, variant,classnames, ...res
             className={cx('give-donor-dashboard-button', classnames, {
                 ['give-donor-dashboard-button--primary']: !variant,
                 ['give-donor-dashboard-button--variant']: variant,
+                ['disabled']: disabled,
             })}
             onClick={onClick ? () => onClick() : null}
             type={type}
+            disabled={disabled}
             {...rest}
         >
             <span>{children}</span>

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
@@ -221,7 +221,7 @@ const Content = () => {
                 value={newPassword}
                 onChange={(value) => setNewPassword(value)}
             />
-            <Button onClick={() => handlePasswordUpdate()} disabled={!newPassword}>
+            <Button onClick={() => handlePasswordUpdate()} disabled={!newPassword.trim()}>
                 {passwordUpdated ? (
                     <Fragment>
                         {__('Updated', 'give')} <FontAwesomeIcon icon="check" fixedWidth />

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
@@ -95,15 +95,13 @@ const Content = () => {
     ];
 
     const [newPassword, setNewPassword] = useState('');
-    const [passwordError, setPasswordError] = useState('');
     const [passwordUpdated, setPasswordUpdated] = useState(false);
     const handlePasswordUpdate = async () => {
         if (!newPassword) {
-            setPasswordError(__('Please enter a new password.', 'give'));
             return;
         }
-        setPasswordError('');
         updatePasswordWithAPI(newPassword);
+        setNewPassword('');
         setPasswordUpdated(true);
     };
 
@@ -221,16 +219,8 @@ const Content = () => {
                 type="password"
                 label={__('New Password', 'give')}
                 value={newPassword}
-                onChange={(value) => {
-                    setNewPassword(value);
-                    setPasswordError('');
-                }}
+                onChange={(value) => setNewPassword(value)}
             />
-            {passwordError && (
-                <div className="give-donor-dashboard__password-error-message">
-                    {passwordError}
-                </div>
-            )}
             <Button onClick={() => handlePasswordUpdate()} disabled={!newPassword}>
                 {passwordUpdated ? (
                     <Fragment>

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
@@ -95,10 +95,15 @@ const Content = () => {
     ];
 
     const [newPassword, setNewPassword] = useState('');
+    const [passwordError, setPasswordError] = useState('');
     const [passwordUpdated, setPasswordUpdated] = useState(false);
     const handlePasswordUpdate = async () => {
-        updatePasswordWithAPI(newPassword)
-        setNewPassword('');
+        if (!newPassword) {
+            setPasswordError(__('Please enter a new password.', 'give'));
+            return;
+        }
+        setPasswordError('');
+        updatePasswordWithAPI(newPassword);
         setPasswordUpdated(true);
     };
 
@@ -216,9 +221,17 @@ const Content = () => {
                 type="password"
                 label={__('New Password', 'give')}
                 value={newPassword}
-                onChange={(value) => setNewPassword(value)}
+                onChange={(value) => {
+                    setNewPassword(value);
+                    setPasswordError('');
+                }}
             />
-            <Button onClick={() => handlePasswordUpdate()}>
+            {passwordError && (
+                <div className="give-donor-dashboard__password-error-message">
+                    {passwordError}
+                </div>
+            )}
+            <Button onClick={() => handlePasswordUpdate()} disabled={!newPassword}>
                 {passwordUpdated ? (
                     <Fragment>
                         {__('Updated', 'give')} <FontAwesomeIcon icon="check" fixedWidth />

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/content.js
@@ -97,7 +97,7 @@ const Content = () => {
     const [newPassword, setNewPassword] = useState('');
     const [passwordUpdated, setPasswordUpdated] = useState(false);
     const handlePasswordUpdate = async () => {
-        if (!newPassword) {
+        if (!newPassword.trim()) {
             return;
         }
         updatePasswordWithAPI(newPassword);

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/style.scss
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/style.scss
@@ -85,3 +85,10 @@
         transform: rotate(360deg);
     }
 }
+
+.give-donor-dashboard__password-error-message {
+    margin-top: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #c91f1f;
+}

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/style.scss
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/style.scss
@@ -86,9 +86,3 @@
     }
 }
 
-.give-donor-dashboard__password-error-message {
-    margin-top: 8px;
-    font-size: 14px;
-    font-weight: 500;
-    color: #c91f1f;
-}

--- a/tests/Unit/DonorDashboards/Routes/TestLoginRoute.php
+++ b/tests/Unit/DonorDashboards/Routes/TestLoginRoute.php
@@ -24,16 +24,16 @@ class TestLoginRoute extends RestApiTestCase
     const ROUTE = '/give-api/v2/donor-dashboard/login';
 
     /** @var string */
-    const KNOWN_USERNAME = 'givewp_donor';
-
-    /** @var string */
-    const KNOWN_EMAIL = 'givewp_donor@example.test';
-
-    /** @var string */
     const KNOWN_PASSWORD = 'correct horse battery staple';
 
     /** @var int */
     private $userId;
+
+    /** @var string */
+    private $knownUsername;
+
+    /** @var string */
+    private $knownEmail;
 
     /**
      * @since TBD
@@ -48,15 +48,21 @@ class TestLoginRoute extends RestApiTestCase
     }
 
     /**
+     * @since TBD Add unique-id suffix to avoid cross-test collisions from TRUNCATE-implicit-commit leakage.
      * @since 4.15.5
      *
      * @return int The created user's ID.
      */
     private function createKnownUser(): int
     {
+        $uniqueId = uniqid('', true);
+
+        $this->knownUsername = 'givewp_donor_' . $uniqueId;
+        $this->knownEmail = 'givewp_donor_' . $uniqueId . '@example.test';
+
         $this->userId = wp_insert_user([
-            'user_login' => self::KNOWN_USERNAME,
-            'user_email' => self::KNOWN_EMAIL,
+            'user_login' => $this->knownUsername,
+            'user_email' => $this->knownEmail,
             'user_pass' => self::KNOWN_PASSWORD,
             'role' => 'subscriber',
         ]);
@@ -86,7 +92,7 @@ class TestLoginRoute extends RestApiTestCase
     {
         $this->createKnownUser();
 
-        $data = $this->login(self::KNOWN_USERNAME, self::KNOWN_PASSWORD);
+        $data = $this->login($this->knownUsername, self::KNOWN_PASSWORD);
 
         $this->assertSame(200, $data['status']);
         $this->assertSame('login_successful', $data['response']);
@@ -111,7 +117,7 @@ class TestLoginRoute extends RestApiTestCase
             $fired = true;
         });
 
-        $this->login(self::KNOWN_USERNAME, 'wrong-password');
+        $this->login($this->knownUsername, 'wrong-password');
 
         $this->assertTrue(
             $fired,
@@ -139,7 +145,7 @@ class TestLoginRoute extends RestApiTestCase
             return $user;
         }, 5);
 
-        $this->login(self::KNOWN_USERNAME, 'wrong-password');
+        $this->login($this->knownUsername, 'wrong-password');
 
         $this->assertTrue(
             $ran,
@@ -162,7 +168,7 @@ class TestLoginRoute extends RestApiTestCase
             return new \WP_Error('too_many_retries', 'Locked out.');
         }, 30);
 
-        $data = $this->login(self::KNOWN_USERNAME, self::KNOWN_PASSWORD);
+        $data = $this->login($this->knownUsername, self::KNOWN_PASSWORD);
 
         $this->assertNotSame(
             'login_successful',
@@ -192,7 +198,7 @@ class TestLoginRoute extends RestApiTestCase
             return new \WP_Error('lockout_plugin_block', 'Too many failed login attempts. Please try again later.');
         }, 30);
 
-        $data = $this->login(self::KNOWN_USERNAME, 'wrong-password');
+        $data = $this->login($this->knownUsername, 'wrong-password');
 
         $this->assertSame(429, $data['status']);
         $this->assertSame('too_many_attempts', $data['response']);
@@ -214,7 +220,7 @@ class TestLoginRoute extends RestApiTestCase
     {
         $this->createKnownUser();
 
-        $data = $this->login(self::KNOWN_USERNAME, 'wrong-password');
+        $data = $this->login($this->knownUsername, 'wrong-password');
 
         $this->assertSame(401, $data['status']);
         $this->assertSame('login_failed', $data['response']);
@@ -239,7 +245,7 @@ class TestLoginRoute extends RestApiTestCase
     {
         $this->createKnownUser();
 
-        $existingUserWrongPassword = $this->login(self::KNOWN_USERNAME, 'wrong-password');
+        $existingUserWrongPassword = $this->login($this->knownUsername, 'wrong-password');
         $nonExistentUser = $this->login('no-such-user-here', 'wrong-password');
 
         $this->assertSame(

--- a/tests/Unit/DonorDashboards/Routes/TestLoginRoute.php
+++ b/tests/Unit/DonorDashboards/Routes/TestLoginRoute.php
@@ -32,6 +32,21 @@ class TestLoginRoute extends RestApiTestCase
     /** @var string */
     const KNOWN_PASSWORD = 'correct horse battery staple';
 
+    /** @var int */
+    private $userId;
+
+    /**
+     * @since TBD
+     */
+    public function tearDown(): void
+    {
+        if ($this->userId > 0 && get_user_by('id', $this->userId)) {
+            wp_delete_user($this->userId);
+        }
+
+        parent::tearDown();
+    }
+
     /**
      * @since 4.15.5
      *
@@ -39,12 +54,14 @@ class TestLoginRoute extends RestApiTestCase
      */
     private function createKnownUser(): int
     {
-        return wp_insert_user([
+        $this->userId = wp_insert_user([
             'user_login' => self::KNOWN_USERNAME,
             'user_email' => self::KNOWN_EMAIL,
             'user_pass' => self::KNOWN_PASSWORD,
             'role' => 'subscriber',
         ]);
+
+        return $this->userId;
     }
 
     /**

--- a/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
+++ b/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
@@ -32,9 +32,11 @@ class TestPasswordRoute extends RestApiTestCase
     {
         parent::setUp();
 
+        $uniqueId = uniqid('', true);
+
         $this->userId = wp_insert_user([
-            'user_login' => 'givewp_test_donor',
-            'user_email' => 'givewp_test_donor@example.test',
+            'user_login' => "givewp_test_donor_{$uniqueId}",
+            'user_email' => "givewp_test_donor_{$uniqueId}@example.test",
             'user_pass' => 'original-password',
             'role' => 'subscriber',
         ]);

--- a/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
+++ b/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
@@ -49,6 +49,18 @@ class TestPasswordRoute extends RestApiTestCase
     /**
      * @since TBD
      */
+    public function tearDown(): void
+    {
+        if ($this->userId > 0 && get_user_by('id', $this->userId)) {
+            wp_delete_user($this->userId);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
     public function testEmptyPasswordReturnsError()
     {
         $request = new WP_REST_Request('POST', self::ROUTE);

--- a/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
+++ b/tests/Unit/DonorDashboards/Tabs/EditProfileTab/TestPasswordRoute.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Give\Tests\Unit\DonorDashboards\Tabs\EditProfileTab;
+
+use Give\Donors\Models\Donor;
+use Give\Tests\RestApiTestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_REST_Request;
+
+/**
+ * @since TBD
+ *
+ * @coversDefaultClass \Give\DonorDashboards\Tabs\EditProfileTab\PasswordRoute
+ */
+class TestPasswordRoute extends RestApiTestCase
+{
+    use RefreshDatabase;
+
+    /** @var string */
+    const ROUTE = '/give-api/v2/donor-dashboard/password';
+
+    /** @var int */
+    private $userId;
+
+    /** @var Donor */
+    private $donor;
+
+    /**
+     * @since TBD
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userId = wp_insert_user([
+            'user_login' => 'givewp_test_donor',
+            'user_email' => 'givewp_test_donor@example.test',
+            'user_pass' => 'original-password',
+            'role' => 'subscriber',
+        ]);
+
+        $this->donor = Donor::factory()->create([
+            'userId' => $this->userId,
+        ]);
+
+        wp_set_current_user($this->userId);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testEmptyPasswordReturnsError()
+    {
+        $request = new WP_REST_Request('POST', self::ROUTE);
+        $request->set_param('newPassword', '');
+        $request->set_param('donor_id', $this->donor->id);
+
+        $data = $this->dispatchRequest($request)->get_data();
+
+        $this->assertSame(400, $data['status']);
+        $this->assertSame('invalid_password', $data['response']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testWhitespacePasswordReturnsError()
+    {
+        $request = new WP_REST_Request('POST', self::ROUTE);
+        $request->set_param('newPassword', '   ');
+        $request->set_param('donor_id', $this->donor->id);
+
+        $data = $this->dispatchRequest($request)->get_data();
+
+        $this->assertSame(400, $data['status']);
+        $this->assertSame('invalid_password', $data['response']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testValidPasswordReturnsSuccess()
+    {
+        $request = new WP_REST_Request('POST', self::ROUTE);
+        $request->set_param('newPassword', 'new-valid-password');
+        $request->set_param('donor_id', $this->donor->id);
+
+        $data = $this->dispatchRequest($request)->get_data();
+
+        $this->assertTrue($data['success']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testValidPasswordUpdatesUserPassword()
+    {
+        $request = new WP_REST_Request('POST', self::ROUTE);
+        $request->set_param('newPassword', 'updated-password');
+        $request->set_param('donor_id', $this->donor->id);
+
+        $this->dispatchRequest($request);
+
+        $user = get_user_by('id', $this->userId);
+        $this->assertNotFalse(
+            wp_check_password('updated-password', $user->user_pass, $this->userId),
+            'User password should be updated to the new value.'
+        );
+    }
+}


### PR DESCRIPTION
Resolves [SMTNC-1541](https://linear.app/nexcess/issue/SMTNC-1541/the-donor-dashboard-should-have-a-validation-when-no-password-is)

## Description

The reset password button of the Donor Dashboard didn't have a proper validation to block the user from clicking with an empty field.

This PR adds the proper style and validation to block the user from clicking that button without a password typed.

## Affects

Visual and behavior of the "Update Password" button from the Donor Dashboard.

## Visuals

### Before

<img width="679" height="250" alt="image" src="https://github.com/user-attachments/assets/29bff3cc-51e9-4e83-b1cf-4f6553e84e46" />

### After

<img width="682" height="227" alt="image" src="https://github.com/user-attachments/assets/dc4322f4-0d46-46f4-9077-d0d835f45692" />

### Demo

https://www.loom.com/share/b12f296c1e924910ba2aab5270225999

## Testing Instructions

1. Go to the Donor Dashboard
2. Edit profile (buttom of the page)
3. See if you CAN'T proceed with an empty password

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@TBD` tags included in DocBlocks
-   [ ] Includes unit tests -> visual changes. No test suit existing for this front-end section
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

