### PR TITLE
Fix: reset Give_DB_Meta filter callback state

### DIFF
--- a/changelog/fix-reset-give-db-meta-filter-callback.yaml
+++ b/changelog/fix-reset-give-db-meta-filter-callback.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: fix
+entry: Reset Give_DB_Meta filter callback state on every exit so a metadata filter bailout cannot affect later direct calls.
+timestamp: 2026-08-30T00:00:00.000Z

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -125,6 +125,7 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Retrieve payment meta field for a payment.
 	 *
+	 * @since TBD Clear filter callback state before returning from any path.
 	 * @since 3.1.0 Return empty array, when request raw metadata if $single is set to false and metadata does not exist.
 	 * @since   2.0
 	 *
@@ -137,9 +138,11 @@ class Give_DB_Meta extends Give_DB {
 	 */
 	public function get_meta( $id = 0, $meta_key = '', $single = false ) {
 		$previousMetaTableName = $this->setMetaTableName();
+		$is_filter_callback   = $this->is_filter_callback;
+		$this->is_filter_callback = false;
 
 		try {
-			if ( ! $this->is_filter_callback ) {
+			if ( ! $is_filter_callback ) {
 				return get_metadata( $this->meta_type, $id, $meta_key, $single );
 			}
 
@@ -177,6 +180,7 @@ class Give_DB_Meta extends Give_DB {
 	 * For internal use only. Use Give_Payment->add_meta() for public usage.
 	 *
 	 * @access  private
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -188,9 +192,11 @@ class Give_DB_Meta extends Give_DB {
 	 */
 	public function add_meta( $id, $meta_key, $meta_value, $unique = false ) {
 		$previousMetaTableName = $this->setMetaTableName();
+		$is_filter_callback   = $this->is_filter_callback;
+		$this->is_filter_callback = false;
 
 		try {
-			if ( $this->is_filter_callback ) {
+			if ( $is_filter_callback ) {
 				$id = $this->sanitize_id( $id );
 
 				// Bailout.
@@ -224,6 +230,7 @@ class Give_DB_Meta extends Give_DB {
 	 * If the meta field for the payment does not exist, it will be added.
 	 *
 	 * @access  public
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -235,9 +242,11 @@ class Give_DB_Meta extends Give_DB {
 	 */
 	public function update_meta( $id, $meta_key, $meta_value, $prev_value = '' ) {
 		$previousMetaTableName = $this->setMetaTableName();
+		$is_filter_callback   = $this->is_filter_callback;
+		$this->is_filter_callback = false;
 
 		try {
-			if ( $this->is_filter_callback ) {
+			if ( $is_filter_callback ) {
 				$id = $this->sanitize_id( $id );
 
 				// Bailout.
@@ -268,6 +277,7 @@ class Give_DB_Meta extends Give_DB {
 	 * allows removing all metadata matching key, if needed.
 	 *
 	 * @access  public
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -279,9 +289,11 @@ class Give_DB_Meta extends Give_DB {
 	 */
 	public function delete_meta( $id = 0, $meta_key = '', $meta_value = '', $delete_all = '' ) {
 		$previousMetaTableName = $this->setMetaTableName();
+		$is_filter_callback   = $this->is_filter_callback;
+		$this->is_filter_callback = false;
 
 		try {
-			if ( $this->is_filter_callback ) {
+			if ( $is_filter_callback ) {
 				$id = $this->sanitize_id( $id );
 
 				// Bailout.
@@ -472,6 +484,7 @@ class Give_DB_Meta extends Give_DB {
 	 *
 	 * @since  2.0
 	 * @since 2.9.6 Added a Short circuit check when updating meta.
+	 * @since TBD Clear filter callback state before bailout and short-circuit returns.
 	 *
 	 * @access public
 	 *
@@ -492,6 +505,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -506,6 +520,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -522,11 +537,13 @@ class Give_DB_Meta extends Give_DB {
 
 				// Short circuit if the meta value has already been updated.
 				if ( null !== $this->check ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -542,6 +559,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 

--- a/includes/database/class-give-db-meta.php
+++ b/includes/database/class-give-db-meta.php
@@ -126,6 +126,7 @@ class Give_DB_Meta extends Give_DB {
 	/**
 	 * Retrieve payment meta field for a payment.
 	 *
+	 * @since TBD Clear filter callback state before returning from any path.
 	 * @since 3.1.0 Return empty array, when request raw metadata if $single is set to false and metadata does not exist.
 	 * @since   2.0
 	 *
@@ -137,7 +138,10 @@ class Give_DB_Meta extends Give_DB {
 	 *                                is true.
 	 */
 	public function get_meta( $id = 0, $meta_key = '', $single = false ) {
-		if ( ! $this->is_filter_callback ) {
+		$is_filter_callback       = $this->is_filter_callback;
+		$this->is_filter_callback = false;
+
+		if ( ! $is_filter_callback ) {
 			return get_metadata( $this->meta_type, $id, $meta_key, $single );
 		}
 
@@ -160,8 +164,6 @@ class Give_DB_Meta extends Give_DB {
 			$value = get_metadata( $this->meta_type, $id, $meta_key, $single );
 		}
 
-		$this->is_filter_callback = false;
-
 		return $value;
 	}
 
@@ -172,6 +174,7 @@ class Give_DB_Meta extends Give_DB {
 	 * For internal use only. Use Give_Payment->add_meta() for public usage.
 	 *
 	 * @access  private
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -182,7 +185,10 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  int|bool                  False for failure. True for success.
 	 */
 	public function add_meta( $id, $meta_key, $meta_value, $unique = false ) {
-		if ( $this->is_filter_callback ) {
+		$is_filter_callback       = $this->is_filter_callback;
+		$this->is_filter_callback = false;
+
+		if ( $is_filter_callback ) {
 			$id = $this->sanitize_id( $id );
 
 			// Bailout.
@@ -196,8 +202,6 @@ class Give_DB_Meta extends Give_DB {
 		if ( $meta_id ) {
 			$this->delete_cache( $id );
 		}
-
-		$this->is_filter_callback = false;
 
 		return $meta_id;
 	}
@@ -213,6 +217,7 @@ class Give_DB_Meta extends Give_DB {
 	 * If the meta field for the payment does not exist, it will be added.
 	 *
 	 * @access  public
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -223,7 +228,10 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  int|bool                  False on failure, true if success.
 	 */
 	public function update_meta( $id, $meta_key, $meta_value, $prev_value = '' ) {
-		if ( $this->is_filter_callback ) {
+		$is_filter_callback       = $this->is_filter_callback;
+		$this->is_filter_callback = false;
+
+		if ( $is_filter_callback ) {
 			$id = $this->sanitize_id( $id );
 
 			// Bailout.
@@ -238,8 +246,6 @@ class Give_DB_Meta extends Give_DB {
 			$this->delete_cache( $id );
 		}
 
-		$this->is_filter_callback = false;
-
 		return $meta_id;
 	}
 
@@ -251,6 +257,7 @@ class Give_DB_Meta extends Give_DB {
 	 * allows removing all metadata matching key, if needed.
 	 *
 	 * @access  public
+	 * @since   TBD Clear filter callback state before returning from any path.
 	 * @since   2.0
 	 *
 	 * @param   int    $id         Post Type ID.
@@ -261,7 +268,10 @@ class Give_DB_Meta extends Give_DB {
 	 * @return  bool                  False for failure. True for success.
 	 */
 	public function delete_meta( $id = 0, $meta_key = '', $meta_value = '', $delete_all = '' ) {
-		if ( $this->is_filter_callback ) {
+		$is_filter_callback       = $this->is_filter_callback;
+		$this->is_filter_callback = false;
+
+		if ( $is_filter_callback ) {
 			$id = $this->sanitize_id( $id );
 
 			// Bailout.
@@ -275,8 +285,6 @@ class Give_DB_Meta extends Give_DB {
 		if ( $is_meta_deleted ) {
 			$this->delete_cache( $id );
 		}
-
-		$this->is_filter_callback = false;
 
 		return $is_meta_deleted;
 	}
@@ -449,6 +457,7 @@ class Give_DB_Meta extends Give_DB {
 	 *
 	 * @since  2.0
 	 * @since 2.9.6 Added a Short circuit check when updating meta.
+	 * @since TBD Clear filter callback state before bailout and short-circuit returns.
 	 *
 	 * @access public
 	 *
@@ -469,6 +478,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -483,6 +493,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -499,11 +510,13 @@ class Give_DB_Meta extends Give_DB {
 
 				// Short circuit if the meta value has already been updated.
 				if ( null !== $this->check ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 
@@ -519,6 +532,7 @@ class Give_DB_Meta extends Give_DB {
 
 				// Bailout.
 				if ( ! $this->is_valid_post_type( $id ) ) {
+					$this->is_filter_callback = false;
 					return $this->check;
 				}
 

--- a/tests/includes/legacy/tests-donor-meta.php
+++ b/tests/includes/legacy/tests-donor-meta.php
@@ -41,6 +41,56 @@ class Tests_Donor_Meta extends Give_Unit_Test_Case {
 	}
 
 	/**
+	 * Ensure direct metadata methods clear stale filter callback state.
+	 *
+	 * @since TBD
+	 */
+	function test_direct_metadata_methods_clear_stale_filter_callback_state() {
+		$meta     = Give()->donor_meta;
+		$property = new ReflectionProperty( Give_DB_Meta::class, 'is_filter_callback' );
+		$property->setAccessible( true );
+
+		$property->setValue( $meta, true );
+		$meta->add_meta( 0, 'test_key', '1' );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$property->setValue( $meta, true );
+		$meta->update_meta( 0, 'test_key', '2' );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$property->setValue( $meta, true );
+		$meta->get_meta( 0, 'test_key', true );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$property->setValue( $meta, true );
+		$meta->delete_meta( 0, 'test_key' );
+		$this->assertFalse( $property->getValue( $meta ) );
+	}
+
+	/**
+	 * Ensure metadata filter bailout paths clear callback state.
+	 *
+	 * @since TBD
+	 */
+	function test_filter_bailout_clears_callback_state() {
+		$meta     = Give()->donor_meta;
+		$property = new ReflectionProperty( Give_DB_Meta::class, 'is_filter_callback' );
+		$property->setAccessible( true );
+
+		$meta->__add_meta( false, 0, 'test_key', '1', false );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$meta->__get_meta( false, 0, 'test_key', true );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$meta->__update_meta( null, 0, 'test_key', '2', '' );
+		$this->assertFalse( $property->getValue( $meta ) );
+
+		$meta->__delete_meta( false, 0, 'test_key', '', '' );
+		$this->assertFalse( $property->getValue( $meta ) );
+	}
+
+	/**
 	 * Test update metadata.
 	 */
 	function test_update_metadata() {

--- a/tests/includes/legacy/tests-donor-meta.php
+++ b/tests/includes/legacy/tests-donor-meta.php
@@ -45,7 +45,7 @@ class Tests_Donor_Meta extends Give_Unit_Test_Case {
 	 *
 	 * @since TBD
 	 */
-	function test_direct_metadata_methods_clear_stale_filter_callback_state() {
+	public function test_direct_metadata_methods_clear_stale_filter_callback_state() {
 		$meta     = Give()->donor_meta;
 		$property = new ReflectionProperty( Give_DB_Meta::class, 'is_filter_callback' );
 		$property->setAccessible( true );
@@ -72,7 +72,7 @@ class Tests_Donor_Meta extends Give_Unit_Test_Case {
 	 *
 	 * @since TBD
 	 */
-	function test_filter_bailout_clears_callback_state() {
+	public function test_filter_bailout_clears_callback_state() {
 		$meta     = Give()->donor_meta;
 		$property = new ReflectionProperty( Give_DB_Meta::class, 'is_filter_callback' );
 		$property->setAccessible( true );


### PR DESCRIPTION
## Summary

`Give_DB_Meta` keeps a private `$is_filter_callback` flag to distinguish calls coming through WordPress metadata filters from direct calls. Filter bailouts returned before clearing the flag, so later direct metadata calls in the same request could be treated as filter calls and silently fail.

This change clears the flag on entry to each public metadata method and before every dispatcher bailout or short-circuit return. PHP 7.4 compatible, with no signature or visibility changes.

Fixes #8287

## Reproduction

```php
// Simulate a metadata filter passing an invalid ID.
Give()->donor_meta->__add_meta( false, 0, 'ignored_key', 'ignored_value', false );

// Later in the same request, a direct call.
$donor = new Give_Donor( $donor_id );
$donor->add_meta( 'real_key', 'real_value' ); // Pre-fix: silently fails. Post-fix: writes.
```

## Changes

### `includes/database/class-give-db-meta.php`

`get_meta()`, `add_meta()`, `update_meta()`, and `delete_meta()` now capture the flag locally and clear object state before branching. Dispatcher arms also clear state before bailout and short-circuit returns. Added `@since TBD` documentation.

### `tests/includes/legacy/tests-donor-meta.php`

Added regression coverage for all four public methods and all four dispatcher bailout paths. Tests use reflection to verify the private flag is cleared, which distinguishes fixed behavior from the pre-fix implementation.

### `changelog/fix-reset-give-db-meta-filter-callback.yaml`

Added patch changelog entry.

## Testing

- `php -l includes/database/class-give-db-meta.php` passed.
- `php -l tests/includes/legacy/tests-donor-meta.php` passed.
- `git diff --check` passed.
- `coderabbit review --agent` returned 0 findings.
- `npm run plugin-zip` completed and produced `give.zip`.
- PHPUnit could not run in this environment because MySQL was unavailable (`mysqli_real_connect(): Connection refused` on `127.0.0.1:3306`). Run the following with the WordPress test environment available:
  ```sh
  npm run env:start
  composer test -- --filter Tests_Donor_Meta
  composer test
  ```

No UI changes. No screenshots needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata operations so filter callback state is consistently cleared after direct calls and filter-related bailouts.
  * Prevented stale metadata-filter state from affecting subsequent operations.
  * Improved metadata table handling to preserve reliable metadata access across operations.

* **Tests**
  * Added coverage for state reset behavior across metadata retrieval, creation, updates, deletion, and bailout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->