### PR TITLE
Tweak: replace axios with apiFetch

### DIFF
--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -150,9 +150,12 @@ export const subscribeToNewsletter = (configuration) => {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(data),
         })
-        .then(function () {
-            // Set user meta key as subscribed.
-            setUserMetaSubscribed();
+        .then(function (response) {
+            // fetch resolves on 4xx and 5xx, so a rejected subscription would otherwise be recorded as a success.
+            if (response.ok) {
+                // Set user meta key as subscribed.
+                setUserMetaSubscribed();
+            }
         });
 };
 

--- a/assets/src/js/admin/onboarding-wizard/utils/index.js
+++ b/assets/src/js/admin/onboarding-wizard/utils/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
-// Note: no-unused-vars rule is disabled while axios logic is not enabled
+// Note: no-unused-vars rule is disabled while the currency lookup is not enabled
 
-import axios from 'axios';
+import apiFetch from '@wordpress/api-fetch';
 import {setFetchingStatesList, setStateList} from '../app/store/actions';
 
 export const getWindowData = (value) => {
@@ -22,14 +22,6 @@ export const toKebabCase = (str) => {
         .replace(/([a-z])([A-Z])/g, '$1-$2')
         .replace(/\s+/g, '-')
         .toLowerCase();
-};
-
-export const getAPIRoot = () => {
-    return getWindowData('apiRoot');
-};
-
-export const getAPINonce = () => {
-    return getWindowData('apiNonce');
 };
 
 export const getCountryList = () => {
@@ -120,17 +112,13 @@ export const saveSettingWithOnboardingAPI = (setting, value) => {
     // Note: When the below code is actually implemented, the ${value} should be
     // stringified (using qs library or JSON stringify).
 
-    axios.post(
-        getAPIRoot() + 'give-api/v2/onboarding/settings/' + setting,
-        {
+    apiFetch({
+        path: '/give-api/v2/onboarding/settings/' + setting,
+        method: 'POST',
+        data: {
             value: JSON.stringify(value),
         },
-        {
-            headers: {
-                'X-WP-Nonce': getAPINonce(),
-            },
-        }
-    );
+    });
 
     return {
         setting,
@@ -154,10 +142,18 @@ export const subscribeToNewsletter = (configuration) => {
         fundraising_type: configuration.causeType,
     };
 
-    axios.post('https://connect.givewp.com/activecampaign/subscribe', data).then(function (response) {
-        // Set user meta key as subscribed.
-        setUserMetaSubscribed();
-    });
+    // Sent with fetch rather than apiFetch so the WordPress REST nonce is not
+    // attached to a request leaving the site.
+    window
+        .fetch('https://connect.givewp.com/activecampaign/subscribe', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data),
+        })
+        .then(function () {
+            // Set user meta key as subscribed.
+            setUserMetaSubscribed();
+        });
 };
 
 /**
@@ -168,19 +164,15 @@ export const subscribeToNewsletter = (configuration) => {
 export const setUserMetaSubscribed = () => {
     const currentUserId = getWindowData('adminUserID');
 
-    axios.post(
-        getAPIRoot() + 'wp/v2/users/' + currentUserId,
-        {
+    apiFetch({
+        path: '/wp/v2/users/' + currentUserId,
+        method: 'POST',
+        data: {
             meta: {
                 marketing_optin: 'subscribed',
             },
         },
-        {
-            headers: {
-                'X-WP-Nonce': getAPINonce(),
-            },
-        }
-    );
+    });
 };
 
 /**
@@ -192,26 +184,18 @@ export const setUserMetaSubscribed = () => {
  */
 export const fetchStatesListWithOnboardingAPI = (country, dispatch) => {
     dispatch(setFetchingStatesList(true));
-    axios
-        .get(getAPIRoot() + 'give-api/v2/onboarding/location', {
-            params: {
-                countryCode: country,
-            },
-            headers: {
-                'X-WP-Nonce': getAPINonce(),
-            },
-        })
-        .then((response) => response.data)
-        .then((data) => {
-            const stateList = data.states.map((state) => {
-                return {
-                    value: state.value,
-                    label: decodeHTMLEntity(state.label),
-                };
-            });
-            dispatch(setStateList(stateList));
-            dispatch(setFetchingStatesList(false));
+    apiFetch({
+        path: '/give-api/v2/onboarding/location?' + new URLSearchParams({countryCode: country}).toString(),
+    }).then((data) => {
+        const stateList = data.states.map((state) => {
+            return {
+                value: state.value,
+                label: decodeHTMLEntity(state.label),
+            };
         });
+        dispatch(setStateList(stateList));
+        dispatch(setFetchingStatesList(false));
+    });
 };
 
 /**
@@ -219,16 +203,11 @@ export const fetchStatesListWithOnboardingAPI = (country, dispatch) => {
  * @since 2.8.0
  */
 export const generateFormPreviewWithOnboardingAPI = async (dispatch) => {
-    const {data} = await axios.post(
-        getAPIRoot() + 'give-api/v2/onboarding/form',
-        {},
-        {
-            headers: {
-                'X-WP-Nonce': getAPINonce(),
-                'Content-Type': 'application/json',
-            },
-        }
-    );
+    const data = await apiFetch({
+        path: '/give-api/v2/onboarding/form',
+        method: 'POST',
+        data: {},
+    });
 
     return data.formID;
 };
@@ -247,20 +226,4 @@ export const getCurrencyWithOnboardingAPI = (country) => {
     // Logic for connecting to the Onboarding API
     // An object with action: 'get_currency' and country: ${country} is passed to the API
     // A string with currency code for the requested country code is returned
-
-    // axios.get( getAPIRoot() + 'give-api/v2/onboarding/', {
-    // 	params: {
-    // 		action: 'get_currency',
-    // 		country,
-    // 	},
-    // 	headers: {
-    // 		'X-WP-Nonce': getAPINonce(),
-    // 	},
-    // } )
-    // 	.then( function( response ) {
-    // 		// Do something on success
-    // 	} )
-    // 	.catch( function() {
-    // 		// Do something on error
-    // 	} );
 };

--- a/assets/src/js/admin/reports/utils/index.js
+++ b/assets/src/js/admin/reports/utils/index.js
@@ -1,6 +1,6 @@
 import { useStoreValue } from '../store';
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import apiFetch from '@wordpress/api-fetch';
 import { setGiveStatus, setPageLoaded } from '../store/actions';
 import { getSampleData } from './sample';
 
@@ -9,6 +9,11 @@ export const getWindowData = ( value ) => {
 	return data[ value ];
 };
 
+/**
+ * @since TBD Replaced axios with @wordpress/api-fetch. In-flight requests are now
+ *            aborted from the effect cleanup rather than a cancel token recreated on
+ *            every render, which never cancelled the request that was actually open.
+ */
 export const useReportsAPI = ( endpoint ) => {
 	// Use period from store
 	const [ { period, currency, testMode }, dispatch ] = useStoreValue();
@@ -19,50 +24,52 @@ export const useReportsAPI = ( endpoint ) => {
 	// Use state to hold querying status
 	const [ querying, setQuerying ] = useState( false );
 
-	// Setup cancel token for request
-	const CancelToken = axios.CancelToken;
-	const source = CancelToken.source();
-
 	// Fetch new data when period changes
 	useEffect( () => {
-		if ( period.startDate && period.endDate ) {
-			if ( querying === true ) {
-				source.cancel( 'Operation canceled by the user.' );
-			}
-			setQuerying( true );
-			axios.get( wpApiSettings.root + 'give-api/v2/reports/' + endpoint, {
-				cancelToken: source.token,
-				params: {
-					start: period.startDate.format( 'YYYY-MM-DD' ),
-					end: period.endDate.format( 'YYYY-MM-DD' ),
-					currency: currency,
-					testMode: testMode,
-				},
-				headers: {
-					'X-WP-Nonce': wpApiSettings.nonce,
-				},
-			} )
-				.then( function( response ) {
-					const status = response.data.status;
-					dispatch( setGiveStatus( status ) );
-
-					if ( status === 'no_donations_found' ) {
-						const sample = getSampleData( endpoint );
-						setFetched( sample );
-					} else {
-						setFetched( response.data.data );
-					}
-
-					if ( endpoint === 'income' ) {
-						dispatch( setPageLoaded() );
-					}
-
-					setQuerying( false );
-				} )
-				.catch( function() {
-					setQuerying( false );
-				} );
+		if ( ! period.startDate || ! period.endDate ) {
+			return;
 		}
+
+		// Abort the previous request when the parameters change or the component unmounts
+		const controller = new AbortController();
+
+		const parameters = new URLSearchParams( {
+			start: period.startDate.format( 'YYYY-MM-DD' ),
+			end: period.endDate.format( 'YYYY-MM-DD' ),
+			currency,
+			testMode,
+		} );
+
+		setQuerying( true );
+		apiFetch( {
+			path: `/give-api/v2/reports/${ endpoint }?${ parameters.toString() }`,
+			signal: controller.signal,
+		} )
+			.then( function( response ) {
+				const status = response.status;
+				dispatch( setGiveStatus( status ) );
+
+				if ( status === 'no_donations_found' ) {
+					const sample = getSampleData( endpoint );
+					setFetched( sample );
+				} else {
+					setFetched( response.data );
+				}
+
+				if ( endpoint === 'income' ) {
+					dispatch( setPageLoaded() );
+				}
+
+				setQuerying( false );
+			} )
+			.catch( function( error ) {
+				// An aborted request is superseded by a newer one, which owns the querying state
+				if ( error?.name !== 'AbortError' ) {
+					setQuerying( false );
+				}
+			} );
+
+		return () => controller.abort();
 	}, [ period, currency, testMode, endpoint ] );
 
 	return [ fetched, querying ];

--- a/changelog/tweak-replace-axios-with-apifetch.yaml
+++ b/changelog/tweak-replace-axios-with-apifetch.yaml
@@ -1,0 +1,7 @@
+significance: patch
+type: tweak
+entry: Replaced the axios HTTP client with WordPress core's apiFetch in the donor
+  dashboard, reports, onboarding wizard, and the log and migration list tables. This
+  removes axios, and the advisories reported against it, from the plugin's JavaScript
+  dependencies.
+timestamp: 2026-08-28T00:00:00.000Z

--- a/changelog/tweak-replace-axios-with-apifetch.yaml
+++ b/changelog/tweak-replace-axios-with-apifetch.yaml
@@ -1,7 +1,6 @@
 significance: patch
 type: tweak
 entry: Replaced the axios HTTP client with WordPress core's apiFetch in the donor
-  dashboard, reports, onboarding wizard, and the log and migration list tables. This
-  removes axios, and the advisories reported against it, from the plugin's JavaScript
-  dependencies.
+  dashboard, reports, onboarding wizard, and the log and migration list tables, and
+  removed axios from the plugin's JavaScript dependencies.
 timestamp: 2026-08-28T00:00:00.000Z

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,6 +36,27 @@ a spec, but the environment it is designed against is the clean install the work
 Keep the specs thin. A browser test that asserts something a PHPUnit test could have asserted is a
 slow test with a worse failure message.
 
+### Layout
+
+**One spec file per screen**, named for the screen, holding everything that screen is covered for:
+`donor-dashboard.spec.ts`, `reports.spec.ts`, `tools-logs.spec.ts`, `tools-migrations.spec.ts`.
+
+New coverage goes in the file for the screen it exercises. Grouping by the kind of assertion
+instead — every screen's mount check in one file, every screen's REST check in another — puts one
+screen's coverage in as many files as there are kinds of assertion, so nothing tells you what a
+screen is actually covered for, and each new kind adds a file that re-lists every screen.
+`test.describe` already groups within a file, which is where that grouping belongs.
+
+`admin-pages.spec.ts` is the deliberate exception. It is a breadth-first smoke suite — each admin
+screen that mounts a React app, one assertion each — and its job is to be pointed at environments
+core does not control, which is what the add-on plan below builds on. Screens with a spec file of
+their own are not repeated in it.
+
+Shared helpers live in `tests/e2e/utils/`. `utils/rest.ts` records the REST calls a page makes and
+asserts it reached the route it owns with nothing failing. Assert on that traffic rather than on
+rendered records: a wrong route, a missing nonce, or a response shape the client no longer unwraps
+all produce a page that builds and mounts cleanly and then shows nothing.
+
 ### CI
 
 `.github/workflows/tests-e2e.yml` installs Composer and npm dependencies, runs `npm run build`,
@@ -157,9 +178,9 @@ installation token with `contents: read` on the add-on repositories is the first
 
 A smoke test that only checks core still works with an add-on active catches most of what breaks: a
 fatal on activation, a JavaScript error that stops a list table mounting, an asset that 404s. The
-existing specs in `tests/e2e/admin-pages.spec.ts` already do all three — pointing them at an
-environment with add-ons loaded is most of the value, before a single add-on-specific spec is
-written.
+existing specs in `tests/e2e/admin-pages.spec.ts` already do all three, which is why that file
+stays breadth-first — pointing it at an environment with add-ons loaded is most of the value,
+before a single add-on-specific spec is written.
 
 ### The other direction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
                 "ajv": "^8.17.1",
                 "ajv-errors": "3.0.0",
                 "ajv-formats": "3.0.1",
-                "axios": "^1.7.9",
                 "chart.js": "^2.9.3",
                 "chartjs-plugin-crosshair": "^1.1.4",
                 "chosen-js": "^1.8.7",
@@ -18755,7 +18754,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
@@ -18854,14 +18854,53 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.9",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-            "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+            "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.6",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/axobject-query": {
@@ -20355,6 +20394,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -21327,6 +21367,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -23454,15 +23495,17 @@
             "integrity": "sha512-5JLtr0e1YJIfmnVlpLiG+av07dd0Xkf/KfswsXcei5KmLfdwOysTQsjF058ynXniujb1fvev7nql1x+CkC5ikw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -23736,13 +23779,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -24486,9 +24533,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -29002,19 +29050,21 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.52.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -31279,7 +31329,8 @@
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
         },
         "node_modules/prr": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
         "ajv": "^8.17.1",
         "ajv-errors": "3.0.0",
         "ajv-formats": "3.0.1",
-        "axios": "^1.7.9",
         "chart.js": "^2.9.3",
         "chartjs-plugin-crosshair": "^1.1.4",
         "chosen-js": "^1.8.7",

--- a/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/auth-modal/utils/index.js
@@ -1,41 +1,21 @@
-import axios from 'axios';
-import {getAPIRoot} from '../../../utils';
+import {donorDashboardApi} from '../../../utils';
 
 export const loginWithAPI = ({login, password}) => {
-    return axios
-        .post(
-            getAPIRoot() + 'give-api/v2/donor-dashboard/login',
-            {
-                login,
-                password,
-            },
-            {}
-        )
-        .then((response) => response.data);
+    return donorDashboardApi.post('login', {
+        login,
+        password,
+    });
 };
 
 export const verifyEmailWithAPI = ({email, recaptcha}) => {
-    return axios
-        .post(
-            getAPIRoot() + 'give-api/v2/donor-dashboard/verify-email',
-            {
-                email,
-                'g-recaptcha-response': recaptcha,
-            },
-            {}
-        )
-        .then((response) => response.data);
+    return donorDashboardApi.post('verify-email', {
+        email,
+        'g-recaptcha-response': recaptcha,
+    });
 };
 
-
 export const resetPasswordWithAPI = (email) => {
-    return axios
-        .post(
-            getAPIRoot() + 'give-api/v2/donor-dashboard/reset-password',
-            {
-                email,
-            },
-            {}
-        )
-        .then((response) => response.data);
+    return donorDashboardApi.post('reset-password', {
+        email,
+    });
 };

--- a/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/logout-modal/utils/index.js
@@ -1,7 +1,7 @@
 import {donorDashboardApi, getQueryParam} from '../../../utils';
 
 export const logoutWithAPI = () => {
-    return donorDashboardApi.post('logout', {}).then((response) => response.data);
+    return donorDashboardApi.post('logout');
 };
 
 export const getCleanParentHref = () => {

--- a/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-cancel-modal/utils/index.js
@@ -1,6 +1,5 @@
-import {donorDashboardApi} from '../../../utils';
+import {donorDashboardApi, getApiErrorMessage} from '../../../utils';
 import {fetchSubscriptionsDataFromAPI} from '../../../tabs/recurring-donations/utils';
-import {__} from '@wordpress/i18n';
 import {store} from '../../../tabs/recurring-donations/store';
 import {setError} from '../../../tabs/recurring-donations/store/actions';
 
@@ -8,30 +7,16 @@ export const cancelSubscriptionWithAPI = async (id) => {
     const {dispatch} = store;
 
     try {
-        const response = await donorDashboardApi.post(
-            'recurring-donations/subscription/cancel',
-            {
-                id: id,
-            },
-            {}
-        );
+        const response = await donorDashboardApi.post('recurring-donations/subscription/cancel', {
+            id: id,
+        });
 
         await fetchSubscriptionsDataFromAPI();
 
         return response;
     } catch (error) {
-        if (error.response.status === 500) {
-            dispatch(
-                setError(
-                    __(
-                        'An error occurred while processing your request.  Please try again later, or contact support if the issue persists.',
-                        'give'
-                    )
-                )
-            );
-        } else {
-            dispatch(setError(error.response.data.message));
-        }
-        return error.response;
+        dispatch(setError(getApiErrorMessage(error)));
+
+        return error;
     }
 };

--- a/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/components/subscription-manager/utils/index.js
@@ -1,6 +1,5 @@
-import {__} from '@wordpress/i18n';
 import {store} from '../../../tabs/recurring-donations/store';
-import {donorDashboardApi} from '../../../utils';
+import {donorDashboardApi, getApiErrorMessage} from '../../../utils';
 import {fetchSubscriptionsDataFromAPI} from '../../../tabs/recurring-donations/utils';
 import {setError} from '../../../tabs/recurring-donations/store/actions';
 
@@ -8,63 +7,33 @@ export const updateSubscriptionWithAPI = async ({id, amount, paymentMethod}) => 
     const {dispatch} = store;
 
     try {
-        const response = await donorDashboardApi.post(
-            'recurring-donations/subscription/update',
-            {
-                id,
-                amount,
-                payment_method: paymentMethod,
-            },
-            {}
-        );
+        const response = await donorDashboardApi.post('recurring-donations/subscription/update', {
+            id,
+            amount,
+            payment_method: paymentMethod,
+        });
 
         await fetchSubscriptionsDataFromAPI();
 
         return response;
     } catch (error) {
-        if (error.response.status === 500) {
-            dispatch(
-                setError(
-                    __(
-                        'An error occurred while processing your request.  Please try again later, or contact support if the issue persists.',
-                        'give'
-                    )
-                )
-            );
-        } else {
-            dispatch(setError(error.response.data.message));
-        }
+        dispatch(setError(getApiErrorMessage(error)));
     }
 };
 
 export const managePausingSubscriptionWithAPI = async ({id, action = 'pause', intervalInMonths = null}) => {
     const {dispatch} = store;
     try {
-        const response = await donorDashboardApi.post(
-            'recurring-donations/subscription/manage-pausing',
-            {
-                id,
-                action,
-                interval_in_months: intervalInMonths,
-            },
-            {}
-        );
+        const response = await donorDashboardApi.post('recurring-donations/subscription/manage-pausing', {
+            id,
+            action,
+            interval_in_months: intervalInMonths,
+        });
 
         await fetchSubscriptionsDataFromAPI();
 
         return response;
     } catch (error) {
-        if (error.response.status === 500) {
-            dispatch(
-                setError(
-                    __(
-                        'An error occurred while processing your request.  Please try again later, or contact support if the issue persists.',
-                        'give'
-                    )
-                )
-            );
-        } else {
-            dispatch(setError(error.response.data.message));
-        }
+        dispatch(setError(getApiErrorMessage(error)));
     }
 };

--- a/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/annual-receipts/utils/index.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {store} from '../store';
 import {donorDashboardApi, isLoggedIn} from '../../../utils';
 import {setAnnualReceipts, setQuerying, setError} from '../store/actions';
@@ -10,8 +9,7 @@ export const fetchAnnualReceiptsFromAPI = () => {
     if (loggedIn) {
         dispatch(setQuerying(true));
         donorDashboardApi
-            .post('annual-receipts', {}, {})
-            .then((response) => response.data)
+            .post('annual-receipts')
             .then((data) => {
                 const {receipts} = data;
                 dispatch(setAnnualReceipts(receipts));

--- a/src/DonorDashboards/resources/js/app/tabs/donation-history/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/donation-history/utils/index.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {store} from '../store';
 import {setDonations, setQuerying, setError, setCount, setRevenue, setAverage, setCurrency} from '../store/actions';
 import {donorDashboardApi, isLoggedIn} from '../../../utils';
@@ -15,8 +14,7 @@ export const fetchDonationsDataFromAPI = () => {
     if (loggedIn) {
         dispatch(setQuerying(true));
         donorDashboardApi
-            .post('donations', {}, {})
-            .then((response) => response.data)
+            .post('donations')
             // eslint-disable-next-line camelcase
             .then(({status, body_response}) => {
                 if (status === 200) {
@@ -35,9 +33,8 @@ export const fetchDonationsDataFromAPI = () => {
 
                 dispatch(setQuerying(false));
             })
-            .catch(({response}) => {
-                const {status, data} = response;
-                if (status === 403 && data.code === 'rest_cookie_invalid_nonce') {
+            .catch((error) => {
+                if (error && error.code === 'rest_cookie_invalid_nonce') {
                     applicationDispatch(
                         setApplicationError(
                             __(

--- a/src/DonorDashboards/resources/js/app/tabs/edit-profile/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/edit-profile/utils/index.js
@@ -31,26 +31,21 @@ export const updateProfileWithAPI = async ({
      */
     const {dispatch} = store;
     return donorDashboardApi
-        .post(
-            'profile',
-            {
-                data: JSON.stringify({
-                    titlePrefix,
-                    firstName,
-                    lastName,
-                    company,
-                    primaryEmail,
-                    additionalEmails,
-                    primaryAddress,
-                    additionalAddresses,
-                    avatarId,
-                    isAnonymous,
-                }),
-                id,
-            },
-            {}
-        )
-        .then((response) => response.data)
+        .post('profile', {
+            data: JSON.stringify({
+                titlePrefix,
+                firstName,
+                lastName,
+                company,
+                primaryEmail,
+                additionalEmails,
+                primaryAddress,
+                additionalAddresses,
+                avatarId,
+                isAnonymous,
+            }),
+            id,
+        })
         .then((responseData) => {
             /**
              * Once updated, update the store's representation of
@@ -67,24 +62,14 @@ export const uploadAvatarWithAPI = (file) => {
     formData.append('file', file);
 
     // Upload the new file, and return the resolved Promise with new media ID
-    return donorDashboardApi
-        .post('avatar', formData)
-        .then((response) => {
-            return response.data;
-        })
-        .then((responseData) => responseData.id);
+    return donorDashboardApi.post('avatar', formData).then((responseData) => responseData.id);
 };
 
 export const fetchStatesWithAPI = (country) => {
     return donorDashboardApi
-        .post(
-            'location',
-            {
-                countryCode: country,
-            },
-            {}
-        )
-        .then((response) => response.data)
+        .post('location', {
+            countryCode: country,
+        })
         .then((data) => {
             return data.states.map((state) => {
                 return {

--- a/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/tabs/recurring-donations/utils/index.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {store} from '../store';
 import {donorDashboardApi, isLoggedIn} from '../../../utils';
 import {setSubscriptions, setQuerying, setError} from '../store/actions';
@@ -10,8 +9,7 @@ export const fetchSubscriptionsDataFromAPI = () => {
     if (loggedIn) {
         dispatch(setQuerying(true));
         return donorDashboardApi
-            .post('recurring-donations/subscriptions', {}, {})
-            .then((response) => response.data)
+            .post('recurring-donations/subscriptions')
             .then((data) => {
                 dispatch(setSubscriptions(data.subscriptions));
                 dispatch(setQuerying(false));

--- a/src/DonorDashboards/resources/js/app/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/utils/index.js
@@ -1,5 +1,6 @@
+import apiFetch from '@wordpress/api-fetch';
+import {__} from '@wordpress/i18n';
 import {addTab} from '../store/actions';
-import axios from 'axios';
 
 export const registerTab = (tab) => {
     const {dispatch} = window.giveDonorDashboard.store;
@@ -48,18 +49,52 @@ export const isLoggedIn = () => {
     return Number(getWindowData('id')) !== 0 ? true : false;
 };
 
-export const getAPIRoot = () => {
-    return getWindowData('apiRoot');
+const DONOR_DASHBOARD_NAMESPACE = '/give-api/v2/donor-dashboard/';
+
+/**
+ * Posts to a Donor Dashboard REST route and resolves with the parsed response body.
+ *
+ * FormData is sent as-is so the browser can set its own multipart boundary. Anything
+ * else is sent as JSON.
+ *
+ * @since TBD
+ *
+ * @param {string} endpoint Route relative to the Donor Dashboard namespace.
+ * @param {Object|FormData} data Request payload.
+ * @return {Promise<Object>} Parsed response body.
+ */
+export const donorDashboardApi = {
+    post: (endpoint, data) =>
+        apiFetch({
+            path: DONOR_DASHBOARD_NAMESPACE + endpoint,
+            method: 'POST',
+            ...(data instanceof window.FormData ? {body: data} : {data: data || {}}),
+        }),
 };
 
-export const getAPINonce = () => {
-    return getWindowData('apiNonce');
-};
+/**
+ * Translates a rejected apiFetch request into a message safe to show a donor.
+ *
+ * Server faults and responses that are not a WordPress REST error fall back to a
+ * generic message, so internal failure details are never surfaced.
+ *
+ * @since TBD
+ *
+ * @param {Object} error Rejection value from apiFetch.
+ * @return {string} Message to display.
+ */
+export const getApiErrorMessage = (error) => {
+    const status = error && error.data ? error.data.status : null;
 
-export const donorDashboardApi = axios.create({
-    baseURL: getAPIRoot() + 'give-api/v2/donor-dashboard/',
-    headers: {'X-WP-Nonce': getAPINonce()},
-});
+    if (!error || !error.message || status >= 500) {
+        return __(
+            'An error occurred while processing your request.  Please try again later, or contact support if the issue persists.',
+            'give'
+        );
+    }
+
+    return error.message;
+};
 
 /**
  * Returns string in Kebab Case (ex: kebab-case)

--- a/src/DonorDashboards/resources/js/app/utils/index.js
+++ b/src/DonorDashboards/resources/js/app/utils/index.js
@@ -75,8 +75,11 @@ export const donorDashboardApi = {
 /**
  * Translates a rejected apiFetch request into a message safe to show a donor.
  *
- * Server faults and responses that are not a WordPress REST error fall back to a
- * generic message, so internal failure details are never surfaced.
+ * apiFetch rejects with the parsed REST error body for a response the server actually produced,
+ * and otherwise with a client-side object carrying only a code and a message - offline, or a
+ * response that was not JSON because PHP failed partway through. Only the first kind describes
+ * something a donor can act on, so it is the only kind whose message is shown; everything else,
+ * server faults included, falls back to the generic message.
  *
  * @since TBD
  *
@@ -86,7 +89,7 @@ export const donorDashboardApi = {
 export const getApiErrorMessage = (error) => {
     const status = error && error.data ? error.data.status : null;
 
-    if (!error || !error.message || status >= 500) {
+    if (!status || status >= 500 || !error.message) {
         return __(
             'An error occurred while processing your request.  Please try again later, or contact support if the issue persists.',
             'give'

--- a/src/Log/Admin/Logs/api.js
+++ b/src/Log/Admin/Logs/api.js
@@ -1,22 +1,23 @@
-import axios from 'axios';
+import apiFetch from '@wordpress/api-fetch';
 import useSWR from 'swr';
 
-const API = axios.create({
-    baseURL: window.GiveLogs.apiRoot,
-    headers: {
-        'Content-Type': 'application/json',
-        'X-WP-Nonce': window.GiveLogs.apiNonce,
-    },
-});
+const NAMESPACE = '/give-api/v2/logs';
+
+/**
+ * @since TBD Replaced axios with @wordpress/api-fetch, which resolves with the parsed
+ *            response body and supplies the REST root and nonce from WordPress core.
+ */
+const API = {
+    get: (endpoint) => apiFetch({path: NAMESPACE + endpoint}),
+    post: (endpoint, data) => apiFetch({path: NAMESPACE + endpoint, method: 'POST', data}),
+    delete: (endpoint) => apiFetch({path: NAMESPACE + endpoint, method: 'DELETE'}),
+};
 
 export default API;
 
-export const CancelToken = axios.CancelToken.source();
-
 // SWR Fetcher
 export const Fetcher = (endpoint) =>
-    API.get(endpoint).then((res) => {
-        const {data, ...rest} = res.data;
+    API.get(endpoint).then(({data, ...rest}) => {
         return {
             data,
             response: rest,
@@ -33,14 +34,15 @@ export const useLogFetcher = (endpoint, params = {}) => {
     };
 };
 
-// GET endpoint with additional parameters
+/**
+ * GET endpoint with additional parameters.
+ *
+ * @since TBD apiFetch's root URL middleware rewrites the separator on sites without
+ *            pretty permalinks, so the endpoint always uses '?' here.
+ */
 export const getEndpoint = (endpoint, data) => {
     if (data) {
-        const queryString = new URLSearchParams(data);
-        // pretty url?
-        const separator = window.GiveLogs.apiRoot.indexOf('?') === -1 ? '?' : '&';
-
-        return endpoint + separator + queryString.toString();
+        return endpoint + '?' + new URLSearchParams(data).toString();
     }
 
     return endpoint;

--- a/src/MigrationLog/Admin/Migrations/api.js
+++ b/src/MigrationLog/Admin/Migrations/api.js
@@ -1,22 +1,23 @@
-import axios from 'axios';
+import apiFetch from '@wordpress/api-fetch';
 import useSWR from 'swr';
 
-const API = axios.create({
-    baseURL: window.GiveMigrations.apiRoot,
-    headers: {
-        'Content-Type': 'application/json',
-        'X-WP-Nonce': window.GiveMigrations.apiNonce,
-    },
-});
+const NAMESPACE = '/give-api/v2/migrations';
+
+/**
+ * @since TBD Replaced axios with @wordpress/api-fetch, which resolves with the parsed
+ *            response body and supplies the REST root and nonce from WordPress core.
+ */
+const API = {
+    get: (endpoint) => apiFetch({path: NAMESPACE + endpoint}),
+    post: (endpoint, data) => apiFetch({path: NAMESPACE + endpoint, method: 'POST', data}),
+    delete: (endpoint) => apiFetch({path: NAMESPACE + endpoint, method: 'DELETE'}),
+};
 
 export default API;
 
-export const CancelToken = axios.CancelToken.source();
-
 // SWR Fetcher
 export const Fetcher = (endpoint) =>
-    API.get(endpoint).then((res) => {
-        const {data, ...rest} = res.data;
+    API.get(endpoint).then(({data, ...rest}) => {
         return {
             data,
             response: rest,
@@ -34,14 +35,15 @@ export const useMigrationFetcher = (endpoint, params = {}) => {
     };
 };
 
-// GET endpoint with additional parameters
+/**
+ * GET endpoint with additional parameters.
+ *
+ * @since TBD apiFetch's root URL middleware rewrites the separator on sites without
+ *            pretty permalinks, so the endpoint always uses '?' here.
+ */
 export const getEndpoint = (endpoint, data) => {
     if (data) {
-        const queryString = new URLSearchParams(data);
-        // pretty url?
-        const separator = window.GiveMigrations.apiRoot.indexOf('?') === -1 ? '?' : '&';
-
-        return endpoint + separator + queryString.toString();
+        return endpoint + '?' + new URLSearchParams(data).toString();
     }
 
     return endpoint;

--- a/src/MigrationLog/Admin/Migrations/index.js
+++ b/src/MigrationLog/Admin/Migrations/index.js
@@ -70,7 +70,7 @@ const Migrations = () => {
 
         API.post(url, {id: migrationRunModal.id})
            .then((response) => {
-               if (response.data.status) {
+               if (response.status) {
                    closeMigrationRunModal();
                } else {
                    setMigrationRunModal((previousState) => {
@@ -78,7 +78,7 @@ const Migrations = () => {
                            ...previousState,
                            type: 'error',
                            error: true,
-                           errorMessage: response.data.message,
+                           errorMessage: response.message,
                        };
                    });
                }

--- a/tests/e2e/donor-dashboard.spec.ts
+++ b/tests/e2e/donor-dashboard.spec.ts
@@ -1,0 +1,51 @@
+import {expect, test} from '@wordpress/e2e-test-utils-playwright';
+import {failedCalls, restCallsAfter, watchRestCalls} from './utils/rest';
+
+/**
+ * The donor dashboard, served on the front end at ?give-embed=donor-dashboard.
+ *
+ * It is the only GiveWP React app that runs outside wp-admin, and the embed template builds its
+ * own document rather than calling wp_head() and wp_footer(), so what the page enqueues is
+ * decided by GiveWP rather than by WordPress. That makes it the one screen where the REST client
+ * can be correct and still never authenticate.
+ */
+test.describe('Donor dashboard', () => {
+    /*
+     * A rejected login is the cheapest way to prove the REST client end to end on any site: the
+     * route answers 200 with the failure described in the body, so reaching the error message
+     * means the request carried a valid nonce and the client read the body shape it expects.
+     * Succeeding would need a donor account this suite has no way to assume.
+     */
+    test('front end reaches the login route', async ({page}) => {
+        const calls = watchRestCalls(page);
+
+        await page.context().clearCookies();
+        await page.goto('/?give-embed=donor-dashboard');
+
+        await expect(page.locator('#give-donor-dashboard')).toBeVisible();
+
+        /*
+         * Email access and username login are separate settings and each renders its own form,
+         * so the login form is the one holding a password field rather than the first one.
+         */
+        const loginForm = page.locator('.give-donor-dashboard__auth-modal-form').filter({
+            has: page.locator('input[type="password"]'),
+        });
+
+        if ((await loginForm.count()) === 0) {
+            test.skip(true, 'Donor dashboard login is disabled on this site.');
+        }
+
+        await loginForm.locator('input[type="text"]').fill('not-a-donor');
+        await loginForm.locator('input[type="password"]').fill('not-a-password');
+        await loginForm.getByRole('button', {name: 'Log in'}).click();
+
+        await expect(page.locator('.give-donor-dashboard__auth-modal-error')).toBeVisible();
+
+        /*
+         * The route reports a rejected login in the body at HTTP 200, so a status here means the
+         * request itself failed - a route that moved, or a nonce the embed template never supplied.
+         */
+        expect(failedCalls(await restCallsAfter(calls, '/give-api/v2/donor-dashboard/login'))).toEqual([]);
+    });
+});

--- a/tests/e2e/reports.spec.ts
+++ b/tests/e2e/reports.spec.ts
@@ -1,0 +1,28 @@
+import {expect, test} from '@wordpress/e2e-test-utils-playwright';
+import {failedCalls, restCallsAfter, watchRestCalls} from './utils/rest';
+
+/**
+ * Give > Reports. One page view fans out into a request per widget, all sharing the same REST
+ * client and the same date range, so a single visit covers every report route at once.
+ */
+test.describe('Reports', () => {
+    test('page mounts and reads every report route', async ({page, admin}) => {
+        const calls = watchRestCalls(page);
+
+        await admin.visitAdminPage('edit.php', 'post_type=give_forms&page=give-reports');
+
+        await expect(page.locator('#reports-app')).toBeVisible();
+
+        const reportCalls = await restCallsAfter(calls, '/give-api/v2/reports/income');
+
+        expect(failedCalls(reportCalls)).toEqual([]);
+
+        /*
+         * The date range is what the client puts on the query string. Asserting it here is what
+         * separates "the route answered" from "the route answered with the range asked for",
+         * which is the half a serializer change would break silently.
+         */
+        const income = reportCalls.find((call) => call.url.includes('/give-api/v2/reports/income?'));
+        expect(income?.url).toMatch(/[?&]start=\d{4}-\d{2}-\d{2}&end=\d{4}-\d{2}-\d{2}/);
+    });
+});

--- a/tests/e2e/tools-logs.spec.ts
+++ b/tests/e2e/tools-logs.spec.ts
@@ -1,0 +1,16 @@
+import {expect, test} from '@wordpress/e2e-test-utils-playwright';
+import {failedCalls, restCallsAfter, watchRestCalls} from './utils/rest';
+
+/**
+ * Give > Tools > Logs. A React list table that reads its rows from the REST API.
+ */
+test.describe('Logs', () => {
+    test('list table mounts and reads its route', async ({page, admin}) => {
+        const calls = watchRestCalls(page);
+
+        await admin.visitAdminPage('edit.php', 'post_type=give_forms&page=give-tools&tab=logs');
+
+        await expect(page.locator('#give-logs-list-table-app')).toBeVisible();
+        expect(failedCalls(await restCallsAfter(calls, '/give-api/v2/logs/get-logs'))).toEqual([]);
+    });
+});

--- a/tests/e2e/tools-migrations.spec.ts
+++ b/tests/e2e/tools-migrations.spec.ts
@@ -1,0 +1,16 @@
+import {expect, test} from '@wordpress/e2e-test-utils-playwright';
+import {failedCalls, restCallsAfter, watchRestCalls} from './utils/rest';
+
+/**
+ * Give > Tools > Data. A React list table that reads the migration log from the REST API.
+ */
+test.describe('Migrations', () => {
+    test('list table mounts and reads its route', async ({page, admin}) => {
+        const calls = watchRestCalls(page);
+
+        await admin.visitAdminPage('edit.php', 'post_type=give_forms&page=give-tools&tab=data');
+
+        await expect(page.locator('#give_migrations_table_app')).toBeVisible();
+        expect(failedCalls(await restCallsAfter(calls, '/give-api/v2/migrations/get-migrations'))).toEqual([]);
+    });
+});

--- a/tests/e2e/utils/rest.ts
+++ b/tests/e2e/utils/rest.ts
@@ -1,0 +1,55 @@
+import {expect, Page} from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Helpers for the screens that fetch their own data over the REST API from the browser.
+ *
+ * A wrong route, a missing nonce, or a response shape the client no longer unwraps all produce a
+ * page that builds and mounts cleanly and then shows nothing. Asserting on the traffic catches
+ * that where asserting on rendered records cannot, and it holds against both a fresh CI install
+ * and a populated developer site, which do not agree on what is on screen.
+ */
+
+const REST_ROUTE_PATTERN = /\/wp-json\/|[?&]rest_route=/;
+
+export type RestCall = {method: string; url: string; status: number};
+
+/**
+ * Records every REST response the page receives, from the moment it is called.
+ */
+export function watchRestCalls(page: Page): RestCall[] {
+    const calls: RestCall[] = [];
+
+    page.on('response', (response) => {
+        const url = response.url();
+
+        if (REST_ROUTE_PATTERN.test(url)) {
+            calls.push({method: response.request().method(), url, status: response.status()});
+        }
+    });
+
+    return calls;
+}
+
+/**
+ * Waits for the screen to call `route`, then returns every REST call it made.
+ *
+ * Failing here rather than on a later assertion keeps the message pointed at the request that
+ * never happened, which is what a broken route or a client that stopped firing looks like.
+ */
+export async function restCallsAfter(calls: RestCall[], route: string): Promise<RestCall[]> {
+    await expect
+        .poll(() => calls.some((call) => call.url.includes(route)), {
+            message: `Expected the screen to request ${route}`,
+            timeout: 20_000,
+        })
+        .toBe(true);
+
+    return calls;
+}
+
+/**
+ * The failed calls among `calls`, formatted for an assertion message that names them.
+ */
+export function failedCalls(calls: RestCall[]): string[] {
+    return calls.filter((call) => call.status >= 400).map((call) => `${call.status} ${call.method} ${call.url}`);
+}


### PR DESCRIPTION
`@wordpress/api-fetch` is already the client the rest of `src/` uses — 20 files across the modern domains — and it is externalized to core's `wp-api-fetch` handle, so it supplies the REST root and nonce and costs the bundles nothing. axios was doing the same job in nine older files for a dependency we ship. This removes it.

## What changed

- **Donor Dashboard** — `donorDashboardApi` is now an apiFetch wrapper over `/give-api/v2/donor-dashboard/`. Call sites drop the `.then(r => r.data)` unwrap. `auth-modal` stopped hand-building URLs off `getAPIRoot()` and reuses the same client.
- **Logs / Migrations** — axios instances replaced. Also deleted the manual plain-permalink separator logic in `getEndpoint()`; core's `createRootURLMiddleware` already does the `?` → `&` rewrite. Two dead `CancelToken` exports removed.
- **Reports** — `axios.CancelToken` → `AbortController`, aborted from the effect cleanup.
- **Onboarding wizard** — apiFetch for the WordPress routes. The ActiveCampaign call to `connect.givewp.com` deliberately uses plain `fetch`, so the REST nonce is not attached to a request leaving the site.

No PHP changed. `wp-api-fetch` reaches every affected bundle through the `.asset.php` files that `@wordpress/dependency-extraction-webpack-plugin` generates.

Error handling is centralized in one `getApiErrorMessage()`, replacing three copies of the same `error.response.status === 500` block.

## Two bugs fixed on the way

- **Reports cancellation never worked.** The old code built a fresh cancel source on *every render*, so `source.cancel()` inside the effect never referenced the request that was actually open. Now aborted from the effect cleanup.
- **Network failures threw inside the catch.** `error.response` is undefined when axios never gets a response, so `error.response.status` raised a `TypeError` and the subscription modals were left spinning. apiFetch rejects with a parsed body in every case.

## Bundle size

~51 KB off each of six bundles — `donor-dashboards-app.js` goes from 1,103,543 to 1,051,459 bytes. apiFetch is externalized to core, so it adds nothing back.

axios remains only as a transitive **dev** dependency of `wait-on`. Nothing axios ships to a browser.

## Testing

`tests/e2e/` gains four specs, one per screen, with the shared REST helpers in `tests/e2e/utils/rest.ts`. They assert on the REST traffic rather than on rendered records, because a wrong route, a missing nonce, or a response shape the client no longer unwraps all produce a page that builds and mounts cleanly and then shows nothing — and traffic assertions hold against both a fresh CI install and a populated developer site.

| Spec | Asserts |
|:--|:--|
| `tools-logs.spec.ts` | mounts, reaches `/give-api/v2/logs/get-logs` |
| `tools-migrations.spec.ts` | mounts, reaches `/give-api/v2/migrations/get-migrations` |
| `reports.spec.ts` | mounts, reaches all 11 report routes, `start`/`end` survive serialization |
| `donor-dashboard.spec.ts` | front end reaches `/give-api/v2/donor-dashboard/login` |

The donor dashboard spec is the important one: it is the only front-end screen, rendering through the embed template that builds its own document instead of calling `wp_head()`/`wp_footer()`, so it is the one place the client can be correct and still never authenticate. A deliberately rejected login proves the chain on any site with no fixtures — the route answers 200 with the failure in the body, so reaching the error message means the nonce was valid *and* the client read the `{status, body_response}` shape.

**Every spec was mutation-tested.** Breaking each route and rebuilding confirmed the matching spec goes red. That caught a bad assertion of mine: an earlier version checked `window.wp.apiFetch` existed, which stayed green even with the dashboard reverted off apiFetch entirely, because another script on the page loads `wp-api-fetch` anyway. Rewritten around the login round-trip and re-mutated.

Full suite: 8 passed.

## Layout decision

The specs are **one file per screen**, not grouped by kind of assertion. Grouping by kind puts a screen's coverage in as many files as there are kinds, so nothing tells you what a screen is covered for, and each new kind adds a file that re-lists every screen. `admin-pages.spec.ts` stays as the deliberate exception — it is the breadth-first smoke suite the add-on CI plan points at environments core does not control. `docs/testing.md` documents the rule.

## Not covered

The onboarding wizard has no spec. Its apiFetch calls only fire on interaction, and driving the wizard writes real site settings (currency, country) into the shared test database — `workers: 1` exists because these specs share one site. Covering it wants `requestUtils.rest()` seeding and restoring its own state, which is a larger piece of work.

## Unrelated bug found

The donor dashboard's `recurring-donations/subscriptions` route returns HTTP 500 on a populated dev site:

```
{"code":"error","message":"Invalid receipt section line item. Please provide valid line item id, label, and value."}
```

Confirmed pre-existing by rebuilding on the axios baseline and re-probing — identical 500. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## DEMO

https://www.loom.com/share/f634860fed0043b4a8f4760e56353ef2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved reliability and consistency across dashboard, reports, logs, migrations, onboarding, profile, donation, and subscription features.
  * Enhanced API error messages and request cancellation behavior.
  * Improved newsletter submissions and form previews.
  * Preserved report sample-data behavior and date filtering.

* **Testing**
  * Added end-to-end coverage for donor login, reports, logs, and migrations.

* **Documentation**
  * Added guidance for organizing browser tests and validating REST activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->