### PR TITLE
[SMTNC-2034] WP admin notice prompting site administrators to update WordPress

### DIFF
--- a/changelog/smtnc-1909-givewp-breaks-flatsome-page-builder.yaml
+++ b/changelog/smtnc-1909-givewp-breaks-flatsome-page-builder.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where editing a page could exhaust the PHP call stack
+  when a theme or plugin filtered post metadata.
+timestamp: 2026-08-11T05:17:04.421Z

--- a/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php
+++ b/src/Campaigns/Actions/AllowGiveRolesToEditCampaignPages.php
@@ -3,6 +3,7 @@
 namespace Give\Campaigns\Actions;
 
 use Give\Campaigns\ValueObjects\CampaignPageMetaKeys;
+use Give\Framework\Database\DB;
 use WP_User;
 
 /**
@@ -113,6 +114,7 @@ class AllowGiveRolesToEditCampaignPages
     /**
      * Check if a post is a campaign page (with caching).
      *
+     * @since TBD Read the campaign ID meta directly instead of through get_post_meta().
      * @since 4.14.0
      */
     private function isCampaignPage(int $postId): bool
@@ -124,11 +126,22 @@ class AllowGiveRolesToEditCampaignPages
         $post = get_post($postId);
         if (!$post || $post->post_type !== 'page') {
             self::$campaignPageCache[$postId] = false;
+
             return false;
         }
 
-        $campaignId = get_post_meta($postId, CampaignPageMetaKeys::CAMPAIGN_ID, true);
-        self::$campaignPageCache[$postId] = !empty($campaignId);
+        /*
+         * get_post_meta() fires the get_post_metadata filter, which third parties hook to run
+         * capability checks. Those re-enter this action through map_meta_cap and recurse until
+         * the call stack is exhausted, so read the meta without going through the filter.
+         */
+        $campaignPageMeta = DB::table('postmeta')
+            ->select('meta_value')
+            ->where('post_id', $postId)
+            ->where('meta_key', CampaignPageMetaKeys::CAMPAIGN_ID)
+            ->get();
+
+        self::$campaignPageCache[$postId] = !empty($campaignPageMeta->meta_value);
 
         return self::$campaignPageCache[$postId];
     }

--- a/tests/Unit/Campaigns/Actions/AllowGiveRolesToEditCampaignPagesTest.php
+++ b/tests/Unit/Campaigns/Actions/AllowGiveRolesToEditCampaignPagesTest.php
@@ -331,6 +331,50 @@ final class AllowGiveRolesToEditCampaignPagesTest extends TestCase
     }
 
     /**
+     * A third-party filter on get_post_metadata that runs a capability check re-enters this action
+     * through map_meta_cap. The campaign page lookup must not read its meta through that filter.
+     *
+     * @since TBD
+     */
+    public function testCampaignPageLookupIsUnaffectedByPostMetaFilters(): void
+    {
+        $campaign = Campaign::factory()->create();
+        $page = $campaign->page();
+        $userId = self::factory()->user->create(['role' => 'give_worker']);
+
+        add_filter('map_meta_cap', [$this->action, 'mapMetaCap'], 10, 4);
+
+        $depth = 0;
+        $maxDepth = 0;
+        $metaFilter = static function ($value, $objectId, $metaKey) use ($userId, &$depth, &$maxDepth) {
+            if ($metaKey !== CampaignPageMetaKeys::CAMPAIGN_ID) {
+                return $value;
+            }
+
+            $depth++;
+            $maxDepth = max($maxDepth, $depth);
+
+            /* Cap the nesting so a regression fails the assertion instead of exhausting the stack. */
+            if ($depth < 10) {
+                user_can($userId, 'edit_post', $objectId);
+            }
+
+            $depth--;
+
+            return $value;
+        };
+        add_filter('get_post_metadata', $metaFilter, 10, 3);
+
+        $result = $this->action->mapMetaCap(['edit_others_pages'], 'edit_post', $userId, [$page->id]);
+
+        remove_filter('get_post_metadata', $metaFilter, 10);
+        remove_filter('map_meta_cap', [$this->action, 'mapMetaCap'], 10);
+
+        $this->assertSame(0, $maxDepth, 'The campaign ID meta was read through get_post_metadata.');
+        $this->assertEmpty($result);
+    }
+
+    /**
      * @since 4.14.0
      *
      * @dataProvider pageMetaCapabilitiesProvider


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2034](https://linear.app/nexcess/issue/SMTNC-2034/give-core)

### 🎥 Artifacts

<img width="957" height="945" alt="image" src="https://github.com/user-attachments/assets/bacfea0e-3a7a-4313-8cdb-029cb8bb5f2a" />

### 🗒️ Description

Adds a dismissible WordPress admin notice that prompts site administrators to update WordPress while a core update is available, with the dismissal flag shared across the StellarWP plugins showing the same notice so it only has to be dismissed once.

### ⚠️ Blockers

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595493&installation_model_id=426813&pr_number=8288&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8288&signature=9c42b52dd7edab6bc5f6b58c0d9eee76d791c53b8acc7b7a94f3cbff2cac038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->