### PR TITLE
Fix: skip empty donor phone save

### DIFF
--- a/changelog/fix-skip-donor-save-when-no-phone-submitted.yaml
+++ b/changelog/fix-skip-donor-save-when-no-phone-submitted.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Prevented a no-op donor save (and re-validation) on every returning
+  donation when the submitted form did not include a phone number.
+timestamp: 2026-08-30T00:00:00.000Z

--- a/src/DonationForms/Actions/GetOrCreateDonor.php
+++ b/src/DonationForms/Actions/GetOrCreateDonor.php
@@ -13,6 +13,7 @@ class GetOrCreateDonor
     public $donorCreated = false;
 
     /**
+     * @since TBD Skip updating donor when no phone is submitted.
      * @since 3.9.0 Add support to "phone" property
      * @since 3.2.0
      *
@@ -41,7 +42,7 @@ class GetOrCreateDonor
         }
 
         // if they exist as a donor & user but don't have a phone number then add it to their profile.
-        if ($donor && empty($donor->phone)) {
+        if ($donor && empty($donor->phone) && !empty($donorPhone)) {
             $donor->phone = $donorPhone;
             $donor->save();
         }

--- a/tests/Unit/DonationForms/Actions/TestGetOrCreateDonor.php
+++ b/tests/Unit/DonationForms/Actions/TestGetOrCreateDonor.php
@@ -101,4 +101,38 @@ class TestGetOrCreateDonor extends TestCase
         $this->assertSame('+120155501234', $donorFromAction->phone);
         $this->assertTrue($action->donorCreated);
     }
+
+    /**
+     * Regression for #8286: a returning donor whose stored phone is empty must
+     * not be saved when the submitted form provides no phone value.
+     *
+     * @since TBD
+     *
+     * @throws Exception
+     */
+    public function testShouldNotSaveDonorWhenStoredAndIncomingPhoneAreEmpty(): void
+    {
+        $donor = Donor::factory()->create(['userId' => 1]);
+        $donor->phone = '';
+        $donor->save();
+
+        $updateCount = 0;
+        $updatingAction = function () use (&$updateCount) {
+            $updateCount++;
+        };
+        add_action('givewp_donor_updating', $updatingAction);
+
+        try {
+            $action = new GetOrCreateDonor();
+            $result = $action($donor->userId, $donor->email, $donor->firstName, $donor->lastName,
+                $donor->prefix, null);
+
+            $this->assertSame($donor->id, $result->id);
+            $this->assertFalse($action->donorCreated);
+            $this->assertSame(0, $updateCount, 'Donor save should be skipped when no phone is submitted.');
+            $this->assertSame('', give()->donors->getById($donor->id)->phone);
+        } finally {
+            remove_action('givewp_donor_updating', $updatingAction);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Prevent `GetOrCreateDonor` from saving an existing donor when both the stored phone and the submitted phone are empty.

This avoids repeated donor validation, database updates, and donor metadata writes on returning donations from forms without a phone field.

Fixes #8286

## Changes

### `GetOrCreateDonor`

**Before:**

```php
if ($donor && empty($donor->phone)) {
    $donor->phone = $donorPhone;
    $donor->save();
}
```

**After:**

```php
if ($donor && empty($donor->phone) && !empty($donorPhone)) {
    $donor->phone = $donorPhone;
    $donor->save();
}
```

The donor is updated only when a phone value is available to add. Existing phone backfill behavior is unchanged.

### Regression test

Added `testShouldNotSaveDonorWhenStoredAndIncomingPhoneAreEmpty` to `TestGetOrCreateDonor`. It creates a donor with an empty stored phone, invokes the action with a null phone, and asserts no `givewp_donor_updating` event fires and the stored phone is untouched.

## How to test the fix

1. Create a donation form without a phone field.
2. Make a donation as a new donor.
3. Make another donation using the same email.
4. Before this change, `GetOrCreateDonor` called `save()` on the existing donor even though no phone value was submitted, re-running validation and writing to `give_donors` plus donor meta.
5. After this change, no donor update occurs and the donation proceeds without the unnecessary write.

## Testing

- Focused PHPUnit run: `TestGetOrCreateDonor` passes with 6 tests, 19 assertions.
- Full PHPUnit suite: 2990 tests, one pre-existing unrelated error in `Tests_Payments::test_update_payment_status_with_invalid_id` (reproduces on `develop` without this change).
- Changelog entry added via `composer run changelog:add`.
- New and changed code carries `@since TBD` docblock tags.

No visual changes, so no screenshots.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700436&installation_model_id=426813&pr_number=8307&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8307&signature=56e75af3c4d0fc2d7c9fc3b8f7c468854b1adc63e35e7a6adf8e7927593a28da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary donor record saves when both stored and submitted phone numbers are empty.
  * Improved re-validation behavior for returning donations submitted without a phone number.

* **Documentation**
  * Added a changelog entry describing the donor-save fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->