### PR TITLE
[SMTNC-1740] All in One SEO plugin script conflict blocks GiveWP Visual Form Builder preview from loading.

### DIFF
--- a/changelog/smtnc-1740-all-in-one-seo-plugin-script-conflict-blocks-givewp-visual.yaml
+++ b/changelog/smtnc-1740-all-in-one-seo-plugin-script-conflict-blocks-givewp-visual.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved a conflict where scripts enqueued by other plugins while a
+  donation form was being rendered could stop the form builder design preview
+  and embedded forms from loading.
+timestamp: 2026-08-11T06:48:00.849Z

--- a/src/DonationForms/Actions/IsolateEnqueuedFormViewAssets.php
+++ b/src/DonationForms/Actions/IsolateEnqueuedFormViewAssets.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Give\DonationForms\Actions;
+
+use WP_Dependencies;
+
+/**
+ * Pins the script and style queues to what has already been enqueued, so a form view route prints
+ * its own assets and nothing else.
+ *
+ * The form view routes render a standalone document by calling wp_print_styles(),
+ * wp_print_head_scripts() and wp_print_footer_scripts() directly. Each of those fires an action that
+ * plugins legitimately enqueue from, so the queues keep growing after the route has finished
+ * enqueuing. Constraining the handles at print time, instead of dequeuing on a hook, keeps the route
+ * independent of the priority the other plugin picked.
+ *
+ * @since TBD
+ */
+class IsolateEnqueuedFormViewAssets
+{
+    /**
+     * @since TBD
+     */
+    public function __invoke()
+    {
+        $this->pinQueue(wp_scripts(), 'print_scripts_array', 'scripts');
+        $this->pinQueue(wp_styles(), 'print_styles_array', 'styles');
+    }
+
+    /**
+     * @since TBD
+     *
+     * @param WP_Dependencies $dependencies The queue to pin.
+     * @param string          $filter       Print-time filter the queue is constrained through.
+     * @param string          $type         Either "scripts" or "styles".
+     */
+    private function pinQueue(WP_Dependencies $dependencies, string $filter, string $type)
+    {
+        $allowedHandles = $this->expandDependencies($dependencies, $dependencies->queue);
+
+        /**
+         * Filters the handles a donation form view route may print. Add a handle here to let an
+         * asset enqueued after the form has been prepared through to the rendered form.
+         *
+         * @since TBD
+         *
+         * @param string[] $allowedHandles Handles the route will print.
+         * @param string   $type           Either "scripts" or "styles".
+         */
+        $allowedHandles = apply_filters(
+            'givewp_donation_form_view_allowed_asset_handles',
+            $allowedHandles,
+            $type
+        );
+
+        add_filter($filter, static function ($handles) use ($allowedHandles) {
+            return array_values(array_intersect($handles, $allowedHandles));
+        });
+    }
+
+    /**
+     * Resolves the given handles together with everything they depend on. Registered dependencies
+     * may be cyclic, so handles are only ever visited once.
+     *
+     * @since TBD
+     *
+     * @param WP_Dependencies $dependencies Queue the handles are registered in.
+     * @param string[]        $handles      Handles to resolve.
+     *
+     * @return string[]
+     */
+    private function expandDependencies(WP_Dependencies $dependencies, array $handles): array
+    {
+        $resolved = [];
+
+        while ($handles) {
+            /* WordPress allows arguments to be appended to a queued handle. */
+            $handle = explode('?', (string)array_shift($handles))[0];
+
+            if (isset($resolved[$handle])) {
+                continue;
+            }
+
+            $resolved[$handle] = true;
+
+            if (isset($dependencies->registered[$handle])) {
+                $handles = array_merge($handles, $dependencies->registered[$handle]->deps);
+            }
+        }
+
+        return array_keys($resolved);
+    }
+}

--- a/src/DonationForms/Actions/IsolateEnqueuedFormViewAssets.php
+++ b/src/DonationForms/Actions/IsolateEnqueuedFormViewAssets.php
@@ -21,7 +21,7 @@ class IsolateEnqueuedFormViewAssets
     /**
      * @since TBD
      */
