### PR TITLE
[SMTNC-2034] WP admin notice prompting site administrators to update WordPress

### DIFF
--- a/changelog/feature-smtnc-2034.yaml
+++ b/changelog/feature-smtnc-2034.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: feature
+entry: Added a WordPress admin notice prompting site administrators to update
+  WordPress when their install is out of date.
+timestamp: 2026-08-17T21:36:27.993Z

--- a/give.php
+++ b/give.php
@@ -193,6 +193,7 @@ final class Give
     private $container;
 
     /**
+     * @since TBD added Notices service provider
      * @since 3.17.0 added Settings service provider
      * @since      2.25.0 added HttpServiceProvider
      * @since      2.19.6 added Donors, Donations, and Subscriptions
@@ -255,6 +256,7 @@ final class Give
         Give\Framework\PaymentGateways\ServiceProvider::class,
         Give\ThirdPartySupport\Elementor\ServiceProvider::class,
         Give\MCP\ServiceProvider::class,
+        Give\Notices\ServiceProvider::class,
         Give\VendorOverrides\Harbor\HarborServiceProvider::class,
     ];
 

--- a/src/Notices/ServiceProvider.php
+++ b/src/Notices/ServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Notices;
+
+use Give\Helpers\Hooks;
+use Give\ServiceProviders\ServiceProvider as ServiceProviderContract;
+
+/**
+ * @since TBD
+ */
+class ServiceProvider implements ServiceProviderContract
+{
+    /**
+     * @inheritDoc
+     *
+     * @since TBD
+     */
+    public function register()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @since TBD
+     */
+    public function boot()
+    {
+        Hooks::addAction('admin_init', WordPressCoreUpdateNotice::class, 'handleDismissal');
+        Hooks::addAction('admin_init', WordPressCoreUpdateNotice::class, 'registerNotice');
+    }
+}

--- a/src/Notices/WordPressCoreUpdateNotice.php
+++ b/src/Notices/WordPressCoreUpdateNotice.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\Notices;
+
+use Give\Vendors\StellarWP\AdminNotices\AdminNotices;
+
+/**
+ * Prompts site administrators to update WordPress while the install is behind the latest release.
+ *
+ * @since TBD
+ */
+class WordPressCoreUpdateNotice
+{
+    /**
+     * Dismissal flag shared with the other StellarWP plugins that display this notice, so a site
+     * running more than one of them only has to dismiss it once.
+     *
+     * @since TBD
+     */
+    const DISMISSED_OPTION = 'nx_wp_core_update_notice_dismissed';
+
+    /**
+     * @since TBD
+     */
+    const NOTICE_ID = 'givewp-wp-core-update';
+
+    /**
+     * @since TBD
+     */
+    const DISMISS_ACTION = 'givewp-dismiss-wp-core-update-notice';
+
+    /**
+     * Registers the notice with the admin notices library.
+     *
+     * @since TBD
+     */
+    public function registerNotice(): void
+    {
+        AdminNotices::show(self::NOTICE_ID, [$this, 'renderNotice'])
+            ->asWarning()
+            ->dismissible()
+            ->withoutAutoParagraph()
+            ->ifUserCan('update_core')
+            ->when([$this, 'shouldDisplay']);
+    }
+
+    /**
+     * Stores the shared dismissal flag when the notice's dismiss control is used.
+     *
+     * @since TBD
+     */
+    public function handleDismissal(): void
+    {
+        if (!isset($_GET[self::DISMISS_ACTION])) {
+            return;
+        }
+
+        check_admin_referer(self::DISMISS_ACTION);
+
+        if (!current_user_can('update_core')) {
+            return;
+        }
+
+        update_option(self::DISMISSED_OPTION, true, false);
+
+        wp_safe_redirect(remove_query_arg([self::DISMISS_ACTION, '_wpnonce']));
+        exit;
+    }
+
+    /**
+     * @since TBD
+     *
+     * @return bool True while a core update is available and the notice has not been dismissed.
+     */
+    public function shouldDisplay(): bool
+    {
+        return !$this->isDismissed() && $this->isCoreUpdateAvailable();
+    }
+
+    /**
+     * @since TBD
+     *
+     * @return string The notice contents.
+     */
+    public function renderNotice(): string
+    {
+        $heading = esc_html__('Keep your site protected. Update to the latest version of WordPress.', 'give');
+
+        $body = esc_html__(
+            'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.',
+            'give'
+        );
+
+        /* The dismiss control is a link so the shared flag can be stored server side, without a script. */
+        $dismiss = sprintf(
+            '<a href="%1$s" class="notice-dismiss" style="text-decoration: none; color: #1e1e1e;">'
+            . '<span class="screen-reader-text">%2$s</span></a>',
+            esc_url($this->getDismissUrl()),
+            esc_html__('Dismiss this notice.', 'give')
+        );
+
+        return "<p><strong>$heading</strong></p><p>$body</p>$dismiss";
+    }
+
+    /**
+     * @since TBD
+     */
+    private function isDismissed(): bool
+    {
+        return (bool) get_option(self::DISMISSED_OPTION, false);
+    }
+
+    /**
+     * @since TBD
+     */
+    private function isCoreUpdateAvailable(): bool
+    {
+        if (!function_exists('get_core_updates')) {
+            require_once ABSPATH . 'wp-admin/includes/update.php';
+        }
+
+        $updates = get_core_updates(['dismissed' => false]);
+
+        if (empty($updates) || !isset($updates[0]->response)) {
+            return false;
+        }
+
+        return $updates[0]->response === 'upgrade';
+    }
+
+    /**
+     * @since TBD
+     */
+    private function getDismissUrl(): string
+    {
+        return wp_nonce_url(add_query_arg(self::DISMISS_ACTION, '1'), self::DISMISS_ACTION);
+    }
+}

