### PR TITLE
ci: grant contents write permission to the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         runs-on: ubuntu-latest
         environment: live
         needs: tests
+        permissions:
+            contents: write
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2


### PR DESCRIPTION
## Problem

The `4.16.7.1` release deployed to WordPress.org successfully, but the `Upload release asset` step failed:

```
##[error]Resource not accessible by integration
```

The GitHub release has no `give.zip` attached, and the Slack notification step was skipped as a consequence.

## Cause

`release.yml` declares no `permissions:` block, so it inherits the repository default. That default is now read-only:

```json
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

The workflow file has not changed since May. What changed is the token under it — the organization was moved into a GitHub Enterprise account on August 21–22, between the `4.16.7` release (which uploaded its zip fine) and `4.16.7.1`.

## Fix

Declare the permission on the job so the workflow no longer depends on a default that can be changed outside the repository:

```yaml
permissions:
    contents: write
```

A job that declares its own permissions bypasses the default entirely, which matters here because the enterprise policy may prevent flipping the repository setting back.

## Notes

- Release runs use the tag's commit on `master`, so this needs to reach `master` before the next release is tagged.
- The `4.16.7.1` release still needs `give.zip` attached manually, or the failed job re-run once this lands.
- The same gap exists in `close-stale-issues.yml`, `pre-release.yml`, `generate-zip.yml`, and `release-assets.yml`. Left out of this PR to keep it focused on the release failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jugbB3kEcQbDRzWuKfHLr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790193814&installation_model_id=426813&pr_number=8298&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8298&signature=4819d6fe65b6321a619bd54344c11b550f1c0ff737afa52936d0390940343d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->