### PR TITLE
Fix: Activation banner doesn't appear when a Give Addon is activated from Harbor

### DIFF
--- a/changelog/smtnc-1935.yaml
+++ b/changelog/smtnc-1935.yaml
@@ -1,0 +1,5 @@
+significance: minor
+type: fix
+entry: Activation banner for addons doesn't show when addons are activated from
+  the Unified License Manager
+timestamp: 2026-08-04T15:29:01.437Z

--- a/changelog/smtnc-1935.yaml
+++ b/changelog/smtnc-1935.yaml
@@ -1,4 +1,4 @@
-significance: minor
+significance: patch
 type: fix
 entry: Activation banner for addons doesn't show when addons are activated from
   the Unified License Manager

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -134,7 +134,7 @@ function give_get_admin_page_menu_title() {
  * @param string $activated_plugin Plugin file passed by the `activated_plugin` action.
  */
 function give_recently_activated_addons( $activated_plugin = '' ) {
-	$plugins = array_values( array_unique( $activated_plugin ) );
+	$plugins = [];
 
 	// Check if action is set.
 	if ( isset( $_REQUEST['action'] ) ) {

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -127,6 +127,7 @@ function give_get_admin_page_menu_title() {
 /**
  * Store recently activated Give's addons to wp options.
  *
+ * @since 2.1.0
  * @since TBD Fall back to the plugin file passed by the `activated_plugin`
  *            action so add-ons activated outside of plugins.php (REST, WP-CLI,
  *            programmatic `activate_plugin()`, etc.) are recorded too.

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -125,63 +125,6 @@ function give_get_admin_page_menu_title() {
 }
 
 /**
- * Store recently activated Give's addons to wp options.
- *
- * @since 2.1.0
- * @since TBD Fall back to the plugin file passed by the `activated_plugin`
- *            action so add-ons activated outside of plugins.php (REST, WP-CLI,
- *            programmatic `activate_plugin()`, etc.) are recorded too.
- *
- * @param string $activated_plugin Plugin file passed by the `activated_plugin` action.
- */
-function give_recently_activated_addons( $activated_plugin = '' ) {
-	$plugins = [];
-
-	// Check if action is set.
-	if ( isset( $_REQUEST['action'] ) ) {
-		$plugin_action = ( '-1' !== $_REQUEST['action'] ) ? $_REQUEST['action'] : ( isset( $_REQUEST['action2'] ) ? $_REQUEST['action2'] : '' );
-
-		switch ( $plugin_action ) {
-			case 'activate': // Single add-on activation.
-				$plugins[] = $_REQUEST['plugin'];
-				break;
-			case 'activate-selected': // If multiple add-ons activated.
-				$plugins = $_REQUEST['checked'];
-				break;
-		}
-	}
-
-	/**
-	 * Activations that do not come from the plugins.php form (Harbor's feature manager,
-	 * WP-CLI, plugin dependencies, any direct `activate_plugin()` call) have no matching
-	 * request parameters, so use the plugin file the action itself provides.
-	 */
-	if ( empty( $plugins ) && ! empty( $activated_plugin ) ) {
-		$plugins[] = $activated_plugin;
-	}
-
-	if ( ! empty( $plugins ) ) {
-
-		$give_addons = give_get_recently_activated_addons();
-
-		foreach ( $plugins as $plugin ) {
-			// Get plugins which has 'Give-' as prefix.
-			if ( stripos( $plugin, 'Give-' ) !== false ) {
-				$give_addons[] = $plugin;
-			}
-		}
-
-		if ( ! empty( $give_addons ) ) {
-			// Update the Give's activated add-ons.
-			update_option( 'give_recently_activated_addons', $give_addons, false );
-		}
-	}
-}
-
-// Add add-on plugins to wp option table.
-add_action( 'activated_plugin', 'give_recently_activated_addons', 10 );
-
-/**
  * Create new menu in plugin section that include all the add-on
  *
  * @since 2.1.0
@@ -450,17 +393,6 @@ function give_plugin_notice_css() {
 }
 
 add_action( 'admin_head', 'give_plugin_notice_css' );
-
-/**
- * Get list of add-on last activated.
- *
- * @since 2.1.3
- *
- * @return mixed|array list of recently activated add-on
- */
-function give_get_recently_activated_addons() {
-	return get_option( 'give_recently_activated_addons', [] );
-}
 
 /**
  * Renders the Give Deactivation Survey Form.

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -127,13 +127,18 @@ function give_get_admin_page_menu_title() {
 /**
  * Store recently activated Give's addons to wp options.
  *
- * @since 2.1.0
+ * @since TBD Fall back to the plugin file passed by the `activated_plugin`
+ *            action so add-ons activated outside of plugins.php (REST, WP-CLI,
+ *            programmatic `activate_plugin()`, etc.) are recorded too.
+ *
+ * @param string $activated_plugin Plugin file passed by the `activated_plugin` action.
  */
-function give_recently_activated_addons() {
+function give_recently_activated_addons( $activated_plugin = '' ) {
+	$plugins = array_values( array_unique( $activated_plugin ) );
+
 	// Check if action is set.
 	if ( isset( $_REQUEST['action'] ) ) {
 		$plugin_action = ( '-1' !== $_REQUEST['action'] ) ? $_REQUEST['action'] : ( isset( $_REQUEST['action2'] ) ? $_REQUEST['action2'] : '' );
-		$plugins       = [];
 
 		switch ( $plugin_action ) {
 			case 'activate': // Single add-on activation.
@@ -143,22 +148,31 @@ function give_recently_activated_addons() {
 				$plugins = $_REQUEST['checked'];
 				break;
 		}
+	}
 
-		if ( ! empty( $plugins ) ) {
+	/**
+	 * Activations that do not come from the plugins.php form (Harbor's feature manager,
+	 * WP-CLI, plugin dependencies, any direct `activate_plugin()` call) have no matching
+	 * request parameters, so use the plugin file the action itself provides.
+	 */
+	if ( empty( $plugins ) && ! empty( $activated_plugin ) ) {
+		$plugins[] = $activated_plugin;
+	}
 
-			$give_addons = give_get_recently_activated_addons();
+	if ( ! empty( $plugins ) ) {
 
-			foreach ( $plugins as $plugin ) {
-				// Get plugins which has 'Give-' as prefix.
-				if ( stripos( $plugin, 'Give-' ) !== false ) {
-					$give_addons[] = $plugin;
-				}
+		$give_addons = give_get_recently_activated_addons();
+
+		foreach ( $plugins as $plugin ) {
+			// Get plugins which has 'Give-' as prefix.
+			if ( stripos( $plugin, 'Give-' ) !== false ) {
+				$give_addons[] = $plugin;
 			}
+		}
 
-			if ( ! empty( $give_addons ) ) {
-				// Update the Give's activated add-ons.
-				update_option( 'give_recently_activated_addons', $give_addons, false );
-			}
+		if ( ! empty( $give_addons ) ) {
+			// Update the Give's activated add-ons.
+			update_option( 'give_recently_activated_addons', $give_addons, false );
 		}
 	}
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1898,6 +1898,76 @@ function give_get_active_by_user_meta( $banner_addon_name ) {
 }
 
 /**
+ * Store recently activated Give's addons to wp options.
+ *
+ * @since TBD Moved from includes/admin/plugins.php so the listener is registered on every
+ *            request, and fall back to the plugin file passed by the `activated_plugin`
+ *            action so add-ons activated outside of plugins.php (REST, WP-CLI,
+ *            programmatic `activate_plugin()`, etc.) are recorded too.
+ * @since 2.1.0
+ *
+ * @param string $activated_plugin Plugin file passed by the `activated_plugin` action.
+ */
+function give_recently_activated_addons( $activated_plugin = '' ) {
+	$plugins = [];
+
+	// Check if action is set.
+	if ( isset( $_REQUEST['action'] ) ) {
+		$plugin_action = ( '-1' !== $_REQUEST['action'] ) ? $_REQUEST['action'] : ( isset( $_REQUEST['action2'] ) ? $_REQUEST['action2'] : '' );
+
+		switch ( $plugin_action ) {
+			case 'activate': // Single add-on activation.
+				$plugins[] = $_REQUEST['plugin'];
+				break;
+			case 'activate-selected': // If multiple add-ons activated.
+				$plugins = $_REQUEST['checked'];
+				break;
+		}
+	}
+
+	/**
+	 * Activations that do not come from the plugins.php form (Harbor's feature manager,
+	 * WP-CLI, plugin dependencies, any direct `activate_plugin()` call) have no matching
+	 * request parameters, so use the plugin file the action itself provides.
+	 */
+	if ( empty( $plugins ) && ! empty( $activated_plugin ) ) {
+		$plugins[] = $activated_plugin;
+	}
+
+	if ( ! empty( $plugins ) ) {
+
+		$give_addons = give_get_recently_activated_addons();
+
+		foreach ( $plugins as $plugin ) {
+			// Get plugins which has 'Give-' as prefix.
+			if ( stripos( $plugin, 'Give-' ) !== false ) {
+				$give_addons[] = $plugin;
+			}
+		}
+
+		if ( ! empty( $give_addons ) ) {
+			// Update the Give's activated add-ons.
+			update_option( 'give_recently_activated_addons', $give_addons, false );
+		}
+	}
+}
+
+// Add add-on plugins to wp option table.
+add_action( 'activated_plugin', 'give_recently_activated_addons', 10 );
+
+/**
+ * Get list of add-on last activated.
+ *
+ * @since TBD Moved from includes/admin/plugins.php.
+ * @since 2.1.3
+ *
+ * @return mixed|array list of recently activated add-on
+ */
+function give_get_recently_activated_addons() {
+	return get_option( 'give_recently_activated_addons', [] );
+}
+
+/**
  * Get time interval for which nonce is valid
  *
  * @return int

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -46,12 +46,20 @@ class HarborServiceProvider implements ServiceProviderContract
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');
 
-        add_action( 'rest_api_init', function() {
-            $file = GIVE_PLUGIN_DIR . 'includes/admin/plugins.php';
-            if ( file_exists( $file ) ) {
-                require_once $file;
-            }
-        });
+        // Fixes Activation banner doesn't appear when the Give Addon is activated from Harbor.
+        add_action( 'rest_api_init', array($this, 'load_plugin_file'));
+    }
+
+    /**
+     * Load the plugin file.
+     *
+     * @since TBD
+     */
+    public function load_plugin_file() {
+        $file = GIVE_PLUGIN_DIR . 'includes/admin/plugins.php';
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
     }
 
 }

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -46,20 +46,23 @@ class HarborServiceProvider implements ServiceProviderContract
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');
 
-        // Fixes Activation banner doesn't appear when the Give Addon is activated from Harbor.
-        add_action( 'rest_api_init', array($this, 'load_plugin_file'));
+        // Fixes Activation banner doesn't appear when a Give Addon is activated from Harbor.
+        add_action('rest_api_init', array($this, 'loadGivePluginFile'));
     }
 
     /**
-     * Load the plugin file.
+     * Load the plugin file so that activation banner appears when
+     * a Give Addon is activated from Harbor.
      *
      * @since TBD
+     *
+     * @return void
      */
-    public function load_plugin_file() {
+    public function loadGivePluginFile()
+    {
         $file = GIVE_PLUGIN_DIR . 'includes/admin/plugins.php';
-        if ( file_exists( $file ) ) {
-            require_once $file;
+        if (file_exists($file)) {
+            include_once $file;
         }
     }
-
 }

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -45,6 +45,13 @@ class HarborServiceProvider implements ServiceProviderContract
 
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');
+
+        add_action( 'rest_api_init', function() {
+            $file = GIVE_PLUGIN_DIR . 'includes/admin/plugins.php';
+            if ( file_exists( $file ) ) {
+                require_once $file;
+            }
+        });
     }
 
 }

--- a/src/VendorOverrides/Harbor/HarborServiceProvider.php
+++ b/src/VendorOverrides/Harbor/HarborServiceProvider.php
@@ -45,24 +45,6 @@ class HarborServiceProvider implements ServiceProviderContract
 
         // adds a "licensing" submenu to Give
         lw_harbor_register_submenu('edit.php?post_type=give_forms');
-
-        // Fixes Activation banner doesn't appear when a Give Addon is activated from Harbor.
-        add_action('rest_api_init', array($this, 'loadGivePluginFile'));
     }
 
-    /**
-     * Load the plugin file so that activation banner appears when
-     * a Give Addon is activated from Harbor.
-     *
-     * @since TBD
-     *
-     * @return void
-     */
-    public function loadGivePluginFile()
-    {
-        $file = GIVE_PLUGIN_DIR . 'includes/admin/plugins.php';
-        if (file_exists($file)) {
-            include_once $file;
-        }
-    }
 }


### PR DESCRIPTION
Resolves [SMTNC-1935](https://linear.app/nexcess/issue/SMTNC-1935/givewp-activation-banner-doesnt-appear-when-the-plugin-is-activated)

## Description

Activation banner doesn't appear when a Give Addon is activated from Harbor

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

<img width="1512" height="729" alt="image" src="https://github.com/user-attachments/assets/f4372062-8e60-4db4-a40a-f60f5ccafabb" />


## Testing Instructions

- Activate the unified license key and install GiveWP
- Activate a new Give addon (Fee recovery, Peer-to-peer, currency switcher) from the Harbor (LW License Manager)
- Notice that the Activation banner for the addon as shown in the screenshot above doesn't appear on the plugins page.
- Switch to this branch, activate the addon again and check the plugins page again. The Activation banner should appear this time.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788447653&installation_model_id=426813&pr_number=8277&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8277&signature=f5f41c123c2eca80878d3c7cb3f8afa26a220cb8e89e78ad80109df08545375a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->