### PR TITLE
fix: update strauss so Composer accepts current GitHub tokens

### DIFF
--- a/bin/strauss-installar.sh
+++ b/bin/strauss-installar.sh
@@ -31,7 +31,7 @@ download_and_install() {
 # Main script execution
 main() {
     local latest_release
-    latest_release="0.29.0" # strauss release version
+    latest_release="0.29.1" # strauss release version
     if is_update_needed "$latest_release"; then
         echo "Updating strauss to $latest_release ..."
         download_and_install "$latest_release"

--- a/bin/strauss-installar.sh
+++ b/bin/strauss-installar.sh
@@ -31,7 +31,7 @@ download_and_install() {
 # Main script execution
 main() {
     local latest_release
-    latest_release="0.20.1" # strauss release version
+    latest_release="0.29.0" # strauss release version
     if is_update_needed "$latest_release"; then
         echo "Updating strauss to $latest_release ..."
         download_and_install "$latest_release"

--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,16 @@
                     "/Tests/"
                 ]
             },
+            "exclude_from_prefix": {
+                "file_patterns": [
+                    "/harbor/src/Harbor/global-functions\\.php$"
+                ]
+            },
+            "exclude_constants": {
+                "constants": [
+                    "FILTER_VALIDATE_BOOL"
+                ]
+            },
             "delete_vendor_packages": true,
             "override_autoload": {
                 "symfony/polyfill-ctype": {},


### PR DESCRIPTION
## Problem

`zip.yml` fails at `pup build`:

```
[error] Your github oauth token for github.com contains invalid characters: "***"
Script @php bin/strauss.phar handling the strauss event returned with error code 1
[FAIL] Build step failed: composer install --no-dev --prefer-dist --no-progress --optimize-autoloader
```

## Cause

Composer validated github-oauth tokens against a character class that omits the hyphen (`BaseIO.php`, 2.9.x and earlier):

```php
// allowed chars for GH tokens are from https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
// plus dots which were at some point used for GH app integration tokens
if (!Preg::isMatch('{^[.A-Za-z0-9_]+$}', $token)) {
```

GitHub App installation tokens are now `ghs_<APPID>_<JWT>`. The JWT is base64url, whose alphabet includes `-`, so these tokens fail the check. Composer removed the validation entirely in 2.10.0.

The runner's Composer is already fine — the failing run logs `✓ composer Added composer 2.10.2`, which is why `composer install` itself succeeded and only the post-install script died. The stale Composer is the one bundled inside `strauss.phar`: 0.20.1 ships 2.8.4. Strauss requires `composer/composer: ^2.10` from 0.27.4 onwards, and 0.21.0 through 0.26.0 all still carry the old one, so 0.27.4 is the floor.

Reproduced under PHP 7.4 with a synthetic `ghs_..._<jwt-with-hyphen>` token:

| strauss | result |
|---|---|
| 0.20.1 | `[error] Your github oauth token for github.com contains invalid characters` |
| 0.29.1 | `[notice] Done` |

## Changes

Two parts. The version bump fixes the build; the config keeps the upgrade from breaking Harbor, now and on future bumps.

**1. Strauss 0.20.1 → 0.29.1** in `bin/strauss-installar.sh`.

**2. Two prefixing exclusions** in `composer.json`:

```json
"exclude_from_prefix": {
    "file_patterns": [
        "/harbor/src/Harbor/global-functions\\.php$"
    ]
},
"exclude_constants": {
    "constants": [
        "FILTER_VALIDATE_BOOL"
    ]
}
```

Strauss has prefixed global functions since 0.21.0 and widened what it catches in 0.29.1, which renames Harbor's `_lw_harbor_*` functions:

```diff
-if ( ! function_exists( '_lw_harbor_instance_registry' ) ) {
+if ( ! function_exists( 'give_vendors__lw_harbor_instance_registry' ) ) {
```

Those are deliberately global. Harbor uses them as a registry shared across every plugin that bundles it, electing a leader by version, so prefixing gives each plugin an isolated copy and the coordination stops working.

Pinning to 0.29.0 also avoids this, but only by staying under the problem — the next upgrade would reintroduce it silently. `exclude_from_prefix` states the constraint where it survives version changes. `exclude_constants` does the same for the polyfilled `FILTER_VALIDATE_BOOL`, whose entire purpose is to define the real constant name on PHP 7.4.

## Regression testing

Installed vendor once with `--no-scripts`, copied the tree per version, ran the full `@strauss` chain under `php:7.4-cli` to match the build, and diffed `vendor/vendor-prefixed` against the 0.20.1 baseline.

With the exclusions in place, content diffs drop from 16 files to 4 — and all four are 0.29.1 correcting things:

| file | change |
|---|---|
| `psr/http-message/.../ServerRequestInterface.php` | docblock reference now prefixed |
| `licensing-api-client/.../CreditsQuotasResource.php` | `@phpstan-import-type` now prefixed |
| `symfony/polyfill-php80/Resources/stubs/PhpToken.php` | `extends Give\Vendors\...` gains its leading `\` |
| `autoload.php` | autoloader restructure |

The `PhpToken` one is a genuine bug in the current 0.20.1 output — a relative class reference where an absolute one was meant.

Verified specifically on the exclusions:

- Definitions stay unprefixed: `_lw_harbor_instance_registry`, `_lw_harbor_global_function_registry`.
- All 35 call sites across Harbor resolve to the unprefixed names, and `give_vendors__lw_harbor` appears nowhere in the output. Strauss's README warns that "where they are used _will_ be updated", which reads like it would desynchronise definitions from call sites. It does not.
- `FILTER_VALIDATE_BOOL` is defined under its real name again.

The remaining difference is file count: 0.29.1 copies 168 more files (5.1 MB → 6.8 MB) — vendor tests, READMEs, licenses, CI config, plus Harbor resources and the ctype/mbstring polyfill sources that 0.20.1 skipped. Nothing references the Harbor images, and the polyfills stay non-autoloaded through the existing `override_autoload` entries, so this is inert.

Trimming the newly-copied dev files is worth a follow-up — the existing `/Tests/` pattern in `exclude_from_copy` is case-sensitive and no longer matches the lowercase `tests/` these packages use — but it is cosmetic and kept out of this PR.

## Worth checking on top of this

The `github-token: ''` workaround in `release.yml` and `wordpress.yml`, added in #8232, targets this same validation. It may now be removable, though `php-actions/composer@v5` pins its own Composer version so that needs confirming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jugbB3kEcQbDRzWuKfHLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled Strauss release to version 0.29.1.
  * Improved compatibility by excluding Harbor’s global functions and a standard validation constant from automatic namespace processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

ZIP
https://github.com/impress-org/givewp/actions/runs/32865299054