-    public function __invoke()
+    public function __invoke(): void
     {
         $this->pinQueue(wp_scripts(), 'print_scripts_array', 'scripts');
         $this->pinQueue(wp_styles(), 'print_styles_array', 'styles');
@@ -34,7 +34,7 @@ class IsolateEnqueuedFormViewAssets
      * @param string          $filter       Print-time filter the queue is constrained through.
      * @param string          $type         Either "scripts" or "styles".
      */
-    private function pinQueue(WP_Dependencies $dependencies, string $filter, string $type)
+    private function pinQueue(WP_Dependencies $dependencies, string $filter, string $type): void
     {
         $allowedHandles = $this->expandDependencies($dependencies, $dependencies->queue);
 

--- a/src/DonationForms/ViewModels/DonationFormViewModel.php
+++ b/src/DonationForms/ViewModels/DonationFormViewModel.php
@@ -7,6 +7,7 @@ use Give\Campaigns\ValueObjects\CampaignGoalType;
 use Give\DonationForms\Actions\GenerateAuthUrl;
 use Give\DonationForms\Actions\GenerateDonateRouteUrl;
 use Give\DonationForms\Actions\GenerateDonationFormValidationRouteUrl;
+use Give\DonationForms\Actions\IsolateEnqueuedFormViewAssets;
 use Give\DonationForms\DataTransferObjects\DonationFormGoalData;
 use Give\DonationForms\Properties\FormSettings;
 use Give\DonationForms\Repositories\DonationFormRepository;
@@ -280,12 +281,16 @@ class DonationFormViewModel
      *  - This ensures template compatability with global WP css variables as needed. Loads before our templates, so they can use things like global font-family, etc.
      * 2. Enqueue our donation form specific scripts & styles.
      *  - We will let WP handle the actual printing depending on how they were enqueued.
-     * 3. Call the specific WP functions wp_print_styles() and wp_print_head_scripts()
+     * 3. Pin the script and style queues to what we enqueued.
+     *  - The print functions below fire actions that other plugins enqueue from, so the queues
+     *    have to be constrained before printing rather than trusted.
+     * 4. Call the specific WP functions wp_print_styles() and wp_print_head_scripts()
      *  - This will only print the styles and scripts that are enqueued within our route - so we don't have to dequeue a bunch of stuff.
-     * 4. Manually echo our window data and root div for our React app to consume
-     * 5. Finally, call the specific WP function wp_print_footer_scripts()
+     * 5. Manually echo our window data and root div for our React app to consume
+     * 6. Finally, call the specific WP function wp_print_footer_scripts()
      *  - This will only print the footer scripts that are enqueued within our route.
      *
+     * @since TBD Isolate the printed assets from anything enqueued after the form has been prepared
      * @since 4.14.3 Escape HTML attributes for classNames property
      * @since 3.20.0 Adds class for form design
      * @since 3.11.0 Sanitize customCSS property
@@ -299,6 +304,8 @@ class DonationFormViewModel
             $this->donationFormId,
             $this->designId()
         );
+
+        (new IsolateEnqueuedFormViewAssets())();
 
         ob_start();
         wp_print_styles();

--- a/tests/Unit/DonationForms/Actions/TestIsolateEnqueuedFormViewAssets.php
+++ b/tests/Unit/DonationForms/Actions/TestIsolateEnqueuedFormViewAssets.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForms\Actions;
+
+use Give\DonationForms\Actions\IsolateEnqueuedFormViewAssets;
+use Give\Tests\TestCase;
+use WP_Scripts;
+use WP_Styles;
+
+final class TestIsolateEnqueuedFormViewAssets extends TestCase
+{
+    /**
+     * @var WP_Scripts
+     */
+    private $originalScripts;
+
+    /**
+     * @var WP_Styles
+     */
+    private $originalStyles;
+
+    /**
+     * Registrations survive WP_Dependencies::reset(), and a re-registered handle keeps its original
+     * dependencies, so each test needs its own queues.
+     *
+     * @since TBD
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalScripts = $GLOBALS['wp_scripts'] ?? null;
+        $this->originalStyles = $GLOBALS['wp_styles'] ?? null;
+
+        $GLOBALS['wp_scripts'] = new WP_Scripts();
+        $GLOBALS['wp_styles'] = new WP_Styles();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function tearDown(): void
+    {
+        $GLOBALS['wp_scripts'] = $this->originalScripts;
+        $GLOBALS['wp_styles'] = $this->originalStyles;
+
+        remove_all_filters('print_scripts_array');
+        remove_all_filters('print_styles_array');
+        remove_all_filters('givewp_donation_form_view_allowed_asset_handles');
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testShouldKeepScriptsEnqueuedBeforeTheQueueIsPinned()
+    {
+        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+
+        (new IsolateEnqueuedFormViewAssets())();
+
+        $this->assertSame(
+            ['givewp-test-form-app'],
+            apply_filters('print_scripts_array', ['givewp-test-form-app'])
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testShouldKeepDependenciesOfScriptsEnqueuedBeforeTheQueueIsPinned()
+    {
+        wp_register_script('givewp-test-registrars', 'https://example.test/registrars.js', [], '1.0', true);
+        wp_enqueue_script(
+            'givewp-test-form-app',
+            'https://example.test/form-app.js',
+            ['givewp-test-registrars'],
+            '1.0',
+            true
+        );
+
+        (new IsolateEnqueuedFormViewAssets())();
+
+        $this->assertSame(
+            ['givewp-test-registrars', 'givewp-test-form-app'],
+            apply_filters('print_scripts_array', ['givewp-test-registrars', 'givewp-test-form-app'])
+        );
+    }
+
+    /**
+     * A third-party plugin enqueueing from wp_print_footer_scripts is what breaks the rendered form.
+     *
+     * @since TBD
+     */
+    public function testShouldDropScriptsEnqueuedAfterTheQueueIsPinned()
+    {
+        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+
+        (new IsolateEnqueuedFormViewAssets())();
+
+        wp_enqueue_script('third-party-test-script', 'https://example.test/third-party.js', [], '1.0', true);
+
+        $this->assertSame(
+            ['givewp-test-form-app'],
+            apply_filters('print_scripts_array', ['givewp-test-form-app', 'third-party-test-script'])
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testShouldDropStylesEnqueuedAfterTheQueueIsPinned()
+    {
+        wp_enqueue_style('givewp-test-form-styles', 'https://example.test/form.css', [], '1.0');
+
+        (new IsolateEnqueuedFormViewAssets())();
+
+        wp_enqueue_style('third-party-test-style', 'https://example.test/third-party.css', [], '1.0');
+
+        $this->assertSame(
+            ['givewp-test-form-styles'],
+            apply_filters('print_styles_array', ['givewp-test-form-styles', 'third-party-test-style'])
+        );
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testShouldAllowHandlesAddedThroughTheFilter()
+    {
+        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+
+        add_filter(
+            'givewp_donation_form_view_allowed_asset_handles',
+            static function (array $handles, string $type): array {
+                if ('scripts' === $type) {
+                    $handles[] = 'third-party-test-script';
+                }
+
+                return $handles;
+            },
+            10,
+            2
+        );
+
+        (new IsolateEnqueuedFormViewAssets())();
+
+        $this->assertSame(
+            ['givewp-test-form-app', 'third-party-test-script'],
+            apply_filters('print_scripts_array', ['givewp-test-form-app', 'third-party-test-script'])
+        );
+    }
+}

--- a/tests/Unit/DonationForms/Actions/TestIsolateEnqueuedFormViewAssets.php
+++ b/tests/Unit/DonationForms/Actions/TestIsolateEnqueuedFormViewAssets.php
@@ -4,36 +4,46 @@ namespace Give\Tests\Unit\DonationForms\Actions;
 
 use Give\DonationForms\Actions\IsolateEnqueuedFormViewAssets;
 use Give\Tests\TestCase;
-use WP_Scripts;
-use WP_Styles;
 
 final class TestIsolateEnqueuedFormViewAssets extends TestCase
 {
     /**
-     * @var WP_Scripts
+     * @var string[]
      */
-    private $originalScripts;
+    private $originalScriptQueue = [];
 
     /**
-     * @var WP_Styles
+     * @var string[]
      */
-    private $originalStyles;
+    private $originalStyleQueue = [];
 
     /**
-     * Registrations survive WP_Dependencies::reset(), and a re-registered handle keeps its original
-     * dependencies, so each test needs its own queues.
+     * Constructing WP_Styles fires wp_default_styles, which reaches wp_is_block_theme() before the
+     * test suite has registered the theme directory. Warming the globals up front keeps that notice
+     * out of the incorrect-usage assertions the individual tests run.
      *
+     * @since TBD
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        wp_scripts();
+        wp_styles();
+    }
+
+    /**
      * @since TBD
      */
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->originalScripts = $GLOBALS['wp_scripts'] ?? null;
-        $this->originalStyles = $GLOBALS['wp_styles'] ?? null;
+        $this->originalScriptQueue = wp_scripts()->queue;
+        $this->originalStyleQueue = wp_styles()->queue;
 
-        $GLOBALS['wp_scripts'] = new WP_Scripts();
-        $GLOBALS['wp_styles'] = new WP_Styles();
+        wp_scripts()->queue = [];
+        wp_styles()->queue = [];
     }
 
     /**
@@ -41,8 +51,8 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
      */
     public function tearDown(): void
     {
-        $GLOBALS['wp_scripts'] = $this->originalScripts;
-        $GLOBALS['wp_styles'] = $this->originalStyles;
+        wp_scripts()->queue = $this->originalScriptQueue;
+        wp_styles()->queue = $this->originalStyleQueue;
 
         remove_all_filters('print_scripts_array');
         remove_all_filters('print_styles_array');
@@ -56,26 +66,29 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
      */
     public function testShouldKeepScriptsEnqueuedBeforeTheQueueIsPinned()
     {
-        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+        wp_enqueue_script('givewp-keep-form-app', 'https://example.test/form-app.js', [], '1.0', true);
 
         (new IsolateEnqueuedFormViewAssets())();
 
         $this->assertSame(
-            ['givewp-test-form-app'],
-            apply_filters('print_scripts_array', ['givewp-test-form-app'])
+            ['givewp-keep-form-app'],
+            apply_filters('print_scripts_array', ['givewp-keep-form-app'])
         );
     }
 
     /**
+     * Registrations survive between tests, and a re-registered handle keeps the dependencies it was
+     * first registered with, so each test needs handles of its own.
+     *
      * @since TBD
      */
     public function testShouldKeepDependenciesOfScriptsEnqueuedBeforeTheQueueIsPinned()
     {
-        wp_register_script('givewp-test-registrars', 'https://example.test/registrars.js', [], '1.0', true);
+        wp_register_script('givewp-deps-registrars', 'https://example.test/registrars.js', [], '1.0', true);
         wp_enqueue_script(
-            'givewp-test-form-app',
+            'givewp-deps-form-app',
             'https://example.test/form-app.js',
-            ['givewp-test-registrars'],
+            ['givewp-deps-registrars'],
             '1.0',
             true
         );
@@ -83,8 +96,8 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
         (new IsolateEnqueuedFormViewAssets())();
 
         $this->assertSame(
-            ['givewp-test-registrars', 'givewp-test-form-app'],
-            apply_filters('print_scripts_array', ['givewp-test-registrars', 'givewp-test-form-app'])
+            ['givewp-deps-registrars', 'givewp-deps-form-app'],
+            apply_filters('print_scripts_array', ['givewp-deps-registrars', 'givewp-deps-form-app'])
         );
     }
 
@@ -95,15 +108,15 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
      */
     public function testShouldDropScriptsEnqueuedAfterTheQueueIsPinned()
     {
-        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+        wp_enqueue_script('givewp-drop-form-app', 'https://example.test/form-app.js', [], '1.0', true);
 
         (new IsolateEnqueuedFormViewAssets())();
 
-        wp_enqueue_script('third-party-test-script', 'https://example.test/third-party.js', [], '1.0', true);
+        wp_enqueue_script('third-party-drop-script', 'https://example.test/third-party.js', [], '1.0', true);
 
         $this->assertSame(
-            ['givewp-test-form-app'],
-            apply_filters('print_scripts_array', ['givewp-test-form-app', 'third-party-test-script'])
+            ['givewp-drop-form-app'],
+            apply_filters('print_scripts_array', ['givewp-drop-form-app', 'third-party-drop-script'])
         );
     }
 
@@ -112,15 +125,15 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
      */
     public function testShouldDropStylesEnqueuedAfterTheQueueIsPinned()
     {
-        wp_enqueue_style('givewp-test-form-styles', 'https://example.test/form.css', [], '1.0');
+        wp_enqueue_style('givewp-drop-form-styles', 'https://example.test/form.css', [], '1.0');
 
         (new IsolateEnqueuedFormViewAssets())();
 
-        wp_enqueue_style('third-party-test-style', 'https://example.test/third-party.css', [], '1.0');
+        wp_enqueue_style('third-party-drop-style', 'https://example.test/third-party.css', [], '1.0');
 
         $this->assertSame(
-            ['givewp-test-form-styles'],
-            apply_filters('print_styles_array', ['givewp-test-form-styles', 'third-party-test-style'])
+            ['givewp-drop-form-styles'],
+            apply_filters('print_styles_array', ['givewp-drop-form-styles', 'third-party-drop-style'])
         );
     }
 
@@ -129,13 +142,13 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
      */
     public function testShouldAllowHandlesAddedThroughTheFilter()
     {
-        wp_enqueue_script('givewp-test-form-app', 'https://example.test/form-app.js', [], '1.0', true);
+        wp_enqueue_script('givewp-filter-form-app', 'https://example.test/form-app.js', [], '1.0', true);
 
         add_filter(
             'givewp_donation_form_view_allowed_asset_handles',
             static function (array $handles, string $type): array {
                 if ('scripts' === $type) {
-                    $handles[] = 'third-party-test-script';
+                    $handles[] = 'third-party-filter-script';
                 }
 
                 return $handles;
@@ -147,8 +160,8 @@ final class TestIsolateEnqueuedFormViewAssets extends TestCase
         (new IsolateEnqueuedFormViewAssets())();
 
         $this->assertSame(
-            ['givewp-test-form-app', 'third-party-test-script'],
-            apply_filters('print_scripts_array', ['givewp-test-form-app', 'third-party-test-script'])
+            ['givewp-filter-form-app', 'third-party-filter-script'],
+            apply_filters('print_scripts_array', ['givewp-filter-form-app', 'third-party-filter-script'])
         );
     }
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1740](https://linear.app/nexcess/issue/SMTNC-1740/all-in-one-seo-plugin-script-conflict-blocks-givewp-visual-form)

### 🎥 Artifacts

https://www.loom.com/share/509f8f2a614746e18482703941e0f940

---

<img width="1277" height="990" alt="image" src="https://github.com/user-attachments/assets/34bd982e-4ced-4df3-8fc4-20c68e5bc65b" />

<img width="1278" height="994" alt="image" src="https://github.com/user-attachments/assets/9bb30e81-0ad8-4e86-b18e-f00ab79fc53e" />

### 🗒️ Description

The donation form view routes now print only the assets they enqueued, so scripts another plugin (in this case the "[All in One SEO](https://wordpress.org/plugins/all-in-one-seo-pack/)") enqueues while the form is rendering can no longer break the form builder design preview or embedded forms.

Now the Visual Form Builder will not be stuck forever in "Preparing your form design…".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789181432&installation_model_id=426813&pr_number=8284&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8284&signature=1bb5adec44753dca19d7948b47a72ddb3d67885eba6b7e350e3c395844870f97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->