### PR TITLE
fix: generate the POT file in the pup zip workflow

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -48,10 +48,8 @@ jobs:
             # pup has no POT generation of its own: `pup i18n` pulls finished translations down from
             # GlotPress, it does not produce the source POT. Generate it here, which the shared workflow
             # runs after `pup build` and before `pup package`, so languages/give.pot ends up in the zip.
+            # WP-CLI is already on the PATH by this point - the shared workflow installs it.
             additional_commands: |
-                curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-                chmod +x wp-cli.phar
-                mv wp-cli.phar /usr/local/bin/wp
                 php -d xdebug.mode=off "$(which wp)" i18n make-pot "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/languages/give.pot" --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/**/*.js,*.js.map,blocks/**/*.js"
             slack_channel: ${{ inputs.slack_channel }}
             slack_thread: ${{ inputs.slack_thread }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -45,6 +45,14 @@ jobs:
             production: ${{ inputs.production }}
             # GiveWP supports PHP 7.4 and up, so the vendor directory has to be built on 7.4.
             php_version: '7.4'
+            # pup has no POT generation of its own: `pup i18n` pulls finished translations down from
+            # GlotPress, it does not produce the source POT. Generate it here, which the shared workflow
+            # runs after `pup build` and before `pup package`, so languages/give.pot ends up in the zip.
+            additional_commands: |
+                curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+                chmod +x wp-cli.phar
+                mv wp-cli.phar /usr/local/bin/wp
+                php -d xdebug.mode=off "$(which wp)" i18n make-pot "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/languages/give.pot" --exclude="$(cat .distignore | tr "\n" "," | sed 's/,$/ /' | tr " " "\n"),src/**/*.js,*.js.map,blocks/**/*.js"
             slack_channel: ${{ inputs.slack_channel }}
             slack_thread: ${{ inputs.slack_thread }}
         secrets:


### PR DESCRIPTION
## Problem

Zips built through `zip.yml` ship no `languages/give.pot`.

`generate-zip.yml` had an explicit `Generate pot file` step. When #8291 moved zip generation to pup, nothing took its place. `pup i18n` looks like the equivalent, but it downloads *finished* translations from a GlotPress instance rather than producing the source POT — and with no `i18n` section in `.puprc` it exits immediately.

From the one `zip.yml` run to date (32520652251):

```
19:56:22.639  composer -- pup i18n
19:56:22.823  composer -- pup package     ← 0.18s
```

Downloading that run's artifact, `languages/` contains only `.gitkeep`. The `4.16.7.1` zip on WordPress.org — still built by `release.yml`, which kept its own make-pot step — has a 904,160 byte `give.pot`.

## Fix

The shared StellarWP workflow runs `additional_commands` after `pup build` and before `pup package`, which is exactly the slot the POT has to be generated in to be included. `.distignore` has no `languages` entry, so the file ships once it exists.

The exclude list is carried over verbatim from `release.yml`, which is what produces the POT currently shipping.

## Verification before merge

Run this workflow manually from the Actions tab with `production: no`, download the artifact, and confirm `languages/give.pot` is present and comparable in size to the 904 KB one on WordPress.org.

Worth checking the size rather than just the presence: `release.yml` runs `npm run dev`, generates the POT, then runs `npm run build`, whereas pup only does the production build. If the production build turns out to hide strings the dev build exposes, the POT will come back noticeably smaller and this needs the dev build too.

## Related, not included

- `RELEASING.md:46` says publishing a release "pushes the pot file to the translations server". No workflow in this repo does that — 26 add-on repos have a `sync-translations.yml` caller, `givewp` does not, and `release.yml` has never had such a step in its history. Either core needs the caller or the doc needs correcting; that's a separate decision.
- `release.yml` still builds its own zip rather than using pup. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jugbB3kEcQbDRzWuKfHLr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790194915&installation_model_id=426813&pr_number=8299&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8299&signature=ed14738e826de6e1e6fe0ff6b48a1577b0f5917f45984a8cb7789b99a2bd1c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->