--- a/tests/Unit/Notices/WordPressCoreUpdateNoticeTest.php
+++ b/tests/Unit/Notices/WordPressCoreUpdateNoticeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Give\Tests\Unit\Notices;
+
+use Give\Notices\WordPressCoreUpdateNotice;
+use Give\Tests\TestCase;
+
+/**
+ * @since TBD
+ */
+final class WordPressCoreUpdateNoticeTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        require_once ABSPATH . 'wp-admin/includes/update.php';
+    }
+
+    public function tearDown(): void
+    {
+        delete_option(WordPressCoreUpdateNotice::DISMISSED_OPTION);
+        delete_site_transient('update_core');
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testDisplaysWhenCoreUpdateIsAvailable()
+    {
+        $this->setCoreUpdateResponse('upgrade');
+
+        $this->assertTrue((new WordPressCoreUpdateNotice())->shouldDisplay());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testDoesNotDisplayWhenCoreIsUpToDate()
+    {
+        $this->setCoreUpdateResponse('latest');
+
+        $this->assertFalse((new WordPressCoreUpdateNotice())->shouldDisplay());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testDoesNotDisplayWhenCoreUpdateDataIsMissing()
+    {
+        $this->assertFalse((new WordPressCoreUpdateNotice())->shouldDisplay());
+    }
+
+    /**
+     * The dismissal flag is shared with the other StellarWP plugins, so a value written by any of
+     * them suppresses the notice here as well.
+     *
+     * @since TBD
+     */
+    public function testDoesNotDisplayOnceTheSharedDismissalFlagIsSet()
+    {
+        $this->setCoreUpdateResponse('upgrade');
+        update_option(WordPressCoreUpdateNotice::DISMISSED_OPTION, true, false);
+
+        $this->assertFalse((new WordPressCoreUpdateNotice())->shouldDisplay());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRenderIncludesTheCopyAndADismissLink()
+    {
+        wp_set_current_user(self::factory()->user->create(['role' => 'administrator']));
+
+        $output = (new WordPressCoreUpdateNotice())->renderNotice();
+
+        $this->assertStringContainsString(
+            'Keep your site protected. Update to the latest version of WordPress.',
+            $output
+        );
+        $this->assertStringContainsString(WordPressCoreUpdateNotice::DISMISS_ACTION, $output);
+        $this->assertStringContainsString('_wpnonce', $output);
+    }
+
+    /**
+     * Stores the offer WordPress caches for the installed version. Only the properties
+     * get_core_updates() reads are set.
+     *
+     * @since TBD
+     *
+     * @param string $response The update response WordPress reports for the installed version.
+     */
+    private function setCoreUpdateResponse(string $response)
+    {
+        set_site_transient(
+            'update_core',
+            (object)[
+                'updates' => [
+                    (object)[
+                        'response' => $response,
+                        'locale' => 'en_US',
+                        'current' => get_bloginfo('version'),
+                    ],
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2034](https://linear.app/nexcess/issue/SMTNC-2034/give-core)

### 🎥 Artifacts

<img width="957" height="945" alt="image" src="https://github.com/user-attachments/assets/bacfea0e-3a7a-4313-8cdb-029cb8bb5f2a" />

### 🗒️ Description

Adds a dismissible WordPress admin notice that prompts site administrators to update WordPress while a core update is available, with the dismissal flag shared across the StellarWP plugins showing the same notice so it only has to be dismissed once.

> Shared flag = `nxs_wp_core_update_notice_dismissed`

### ⚠️ Blockers

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595493&installation_model_id=426813&pr_number=8288&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8288&signature=9c42b52dd7edab6bc5f6b58c0d9eee76d791c53b8acc7b7a94f3cbff2cac038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->