### PR TITLE
[SMTNC-2034] WP admin notice prompting site administrators to update WordPress

### DIFF
--- a/changelog/feature-smtnc-2034-core-update-notice.yaml
+++ b/changelog/feature-smtnc-2034-core-update-notice.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: feature
+entry: Added a WordPress admin notice prompting site administrators to update
+  WordPress when their install is out of date.
+timestamp: 2026-08-18T14:11:55.371Z

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "stellarwp/arrays": "^1.3",
         "moneyphp/money": "^3.3.3",
         "stellarwp/harbor": "^1.6",
-        "stellarwp/core-update-notice": "dev-main",
-        "stellarwp/container-contract": "1.0.4 as 1.1.0"
+        "stellarwp/core-update-notice": "dev-main"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -141,7 +140,7 @@
         },
         {
             "type": "vcs",
-            "url": "git@github.com:stellarwp/core-update-notice.git"
+            "url": "https://github.com/stellarwp/core-update-notice.git"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "stellarwp/admin-notices": "^2.0.1",
         "stellarwp/arrays": "^1.3",
         "moneyphp/money": "^3.3.3",
-        "stellarwp/harbor": "^1.6"
+        "stellarwp/harbor": "^1.6",
+        "stellarwp/core-update-notice": "dev-main",
+        "stellarwp/container-contract": "1.0.4 as 1.1.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
@@ -103,6 +105,7 @@
             "packages": [
                 "stellarwp/arrays",
                 "stellarwp/admin-notices",
+                "stellarwp/core-update-notice",
                 "stellarwp/validation",
                 "stellarwp/field-conditions",
                 "symfony/polyfill-ctype",
@@ -135,6 +138,10 @@
         {
             "type": "git",
             "url": "https://github.com/wordpress/wordpress-develop.git"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:stellarwp/core-update-notice.git"
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7da5f499e25b24e3e6154d5b6df3f344",
+    "content-hash": "79843faac335a960ca5e23c2f6e3b16b",
     "packages": [
         {
             "name": "composer/installers",
@@ -778,18 +778,17 @@
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "git@github.com:stellarwp/core-update-notice.git",
-                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd"
+                "url": "https://github.com/stellarwp/core-update-notice.git",
+                "reference": "4b2177c542a22ad7e37b90bf822a2265b75cac98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/c3c243e3fc3e5318b7209314c875f15f10339dfd",
-                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd",
+                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/4b2177c542a22ad7e37b90bf822a2265b75cac98",
+                "reference": "4b2177c542a22ad7e37b90bf822a2265b75cac98",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "stellarwp/container-contract": "^1.1"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "brain/monkey": "^2.6",
@@ -797,6 +796,7 @@
                 "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.9",
+                "stellarwp/nexcess-coding-standards": "^2.0",
                 "szepeviktor/phpstan-wordpress": "^2.0"
             },
             "default-branch": true,
@@ -839,8 +839,12 @@
                     "email": "dev@stellarwp.com"
                 }
             ],
-            "description": "A WordPress admin notice prompting site administrators to update WordPress, with a dismissal flag shared across the plugins that display it.",
-            "time": "2026-08-18T06:42:06+00:00"
+            "description": "A WordPress core update notice scoped to consuming plugins' admin pages, with dismissal shared across plugins.",
+            "support": {
+                "source": "https://github.com/stellarwp/core-update-notice/tree/1.0.0",
+                "issues": "https://github.com/stellarwp/core-update-notice/issues"
+            },
+            "time": "2026-08-18T17:56:47+00:00"
         },
         {
             "name": "stellarwp/field-conditions",
@@ -8805,14 +8809,7 @@
             "time": "2025-02-09T18:58:54+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "stellarwp/container-contract",
-            "version": "1.0.4.0",
-            "alias": "1.1.0",
-            "alias_normalized": "1.1.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "stellarwp/core-update-notice": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b75550006f5bc80dbe46d39f13664bf0",
+    "content-hash": "84319914fed42bd796e3e54086c35f12",
     "packages": [
         {
             "name": "composer/installers",
@@ -772,6 +772,75 @@
                 "source": "https://github.com/stellarwp/container-contract/tree/1.0.4"
             },
             "time": "2022-12-20T21:29:17+00:00"
+        },
+        {
+            "name": "stellarwp/core-update-notice",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:stellarwp/core-update-notice.git",
+                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/c3c243e3fc3e5318b7209314c875f15f10339dfd",
+                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "stellarwp/container-contract": "^1.1"
+            },
+            "require-dev": {
+                "brain/monkey": "^2.6",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.2",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.9",
+                "szepeviktor/phpstan-wordpress": "^2.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellarWP\\CoreUpdateNotice\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "StellarWP\\CoreUpdateNotice\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "phpstan": [
+                    "phpstan analyse --memory-limit=512M"
+                ],
+                "phpcs": [
+                    "phpcs"
+                ],
+                "phpcbf": [
+                    "phpcbf"
+                ],
+                "check": [
+                    "@phpcs",
+                    "@phpstan",
+                    "@test"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "StellarWP",
+                    "email": "dev@stellarwp.com"
+                }
+            ],
+            "description": "A WordPress admin notice prompting site administrators to update WordPress, with a dismissal flag shared across the plugins that display it.",
+            "time": "2026-08-18T06:42:06+00:00"
         },
         {
             "name": "stellarwp/field-conditions",
@@ -8736,9 +8805,17 @@
             "time": "2025-02-09T18:58:54+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "stellarwp/container-contract",
+            "version": "1.0.4.0",
+            "alias": "1.1.0",
+            "alias_normalized": "1.1.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "stellarwp/core-update-notice": 20,
         "wordpress/wordpress": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84319914fed42bd796e3e54086c35f12",
+    "content-hash": "7da5f499e25b24e3e6154d5b6df3f344",
     "packages": [
         {
             "name": "composer/installers",

--- a/give.php
+++ b/give.php
@@ -193,6 +193,7 @@ final class Give
     private $container;
 
     /**
+     * @since TBD added Core Update Notice service provider
      * @since 3.17.0 added Settings service provider
      * @since      2.25.0 added HttpServiceProvider
      * @since      2.19.6 added Donors, Donations, and Subscriptions
@@ -256,6 +257,7 @@ final class Give
         Give\ThirdPartySupport\Elementor\ServiceProvider::class,
         Give\MCP\ServiceProvider::class,
         Give\VendorOverrides\Harbor\HarborServiceProvider::class,
+        Give\VendorOverrides\CoreUpdateNotice\CoreUpdateNoticeServiceProvider::class,
     ];
 
     /**

--- a/src/VendorOverrides/CoreUpdateNotice/CoreUpdateNoticeServiceProvider.php
+++ b/src/VendorOverrides/CoreUpdateNotice/CoreUpdateNoticeServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Give\VendorOverrides\CoreUpdateNotice;
+
+use Give\ServiceProviders\ServiceProvider;
+use Give\Vendors\StellarWP\CoreUpdateNotice\Config;
+use Give\Vendors\StellarWP\CoreUpdateNotice\Register;
+
+/**
+ * Registers and boots the Core Update Notice library
+ *
+ * @since TBD
+ *
+ * @see https://github.com/stellarwp/core-update-notice
+ */
+class CoreUpdateNoticeServiceProvider implements ServiceProvider
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @since TBD
+     */
+    public function register()
+    {
+        Config::setContainer(give()->getContainer());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since TBD
+     */
+    public function boot()
+    {
+        /* Deferred to init because the copy below is only translatable once the text domain loads. */
+        add_action('init', static function () {
+            Register::notice([
+                'heading' => __('Keep your site protected. Update to the latest version of WordPress.', 'give'),
+                'body' => __(
+                    'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.',
+                    'give'
+                ),
+                'dismiss' => __('Dismiss this notice.', 'give'),
+            ]);
+        });
+    }
+}

--- a/src/VendorOverrides/CoreUpdateNotice/CoreUpdateNoticeServiceProvider.php
+++ b/src/VendorOverrides/CoreUpdateNotice/CoreUpdateNoticeServiceProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Give\VendorOverrides\CoreUpdateNotice;
 
 use Give\ServiceProviders\ServiceProvider;
-use Give\Vendors\StellarWP\CoreUpdateNotice\Config;
+use Give\Vendors\StellarWP\CoreUpdateNotice\CoreUpdateNotice;
 use Give\Vendors\StellarWP\CoreUpdateNotice\Register;
 
 /**
@@ -24,7 +24,7 @@ class CoreUpdateNoticeServiceProvider implements ServiceProvider
      */
     public function register()
     {
-        Config::setContainer(give()->getContainer());
+        /* The notice is registered on init in boot(), once the text domain has loaded. */
     }
 
     /**
@@ -34,16 +34,29 @@ class CoreUpdateNoticeServiceProvider implements ServiceProvider
      */
     public function boot()
     {
-        /* Deferred to init because the copy below is only translatable once the text domain loads. */
         add_action('init', static function () {
-            Register::notice([
-                'heading' => __('Keep your site protected. Update to the latest version of WordPress.', 'give'),
-                'body' => __(
-                    'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.',
-                    'give'
-                ),
-                'dismiss' => __('Dismiss this notice.', 'give'),
-            ]);
+            Register::notice(
+                new CoreUpdateNotice([
+                    'heading' => __(
+                        'Keep your site protected. Update to the latest version of WordPress.',
+                        'give'
+                    ),
+                    'body' => __(
+                        'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.',
+                        'give'
+                    ),
+                    'dismiss' => __('Dismiss this notice.', 'give'),
+                ]),
+                static function (): bool {
+                    $screen = get_current_screen();
+
+                    return $screen !== null && (
+                        $screen->post_type === 'give_forms'
+                        || strpos($screen->id, 'give_forms_page_') === 0
+                        || strpos($screen->id, 'admin_page_give-') === 0
+                    );
+                }
+            );
         });
     }
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2034](https://linear.app/nexcess/issue/SMTNC-2034/give-core)

### 🎥 Artifacts

<img width="1479" height="900" alt="image" src="https://github.com/user-attachments/assets/28e85230-24c3-4f2f-ad3e-c6f6a958d21d" />

### 🗒️ Description

Displays a dismissible WordPress admin notice prompting site administrators to update WordPress while a core update is available, using the shared `stellarwp/core-update-notice` package so the dismissal carries across every StellarWP plugin that shows the same notice.

### ⚠️ Blockers

The package declares `stellarwp/container-contract: ^1.1`, which cannot resolve here — `stellarwp/validation` pins that package to `1.0.4` exactly, and Give's `Container` implements the `1.0.4` interface. Both versions declare an identical interface, so the root `require` aliases `1.0.4 as 1.1.0` as a temporary workaround. That alias should be removed once the package widens its constraint to `^1.0 || ^1.1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789655304&installation_model_id=426813&pr_number=8289&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8289&signature=ee48168da179d833ffb45f069ad3ec0bdc6898e53112f8f265fc1ed0eb73a6da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->