### PR TITLE
Fix: read campaign page meta directly to prevent capability check recursion

### DIFF
--- a/changelog/smtnc-1909-givewp-breaks-flatsome-page-builder.yaml
+++ b/changelog/smtnc-1909-givewp-breaks-flatsome-page-builder.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where editing a page could exhaust the PHP call stack
+  when a theme or plugin filtered post metadata.
+timestamp: 2026-08-11T05:17:04.421Z

--- a/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php
+++ b/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\ValueObjects\CampaignPageMetaKeys;
+use Give\Framework\Database\DB;
 use WP_User;
 
 /**
@@ -113,6 +114,7 @@ class AllowGiveRolesToEditCampaignPages
     /**
      * Check if a post is a campaign page (with caching).
      *
+     * @since TBD Read the campaign ID meta directly instead of through get_post_meta().
      * @since 4.14.0
      */
     private function isCampaignPage(int $postId): bool
@@ -124,11 +126,22 @@ class AllowGiveRolesToEditCampaignPages
         $post = get_post($postId);
         if (!$post || $post->post_type !== 'page') {
             self::$campaignPageCache[$postId] = false;
+
             return false;
         }
 
-        $campaignId = get_post_meta($postId, CampaignPageMetaKeys::CAMPAIGN_ID, true);
-        self::$campaignPageCache[$postId] = !empty($campaignId);
+        /*
+         * get_post_meta() fires the get_post_metadata filter, which third parties hook to run
+         * capability checks. Those re-enter this action through map_meta_cap and recurse until
+         * the call stack is exhausted, so read the meta without going through the filter.
+         */
+        $campaignPageMeta = DB::table('postmeta')
+            ->select('meta_value')
+            ->where('post_id', $postId)
+            ->where('meta_key', CampaignPageMetaKeys::CAMPAIGN_ID)
+            ->get();
+
+        self::$campaignPageCache[$postId] = !empty($campaignPageMeta->meta_value);
 
         return self::$campaignPageCache[$postId];
     }

--- a/tests/Unit/Campaigns/Actions/AllowGiveRolesToEditCampaignPagesTest.php
+++ b/tests/Unit/Campaigns/Actions/AllowGiveRolesToEditCampaignPagesTest.php
@@ -331,6 +331,50 @@ final class AllowGiveRolesToEditCampaignPagesTest extends TestCase
     }
 
     /**
+     * A third-party filter on get_post_metadata that runs a capability check re-enters this action
+     * through map_meta_cap. The campaign page lookup must not read its meta through that filter.
+     *
+     * @since TBD
+     */
+    public function testCampaignPageLookupIsUnaffectedByPostMetaFilters(): void
+    {
+        $campaign = Campaign::factory()->create();
+        $page = $campaign->page();
+        $userId = self::factory()->user->create(['role' => 'give_worker']);
+
+        add_filter('map_meta_cap', [$this->action, 'mapMetaCap'], 10, 4);
+
+        $depth = 0;
+        $maxDepth = 0;
+        $metaFilter = static function ($value, $objectId, $metaKey) use ($userId, &$depth, &$maxDepth) {
+            if ($metaKey !== CampaignPageMetaKeys::CAMPAIGN_ID) {
+                return $value;
+            }
+
+            $depth++;
+            $maxDepth = max($maxDepth, $depth);
+
+            /* Cap the nesting so a regression fails the assertion instead of exhausting the stack. */
+            if ($depth < 10) {
+                user_can($userId, 'edit_post', $objectId);
+            }
+
+            $depth--;
+
+            return $value;
+        };
+        add_filter('get_post_metadata', $metaFilter, 10, 3);
+
+        $result = $this->action->mapMetaCap(['edit_others_pages'], 'edit_post', $userId, [$page->id]);
+
+        remove_filter('get_post_metadata', $metaFilter, 10);
+        remove_filter('map_meta_cap', [$this->action, 'mapMetaCap'], 10);
+
+        $this->assertSame(0, $maxDepth, 'The campaign ID meta was read through get_post_metadata.');
+        $this->assertEmpty($result);
+    }
+
+    /**
      * @since 4.14.0
      *
      * @dataProvider pageMetaCapabilitiesProvider


### PR DESCRIPTION
Resolves [SMTNC-1909](https://linear.app/nexcess/issue/SMTNC-1909/givewp-breaks-flatsome-page-builder)

### Description

Even if this happened there because of Flatsome theme, anything that triggered `map_meta_cap` or `user_has_cap` would cause the same problem.
**This problem has to do with recursion, and follows this logic:**

> Theme triggers this filter
https://github.com/impress-org/givewp/blob/2fe570100c08bbd3b0763c684fa0008bd48ecb89/src/Campaigns/ServiceProvider.php#L188

> The callback calls `$this->isCampaignPage`
https://github.com/impress-org/givewp/blob/2fe570100c08bbd3b0763c684fa0008bd48ecb89/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php#L55

> And inside the method it calls `get_post_meta`, that calls this filter again and go to the first step, causing the recursion
https://github.com/impress-org/givewp/blob/2fe570100c08bbd3b0763c684fa0008bd48ecb89/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php#L130

The solution implemented was to use the [`DB`](https://github.com/impress-org/givewp/blob/2fe570100c08bbd3b0763c684fa0008bd48ecb89/src/Framework/Database/DB.php#L30) utility available on GiveWP, that don't call this filter.

## Affects

- Campaign landing page capability checks for `give_worker` / `give_manager` (`map_meta_cap`, `user_has_cap`). Behaviour is unchanged; only the meta read path moved.
- No public API, hook, option, or stored data shape changed.

## Visuals

https://www.loom.com/share/2ae5ce5c29b1440a82925d2b6cd37aa1

## Testing Instructions

1. Install and activate the Flatsome theme (download link is in the Linear ticket) with GiveWP active.
2. Create a campaign with a landing page under Donations → Campaigns.
3. Go to Pages, open any page, and launch the UX Builder.
4. Confirm the builder iframe loads instead of erroring.
5. Check `wp-content/debug.log` — there should be no `Maximum call stack size ... reached. Infinite recursion?` fatal.
6. Regression check the capability grant itself: log in as a user with the `give_worker` role and confirm they can still edit and publish the campaign landing page from step 2, and still cannot edit an unrelated page.

The new unit test covers the recursion path directly. It registers a `get_post_metadata` filter that runs a capability check and asserts the campaign meta is never read through it — reverting the fix makes it fail with `Failed asserting that 10 is identical to 0`.

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since TBD` tags included in DocBlocks (GiveWP replaced `@unreleased` in `74e6aa779`)
-   [x] Includes unit tests
-   [N/A] Reviewed by the designer (if follows a design) — N/A, no design
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789017888&installation_model_id=426813&pr_number=8283&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8283&signature=ee9c07ee704f4f575e2b2309239f1182ae6da03df5a8b627fd94aaa1e7f7dd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->