### PR TITLE
Fix: intermittent CI failures from floating-point precision in payment tests

### DIFF
--- a/tests/includes/legacy/tests-payment-class.php
+++ b/tests/includes/legacy/tests-payment-class.php
@@ -254,10 +254,10 @@ class Tests_Payment_Class extends Give_Unit_Test_Case {
 
 		$form2 = new Give_Donate_Form( $form->ID );
 
-		$this->assertEquals( $earnings - $form2->price, $form2->earnings );
+		$this->assertEqualsWithDelta( $earnings - $form2->price, $form2->earnings, 0.001 );
 		$this->assertEquals( $sales - 1, $form2->sales );
 
-		$this->assertEquals( $site_earnings - $payment->total, give_get_total_earnings() );
+		$this->assertEqualsWithDelta( $site_earnings - $payment->total, give_get_total_earnings(), 0.001 );
 		$this->assertEquals( $site_sales - 1, give_get_total_donations() );
 	}
 
@@ -285,7 +285,7 @@ class Tests_Payment_Class extends Give_Unit_Test_Case {
 
 		$form2 = new Give_Donate_Form( $form->ID );
 
-		$this->assertEquals( $earnings - $form->price, $form2->earnings );
+		$this->assertEqualsWithDelta( $earnings - $form->price, $form2->earnings, 0.001 );
 		$this->assertEquals( $sales - 1, $form2->sales );
 
 	}
@@ -317,13 +317,13 @@ class Tests_Payment_Class extends Give_Unit_Test_Case {
 		$donor = new Give_Donor( $payment->customer_id );
 		$form  = new Give_Donate_Form( $payment->form_id );
 
-		$this->assertEquals( $donor_earnings - $payment->total, $donor->get_total_donation_amount() );
+		$this->assertEqualsWithDelta( $donor_earnings - $payment->total, $donor->get_total_donation_amount(), 0.001 );
 		$this->assertEquals( $donor_sales - 1, $donor->purchase_count );
 
-		$this->assertEquals( $form_earnings - $payment->total, $form->earnings );
+		$this->assertEqualsWithDelta( $form_earnings - $payment->total, $form->earnings, 0.001 );
 		$this->assertEquals( $form_sales - 1, $form->sales );
 
-		$this->assertEquals( $site_earnings - $payment->total, give_get_total_earnings() );
+		$this->assertEqualsWithDelta( $site_earnings - $payment->total, give_get_total_earnings(), 0.001 );
 		$this->assertEquals( $site_sales - 1, give_get_total_donations() );
 	}
 
@@ -407,13 +407,13 @@ class Tests_Payment_Class extends Give_Unit_Test_Case {
 		$donor = new Give_Donor( $payment->customer_id );
 		$form  = new Give_Donate_Form( $payment->form_id );
 
-		$this->assertEquals( $donor_earnings - $payment->total, $donor->get_total_donation_amount() );
+		$this->assertEqualsWithDelta( $donor_earnings - $payment->total, $donor->get_total_donation_amount(), 0.001 );
 		$this->assertEquals( $donor_sales - 1, $donor->purchase_count );
 
-		$this->assertEquals( $form_earnings - $payment->total, $form->earnings );
+		$this->assertEqualsWithDelta( $form_earnings - $payment->total, $form->earnings, 0.001 );
 		$this->assertEquals( $form_sales - 1, $form->sales );
 
-		$this->assertEquals( $site_earnings - $payment->total, give_get_total_earnings() );
+		$this->assertEqualsWithDelta( $site_earnings - $payment->total, give_get_total_earnings(), 0.001 );
 		$this->assertEquals( $site_sales - 1, give_get_total_donations() );
 	}
 


### PR DESCRIPTION
# housekeeping: Ocasional CI failures due to floating-point precision

**Some failures occur ocasionally on CI, which needs to be re-runned.
This PR solves that by asseting with a floating-point margin of error.**

One example: https://github.com/impress-org/givewp/actions/runs/33211028525/job/98983999701?pr=8305

<details>
<summary>Details</summary>

Fixes intermittent CI failures caused by floating-point precision errors in Tests_Payment_Class.

PHP floating-point arithmetic on monetary values (e.g., 2050.07 - 20.00 = 2030.0700000000002) caused strict assertEquals to fail with 'Failed asserting that 2030.07 matches expected 2030.0700000000002'.

Replaces 9 strict assertions with assertEqualsWithDelta(..., 0.001) in test_refund_payment, test_refund_payment_legacy, test_refund_affecting_stats, test_pending_affecting_stats. Delta 0.001 is sufficient for monetary values while catching genuine errors.
</details>


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790809650&installation_model_id=426813&pr_number=8308&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8308&signature=dfe8a35c99b8edb13d9a41420fd47d1327f4b4387f91fd43870aaa0b075f6b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of refund and pending-payment earnings statistics by allowing for minor floating-point calculation differences.
  * Coverage now consistently checks donor, form, and site earnings while preserving existing sales assertions.
  * No changes to payment behavior or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->