### PR TITLE
Fix: donor name recording conflict with Charitable plugin

### DIFF
--- a/changelog/smtnc-1448-givewp-conflict-with-charitable-donor-names-should-not-be.yaml
+++ b/changelog/smtnc-1448-givewp-conflict-with-charitable-donor-names-should-not-be.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved a plugin conflict that prevented donor first and last names from
+  being recorded when the Charitable plugin was active alongside GiveWP.
+timestamp: 2026-08-19T01:38:00.242Z

--- a/includes/admin/tools/data/class-give-tools-reset-stats.php
+++ b/includes/admin/tools/data/class-give-tools-reset-stats.php
@@ -111,6 +111,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 
 			$sql        = [];
 			$meta_table = give_v20_bc_table_details( 'form' );
+			$donor_meta_table_name = Give()->donor_meta->table_name;
 
 			foreach ( $step_ids as $type => $ids ) {
 
@@ -124,7 +125,7 @@ class Give_Tools_Reset_Stats extends Give_Batch_Export {
 					case 'customers':
 						// Delete all the Give related donor and its meta.
 						$sql[] = "DELETE FROM {$wpdb->donors}";
-						$sql[] = "DELETE FROM {$wpdb->donormeta}";
+						$sql[] = "DELETE FROM {$donor_meta_table_name}";
 						break;
 					case 'forms':
 						$sql[] = "UPDATE {$meta_table['name']} SET meta_value = 0 WHERE meta_key = '_give_form_sales' AND {$meta_table['column']['id']} IN ($ids)";

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -3113,7 +3113,9 @@ function give_v230_delete_dw_related_donor_data_callback() {
 
 	$give_updates = Give_Updates::get_instance();
 
-	$wpdb->query( "DELETE FROM {$wpdb->donormeta} WHERE meta_key LIKE '%_give_anonymous_donor%' OR meta_key='_give_has_comment';" );
+	$donor_meta_table_name = Give()->donor_meta->table_name;
+
+	$wpdb->query( "DELETE FROM {$donor_meta_table_name} WHERE meta_key LIKE '%_give_anonymous_donor%' OR meta_key='_give_has_comment';" );
 
 	$give_updates->percentage = 100;
 

--- a/includes/class-give-donor.php
+++ b/includes/class-give-donor.php
@@ -245,7 +245,8 @@ class Give_Donor {
 	 */
 	public function setup_address() {
 		global $wpdb;
-		$meta_type = Give()->donor_meta->meta_type;
+		$meta_type       = Give()->donor_meta->meta_type;
+		$meta_table_name = Give()->donor_meta->table_name;
 
 		$addresses = $this->get_addresses_from_meta_cache();
 
@@ -254,7 +255,7 @@ class Give_Donor {
 			: $wpdb->get_results(
 				$wpdb->prepare(
 					"
-				SELECT meta_key, meta_value FROM {$wpdb->donormeta}
+				SELECT meta_key, meta_value FROM {$meta_table_name}
 				WHERE meta_key
 				LIKE '%s'
 				AND {$meta_type}_id=%d
@@ -1387,6 +1388,7 @@ class Give_Donor {
 		global $wpdb;
 		$meta_key_prefix = "_give_donor_address_{$address_type}_{address_name}";
 		$meta_type       = Give()->donor_meta->meta_type;
+		$meta_table_name = Give()->donor_meta->table_name;
 
 		if ( $is_multi_address ) {
 			if ( is_null( $multi_address_id ) ) {
@@ -1394,7 +1396,7 @@ class Give_Donor {
 				$multi_address_id = $wpdb->get_var(
 					$wpdb->prepare(
 						"
-						SELECT meta_key FROM {$wpdb->donormeta}
+						SELECT meta_key FROM {$meta_table_name}
 						WHERE meta_key
 						LIKE '%s'
 						AND {$meta_type}_id=%d
@@ -1456,13 +1458,14 @@ class Give_Donor {
 			$meta_key_prefix .= "_{$address_count}";
 		}
 
-		$meta_type = Give()->donor_meta->meta_type;
+		$meta_type       = Give()->donor_meta->meta_type;
+		$meta_table_name = Give()->donor_meta->table_name;
 
 		// Process query.
 		$row_affected = $wpdb->query(
 			$wpdb->prepare(
 				"
-				DELETE FROM {$wpdb->donormeta}
+				DELETE FROM {$meta_table_name}
 				WHERE meta_key
 				LIKE '%s'
 				AND {$meta_type}_id=%d
@@ -1510,13 +1513,14 @@ class Give_Donor {
 			$meta_key_prefix .= "_{$address_count}";
 		}
 
-		$meta_type = Give()->donor_meta->meta_type;
+		$meta_type       = Give()->donor_meta->meta_type;
+		$meta_table_name = Give()->donor_meta->table_name;
 
 		// Process query.
 		$row_affected = $wpdb->get_results(
 			$wpdb->prepare(
 				"
-				SELECT meta_key FROM {$wpdb->donormeta}
+				SELECT meta_key FROM {$meta_table_name}
 				WHERE meta_key
 				LIKE '%s'
 				AND {$meta_type}_id=%d

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -122,46 +122,6 @@ class Give_DB_Meta extends Give_DB {
 		}
 	}
 
-
-	/**
-	 * Temporarily re-assert the meta table name in the global $wpdb object.
-	 *
-	 * Other plugins can overwrite the global meta table property. For example, both GiveWP and
-	 * Charitable register a "donor" meta type, and Charitable re-assigns $wpdb->donormeta to its
-	 * own table after GiveWP loads. Point the global at GiveWP's own table before each metadata
-	 * operation so data is always written to and read from GiveWP's table, then restore the
-	 * previous value afterwards so other plugins are unaffected.
-	 *
-	 * @since TBD
-	 *
-	 * @return string The previous meta table name to restore.
-	 */
-	private function setMetaTableName() {
-		global $wpdb;
-
-		$metaTableProperty = $this->meta_type . 'meta';
-		$previousMetaTableName = $wpdb->{$metaTableProperty};
-
-		$wpdb->{$metaTableProperty} = $this->table_name;
-
-		return $previousMetaTableName;
-	}
-
-	/**
-	 * Restore a previously saved meta table name.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $metaTableName The meta table name to restore.
-	 *
-	 * @return void
-	 */
-	private function restoreMetaTableName( $metaTableName ) {
-		global $wpdb;
-
-		$wpdb->{$this->meta_type . 'meta'} = $metaTableName;
-	}
-
 	/**
 	 * Retrieve payment meta field for a payment.
 	 *
@@ -649,4 +609,44 @@ class Give_DB_Meta extends Give_DB {
 
 		return $status;
 	}
+
+	/**
+	 * Temporarily re-assert the meta table name in the global $wpdb object.
+	 *
+	 * Other plugins can overwrite the global meta table property. For example, both GiveWP and
+	 * Charitable register a "donor" meta type, and Charitable re-assigns $wpdb->donormeta to its
+	 * own table after GiveWP loads. Point the global at GiveWP's own table before each metadata
+	 * operation so data is always written to and read from GiveWP's table, then restore the
+	 * previous value afterwards so other plugins are unaffected.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The previous meta table name to restore.
+	 */
+	private function setMetaTableName() {
+		global $wpdb;
+
+		$metaTableProperty = $this->meta_type . 'meta';
+		$previousMetaTableName = $wpdb->{$metaTableProperty};
+
+		$wpdb->{$metaTableProperty} = $this->table_name;
+
+		return $previousMetaTableName;
+	}
+
+	/**
+	 * Restore a previously saved meta table name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $metaTableName The meta table name to restore.
+	 *
+	 * @return void
+	 */
+	private function restoreMetaTableName( $metaTableName ) {
+		global $wpdb;
+
+		$wpdb->{$this->meta_type . 'meta'} = $metaTableName;
+	}
+
 }

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -124,6 +124,45 @@ class Give_DB_Meta extends Give_DB {
 
 
 	/**
+	 * Temporarily re-assert the meta table name in the global $wpdb object.
+	 *
+	 * Other plugins can overwrite the global meta table property. For example, both GiveWP and
+	 * Charitable register a "donor" meta type, and Charitable re-assigns $wpdb->donormeta to its
+	 * own table after GiveWP loads. Point the global at GiveWP's own table before each metadata
+	 * operation so data is always written to and read from GiveWP's table, then restore the
+	 * previous value afterwards so other plugins are unaffected.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The previous meta table name to restore.
+	 */
+	private function setMetaTableName() {
+		global $wpdb;
+
+		$metaTableProperty = $this->meta_type . 'meta';
+		$previousMetaTableName = $wpdb->{$metaTableProperty};
+
+		$wpdb->{$metaTableProperty} = $this->table_name;
+
+		return $previousMetaTableName;
+	}
+
+	/**
+	 * Restore a previously saved meta table name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $metaTableName The meta table name to restore.
+	 *
+	 * @return void
+	 */
+	private function restoreMetaTableName( $metaTableName ) {
+		global $wpdb;
+
+		$wpdb->{$this->meta_type . 'meta'} = $metaTableName;
+	}
+
+	/**
 	 * Retrieve payment meta field for a payment.
 	 *
 	 * @since 3.1.0 Return empty array, when request raw metadata if $single is set to false and metadata does not exist.
@@ -137,32 +176,38 @@ class Give_DB_Meta extends Give_DB {
 	 *                                is true.
 	 */
 	public function get_meta( $id = 0, $meta_key = '', $single = false ) {
-		if ( ! $this->is_filter_callback ) {
-			return get_metadata( $this->meta_type, $id, $meta_key, $single );
-		}
+		$previousMetaTableName = $this->setMetaTableName();
 
-		$id = $this->sanitize_id( $id );
-
-		// Bailout.
-		if ( ! $this->is_valid_post_type( $id ) ) {
-			return $this->check;
-		}
-
-		if ( $this->raw_result ) {
-			if ( ! ( $value = get_metadata( $this->meta_type, $id, $meta_key, false ) ) ) {
-				$value = $single ? '' : array();
+		try {
+			if ( ! $this->is_filter_callback ) {
+				return get_metadata( $this->meta_type, $id, $meta_key, $single );
 			}
 
-			// Reset flag.
-			$this->raw_result = false;
+			$id = $this->sanitize_id( $id );
 
-		} else {
-			$value = get_metadata( $this->meta_type, $id, $meta_key, $single );
+			// Bailout.
+			if ( ! $this->is_valid_post_type( $id ) ) {
+				return $this->check;
+			}
+
+			if ( $this->raw_result ) {
+				if ( ! ( $value = get_metadata( $this->meta_type, $id, $meta_key, false ) ) ) {
+					$value = $single ? '' : array();
+				}
+
+				// Reset flag.
+				$this->raw_result = false;
+
+			} else {
+				$value = get_metadata( $this->meta_type, $id, $meta_key, $single );
+			}
+
+			$this->is_filter_callback = false;
+
+			return $value;
+		} finally {
+			$this->restoreMetaTableName( $previousMetaTableName );
 		}
-
-		$this->is_filter_callback = false;
-
-		return $value;
 	}
 
 
@@ -182,24 +227,30 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  int|bool                  False for failure. True for success.
 	 */
 	public function add_meta( $id, $meta_key, $meta_value, $unique = false ) {
-		if ( $this->is_filter_callback ) {
-			$id = $this->sanitize_id( $id );
+		$previousMetaTableName = $this->setMetaTableName();
 
-			// Bailout.
-			if ( ! $this->is_valid_post_type( $id ) ) {
-				return $this->check;
+		try {
+			if ( $this->is_filter_callback ) {
+				$id = $this->sanitize_id( $id );
+
+				// Bailout.
+				if ( ! $this->is_valid_post_type( $id ) ) {
+					return $this->check;
+				}
 			}
+
+			$meta_id = add_metadata( $this->meta_type, $id, $meta_key, $meta_value, $unique );
+
+			if ( $meta_id ) {
+				$this->delete_cache( $id );
+			}
+
+			$this->is_filter_callback = false;
+
+			return $meta_id;
+		} finally {
+			$this->restoreMetaTableName( $previousMetaTableName );
 		}
-
-		$meta_id = add_metadata( $this->meta_type, $id, $meta_key, $meta_value, $unique );
-
-		if ( $meta_id ) {
-			$this->delete_cache( $id );
-		}
-
-		$this->is_filter_callback = false;
-
-		return $meta_id;
 	}
 
 	/**
@@ -223,24 +274,30 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  int|bool                  False on failure, true if success.
 	 */
 	public function update_meta( $id, $meta_key, $meta_value, $prev_value = '' ) {
-		if ( $this->is_filter_callback ) {
-			$id = $this->sanitize_id( $id );
+		$previousMetaTableName = $this->setMetaTableName();
 
-			// Bailout.
-			if ( ! $this->is_valid_post_type( $id ) ) {
-				return $this->check;
+		try {
+			if ( $this->is_filter_callback ) {
+				$id = $this->sanitize_id( $id );
+
+				// Bailout.
+				if ( ! $this->is_valid_post_type( $id ) ) {
+					return $this->check;
+				}
 			}
+
+			$meta_id = update_metadata( $this->meta_type, $id, $meta_key, $meta_value, $prev_value );
+
+			if ( $meta_id ) {
+				$this->delete_cache( $id );
+			}
+
+			$this->is_filter_callback = false;
+
+			return $meta_id;
+		} finally {
+			$this->restoreMetaTableName( $previousMetaTableName );
 		}
-
-		$meta_id = update_metadata( $this->meta_type, $id, $meta_key, $meta_value, $prev_value );
-
-		if ( $meta_id ) {
-			$this->delete_cache( $id );
-		}
-
-		$this->is_filter_callback = false;
-
-		return $meta_id;
 	}
 
 	/**
@@ -261,24 +318,30 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  bool                  False for failure. True for success.
 	 */
 	public function delete_meta( $id = 0, $meta_key = '', $meta_value = '', $delete_all = '' ) {
-		if ( $this->is_filter_callback ) {
-			$id = $this->sanitize_id( $id );
+		$previousMetaTableName = $this->setMetaTableName();
 
-			// Bailout.
-			if ( ! $this->is_valid_post_type( $id ) ) {
-				return $this->check;
+		try {
+			if ( $this->is_filter_callback ) {
+				$id = $this->sanitize_id( $id );
+
+				// Bailout.
+				if ( ! $this->is_valid_post_type( $id ) ) {
+					return $this->check;
+				}
 			}
+
+			$is_meta_deleted = delete_metadata( $this->meta_type, $id, $meta_key, $meta_value, $delete_all );
+
+			if ( $is_meta_deleted ) {
+				$this->delete_cache( $id );
+			}
+
+			$this->is_filter_callback = false;
+
+			return $is_meta_deleted;
+		} finally {
+			$this->restoreMetaTableName( $previousMetaTableName );
 		}
-
-		$is_meta_deleted = delete_metadata( $this->meta_type, $id, $meta_key, $meta_value, $delete_all );
-
-		if ( $is_meta_deleted ) {
-			$this->delete_cache( $id );
-		}
-
-		$this->is_filter_callback = false;
-
-		return $is_meta_deleted;
 	}
 
 	/**

--- a/tests/Unit/Donors/Repositories/TestDonorRepository.php
+++ b/tests/Unit/Donors/Repositories/TestDonorRepository.php
@@ -240,4 +240,47 @@ class TestDonorRepository extends TestCase
         $this->assertSame($serializedFirstName, $metaValue);
         $this->assertSame(serialize($serializedFirstName), $metaQuery->meta_value);
     }
+
+    /**
+     * Verifies that donor meta is written to GiveWP's own table even when another plugin
+     * re-assigns the global donor meta table (as Charitable does), and that the global is
+     * restored afterwards so the other plugin is unaffected.
+     *
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testInsertShouldStoreDonorNameInGiveTableWhenDonorMetaTableIsOverwritten(): void
+    {
+        global $wpdb;
+
+        $originalDonorMetaTable = $wpdb->donormeta;
+
+        // Simulate Charitable re-assigning $wpdb->donormeta to its own table.
+        $wpdb->donormeta = $wpdb->prefix . 'charitable_donormeta';
+
+        $donor = new Donor([
+            'name' => 'Bill Murray',
+            'firstName' => 'Bill',
+            'lastName' => 'Murray',
+            'email' => 'billMurray@givewp.com',
+        ]);
+
+        try {
+            (new DonorRepository())->insert($donor);
+
+            // The global must be restored so Charitable is unaffected.
+            $this->assertSame($wpdb->prefix . 'charitable_donormeta', $wpdb->donormeta);
+        } finally {
+            $wpdb->donormeta = $originalDonorMetaTable;
+        }
+
+        $firstName = DB::table('give_donormeta')
+            ->where('donor_id', $donor->id)
+            ->where('meta_key', DonorMetaKeys::FIRST_NAME)
+            ->get();
+
+        $this->assertNotNull($firstName);
+        $this->assertSame('Bill', $firstName->meta_value);
+    }
 }


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

Resolves [SMTNC-1448](https://linear.app/nexcess/issue/SMTNC-1448/givewp-conflict-with-charitable-donor-names-should-not-be-missing-when)

1. Have [Charitable](https://br.wordpress.org/plugins/charitable/) install and active.

2. Simply make a new donation logged-out (to create a new donor)

**In the current version name will not be recorded.**
**In the fixed it will.**

<img width="778" height="988" alt="image" src="https://github.com/user-attachments/assets/529d8e42-a3f0-4077-8811-6d5b17684331" />

<img width="1917" height="1029" alt="image" src="https://github.com/user-attachments/assets/4bcc3e78-c825-4232-965c-764e83886729" />


## Description

When both GiveWP and Charitable are active, donor first and last names were not recorded for new donors.

Charitable registers a `plugins_loaded` hook that reassigns the global `$wpdb->donormeta` to its own `charitable_donormeta` table. GiveWP's donor meta operations go through WordPress's `add_metadata('donor', …)` / `get_metadata('donor', …)`, which resolve the table via `_get_meta_table()` using that same global. As a result, the first/last name meta was written to Charitable's table instead of `give_donormeta`, leaving GiveWP's Donor list names blank.

This change makes `Give_DB_Meta` temporarily re-assert `$wpdb->{meta_type}meta` to GiveWP's own table around each metadata operation, then restore the previous value so other plugins (like Charitable) are unaffected.

## Affects

- Donor, donation, form, and comment meta read/write operations now re-assert the global meta table name around each operation.

## Testing Instructions

1. Install Charitable and GiveWP on a test site.
2. Submit a test donation while logged out (to create a new donor).
4. Confirm the new donor's first and last name appear in the Donors list.

## Pre-review Checklist

- [X] Acceptance criteria satisfied and marked in related issue
- [X] Relevant `@unreleased` tags included in DocBlocks
- [X] Includes unit tests
- [ ] Reviewed by the designer (if follows a design)
- [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789701419&installation_model_id=426813&pr_number=8292&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8292&signature=4b57bb76795dcf72f3afb2974a2ee4ad3323ac483aa484440d19a6fb2cd004d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conflicts with other donation plugins that could prevent donor first and last names from being recorded.
  * Improved donor metadata handling when another plugin changes the shared metadata table reference.
  * Ensured donor addresses, anonymous donor data, and related metadata are saved, updated, and removed from the correct GiveWP tables.
  * Preserved table references after metadata operations, including when an operation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->