### PR TITLE
Fix: Prevent fatal error when resuming paused Stripe subscriptions an…

### DIFF
--- a/changelog/smtnc-2057-prevent-fatal-error-when-resuming-paused-stripe.yaml
+++ b/changelog/smtnc-2057-prevent-fatal-error-when-resuming-paused-stripe.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where resuming a paused Stripe subscription triggered a
+  fatal error.
+timestamp: 2026-08-25T05:16:10.341Z

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -41,6 +41,7 @@ function give_stripe_supported_payment_methods()
 /**
  * This function is used to check whether a payment method supported by Stripe with Give is active or not.
  *
+ * @since TBD Also check the `gateways_v3` option so modern Stripe gateways are recognized.
  * @since 2.5.5
  *
  * @return bool
@@ -48,8 +49,16 @@ function give_stripe_supported_payment_methods()
 function give_stripe_is_any_payment_method_active()
 {
 	$settings             = give_get_settings();
-    $gateways = $settings['gateways'] ?? [];
     $stripePaymentMethods = give_stripe_supported_payment_methods();
+
+    // The modern Stripe gateways (e.g. Stripe Payment Element) are stored in the
+    // `gateways_v3` option, while the legacy gateways live in the `gateways`
+    // setting. Both must be checked, so a site using only a modern Stripe gateway
+    // is still reported as having an active Stripe payment method.
+    $gateways = array_merge(
+        $settings['gateways'] ?? [],
+        (array) give_get_option('gateways_v3', [])
+    );
 
     $active = false;
     foreach (array_keys($gateways) as $gateway) {

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -50,10 +50,12 @@ function give_stripe_is_any_payment_method_active()
 {
     $stripePaymentMethods = give_stripe_supported_payment_methods();
 
-    // The modern Stripe gateways (e.g. Stripe Payment Element) are stored in the
-    // `gateways_v3` option, while the legacy gateways live in the `gateways`
-    // setting. Both must be checked, so a site using only a modern Stripe gateway
-    // is still reported as having an active Stripe payment method.
+    /*
+     * The modern Stripe gateways (e.g. Stripe Payment Element) are stored in the
+     * `gateways_v3` option, while the legacy gateways live in the `gateways`
+     * setting. Both must be checked, so a site using only a modern Stripe gateway
+     * is still reported as having an active Stripe payment method.
+     */
     $gateways = array_merge(
         (array) give_get_option('gateways', []),
         (array) give_get_option('gateways_v3', [])

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -48,7 +48,6 @@ function give_stripe_supported_payment_methods()
  */
 function give_stripe_is_any_payment_method_active()
 {
-	$settings             = give_get_settings();
     $stripePaymentMethods = give_stripe_supported_payment_methods();
 
     // The modern Stripe gateways (e.g. Stripe Payment Element) are stored in the
@@ -56,7 +55,7 @@ function give_stripe_is_any_payment_method_active()
     // setting. Both must be checked, so a site using only a modern Stripe gateway
     // is still reported as having an active Stripe payment method.
     $gateways = array_merge(
-        $settings['gateways'] ?? [],
+        (array) give_get_option('gateways', []),
         (array) give_get_option('gateways_v3', [])
     );
 

--- a/includes/gateways/stripe/includes/admin/admin-helpers.php
+++ b/includes/gateways/stripe/includes/admin/admin-helpers.php
@@ -48,6 +48,7 @@ function give_stripe_supported_payment_methods()
  */
 function give_stripe_is_any_payment_method_active()
 {
+    $settings             = give_get_settings();
     $stripePaymentMethods = give_stripe_supported_payment_methods();
 
     /*
@@ -57,7 +58,7 @@ function give_stripe_is_any_payment_method_active()
      * is still reported as having an active Stripe payment method.
      */
     $gateways = array_merge(
-        (array) give_get_option('gateways', []),
+        (array) ($settings['gateways'] ?? []),
         (array) give_get_option('gateways_v3', [])
     );
 

--- a/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
+++ b/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
@@ -145,6 +145,12 @@ class Tests_Give_Stripe_Admin_Helpers extends Give_Unit_Test_Case {
 	 */
 	public function test_give_stripe_is_any_payment_method_active_with_v3_gateway() {
 
+		// Disable every legacy Stripe gateway so the result depends only on the v3 gateway.
+		foreach ( give_stripe_supported_payment_methods() as $gateway ) {
+			unset( $this->gateways[ $gateway ] );
+		}
+		give_update_option( 'gateways', $this->gateways );
+
 		// Simulate a site using only the modern Stripe Payment Element gateway.
 		give_update_option(
 			'gateways_v3',

--- a/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
+++ b/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
@@ -134,4 +134,38 @@ class Tests_Give_Stripe_Admin_Helpers extends Give_Unit_Test_Case {
 		$is_stripe_active = give_stripe_is_any_payment_method_active();
 		$this->assertFalse( $is_stripe_active );
 	}
+
+	/**
+	 * Ensure Stripe is reported as active when only a modern Stripe gateway is
+	 * enabled in the v3 settings.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function test_give_stripe_is_any_payment_method_active_with_v3_gateway() {
+
+		// Simulate a site using only the modern Stripe Payment Element gateway.
+		give_update_option(
+			'gateways_v3',
+			array(
+				'stripe_payment_element' => 1,
+			)
+		);
+
+		// The modern gateway is registered as a supported Stripe payment method
+		// by GiveWP core's LegacyStripeAdapter.
+		add_filter(
+			'give_stripe_supported_payment_methods',
+			static function ( $gateways ) {
+				if ( ! in_array( 'stripe_payment_element', $gateways, true ) ) {
+					$gateways[] = 'stripe_payment_element';
+				}
+
+				return $gateways;
+			}
+		);
+
+		$this->assertTrue( give_stripe_is_any_payment_method_active() );
+	}
 }

--- a/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
+++ b/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
@@ -159,8 +159,10 @@ class Tests_Give_Stripe_Admin_Helpers extends Give_Unit_Test_Case {
 			)
 		);
 
-		// The modern gateway is registered as a supported Stripe payment method
-		// by GiveWP core's LegacyStripeAdapter.
+		/*
+		 * The modern gateway is registered as a supported Stripe payment method
+		 * by GiveWP core's LegacyStripeAdapter.
+		 */
 		$this->assertContains( 'stripe_payment_element', give_stripe_supported_payment_methods() );
 
 		$this->assertTrue( give_stripe_is_any_payment_method_active() );

--- a/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
+++ b/tests/includes/legacy/stripe/tests-give-stripe-admin-helpers.php
@@ -161,16 +161,7 @@ class Tests_Give_Stripe_Admin_Helpers extends Give_Unit_Test_Case {
 
 		// The modern gateway is registered as a supported Stripe payment method
 		// by GiveWP core's LegacyStripeAdapter.
-		add_filter(
-			'give_stripe_supported_payment_methods',
-			static function ( $gateways ) {
-				if ( ! in_array( 'stripe_payment_element', $gateways, true ) ) {
-					$gateways[] = 'stripe_payment_element';
-				}
-
-				return $gateways;
-			}
-		);
+		$this->assertContains( 'stripe_payment_element', give_stripe_supported_payment_methods() );
 
 		$this->assertTrue( give_stripe_is_any_payment_method_active() );
 	}


### PR DESCRIPTION
Solves [SMTNC-2057](https://linear.app/nexcess/issue/SMTNC-2057/prevent-fatal-error-when-resuming-paused-stripe-subscriptions)

Slack: https://lw.slack.com/archives/C0A32QSRQUS/p1787139786399679

---

## What changed

[include_stripe_files()](https://github.com/impress-org/give-recurring/blob/5a6e1d99daecf9410449b5b7a2bb011e7d09ba4d/give-recurring.php#L305): removed the bailout that skipped loading the Stripe helper files when `give_stripe_is_any_payment_method_active()` returned false.

**Now GiveWP fixes `give_stripe_is_any_payment_method_active()` to return true if stripe is being used.**

That check only looks at the legacy gateway list, so it returns false for the next-gen stripe_payment_element gateway — which is exactly why the function was undefined. The two files it loads are definition-only (4 functions + one lazy class), so loading them unconditionally is safe.

InvoicePaymentSucceeded.php: reverted to the original direct call to give_recurring_stripe_is_subscription_completed().

Now the function is always defined, so the direct call runs the real completion + Stripe-cancel logic instead of silently skipping it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790253726&installation_model_id=426813&pr_number=8301&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8301&signature=bba1955bec79e4bde9ca4202123f257dbe49b41ab49b1f1998a665da22f9cf1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a fatal error that could occur when resuming paused Stripe subscriptions.
  - Improved recognition of enabled modern Stripe payment methods, including Stripe Payment Element, alongside legacy Stripe methods.
- **Tests**
  - Added coverage to verify active Stripe payment methods are detected correctly.
- **Documentation**
  - Added a changelog entry documenting the Stripe subscription fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->