### PR TITLE
Fix: scope custom amount minimum and maximum to the custom amount

### DIFF
--- a/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
+++ b/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
@@ -3,5 +3,6 @@ type: fix
 entry: Resolved an issue where the custom amount minimum and maximum also
   applied to the donation levels and the set donation amount, so a level below
   the minimum could not be donated. Forms that leave the minimum empty now fall
-  back to the lowest donation level.
+  back to the lowest configured amount, and a minimum or maximum with cents is
+  no longer rounded down.
 timestamp: 2026-08-19T16:58:46.460Z

--- a/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
+++ b/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
@@ -2,5 +2,6 @@ significance: patch
 type: fix
 entry: Resolved an issue where the custom amount minimum and maximum also
   applied to the donation levels and the set donation amount, so a level below
-  the minimum could not be donated.
+  the minimum could not be donated. Forms that leave the minimum empty now fall
+  back to the lowest donation level.
 timestamp: 2026-08-19T16:58:46.460Z

--- a/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
+++ b/changelog/smtnc-1454-setting-a-minimum-custom-amount-should-still-allow-set.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the custom amount minimum and maximum also
+  applied to the donation levels and the set donation amount, so a level below
+  the minimum could not be donated.
+timestamp: 2026-08-19T16:58:46.460Z

--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -28,6 +28,7 @@ class ConvertDonationAmountBlockToFieldsApi
 {
 
     /**
+     * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum.
      * @since 4.16.5 Set default value for the levelId hidden field.
      * @since 4.10.0 Replaced generic 'currency' rule with custom CurrencyRule that uses GiveWP's currency list
      * @since 3.0.0
@@ -48,12 +49,16 @@ class ConvertDonationAmountBlockToFieldsApi
             }
 
             if ($block->isCustomAmountEnabled()) {
+                $exemptAmounts = $this->getAdminDefinedAmounts($block);
+
                 if ($block->hasAttribute('customAmountMin')) {
-                    $amountRules[] = new Min($block->getAttribute('customAmountMin'));
+                    $amountRules[] = (new Min($block->getAttribute('customAmountMin')))
+                        ->exemptAmounts(...$exemptAmounts);
                 }
 
                 if ($block->hasAttribute('customAmountMax') && $block->getAttribute('customAmountMax') > 0) {
-                    $amountRules[] = new Max($block->getAttribute('customAmountMax'));
+                    $amountRules[] = (new Max($block->getAttribute('customAmountMax')))
+                        ->exemptAmounts(...$exemptAmounts);
                 }
             }
 
@@ -184,6 +189,31 @@ class ConvertDonationAmountBlockToFieldsApi
             ->label(__('Choose your donation frequency', 'give'))
             ->options(...$options)
             ->rules(new SubscriptionPeriodRule());
+    }
+
+    /**
+     * The amounts the admin configured on the block: the donation levels, or the fixed set price. The custom
+     * amount minimum and maximum never apply to these.
+     *
+     * @since TBD
+     *
+     * @return float[]
+     */
+    private function getAdminDefinedAmounts(DonationAmountBlockModel $block): array
+    {
+        $amounts = $block->getPriceOption() === 'multi'
+            ? array_column($this->prepareLevelsArray($block)['levels'], 'value')
+            : [$block->getSetPrice()];
+
+        // An unset level or set price sanitizes to 0, which must never be exempt from the minimum.
+        return array_values(
+            array_filter(
+                array_map('floatval', $amounts),
+                static function (float $amount): bool {
+                    return $amount > 0;
+                }
+            )
+        );
     }
 
     /**

--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -29,7 +29,7 @@ class ConvertDonationAmountBlockToFieldsApi
 
     /**
      * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum, and fall back
-     *            to the lowest admin-defined amount when no custom amount minimum is set.
+     *            to the lowest admin-defined amount when no custom amount minimum applies.
      * @since 4.16.5 Set default value for the levelId hidden field.
      * @since 4.10.0 Replaced generic 'currency' rule with custom CurrencyRule that uses GiveWP's currency list
      * @since 3.0.0
@@ -41,30 +41,23 @@ class ConvertDonationAmountBlockToFieldsApi
     {
         $amountField = DonationAmount::make('donationAmount')->tap(function (Group $group) use ($block, $currency) {
             $amountRules = ['required', 'numeric'];
-            $priceOptions = $block->getPriceOption();
-            ['levels' => $levels, 'checked' => $checked] = $priceOptions === 'multi'
-                ? $this->prepareLevelsArray($block)
-                : ['levels' => [], 'checked' => null];
+            $exemptAmounts = $block->getAdminDefinedAmounts();
 
             if (!$block->isCustomAmountEnabled() &&
-                $priceOptions === 'set') {
+                $block->getPriceOption() === 'set') {
                 $size = $block->getSetPrice();
 
                 $amountRules[] = new Size($size);
-            }
-
-            if ($block->isCustomAmountEnabled()) {
-                $exemptAmounts = $this->getAdminDefinedAmounts($block, $levels);
-                $minimum = $this->getMinimumAmount($block, $exemptAmounts);
+            } else {
+                $minimum = $block->getMinimumAmount();
 
                 if ($minimum !== null) {
                     $amountRules[] = (new Min($minimum))->exemptAmounts(...$exemptAmounts);
                 }
+            }
 
-                if ($block->hasAttribute('customAmountMax') && $block->getAttribute('customAmountMax') > 0) {
-                    $amountRules[] = (new Max($block->getAttribute('customAmountMax')))
-                        ->exemptAmounts(...$exemptAmounts);
-                }
+            if ($block->isCustomAmountEnabled() && $block->getCustomAmountMax() > 0) {
+                $amountRules[] = (new Max($block->getCustomAmountMax()))->exemptAmounts(...$exemptAmounts);
             }
 
             /** @var Amount $amountNode */
@@ -74,8 +67,11 @@ class ConvertDonationAmountBlockToFieldsApi
                 ->allowCustomAmount($block->isCustomAmountEnabled())
                 ->rules(...$amountRules);
 
+            $priceOptions = $block->getPriceOption();
             $defaultLevelId = '';
             if ($priceOptions === 'multi') {
+                ['levels' => $levels, 'checked' => $checked] = $this->prepareLevelsArray($block);
+
                 $amountNode
                     ->allowLevels()
                     ->levels(...$levels)
@@ -191,61 +187,6 @@ class ConvertDonationAmountBlockToFieldsApi
             ->label(__('Choose your donation frequency', 'give'))
             ->options(...$options)
             ->rules(new SubscriptionPeriodRule());
-    }
-
-    /**
-     * The custom amount minimum, falling back to the lowest amount the admin configured. Without that
-     * fallback a form that leaves the minimum empty accepts any amount, which is a donation spam and card
-     * testing vector.
-     *
-     * The Min rule takes an integer size, so a fractional amount truncates down and stays permissive.
-     *
-     * @since TBD
-     *
-     * @param float[] $exemptAmounts
-     *
-     * @return int|null Null when the block defines neither a minimum nor an amount to derive one from.
-     */
-    private function getMinimumAmount(DonationAmountBlockModel $block, array $exemptAmounts): ?int
-    {
-        $customAmountMin = $block->hasAttribute('customAmountMin')
-            ? (int)$block->getAttribute('customAmountMin')
-            : 0;
-
-        if ($customAmountMin > 0) {
-            return $customAmountMin;
-        }
-
-        $lowestAmount = $exemptAmounts ? (int)min($exemptAmounts) : 0;
-
-        return $lowestAmount > 0 ? $lowestAmount : null;
-    }
-
-    /**
-     * The amounts the admin configured on the block: the donation levels, or the fixed set price. The custom
-     * amount minimum and maximum never apply to these.
-     *
-     * @since TBD
-     *
-     * @param array $levels Prepared levels, empty unless the price option is 'multi'.
-     *
-     * @return float[]
-     */
-    private function getAdminDefinedAmounts(DonationAmountBlockModel $block, array $levels): array
-    {
-        $amounts = $block->getPriceOption() === 'multi'
-            ? array_column($levels, 'value')
-            : [$block->getSetPrice()];
-
-        // An unset level or set price sanitizes to 0, which must never be exempt from the minimum.
-        return array_values(
-            array_filter(
-                array_map('floatval', $amounts),
-                static function (float $amount): bool {
-                    return $amount > 0;
-                }
-            )
-        );
     }
 
     /**

--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -28,7 +28,8 @@ class ConvertDonationAmountBlockToFieldsApi
 {
 
     /**
-     * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum.
+     * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum, and fall back
+     *            to the lowest admin-defined amount when no custom amount minimum is set.
      * @since 4.16.5 Set default value for the levelId hidden field.
      * @since 4.10.0 Replaced generic 'currency' rule with custom CurrencyRule that uses GiveWP's currency list
      * @since 3.0.0
@@ -54,10 +55,10 @@ class ConvertDonationAmountBlockToFieldsApi
 
             if ($block->isCustomAmountEnabled()) {
                 $exemptAmounts = $this->getAdminDefinedAmounts($block, $levels);
+                $minimum = $this->getMinimumAmount($block, $exemptAmounts);
 
-                if ($block->hasAttribute('customAmountMin')) {
-                    $amountRules[] = (new Min($block->getAttribute('customAmountMin')))
-                        ->exemptAmounts(...$exemptAmounts);
+                if ($minimum !== null) {
+                    $amountRules[] = (new Min($minimum))->exemptAmounts(...$exemptAmounts);
                 }
 
                 if ($block->hasAttribute('customAmountMax') && $block->getAttribute('customAmountMax') > 0) {
@@ -190,6 +191,34 @@ class ConvertDonationAmountBlockToFieldsApi
             ->label(__('Choose your donation frequency', 'give'))
             ->options(...$options)
             ->rules(new SubscriptionPeriodRule());
+    }
+
+    /**
+     * The custom amount minimum, falling back to the lowest amount the admin configured. Without that
+     * fallback a form that leaves the minimum empty accepts any amount, which is a donation spam and card
+     * testing vector.
+     *
+     * The Min rule takes an integer size, so a fractional amount truncates down and stays permissive.
+     *
+     * @since TBD
+     *
+     * @param float[] $exemptAmounts
+     *
+     * @return int|null Null when the block defines neither a minimum nor an amount to derive one from.
+     */
+    private function getMinimumAmount(DonationAmountBlockModel $block, array $exemptAmounts): ?int
+    {
+        $customAmountMin = $block->hasAttribute('customAmountMin')
+            ? (int)$block->getAttribute('customAmountMin')
+            : 0;
+
+        if ($customAmountMin > 0) {
+            return $customAmountMin;
+        }
+
+        $lowestAmount = $exemptAmounts ? (int)min($exemptAmounts) : 0;
+
+        return $lowestAmount > 0 ? $lowestAmount : null;
     }
 
     /**

--- a/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
+++ b/src/DonationForms/Actions/ConvertDonationAmountBlockToFieldsApi.php
@@ -40,16 +40,20 @@ class ConvertDonationAmountBlockToFieldsApi
     {
         $amountField = DonationAmount::make('donationAmount')->tap(function (Group $group) use ($block, $currency) {
             $amountRules = ['required', 'numeric'];
+            $priceOptions = $block->getPriceOption();
+            ['levels' => $levels, 'checked' => $checked] = $priceOptions === 'multi'
+                ? $this->prepareLevelsArray($block)
+                : ['levels' => [], 'checked' => null];
 
             if (!$block->isCustomAmountEnabled() &&
-                $block->getPriceOption() === 'set') {
+                $priceOptions === 'set') {
                 $size = $block->getSetPrice();
 
                 $amountRules[] = new Size($size);
             }
 
             if ($block->isCustomAmountEnabled()) {
-                $exemptAmounts = $this->getAdminDefinedAmounts($block);
+                $exemptAmounts = $this->getAdminDefinedAmounts($block, $levels);
 
                 if ($block->hasAttribute('customAmountMin')) {
                     $amountRules[] = (new Min($block->getAttribute('customAmountMin')))
@@ -69,11 +73,8 @@ class ConvertDonationAmountBlockToFieldsApi
                 ->allowCustomAmount($block->isCustomAmountEnabled())
                 ->rules(...$amountRules);
 
-            $priceOptions = $block->getPriceOption();
             $defaultLevelId = '';
             if ($priceOptions === 'multi') {
-                ['levels' => $levels, 'checked' => $checked] = $this->prepareLevelsArray($block);
-
                 $amountNode
                     ->allowLevels()
                     ->levels(...$levels)
@@ -197,12 +198,14 @@ class ConvertDonationAmountBlockToFieldsApi
      *
      * @since TBD
      *
+     * @param array $levels Prepared levels, empty unless the price option is 'multi'.
+     *
      * @return float[]
      */
-    private function getAdminDefinedAmounts(DonationAmountBlockModel $block): array
+    private function getAdminDefinedAmounts(DonationAmountBlockModel $block, array $levels): array
     {
         $amounts = $block->getPriceOption() === 'multi'
-            ? array_column($this->prepareLevelsArray($block)['levels'], 'value')
+            ? array_column($levels, 'value')
             : [$block->getSetPrice()];
 
         // An unset level or set price sanitizes to 0, which must never be exempt from the minimum.

--- a/src/DonationForms/Rules/Concerns/HasExemptAmounts.php
+++ b/src/DonationForms/Rules/Concerns/HasExemptAmounts.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Give\DonationForms\Rules\Concerns;
+
+use function in_array;
+use function is_numeric;
+
+/**
+ * Amounts an admin configured on the donation amount block, such as the donation levels or the fixed set
+ * price. The custom amount minimum and maximum only constrain what a donor types into the custom amount
+ * input, so those amounts are always accepted.
+ *
+ * @since TBD
+ */
+trait HasExemptAmounts
+{
+    /**
+     * @since TBD
+     *
+     * @var float[]
+     */
+    protected $exemptAmounts = [];
+
+    /**
+     * @since TBD
+     */
+    public function exemptAmounts(float ...$amounts): self
+    {
+        $this->exemptAmounts = $amounts;
+
+        return $this;
+    }
+
+    /**
+     * @since TBD
+     *
+     * @return float[]
+     */
+    public function getExemptAmounts(): array
+    {
+        return $this->exemptAmounts;
+    }
+
+    /**
+     * @since TBD
+     *
+     * @param mixed $value
+     */
+    protected function isExemptAmount($value): bool
+    {
+        return is_numeric($value) && in_array((float)$value, $this->exemptAmounts, true);
+    }
+}

--- a/src/DonationForms/Rules/Max.php
+++ b/src/DonationForms/Rules/Max.php
@@ -3,12 +3,15 @@ namespace Give\DonationForms\Rules;
 
 
 use Closure;
+use Give\DonationForms\Rules\Concerns\HasExemptAmounts;
 use Give\Vendors\StellarWP\Validation\Config;
 
 use function is_numeric;
 
 class Max extends \Give\Vendors\StellarWP\Validation\Rules\Max
 {
+    use HasExemptAmounts;
+
     /**
      * @since 3.0.0
      */
@@ -28,19 +31,25 @@ class Max extends \Give\Vendors\StellarWP\Validation\Rules\Max
     /**
      * @inheritDoc
      *
+     * @since TBD Skip amounts the admin configured on the form, and report exceeding the maximum instead of
+     *            repeating the minimum wording.
      * @since 3.0.0
      **/
     public function __invoke($value, Closure $fail, string $key, array $values)
     {
         $value = $this->sanitize($value);
 
+        if ($this->isExemptAmount($value)) {
+            return;
+        }
+
         if (is_numeric($value)) {
             if ($value > $this->getSize()) {
-                $fail(sprintf(__('%s must be greater than or equal to %s', 'give'), '{field}', $this->getSize()));
+                $fail(sprintf(__('%s must be less than or equal to %s', 'give'), '{field}', $this->getSize()));
             }
         } elseif (is_string($value)) {
             if (mb_strlen($value) > $this->getSize()) {
-                $fail(sprintf(__('%s must be more than or equal to %d characters', 'give'), '{field}', $this->getSize()));
+                $fail(sprintf(__('%s must be less than or equal to %d characters', 'give'), '{field}', $this->getSize()));
             }
         } else {
             Config::throwValidationException("Field value must be a number or string");

--- a/src/DonationForms/Rules/Max.php
+++ b/src/DonationForms/Rules/Max.php
@@ -5,12 +5,57 @@ namespace Give\DonationForms\Rules;
 use Closure;
 use Give\DonationForms\Rules\Concerns\HasExemptAmounts;
 use Give\Vendors\StellarWP\Validation\Config;
+use Give\Vendors\StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use Give\Vendors\StellarWP\Validation\Contracts\ValidationRule;
 
 use function is_numeric;
 
-class Max extends \Give\Vendors\StellarWP\Validation\Rules\Max
+/**
+ * @since TBD Implement the rule directly instead of extending the vendor rule, whose size is an integer.
+ * @since 3.0.0
+ */
+class Max implements ValidationRule, ValidatesOnFrontEnd
 {
     use HasExemptAmounts;
+
+    /**
+     * @var numeric
+     */
+    protected $size;
+
+    /**
+     * @since TBD
+     *
+     * @param numeric $size
+     */
+    public function __construct($size)
+    {
+        if ($size <= 0) {
+            Config::throwInvalidArgumentException('Max validation rule requires a non-negative value');
+        }
+
+        $this->size = $this->sanitize($size);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'max';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function fromString(?string $options = null): ValidationRule
+    {
+        if (!is_numeric($options)) {
+            Config::throwInvalidArgumentException('Max validation rule requires a numeric value');
+        }
+
+        return new self($options);
+    }
 
     /**
      * @since 3.0.0
@@ -18,7 +63,7 @@ class Max extends \Give\Vendors\StellarWP\Validation\Rules\Max
     public function sanitize($value)
     {
         if (is_numeric($value)) {
-            if (strpos($value, '.') !== false) {
+            if (strpos((string)$value, '.') !== false) {
                 return (float)$value;
             }
 
@@ -54,5 +99,41 @@ class Max extends \Give\Vendors\StellarWP\Validation\Rules\Max
         } else {
             Config::throwValidationException("Field value must be a number or string");
         }
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @return numeric
+     */
+    public function serializeOption()
+    {
+        return $this->size;
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @return numeric
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @param numeric $size
+     *
+     * @return void
+     */
+    public function size($size)
+    {
+        if ($size <= 0) {
+            Config::throwInvalidArgumentException('Max validation rule requires a non-negative value');
+        }
+
+        $this->size = $this->sanitize($size);
     }
 }

--- a/src/DonationForms/Rules/Min.php
+++ b/src/DonationForms/Rules/Min.php
@@ -5,12 +5,57 @@ namespace Give\DonationForms\Rules;
 use Closure;
 use Give\DonationForms\Rules\Concerns\HasExemptAmounts;
 use Give\Vendors\StellarWP\Validation\Config;
+use Give\Vendors\StellarWP\Validation\Contracts\ValidatesOnFrontEnd;
+use Give\Vendors\StellarWP\Validation\Contracts\ValidationRule;
 
 use function is_numeric;
 
-class Min extends \Give\Vendors\StellarWP\Validation\Rules\Min
+/**
+ * @since TBD Implement the rule directly instead of extending the vendor rule, whose size is an integer.
+ * @since 3.0.0
+ */
+class Min implements ValidationRule, ValidatesOnFrontEnd
 {
     use HasExemptAmounts;
+
+    /**
+     * @var numeric
+     */
+    protected $size;
+
+    /**
+     * @since TBD
+     *
+     * @param numeric $size
+     */
+    public function __construct($size)
+    {
+        if ($size <= 0) {
+            Config::throwInvalidArgumentException('Min validation rule requires a non-negative value');
+        }
+
+        $this->size = $this->sanitize($size);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function id(): string
+    {
+        return 'min';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function fromString(?string $options = null): ValidationRule
+    {
+        if (!is_numeric($options)) {
+            Config::throwInvalidArgumentException('Min validation rule requires a numeric value');
+        }
+
+        return new self($options);
+    }
 
     /**
      * @since 3.0.0
@@ -18,7 +63,7 @@ class Min extends \Give\Vendors\StellarWP\Validation\Rules\Min
     public function sanitize($value)
     {
         if (is_numeric($value)) {
-            if (strpos($value, '.') !== false) {
+            if (strpos((string)$value, '.') !== false) {
                 return (float)$value;
             }
 
@@ -53,5 +98,41 @@ class Min extends \Give\Vendors\StellarWP\Validation\Rules\Min
         } else {
             Config::throwValidationException("Field value must be a number or string");
         }
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @return numeric
+     */
+    public function serializeOption()
+    {
+        return $this->size;
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @return numeric
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * @since 3.0.0
+     *
+     * @param numeric $size
+     *
+     * @return void
+     */
+    public function size($size)
+    {
+        if ($size <= 0) {
+            Config::throwInvalidArgumentException('Min validation rule requires a non-negative value');
+        }
+
+        $this->size = $this->sanitize($size);
     }
 }

--- a/src/DonationForms/Rules/Min.php
+++ b/src/DonationForms/Rules/Min.php
@@ -3,12 +3,15 @@ namespace Give\DonationForms\Rules;
 
 
 use Closure;
+use Give\DonationForms\Rules\Concerns\HasExemptAmounts;
 use Give\Vendors\StellarWP\Validation\Config;
 
 use function is_numeric;
 
 class Min extends \Give\Vendors\StellarWP\Validation\Rules\Min
 {
+    use HasExemptAmounts;
+
     /**
      * @since 3.0.0
      */
@@ -28,11 +31,16 @@ class Min extends \Give\Vendors\StellarWP\Validation\Rules\Min
     /**
      * @inheritDoc
      *
+     * @since TBD Skip amounts the admin configured on the form.
      * @since 3.0.0
      **/
     public function __invoke($value, Closure $fail, string $key, array $values)
     {
         $value = $this->sanitize($value);
+
+        if ($this->isExemptAmount($value)) {
+            return;
+        }
 
         if (is_numeric($value)) {
             if ($value < $this->getSize()) {

--- a/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
+++ b/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
@@ -1,5 +1,5 @@
 import Joi, {AnySchema, ObjectSchema} from 'joi';
-import {BasicCondition, Field, Form, isField} from '@givewp/forms/types';
+import {AmountField, BasicCondition, Field, Form, isField} from '@givewp/forms/types';
 import {__, sprintf} from '@wordpress/i18n';
 import conditionOperatorFunctions from '@givewp/forms/app/utilities/conditionOperatorFunctions';
 
@@ -36,16 +36,62 @@ export default function getJoiRulesForForm(form: Form): ObjectSchema {
 }
 
 /**
+ * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum.
  * @since 3.0.0
  */
 function getJoiRulesForField(field: Field): AnySchema {
-    let rules: AnySchema = convertFieldAPIRulesToJoi(field.validationRules);
+    const exemptAmounts = getExemptAmounts(field);
+    const {min, max, ...remainingRules} = field.validationRules;
+    const hasExemptRange = exemptAmounts.length > 0 && (min !== undefined || max !== undefined);
+
+    let rules: AnySchema = convertFieldAPIRulesToJoi(hasExemptRange ? remainingRules : field.validationRules);
+
+    if (hasExemptRange) {
+        rules = rules.custom((value, helpers) => {
+            const amount = Number(value);
+
+            if (exemptAmounts.includes(amount)) {
+                return value;
+            }
+
+            if (min !== undefined && amount < min) {
+                return helpers.error('number.min', {limit: min});
+            }
+
+            if (max !== undefined && amount > max) {
+                return helpers.error('number.max', {limit: max});
+            }
+
+            return value;
+        }, 'custom amount range');
+    }
 
     if (field.label) {
         rules = rules.label(field.label);
     }
 
     return rules;
+}
+
+/**
+ * The amounts the admin configured on the donation amount field. The custom amount minimum and maximum only
+ * constrain what a donor types into the custom amount input, so these are always accepted.
+ *
+ * @since TBD
+ */
+function getExemptAmounts(field: Field): number[] {
+    if (field.type !== 'amount') {
+        return [];
+    }
+
+    const {levels, allowLevels, fixedAmountValue} = field as AmountField;
+
+    // An unset level or fixed amount reads as 0, which must never be exempt from the minimum.
+    if (allowLevels) {
+        return (levels ?? []).map((level) => Number(level.value)).filter((amount) => amount > 0);
+    }
+
+    return fixedAmountValue > 0 ? [Number(fixedAmountValue)] : [];
 }
 
 /**

--- a/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
+++ b/src/DonationForms/resources/app/utilities/ConvertFieldAPIRulesToJoi.ts
@@ -36,35 +36,11 @@ export default function getJoiRulesForForm(form: Form): ObjectSchema {
 }
 
 /**
- * @since TBD Exempt admin-defined amounts from the custom amount minimum and maximum.
+ * @since TBD collect the amounts exempt from the minimum and maximum
  * @since 3.0.0
  */
 function getJoiRulesForField(field: Field): AnySchema {
-    const exemptAmounts = getExemptAmounts(field);
-    const {min, max, ...remainingRules} = field.validationRules;
-    const hasExemptRange = exemptAmounts.length > 0 && (min !== undefined || max !== undefined);
-
-    let rules: AnySchema = convertFieldAPIRulesToJoi(hasExemptRange ? remainingRules : field.validationRules);
-
-    if (hasExemptRange) {
-        rules = rules.custom((value, helpers) => {
-            const amount = Number(value);
-
-            if (exemptAmounts.includes(amount)) {
-                return value;
-            }
-
-            if (min !== undefined && amount < min) {
-                return helpers.error('number.min', {limit: min});
-            }
-
-            if (max !== undefined && amount > max) {
-                return helpers.error('number.max', {limit: max});
-            }
-
-            return value;
-        }, 'custom amount range');
-    }
+    let rules: AnySchema = convertFieldAPIRulesToJoi(field.validationRules, getExemptAmounts(field));
 
     if (field.label) {
         rules = rules.label(field.label);
@@ -95,11 +71,12 @@ function getExemptAmounts(field: Field): number[] {
 }
 
 /**
+ * @since TBD exempt admin-defined amounts from the minimum and maximum
  * @since 4.13.1 account for custom rules with only excludeUnless property
  * @since 4.13.0 add support for optional false values
  * @since 3.0.0
  */
-function convertFieldAPIRulesToJoi(rules): AnySchema {
+function convertFieldAPIRulesToJoi(rules, exemptAmounts: number[] = []): AnySchema {
     let joiRules;
     const ruleKeys = Object.keys(rules);
 
@@ -138,12 +115,35 @@ function convertFieldAPIRulesToJoi(rules): AnySchema {
     }
 
     if (rules.hasOwnProperty('number') || !rules.hasOwnProperty('boolean')) {
-        if (rules.hasOwnProperty('min')) {
-            joiRules = joiRules.min(rules.min);
-        }
+        const hasMin = rules.hasOwnProperty('min');
+        const hasMax = rules.hasOwnProperty('max');
 
-        if (rules.hasOwnProperty('max')) {
-            joiRules = joiRules.max(rules.max);
+        if (exemptAmounts.length > 0 && (hasMin || hasMax)) {
+            joiRules = joiRules.custom((value, helpers) => {
+                const amount = Number(value);
+
+                if (exemptAmounts.includes(amount)) {
+                    return value;
+                }
+
+                if (hasMin && amount < rules.min) {
+                    return helpers.error('number.min', {limit: rules.min});
+                }
+
+                if (hasMax && amount > rules.max) {
+                    return helpers.error('number.max', {limit: rules.max});
+                }
+
+                return value;
+            }, 'exempt amount range');
+        } else {
+            if (hasMin) {
+                joiRules = joiRules.min(rules.min);
+            }
+
+            if (hasMax) {
+                joiRules = joiRules.max(rules.max);
+            }
         }
     }
 

--- a/src/DonationForms/resources/types.ts
+++ b/src/DonationForms/resources/types.ts
@@ -154,6 +154,19 @@ export interface Field extends Node {
     fieldError: string | null;
 }
 
+/**
+ * The donation amount field. Its levels and fixed amount are the amounts the admin configured on the form.
+ *
+ * @since TBD
+ */
+export interface AmountField extends Field {
+    type: 'amount';
+    levels: {label: string; value: number; checked?: boolean}[];
+    allowLevels: boolean;
+    allowCustomAmount: boolean;
+    fixedAmountValue: number;
+}
+
 export interface Group extends Node {
     nodeType: 'group';
     nodes: Node[];

--- a/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
+++ b/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
@@ -231,9 +231,9 @@ class DonationAmountBlockModel
      *
      * @since TBD
      */
-    public function getCustomAmountMin(): int
+    public function getCustomAmountMin(): float
     {
-        return $this->hasAttribute('customAmountMin') ? (int)$this->getAttribute('customAmountMin') : 0;
+        return $this->hasAttribute('customAmountMin') ? (float)$this->getAttribute('customAmountMin') : 0.0;
     }
 
     /**
@@ -242,9 +242,9 @@ class DonationAmountBlockModel
      *
      * @since TBD
      */
-    public function getCustomAmountMax(): int
+    public function getCustomAmountMax(): float
     {
-        return $this->hasAttribute('customAmountMax') ? (int)$this->getAttribute('customAmountMax') : 0;
+        return $this->hasAttribute('customAmountMax') ? (float)$this->getAttribute('customAmountMax') : 0.0;
     }
 
     /**
@@ -277,21 +277,18 @@ class DonationAmountBlockModel
      * fallback a form that leaves the minimum empty accepts any amount, which is a donation spam and card
      * testing vector.
      *
-     * The Min validation rule takes an integer size, so a fractional amount truncates down and stays
-     * permissive.
-     *
      * @since TBD
      *
-     * @return int|null Null when the block defines neither a minimum nor an amount to derive one from.
+     * @return float|null Null when the block defines neither a minimum nor an amount to derive one from.
      */
-    public function getMinimumAmount(): ?int
+    public function getMinimumAmount(): ?float
     {
         if ($this->isCustomAmountEnabled() && $this->getCustomAmountMin() > 0) {
             return $this->getCustomAmountMin();
         }
 
         $adminDefinedAmounts = $this->getAdminDefinedAmounts();
-        $lowestAmount = $adminDefinedAmounts ? (int)min($adminDefinedAmounts) : 0;
+        $lowestAmount = $adminDefinedAmounts ? min($adminDefinedAmounts) : 0.0;
 
         return $lowestAmount > 0 ? $lowestAmount : null;
     }

--- a/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
+++ b/src/FormBuilder/BlockModels/DonationAmountBlockModel.php
@@ -224,4 +224,75 @@ class DonationAmountBlockModel
     {
         return $this->block->getAttribute('setPrice');
     }
+
+    /**
+     * The lowest amount a donor may type into the custom amount input, or zero when the block does not
+     * define one.
+     *
+     * @since TBD
+     */
+    public function getCustomAmountMin(): int
+    {
+        return $this->hasAttribute('customAmountMin') ? (int)$this->getAttribute('customAmountMin') : 0;
+    }
+
+    /**
+     * The highest amount a donor may type into the custom amount input, or zero when the block does not
+     * define one.
+     *
+     * @since TBD
+     */
+    public function getCustomAmountMax(): int
+    {
+        return $this->hasAttribute('customAmountMax') ? (int)$this->getAttribute('customAmountMax') : 0;
+    }
+
+    /**
+     * The amounts the admin configured on the block: the donation levels, or the fixed set price. The
+     * custom amount minimum and maximum never apply to these.
+     *
+     * @since TBD
+     *
+     * @return float[]
+     */
+    public function getAdminDefinedAmounts(): array
+    {
+        $amounts = $this->getPriceOption() === 'multi'
+            ? array_column($this->getLevels(), 'value')
+            : [$this->getSetPrice()];
+
+        // An unset level or set price sanitizes to 0, which must never be exempt from the minimum.
+        return array_values(
+            array_filter(
+                array_map('floatval', $amounts),
+                static function (float $amount): bool {
+                    return $amount > 0;
+                }
+            )
+        );
+    }
+
+    /**
+     * The custom amount minimum, falling back to the lowest amount the admin configured. Without that
+     * fallback a form that leaves the minimum empty accepts any amount, which is a donation spam and card
+     * testing vector.
+     *
+     * The Min validation rule takes an integer size, so a fractional amount truncates down and stays
+     * permissive.
+     *
+     * @since TBD
+     *
+     * @return int|null Null when the block defines neither a minimum nor an amount to derive one from.
+     */
+    public function getMinimumAmount(): ?int
+    {
+        if ($this->isCustomAmountEnabled() && $this->getCustomAmountMin() > 0) {
+            return $this->getCustomAmountMin();
+        }
+
+        $adminDefinedAmounts = $this->getAdminDefinedAmounts();
+        $lowestAmount = $adminDefinedAmounts ? (int)min($adminDefinedAmounts) : 0;
+
+        return $lowestAmount > 0 ? $lowestAmount : null;
+    }
 }

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -244,7 +244,7 @@ const Inspector = ({attributes, setAttributes}) => {
                             value={customAmountMin}
                             onValueChange={(value) => setAttributes({customAmountMin: value})}
                             help={__(
-                                'The lowest amount a donor can enter in the custom amount field. Donation levels are not affected.',
+                                'The lowest amount a donor can enter in the custom amount field. Donation levels are not affected. Leave empty to use the lowest donation level.',
                                 'give'
                             )}
                         />

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -244,7 +244,7 @@ const Inspector = ({attributes, setAttributes}) => {
                             value={customAmountMin}
                             onValueChange={(value) => setAttributes({customAmountMin: value})}
                             help={__(
-                                'The lowest amount a donor can enter in the custom amount field. Donation levels are not affected. Leave empty to use the lowest donation level.',
+                                'The lowest amount a donor can enter in the custom amount field. Donation levels and the set donation amount are not affected. Leave empty to use the lowest of those amounts.',
                                 'give'
                             )}
                         />
@@ -253,7 +253,7 @@ const Inspector = ({attributes, setAttributes}) => {
                             value={customAmountMax}
                             onValueChange={(value) => setAttributes({customAmountMax: value})}
                             help={__(
-                                'The highest amount a donor can enter in the custom amount field. Donation levels are not affected. Leave empty for no maximum amount.',
+                                'The highest amount a donor can enter in the custom amount field. Donation levels and the set donation amount are not affected. Leave empty for no maximum amount.',
                                 'give'
                             )}
                         />

--- a/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/blocks/fields/amount/inspector/index.tsx
@@ -243,14 +243,17 @@ const Inspector = ({attributes, setAttributes}) => {
                             label={__('Minimum', 'give')}
                             value={customAmountMin}
                             onValueChange={(value) => setAttributes({customAmountMin: value})}
-                            help={__('Sets the minimum donation amount for all gateways.', 'give')}
+                            help={__(
+                                'The lowest amount a donor can enter in the custom amount field. Donation levels are not affected.',
+                                'give'
+                            )}
                         />
                         <CurrencyControl
                             label={__('Maximum', 'give')}
                             value={customAmountMax}
                             onValueChange={(value) => setAttributes({customAmountMax: value})}
                             help={__(
-                                'Sets the maximum donation amount for all gateways. Leave empty for no maximum amount.',
+                                'The highest amount a donor can enter in the custom amount field. Donation levels are not affected. Leave empty for no maximum amount.',
                                 'give'
                             )}
                         />

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
@@ -388,6 +388,45 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
     /**
      * @since TBD
      */
+    public function testFallsBackToTheLowestDonationLevelWhenCustomAmountIsDisabled(): void
+    {
+        $attributes = [
+            'priceOption' => 'multi',
+            'levels' => [['value' => 25], ['value' => 10, 'checked' => true]],
+            'customAmount' => false,
+        ];
+
+        /** @var Min $min */
+        $min = $this->_amountNode($attributes)->getValidationRules()->getRule('min');
+
+        $this->assertSame(10, $min->getSize());
+        $this->assertTrue($this->_validator($attributes, 5)->fails());
+        $this->assertTrue($this->_validator($attributes, 10)->passes());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testIgnoresTheCustomAmountMinimumWhenCustomAmountIsDisabled(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10, 'checked' => true], ['value' => 25]],
+                'customAmount' => false,
+                'customAmountMin' => 500,
+            ]
+        );
+
+        /** @var Min $min */
+        $min = $amountNode->getValidationRules()->getRule('min');
+
+        $this->assertSame(10, $min->getSize());
+    }
+
+    /**
+     * @since TBD
+     */
     public function testAppliesNoMinimumWhenTheBlockDefinesNoAmounts(): void
     {
         $amountNode = $this->_amountNode(

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
@@ -3,9 +3,17 @@
 namespace Give\Tests\Unit\DonationForms\Actions;
 
 use Give\DonationForms\Actions\ConvertDonationAmountBlockToFieldsApi;
+use Give\DonationForms\Rules\Max;
+use Give\DonationForms\Rules\Min;
 use Give\FormBuilder\BlockModels\DonationAmountBlockModel;
 use Give\Framework\Blocks\BlockModel;
+use Give\Framework\FieldsAPI\Actions\CreateValidatorFromForm;
+use Give\Framework\FieldsAPI\Amount;
+use Give\Framework\FieldsAPI\DonationAmount;
+use Give\Framework\FieldsAPI\Form;
+use Give\Framework\FieldsAPI\Section;
 use Give\Tests\TestCase;
+use Give\Vendors\StellarWP\Validation\Validator;
 
 /**
  * @since 4.16.5
@@ -148,6 +156,212 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
         }
     }
 
+
+    /**
+     * @since TBD
+     */
+    public function testValidatesADonationLevelBelowTheCustomAmountMinimum(): void
+    {
+        $validator = $this->_validator(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10], ['value' => 25], ['value' => 500, 'checked' => true]],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+            ],
+            10
+        );
+
+        $this->assertTrue($validator->passes(), print_r($validator->errors(), true));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRejectsACustomAmountBelowTheCustomAmountMinimum(): void
+    {
+        $validator = $this->_validator(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10], ['value' => 25], ['value' => 500, 'checked' => true]],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+            ],
+            11
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testValidatesADonationLevelAboveTheCustomAmountMaximum(): void
+    {
+        $validator = $this->_validator(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10, 'checked' => true], ['value' => 250]],
+                'customAmount' => true,
+                'customAmountMin' => 1,
+                'customAmountMax' => 100,
+            ],
+            250
+        );
+
+        $this->assertTrue($validator->passes(), print_r($validator->errors(), true));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRejectsACustomAmountAboveTheCustomAmountMaximum(): void
+    {
+        $validator = $this->_validator(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10, 'checked' => true], ['value' => 250]],
+                'customAmount' => true,
+                'customAmountMin' => 1,
+                'customAmountMax' => 100,
+            ],
+            251
+        );
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testExemptsDonationLevelsFromTheCustomAmountRange(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'multi',
+                'levels' => [
+                    ['value' => 10],
+                    ['value' => 25],
+                    ['value' => 500, 'checked' => true],
+                ],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+                'customAmountMax' => 1000,
+            ]
+        );
+
+        /** @var Min $min */
+        $min = $amountNode->getValidationRules()->getRule('min');
+        /** @var Max $max */
+        $max = $amountNode->getValidationRules()->getRule('max');
+
+        $this->assertSame([10.0, 25.0, 500.0], $min->getExemptAmounts());
+        $this->assertSame([10.0, 25.0, 500.0], $max->getExemptAmounts());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testExemptsTheSetPriceFromTheCustomAmountRange(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'set',
+                'setPrice' => 25,
+                'levels' => [],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+            ]
+        );
+
+        /** @var Min $min */
+        $min = $amountNode->getValidationRules()->getRule('min');
+
+        $this->assertSame([25.0], $min->getExemptAmounts());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLevelsWithoutAValueAreNotExempt(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'multi',
+                'levels' => [
+                    ['value' => 10],
+                    ['value' => ''],
+                    ['value' => 500, 'checked' => true],
+                ],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+            ]
+        );
+
+        /** @var Min $min */
+        $min = $amountNode->getValidationRules()->getRule('min');
+
+        $this->assertSame([10.0, 500.0], $min->getExemptAmounts());
+    }
+
+    /**
+     * Validates the given amount against the donation amount group built from the given block attributes.
+     *
+     * @since TBD
+     */
+    private function _validator(array $attributes, float $amount): Validator
+    {
+        $form = new Form('Test Form');
+        $form->append((new Section('Test Section'))->append($this->_donationAmountGroup($attributes)));
+
+        return (new CreateValidatorFromForm())(
+            $form,
+            [
+                'amount' => $amount,
+                'currency' => 'USD',
+                'levelId' => 'custom',
+                'donationType' => 'single',
+            ]
+        );
+    }
+
+    /**
+     * Builds the donation amount group from the given block attributes and returns its amount field.
+     *
+     * @since TBD
+     */
+    private function _amountNode(array $attributes): Amount
+    {
+        /** @var Amount $amountNode */
+        $amountNode = $this->_donationAmountGroup($attributes)->getNodeByName('amount');
+
+        return $amountNode;
+    }
+
+    /**
+     * @since TBD
+     */
+    private function _donationAmountGroup(array $attributes): DonationAmount
+    {
+        $block = new DonationAmountBlockModel(
+            BlockModel::make(
+                [
+                    'name' => 'givewp/donation-amount',
+                    'attributes' => array_merge(
+                        [
+                            'label' => 'Donation Amount',
+                            'descriptionsEnabled' => false,
+                        ],
+                        $attributes
+                    ),
+                ]
+            )
+        );
+
+        return (new ConvertDonationAmountBlockToFieldsApi())($block, 'USD');
+    }
 
     /**
      * Invokes the private prepareLevelsArray() method against a donation amount block

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
@@ -441,6 +441,65 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
     }
 
     /**
+     * @since TBD
+     */
+    public function testKeepsAFractionalCustomAmountMinimum(): void
+    {
+        $attributes = [
+            'priceOption' => 'multi',
+            'levels' => [['value' => 5, 'checked' => true], ['value' => 50]],
+            'customAmount' => true,
+            'customAmountMin' => '10.50',
+        ];
+
+        /** @var Min $min */
+        $min = $this->_amountNode($attributes)->getValidationRules()->getRule('min');
+
+        $this->assertSame(10.5, $min->getSize());
+        $this->assertTrue($this->_validator($attributes, 10.25)->fails());
+        $this->assertTrue($this->_validator($attributes, 10.5)->passes());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testKeepsAFractionalCustomAmountMaximum(): void
+    {
+        $attributes = [
+            'priceOption' => 'multi',
+            'levels' => [['value' => 5, 'checked' => true]],
+            'customAmount' => true,
+            'customAmountMax' => '10.50',
+        ];
+
+        /** @var Max $max */
+        $max = $this->_amountNode($attributes)->getValidationRules()->getRule('max');
+
+        $this->assertSame(10.5, $max->getSize());
+        $this->assertTrue($this->_validator($attributes, 10.5)->passes());
+        $this->assertTrue($this->_validator($attributes, 10.75)->fails());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testKeepsAFractionalLowestDonationLevelAsTheFallbackMinimum(): void
+    {
+        $attributes = [
+            'priceOption' => 'multi',
+            'levels' => [['value' => '10.50', 'checked' => true], ['value' => 25]],
+            'customAmount' => true,
+        ];
+
+        /** @var Min $min */
+        $min = $this->_amountNode($attributes)->getValidationRules()->getRule('min');
+
+        $this->assertSame(10.5, $min->getSize());
+        $this->assertTrue($this->_validator($attributes, 10.25)->fails());
+        $this->assertTrue($this->_validator($attributes, 10.5)->passes());
+    }
+
+    /**
      * Validates the given amount against the donation amount group built from the given block attributes.
      *
      * @since TBD

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
@@ -191,7 +191,7 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
         );
 
         $this->assertTrue($validator->fails());
-        $this->assertArrayHasKey('amount', $validator->errors());
+        $this->assertStringContainsString('greater than or equal to 500', $validator->errors()['amount']);
     }
 
     /**
@@ -230,7 +230,26 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
         );
 
         $this->assertTrue($validator->fails());
-        $this->assertArrayHasKey('amount', $validator->errors());
+        $this->assertStringContainsString('less than or equal to 100', $validator->errors()['amount']);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testValidatesTheSetPriceBelowTheCustomAmountMinimum(): void
+    {
+        $validator = $this->_validator(
+            [
+                'priceOption' => 'set',
+                'setPrice' => 25,
+                'levels' => [],
+                'customAmount' => true,
+                'customAmountMin' => 500,
+            ],
+            25
+        );
+
+        $this->assertTrue($validator->passes(), print_r($validator->errors(), true));
     }
 
     /**
@@ -285,7 +304,7 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
     /**
      * @since TBD
      */
-    public function testLevelsWithoutAValueAreNotExempt(): void
+    public function testLevelsWithoutAPositiveValueAreNotExempt(): void
     {
         $amountNode = $this->_amountNode(
             [
@@ -314,7 +333,7 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
     private function _validator(array $attributes, float $amount): Validator
     {
         $form = new Form('Test Form');
-        $form->append((new Section('Test Section'))->append($this->_donationAmountGroup($attributes)));
+        $form->append(Section::make('Test Section')->append($this->_donationAmountGroup($attributes)));
 
         return (new CreateValidatorFromForm())(
             $form,

--- a/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
+++ b/tests/Unit/DonationForms/Actions/TestConvertDonationAmountBlockToFieldsApi.php
@@ -326,6 +326,82 @@ final class TestConvertDonationAmountBlockToFieldsApi extends TestCase
     }
 
     /**
+     * @since TBD
+     */
+    public function testFallsBackToTheLowestDonationLevelWhenNoCustomAmountMinimumIsSet(): void
+    {
+        $attributes = [
+            'priceOption' => 'multi',
+            'levels' => [['value' => 25], ['value' => 10, 'checked' => true], ['value' => 500]],
+            'customAmount' => true,
+        ];
+
+        /** @var Min $min */
+        $min = $this->_amountNode($attributes)->getValidationRules()->getRule('min');
+
+        $this->assertSame(10, $min->getSize());
+        $this->assertTrue($this->_validator($attributes, 5)->fails());
+        $this->assertTrue($this->_validator($attributes, 10)->passes());
+        $this->assertTrue($this->_validator($attributes, 15)->passes());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testFallsBackToTheLowestDonationLevelWhenTheCustomAmountMinimumIsZero(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'multi',
+                'levels' => [['value' => 10, 'checked' => true], ['value' => 25]],
+                'customAmount' => true,
+                'customAmountMin' => 0,
+            ]
+        );
+
+        /** @var Min $min */
+        $min = $amountNode->getValidationRules()->getRule('min');
+
+        $this->assertSame(10, $min->getSize());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testFallsBackToTheSetPriceWhenNoCustomAmountMinimumIsSet(): void
+    {
+        $attributes = [
+            'priceOption' => 'set',
+            'setPrice' => 25,
+            'levels' => [],
+            'customAmount' => true,
+        ];
+
+        /** @var Min $min */
+        $min = $this->_amountNode($attributes)->getValidationRules()->getRule('min');
+
+        $this->assertSame(25, $min->getSize());
+        $this->assertTrue($this->_validator($attributes, 5)->fails());
+        $this->assertTrue($this->_validator($attributes, 25)->passes());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testAppliesNoMinimumWhenTheBlockDefinesNoAmounts(): void
+    {
+        $amountNode = $this->_amountNode(
+            [
+                'priceOption' => 'multi',
+                'levels' => [],
+                'customAmount' => true,
+            ]
+        );
+
+        $this->assertFalse($amountNode->getValidationRules()->hasRule('min'));
+    }
+
+    /**
      * Validates the given amount against the donation amount group built from the given block attributes.
      *
      * @since TBD

--- a/tests/Unit/DonationForms/Rules/TestMaxRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMaxRule.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForms\Rules;
+
+use Give\DonationForms\Rules\Max;
+use Give\Tests\TestCase;
+use Give\Tests\Unit\DonationForms\TestTraits\HasValidationRules;
+
+/**
+ * @since TBD
+ * @covers \Give\DonationForms\Rules\Max
+ */
+class TestMaxRule extends TestCase
+{
+    use HasValidationRules;
+
+    /**
+     * @since TBD
+     */
+    public function testFailsWhenAmountIsAboveTheMaximum(): void
+    {
+        self::assertValidationRuleFailed(new Max(100), 101);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testPassesWhenAmountIsAtOrBelowTheMaximum(): void
+    {
+        self::assertValidationRulePassed(new Max(100), 100);
+        self::assertValidationRulePassed(new Max(100), 99);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testPassesWhenAmountIsExemptEvenThoughItIsAboveTheMaximum(): void
+    {
+        $rule = (new Max(100))->exemptAmounts(10.0, 250.0, 500.0);
+
+        self::assertValidationRulePassed($rule, 250);
+        self::assertValidationRulePassed($rule, '500');
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testFailsWhenAmountIsAboveTheMaximumAndNotExempt(): void
+    {
+        $rule = (new Max(100))->exemptAmounts(10.0, 250.0, 500.0);
+
+        self::assertValidationRuleFailed($rule, 251);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testReportsExceedingTheMaximum(): void
+    {
+        $error = null;
+        $fail = static function ($message) use (&$error) {
+            $error = $message;
+        };
+
+        (new Max(100))(101, $fail, 'amount', []);
+
+        self::assertSame('{field} must be less than or equal to 100', $error);
+    }
+}

--- a/tests/Unit/DonationForms/Rules/TestMaxRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMaxRule.php
@@ -55,6 +55,27 @@ class TestMaxRule extends TestCase
     /**
      * @since TBD
      */
+    public function testKeepsAFractionalSize(): void
+    {
+        $rule = new Max('10.50');
+
+        self::assertSame(10.5, $rule->getSize());
+        self::assertSame(10.5, $rule->serializeOption());
+        self::assertValidationRulePassed($rule, 10.5);
+        self::assertValidationRuleFailed($rule, 10.75);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testKeepsAWholeSizeAnInteger(): void
+    {
+        self::assertSame(100, (new Max('100'))->serializeOption());
+    }
+
+    /**
+     * @since TBD
+     */
     public function testReportsExceedingTheMaximum(): void
     {
         self::assertSame('{field} must be less than or equal to 100', $this->_failureMessage(new Max(100), 101));

--- a/tests/Unit/DonationForms/Rules/TestMaxRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMaxRule.php
@@ -8,7 +8,7 @@ use Give\Tests\Unit\DonationForms\TestTraits\HasValidationRules;
 
 /**
  * @since TBD
- * @covers \Give\DonationForms\Rules\Max
+ * @covers Give\DonationForms\Rules\Max
  */
 class TestMaxRule extends TestCase
 {
@@ -57,13 +57,36 @@ class TestMaxRule extends TestCase
      */
     public function testReportsExceedingTheMaximum(): void
     {
+        self::assertSame('{field} must be less than or equal to 100', $this->_failureMessage(new Max(100), 101));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testReportsExceedingTheMaximumLength(): void
+    {
+        self::assertSame(
+            '{field} must be less than or equal to 3 characters',
+            $this->_failureMessage(new Max(3), 'abcd')
+        );
+    }
+
+    /**
+     * Runs the rule against a failing value and returns the message it reported.
+     *
+     * @since TBD
+     *
+     * @param mixed $value
+     */
+    private function _failureMessage(Max $rule, $value): string
+    {
         $error = null;
         $fail = static function ($message) use (&$error) {
             $error = $message;
         };
 
-        (new Max(100))(101, $fail, 'amount', []);
+        $rule($value, $fail, 'amount', []);
 
-        self::assertSame('{field} must be less than or equal to 100', $error);
+        return (string)$error;
     }
 }

--- a/tests/Unit/DonationForms/Rules/TestMinRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMinRule.php
@@ -69,6 +69,27 @@ class TestMinRule extends TestCase
     /**
      * @since TBD
      */
+    public function testKeepsAFractionalSize(): void
+    {
+        $rule = new Min('10.50');
+
+        self::assertSame(10.5, $rule->getSize());
+        self::assertSame(10.5, $rule->serializeOption());
+        self::assertValidationRuleFailed($rule, 10.25);
+        self::assertValidationRulePassed($rule, 10.5);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testKeepsAWholeSizeAnInteger(): void
+    {
+        self::assertSame(500, (new Min('500'))->serializeOption());
+    }
+
+    /**
+     * @since TBD
+     */
     public function testExemptAmountsDefaultToAnEmptyList(): void
     {
         self::assertSame([], (new Min(500))->getExemptAmounts());

--- a/tests/Unit/DonationForms/Rules/TestMinRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMinRule.php
@@ -8,7 +8,7 @@ use Give\Tests\Unit\DonationForms\TestTraits\HasValidationRules;
 
 /**
  * @since TBD
- * @covers \Give\DonationForms\Rules\Min
+ * @covers Give\DonationForms\Rules\Min
  */
 class TestMinRule extends TestCase
 {
@@ -52,6 +52,18 @@ class TestMinRule extends TestCase
 
         self::assertValidationRuleFailed($rule, 11);
         self::assertValidationRuleFailed($rule, 24.99);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testPassesWhenAnExemptAmountIsADecimal(): void
+    {
+        $rule = (new Min(500))->exemptAmounts(10.5, 25.0);
+
+        self::assertValidationRulePassed($rule, '10.50');
+        self::assertValidationRulePassed($rule, 10.5);
+        self::assertValidationRuleFailed($rule, '10.51');
     }
 
     /**

--- a/tests/Unit/DonationForms/Rules/TestMinRule.php
+++ b/tests/Unit/DonationForms/Rules/TestMinRule.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForms\Rules;
+
+use Give\DonationForms\Rules\Min;
+use Give\Tests\TestCase;
+use Give\Tests\Unit\DonationForms\TestTraits\HasValidationRules;
+
+/**
+ * @since TBD
+ * @covers \Give\DonationForms\Rules\Min
+ */
+class TestMinRule extends TestCase
+{
+    use HasValidationRules;
+
+    /**
+     * @since TBD
+     */
+    public function testFailsWhenAmountIsBelowTheMinimum(): void
+    {
+        self::assertValidationRuleFailed(new Min(500), 499);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testPassesWhenAmountIsAtOrAboveTheMinimum(): void
+    {
+        self::assertValidationRulePassed(new Min(500), 500);
+        self::assertValidationRulePassed(new Min(500), 501);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testPassesWhenAmountIsExemptEvenThoughItIsBelowTheMinimum(): void
+    {
+        $rule = (new Min(500))->exemptAmounts(10.0, 25.0, 500.0);
+
+        self::assertValidationRulePassed($rule, 10);
+        self::assertValidationRulePassed($rule, '25');
+        self::assertValidationRulePassed($rule, 25.00);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testFailsWhenAmountIsBelowTheMinimumAndNotExempt(): void
+    {
+        $rule = (new Min(500))->exemptAmounts(10.0, 25.0, 500.0);
+
+        self::assertValidationRuleFailed($rule, 11);
+        self::assertValidationRuleFailed($rule, 24.99);
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testExemptAmountsDefaultToAnEmptyList(): void
+    {
+        self::assertSame([], (new Min(500))->getExemptAmounts());
+    }
+}


### PR DESCRIPTION
Ticket: SMTNC-1454

The `Min`/`Max` rules built from the custom amount settings were attached to the `amount` field itself. Donation levels and the custom amount input write that same value, so a level below the minimum was rejected.

Admin-configured amounts, the donation levels or the fixed set price, are now exempt from both rules. Legacy v2 behaves this way already: `give_verify_minimum_price()` short-circuits when the submitted amount matches a level, and `give_get_form_minimum_price()` documents the minimum as "only enforced for the custom amount input".

The exemption keys on the submitted amount rather than the `levelId` hidden field, so a crafted POST cannot forge its way under the minimum. It follows that a typed custom amount that happens to equal a level is also accepted, matching v2.

The client needs the same rule or the donor never reaches the server, since the message the donor sees is Joi's. No new serialization was needed: the amount field's JSON already carries `levels` and `fixedAmountValue`.

`Max` reported an over-maximum amount as "must be greater than or equal to" the maximum. Corrected while in the file.

Unchanged by this: with the Currency Switcher on a non-base currency, level values are scaled by the exchange rate client-side while `customAmountMin` is not, so a converted level can still trip the minimum. The same mismatch already affects the minimum itself and `UpdateDonationLevelId`.


## Demo

https://www.loom.com/share/266822d04df44099a09b4645ec2e013e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom donation amount minimum and maximum validation now correctly allows configured donation levels and fixed prices.
  * Empty minimum values now default to the lowest available donation amount.
  * Empty maximum values allow unlimited custom amounts.
  * Validation messages now accurately describe maximum limits.

* **Documentation**
  * Updated custom amount guidance to clarify how minimums, maximums, and predefined donation levels work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->