### PR TITLE
Feature: external embed snippet in the form builder embed flow

### DIFF
--- a/changelog/enhancement-external-embed-code-in-form-builder.yaml
+++ b/changelog/enhancement-external-embed-code-in-form-builder.yaml
@@ -1,4 +1,0 @@
-significance: patch
-type: enhancement
-entry: Added a copyable external website embed snippet to the form builder's Embed Form flow.
-timestamp: 2026-09-01T00:00:00.000Z

--- a/changelog/enhancement-external-embed-code-in-form-builder.yaml
+++ b/changelog/enhancement-external-embed-code-in-form-builder.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: enhancement
+entry: Added a copyable external website embed snippet to the form builder's Embed Form flow.
+timestamp: 2026-09-01T00:00:00.000Z

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -25,6 +25,7 @@ use Give_License;
 class FormBuilderViewModel
 {
     /**
+     * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the returned array
      * @since 4.14.0 Add countries key to the returned array
      * @since 3.12.0 Add goalProgressOptions key to the returned array
      * @since 3.9.0 Add support to intlTelInputSettings key in the returned array
@@ -41,6 +42,8 @@ class FormBuilderViewModel
             'formId' => $donationFormId,
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
+            'homeUrl' => home_url(),
+            'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . 'build/externalFormEmbed.js',
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),
             'settings' => $donationForm->settings->toJson(),

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -4,6 +4,7 @@ namespace Give\FormBuilder\ViewModels;
 
 use Give\Campaigns\Models\Campaign;
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
+use Give\DonationForms\Actions\GenerateExternalEmbedScriptUrl;
 use Give\DonationForms\Models\DonationForm;
 use Give\DonationForms\ValueObjects\GoalProgressType;
 use Give\DonationForms\ValueObjects\GoalSource;
@@ -17,7 +18,6 @@ use Give\FormBuilder\ValueObjects\FormBuilderRestRouteConfig;
 use Give\Framework\FormDesigns\FormDesign;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\PaymentGateways\PaymentGateway;
-use Give\DonationForms\Routes\ExternalEmbedScriptRoute;
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Helpers\IntlTelInput;
 use Give\Subscriptions\Models\Subscription;
@@ -44,7 +44,7 @@ class FormBuilderViewModel
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
             'homeUrl' => home_url(),
-            'externalEmbedScriptUrl' => ExternalEmbedScriptRoute::url(),
+            'externalEmbedScriptUrl' => (new GenerateExternalEmbedScriptUrl())(),
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),
             'settings' => $donationForm->settings->toJson(),

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -26,7 +26,7 @@ use Give_License;
 class FormBuilderViewModel
 {
     /**
-     * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the returned array
+     * @since TBD Add externalEmbedScriptUrl key to the returned array
      * @since 4.14.0 Add countries key to the returned array
      * @since 3.12.0 Add goalProgressOptions key to the returned array
      * @since 3.9.0 Add support to intlTelInputSettings key in the returned array
@@ -43,7 +43,6 @@ class FormBuilderViewModel
             'formId' => $donationFormId,
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
-            'homeUrl' => home_url(),
             'externalEmbedScriptUrl' => (new GenerateExternalEmbedScriptUrl())(),
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -17,6 +17,7 @@ use Give\FormBuilder\ValueObjects\FormBuilderRestRouteConfig;
 use Give\Framework\FormDesigns\FormDesign;
 use Give\Framework\FormDesigns\Registrars\FormDesignRegistrar;
 use Give\Framework\PaymentGateways\PaymentGateway;
+use Give\DonationForms\Routes\ExternalEmbedScriptRoute;
 use Give\Framework\Support\Facades\Scripts\ScriptAsset;
 use Give\Helpers\IntlTelInput;
 use Give\Subscriptions\Models\Subscription;
@@ -24,15 +25,6 @@ use Give_License;
 
 class FormBuilderViewModel
 {
-    /**
-     * The built script that renders a form on another website. The path
-     * matches the externalFormEmbed entry in webpack.config.js, and snippets
-     * already pasted into third-party sites point at it, so it must not move.
-     *
-     * @since TBD
-     */
-    public const EXTERNAL_EMBED_SCRIPT_PATH = 'build/externalFormEmbed.js';
-
     /**
      * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the returned array
      * @since 4.14.0 Add countries key to the returned array
@@ -52,7 +44,7 @@ class FormBuilderViewModel
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
             'homeUrl' => home_url(),
-            'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . self::EXTERNAL_EMBED_SCRIPT_PATH,
+            'externalEmbedScriptUrl' => ExternalEmbedScriptRoute::url(),
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),
             'settings' => $donationForm->settings->toJson(),

--- a/src/FormBuilder/ViewModels/FormBuilderViewModel.php
+++ b/src/FormBuilder/ViewModels/FormBuilderViewModel.php
@@ -25,6 +25,15 @@ use Give_License;
 class FormBuilderViewModel
 {
     /**
+     * The built script that renders a form on another website. The path
+     * matches the externalFormEmbed entry in webpack.config.js, and snippets
+     * already pasted into third-party sites point at it, so it must not move.
+     *
+     * @since TBD
+     */
+    public const EXTERNAL_EMBED_SCRIPT_PATH = 'build/externalFormEmbed.js';
+
+    /**
      * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the returned array
      * @since 4.14.0 Add countries key to the returned array
      * @since 3.12.0 Add goalProgressOptions key to the returned array
@@ -43,7 +52,7 @@ class FormBuilderViewModel
             'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $donationFormId),
             'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($donationFormId),
             'homeUrl' => home_url(),
-            'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . 'build/externalFormEmbed.js',
+            'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . self::EXTERNAL_EMBED_SCRIPT_PATH,
             'nonce' => wp_create_nonce('wp_rest'),
             'blockData' => $donationForm->blocks->toJson(),
             'settings' => $donationForm->settings->toJson(),

--- a/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
@@ -39,6 +39,7 @@ type GoalProgressOption = {
 };
 
 /**
+ * @since TBD Added homeUrl and externalEmbedScriptUrl
  * @since 3.12.0 Added goalProgressOptions
  * @since 3.9.0 Added intlTelInputSettings
  * @since 3.7.0 Added isExcerptEnabled
@@ -49,6 +50,8 @@ interface FormBuilderWindowData {
     nonce: string;
     resourceURL: string;
     previewURL: string;
+    homeUrl: string;
+    externalEmbedScriptUrl: string;
     blockData: string;
     settings: string;
     formDesigns: FormDesign[];

--- a/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/common/getWindowData.ts
@@ -39,7 +39,7 @@ type GoalProgressOption = {
 };
 
 /**
- * @since TBD Added homeUrl and externalEmbedScriptUrl
+ * @since TBD Added externalEmbedScriptUrl
  * @since 3.12.0 Added goalProgressOptions
  * @since 3.9.0 Added intlTelInputSettings
  * @since 3.7.0 Added isExcerptEnabled
@@ -50,7 +50,6 @@ interface FormBuilderWindowData {
     nonce: string;
     resourceURL: string;
     previewURL: string;
-    homeUrl: string;
     externalEmbedScriptUrl: string;
     blockData: string;
     settings: string;

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -290,12 +290,31 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     }
 
     /**
+     * The snippet carries the selected display style and the translated
+     * donor-facing strings, since the standalone embed script has no access
+     * to WordPress translations.
+     *
      * @since TBD
      */
     const getExternalEmbedSnippet = () => {
+        const attributes = [
+            `form-id="${formId}"`,
+            `wp-url="${homeUrl}"`,
+            `fallback-text="${__('Open donation form', 'give')}"`,
+        ];
+
+        if (isButton) {
+            attributes.push(`display-style="${state.selectedStyle}"`);
+            attributes.push(`button-text="${state.openFormButton || __('Donate', 'give')}"`);
+        }
+
+        if (state.selectedStyle === 'modal') {
+            attributes.push(`close-text="${__('Close', 'give')}"`);
+        }
+
         return [
             `<script src="${externalEmbedScriptUrl}" defer></script>`,
-            `<givewp-donation-form form-id="${formId}" wp-url="${homeUrl}"></givewp-donation-form>`,
+            `<givewp-donation-form ${attributes.join(' ')}></givewp-donation-form>`,
         ].join('\n');
     };
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -47,8 +47,29 @@ interface StateProps {
  */
 export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
-    const {formId, homeUrl, externalEmbedScriptUrl, blockData} = getWindowData();
+    const {formId, homeUrl, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
     const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
+
+    /**
+     * The external embed script cannot read form settings, so the snippet
+     * carries the form's colors as attributes. Campaign colors win when the
+     * form inherits them, matching how the form itself resolves colors.
+     *
+     * @since TBD
+     */
+    const getEmbedColors = (): {primary: string; secondary: string} => {
+        try {
+            const parsedSettings = JSON.parse(settings);
+            const inherit = parsedSettings.inheritCampaignColors;
+
+            return {
+                primary: (inherit && campaignColors?.primaryColor) || parsedSettings.primaryColor || '',
+                secondary: (inherit && campaignColors?.secondaryColor) || parsedSettings.secondaryColor || '',
+            };
+        } catch (error) {
+            return {primary: '', secondary: ''};
+        }
+    };
 
     /**
      * Login inside a cross-origin embed is unreliable in some browsers, so
@@ -302,6 +323,14 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
             `wp-url="${homeUrl}"`,
             `fallback-text="${__('Open donation form', 'give')}"`,
         ];
+
+        const colors = getEmbedColors();
+        if (colors.primary) {
+            attributes.push(`primary-color="${colors.primary}"`);
+        }
+        if (colors.secondary) {
+            attributes.push(`secondary-color="${colors.secondary}"`);
+        }
 
         if (isButton) {
             attributes.push(`display-style="${state.selectedStyle}"`);

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -4,7 +4,7 @@ import {createPortal} from 'react-dom';
 import {useDispatch, useSelect} from '@wordpress/data';
 import {store} from '@wordpress/core-data';
 import {__, sprintf} from '@wordpress/i18n';
-import {Button, RadioControl, SelectControl, Spinner, TextControl} from '@wordpress/components';
+import {Button, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
 import {external} from '@wordpress/icons';
 import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
@@ -50,6 +50,14 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     const {formId, homeUrl, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
     const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
 
+    const parsedSettings = (() => {
+        try {
+            return JSON.parse(settings);
+        } catch (error) {
+            return {};
+        }
+    })();
+
     /**
      * The external embed script cannot read form settings, so the snippet
      * carries the form's colors as attributes. Campaign colors win when the
@@ -58,18 +66,22 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      * @since TBD
      */
     const getEmbedColors = (): {primary: string; secondary: string} => {
-        try {
-            const parsedSettings = JSON.parse(settings);
-            const inherit = parsedSettings.inheritCampaignColors;
+        const inherit = parsedSettings.inheritCampaignColors;
 
-            return {
-                primary: (inherit && campaignColors?.primaryColor) || parsedSettings.primaryColor || '',
-                secondary: (inherit && campaignColors?.secondaryColor) || parsedSettings.secondaryColor || '',
-            };
-        } catch (error) {
-            return {primary: '', secondary: ''};
-        }
+        return {
+            primary: (inherit && campaignColors?.primaryColor) || parsedSettings.primaryColor || '',
+            secondary: (inherit && campaignColors?.secondaryColor) || parsedSettings.secondaryColor || '',
+        };
     };
+
+    /**
+     * The confirmation page redirect sends donors to a page on this
+     * WordPress site after donating - which means leaving the site the form
+     * is embedded on, so the external tab warns about it.
+     *
+     * @since TBD
+     */
+    const hasConfirmationRedirect = !!parsedSettings.enableReceiptConfirmationPage;
 
     /**
      * Login inside a cross-origin embed is unreliable in some browsers, so
@@ -461,6 +473,78 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                 </button>
             </div>
 
+            <TabPanel
+                className="give-embed-modal-tabs"
+                tabs={[
+                    {name: 'internal', title: __('This site', 'give')},
+                    {name: 'external', title: __('External website', 'give')},
+                ]}
+            >
+                {(tab) => tab.name === 'external' ? (
+                    <>
+                        <div className="give-embed-modal-row">
+                            <strong>
+                                {__('Embed on an external website', 'give')}
+                            </strong>
+
+                            <div className="give-embed-modal-helptext">
+                                {__('Copy and paste this snippet into any non-WordPress website to display this donation form there.', 'give')}
+                            </div>
+
+                            <SelectControl
+                                label={__('Display style', 'give')}
+                                value={state.selectedStyle}
+                                options={displayStyles}
+                                onChange={value => setState(prevState => {
+                                    return {
+                                        ...prevState,
+                                        selectedStyle: value,
+                                    };
+                                })}
+                                help={getStyleDescription()}
+                            />
+
+                            {isButton && (
+                                <TextControl
+                                    placeholder={__('Donate', 'give')}
+                                    label={__('Button label', 'give')}
+                                    value={state.openFormButton}
+                                    onChange={value => setState(prevState => {
+                                        return {
+                                            ...prevState,
+                                            openFormButton: value,
+                                        };
+                                    })}
+                                />
+                            )}
+
+                            {hasRequiredLogin && (
+                                <div className="give-embed-modal-helptext">
+                                    {__('This form requires donor login, which is unreliable inside embedded forms in some browsers (like Safari). Consider making login optional for external embedding.', 'give')}
+                                </div>
+                            )}
+
+                            {hasConfirmationRedirect && (
+                                <div className="give-embed-modal-helptext">
+                                    {__('This form redirects to a page on your WordPress site after donating, so donors will leave the site the form is embedded on. Consider the inline receipt for external embeds.', 'give')}
+                                </div>
+                            )}
+
+                            <div className="give-embed-modal-items give-embed-modal-copy">
+                                <div>
+                                    <Button
+                                        icon={isExternalEmbedCopied ? CheckIcon : CopyIcon}
+                                        variant="secondary"
+                                        onClick={handleCopyExternalEmbed}
+                                    >
+                                        {isExternalEmbedCopied ? __('Copied', 'give') : __('Copy Embed Code', 'give')}
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    </>
+                ) : (
+                    <>
             <div className="give-embed-modal-row">
 
                 <strong>
@@ -698,33 +782,9 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                 </div>
             </div>
 
-            <div className="give-embed-modal-row">
-                <strong>
-                    {__('Embed on an external website', 'give')}
-                </strong>
-
-                <div className="give-embed-modal-helptext">
-                    {__('Copy and paste this snippet into any non-WordPress website to display this donation form there.', 'give')}
-                </div>
-
-                {hasRequiredLogin && (
-                    <div className="give-embed-modal-helptext">
-                        {__('This form requires donor login, which is unreliable inside embedded forms in some browsers (like Safari). Consider making login optional for external embedding.', 'give')}
-                    </div>
+                    </>
                 )}
-
-                <div className="give-embed-modal-items give-embed-modal-copy">
-                    <div>
-                        <Button
-                            icon={isExternalEmbedCopied ? CheckIcon : CopyIcon}
-                            variant="secondary"
-                            onClick={handleCopyExternalEmbed}
-                        >
-                            {isExternalEmbedCopied ? __('Copied', 'give') : __('Copy Embed Code', 'give')}
-                        </Button>
-                    </div>
-                </div>
-            </div>
+            </TabPanel>
         </div>,
         document.body,
     );

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -488,7 +488,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                             </strong>
 
                             <div className="give-embed-modal-helptext">
-                                {__('Copy and paste this snippet into any non-WordPress website to display this donation form there.', 'give')}
+                                {__('Copy and paste this snippet into any other website to display this donation form there.', 'give')}
                             </div>
 
                             <SelectControl

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -526,7 +526,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
                             {hasConfirmationRedirect && (
                                 <div className="give-embed-modal-helptext">
-                                    {__('This form redirects to a page on your WordPress site after donating, so donors will leave the site the form is embedded on. Consider the inline receipt for external embeds.', 'give')}
+                                    {__('This form has "Confirmation Page Redirect" enabled in its settings, so donors will leave the site the form is embedded on after donating.', 'give')}
                                 </div>
                             )}
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -240,22 +240,27 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      */
     const writeToClipboard = async (text: string) => {
         if (navigator.clipboard && window.isSecureContext) {
-            await navigator.clipboard.writeText(text);
-        } else {
-            const textArea = document.createElement('textarea');
-
-            textArea.value = text;
-            textArea.style.display = 'hidden';
-            document.body.appendChild(textArea);
-            textArea.focus();
-            textArea.select();
             try {
-                document.execCommand('copy');
+                await navigator.clipboard.writeText(text);
+                return;
             } catch (error) {
-                console.error(error);
-            } finally {
-                textArea.remove();
+                // Clipboard API can reject (permissions); fall through to the textarea fallback.
             }
+        }
+
+        const textArea = document.createElement('textarea');
+
+        textArea.value = text;
+        textArea.style.display = 'hidden';
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            document.execCommand('copy');
+        } catch (error) {
+            console.error(error);
+        } finally {
+            textArea.remove();
         }
     };
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -47,7 +47,31 @@ interface StateProps {
  */
 export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
-    const {formId} = getWindowData();
+    const {formId, homeUrl, externalEmbedScriptUrl, blockData} = getWindowData();
+    const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
+
+    /**
+     * Login inside a cross-origin embed is unreliable in some browsers, so
+     * warn when this form requires it. Based on the saved block data.
+     *
+     * @since TBD
+     */
+    const hasRequiredLogin = (() => {
+        try {
+            const containsRequiredLogin = (blocks): boolean =>
+                Array.isArray(blocks) &&
+                blocks.some(
+                    (block) =>
+                        (block?.name === 'givewp/login' && block?.attributes?.required) ||
+                        containsRequiredLogin(block?.innerBlocks)
+                );
+
+            return containsRequiredLogin(JSON.parse(blockData));
+        } catch (error) {
+            return false;
+        }
+    })();
+
     const newPostNameRef = useRef<HTMLInputElement>(null);
     const openFormBtnRef = useRef<HTMLInputElement>(null);
     const viewInsertedPageBtnRef = useRef<HTMLButtonElement>(null);
@@ -212,15 +236,15 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     }
 
     /**
-     * Handle copying shortcode to clipboard
+     * @since TBD
      */
-    const handleCopy = async () => {
+    const writeToClipboard = async (text: string) => {
         if (navigator.clipboard && window.isSecureContext) {
-            await navigator.clipboard.writeText(getShortcode());
+            await navigator.clipboard.writeText(text);
         } else {
             const textArea = document.createElement('textarea');
 
-            textArea.value = getShortcode();
+            textArea.value = text;
             textArea.style.display = 'hidden';
             document.body.appendChild(textArea);
             textArea.focus();
@@ -233,6 +257,15 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                 textArea.remove();
             }
         }
+    };
+
+    /**
+     * Handle copying shortcode to clipboard
+     *
+     * @since TBD extracted writeToClipboard
+     */
+    const handleCopy = async () => {
+        await writeToClipboard(getShortcode());
 
         setState(prevState => {
             return {
@@ -250,6 +283,26 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
             });
         }, 2000);
     }
+
+    /**
+     * @since TBD
+     */
+    const getExternalEmbedSnippet = () => {
+        return [
+            `<script src="${externalEmbedScriptUrl}" defer></script>`,
+            `<givewp-donation-form form-id="${formId}" wp-url="${homeUrl}"></givewp-donation-form>`,
+        ].join('\n');
+    };
+
+    /**
+     * @since TBD
+     */
+    const handleCopyExternalEmbed = async () => {
+        await writeToClipboard(getExternalEmbedSnippet());
+
+        setIsExternalEmbedCopied(true);
+        setTimeout(() => setIsExternalEmbedCopied(false), 2000);
+    };
 
     /**
      * Handle inserting form into existing post/page
@@ -588,6 +641,34 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                 `<a href="https://givewp.com/documentation/core/shortcodes/" target="_blank">${__('Learn more', 'give')}</a>`,
                             )}
                         />
+                    </div>
+                </div>
+            </div>
+
+            <div className="give-embed-modal-row">
+                <strong>
+                    {__('Embed on an external website', 'give')}
+                </strong>
+
+                <div className="give-embed-modal-helptext">
+                    {__('Copy and paste this snippet into any non-WordPress website to display this donation form there.', 'give')}
+                </div>
+
+                {hasRequiredLogin && (
+                    <div className="give-embed-modal-helptext">
+                        {__('This form requires donor login, which is unreliable inside embedded forms in some browsers (like Safari). Consider making login optional for external embedding.', 'give')}
+                    </div>
+                )}
+
+                <div className="give-embed-modal-items give-embed-modal-copy">
+                    <div>
+                        <Button
+                            icon={isExternalEmbedCopied ? CheckIcon : CopyIcon}
+                            variant="secondary"
+                            onClick={handleCopyExternalEmbed}
+                        >
+                            {isExternalEmbedCopied ? __('Copied', 'give') : __('Copy Embed Code', 'give')}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -271,11 +271,11 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     /**
      * @since TBD
      */
-    const writeToClipboard = async (text: string) => {
+    const writeToClipboard = async (text: string): Promise<boolean> => {
         if (navigator.clipboard && window.isSecureContext) {
             try {
                 await navigator.clipboard.writeText(text);
-                return;
+                return true;
             } catch (error) {
                 // Clipboard API can reject (permissions); fall through to the textarea fallback.
             }
@@ -284,17 +284,37 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
         const textArea = document.createElement('textarea');
 
         textArea.value = text;
-        textArea.style.display = 'hidden';
+        textArea.setAttribute('readonly', '');
+        textArea.style.position = 'fixed';
+        textArea.style.top = '0';
+        textArea.style.left = '-9999px';
+        textArea.style.opacity = '0';
         document.body.appendChild(textArea);
         textArea.focus();
         textArea.select();
         try {
-            document.execCommand('copy');
+            return document.execCommand('copy');
         } catch (error) {
-            console.error(error);
+            return false;
         } finally {
             textArea.remove();
         }
+    };
+
+    /**
+     * The snippet is pasted as HTML, so every interpolated attribute value is
+     * encoded. A button label with a quote must not break the markup.
+     *
+     * @since TBD
+     */
+    const attribute = (name: string, value: string | number): string => {
+        const encoded = String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+
+        return `${name}="${encoded}"`;
     };
 
     /**
@@ -303,7 +323,9 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      * @since TBD extracted writeToClipboard
      */
     const handleCopy = async () => {
-        await writeToClipboard(getShortcode());
+        if (!(await writeToClipboard(getShortcode()))) {
+            return;
+        }
 
         setState(prevState => {
             return {
@@ -331,30 +353,30 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      */
     const getExternalEmbedSnippet = () => {
         const attributes = [
-            `form-id="${formId}"`,
-            `wp-url="${homeUrl}"`,
-            `fallback-text="${__('Open donation form', 'give')}"`,
+            attribute('form-id', formId),
+            attribute('wp-url', homeUrl),
+            attribute('fallback-text', __('Open donation form', 'give')),
         ];
 
         const colors = getEmbedColors();
         if (colors.primary) {
-            attributes.push(`primary-color="${colors.primary}"`);
+            attributes.push(attribute('primary-color', colors.primary));
         }
         if (colors.secondary) {
-            attributes.push(`secondary-color="${colors.secondary}"`);
+            attributes.push(attribute('secondary-color', colors.secondary));
         }
 
         if (isButton) {
-            attributes.push(`display-style="${state.selectedStyle}"`);
-            attributes.push(`button-text="${state.openFormButton || __('Donate', 'give')}"`);
+            attributes.push(attribute('display-style', state.selectedStyle));
+            attributes.push(attribute('button-text', state.openFormButton || __('Donate', 'give')));
         }
 
         if (state.selectedStyle === 'modal') {
-            attributes.push(`close-text="${__('Close', 'give')}"`);
+            attributes.push(attribute('close-text', __('Close', 'give')));
         }
 
         return [
-            `<script src="${externalEmbedScriptUrl}" defer></script>`,
+            `<script ${attribute('src', externalEmbedScriptUrl)} defer></script>`,
             `<givewp-donation-form ${attributes.join(' ')}></givewp-donation-form>`,
         ].join('\n');
     };
@@ -363,7 +385,9 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      * @since TBD
      */
     const handleCopyExternalEmbed = async () => {
-        await writeToClipboard(getExternalEmbedSnippet());
+        if (!(await writeToClipboard(getExternalEmbedSnippet()))) {
+            return;
+        }
 
         setIsExternalEmbedCopied(true);
         setTimeout(() => setIsExternalEmbedCopied(false), 2000);

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -1,4 +1,4 @@
-import {MouseEventHandler, useCallback, useEffect, useRef, useState} from 'react';
+import {MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import cx from 'classnames';
 import {createPortal} from 'react-dom';
 import {useDispatch, useSelect} from '@wordpress/data';
@@ -10,6 +10,8 @@ import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
 import {CopyIcon, ExitIcon} from '@givewp/components/AdminUI/Icons';
 import {Interweave} from 'interweave';
+import type {BlockInstance} from '@wordpress/blocks';
+import type {FormSettings} from '@givewp/form-builder/types/formSettings';
 
 import './styles.scss';
 
@@ -50,7 +52,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     const {formId, homeUrl, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
     const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
 
-    const parsedSettings = (() => {
+    const parsedSettings = useMemo((): Partial<FormSettings> => {
         try {
             return JSON.parse(settings);
         } catch (error) {
@@ -58,7 +60,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
             return {};
         }
-    })();
+    }, [settings]);
 
     /**
      * The external embed script cannot read form settings, so the snippet
@@ -91,9 +93,9 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      *
      * @since TBD
      */
-    const hasRequiredLogin = (() => {
+    const hasRequiredLogin = useMemo((): boolean => {
         try {
-            const containsRequiredLogin = (blocks): boolean =>
+            const containsRequiredLogin = (blocks: BlockInstance[]): boolean =>
                 Array.isArray(blocks) &&
                 blocks.some(
                     (block) =>
@@ -107,7 +109,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
             return false;
         }
-    })();
+    }, [blockData]);
 
     const newPostNameRef = useRef<HTMLInputElement>(null);
     const openFormBtnRef = useRef<HTMLInputElement>(null);

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -299,10 +299,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      * @since TBD
      */
     const getExternalEmbedSnippet = () => {
-        const attributes = [
-            attribute('form-id', formId),
-            attribute('fallback-text', __('Open donation form', 'give')),
-        ];
+        const attributes = [attribute('form-id', formId)];
 
         const colors = getEmbedColors();
         if (colors.primary) {
@@ -312,13 +309,13 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
             attributes.push(attribute('secondary-color', colors.secondary));
         }
 
+        // Default labels travel with the script in the site's locale (see
+        // GetExternalEmbedScriptData); only an admin-chosen label is written out.
         if (isButton) {
             attributes.push(attribute('display-style', state.selectedStyle));
-            attributes.push(attribute('button-text', state.openFormButton || __('Donate', 'give')));
-        }
-
-        if (state.selectedStyle === 'modal') {
-            attributes.push(attribute('close-text', __('Close', 'give')));
+            if (state.openFormButton) {
+                attributes.push(attribute('button-text', state.openFormButton));
+            }
         }
 
         return [

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -50,7 +50,7 @@ interface StateProps {
  */
 export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
-    const {formId, homeUrl, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
+    const {formId, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
     const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
 
     const parsedSettings = useMemo((): Partial<FormSettings> => {
@@ -301,7 +301,6 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     const getExternalEmbedSnippet = () => {
         const attributes = [
             attribute('form-id', formId),
-            attribute('wp-url', homeUrl),
             attribute('fallback-text', __('Open donation form', 'give')),
         ];
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -5,7 +5,7 @@ import {useDispatch, useSelect} from '@wordpress/data';
 import {useCopyToClipboard} from '@wordpress/compose';
 import {store} from '@wordpress/core-data';
 import {__, sprintf} from '@wordpress/i18n';
-import {BaseControl, Button, ColorPalette, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
+import {BaseControl, Button, ColorPalette, Popover, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
 import {external} from '@wordpress/icons';
 import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
@@ -428,7 +428,18 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
             : __('post', 'give');
     }
 
+    /*
+     * The builder's Popover.Slot lives inside the block editor, far below this
+     * panel's z-index, so a color picker opened from here would render behind
+     * the panel. Popovers from this panel go to a sibling slot at the same
+     * z-index instead. The slot-name provider is the documented way to pick a
+     * slot, but it is not in the components' type definitions.
+     */
+    // @ts-expect-error __unstableSlotNameProvider is missing from the Popover types.
+    const PopoverSlotName = Popover.__unstableSlotNameProvider;
+
     return createPortal(
+        <PopoverSlotName value="give-embed-modal">
         <div className="give-embed-modal">
 
             <div className="give-embed-modal-header">
@@ -501,6 +512,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                             value={buttonColor}
                                             onChange={(value) => setState((prevState) => ({...prevState, buttonColor: value ?? ''}))}
                                             clearable={false}
+                                            __experimentalIsRenderedInSidebar
                                         />
                                     </BaseControl>
                                 </>
@@ -777,7 +789,12 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                     </>
                 )}
             </TabPanel>
-        </div>,
+        </div>
+        <div className="give-embed-modal-popovers">
+            {/* @ts-ignore Popover.Slot is missing from the components' types, as in BlockEditorContainer. */}
+            <Popover.Slot name="give-embed-modal" />
+        </div>
+        </PopoverSlotName>,
         document.body,
     );
 }

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -1,4 +1,4 @@
-import {MouseEventHandler, Ref, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import cx from 'classnames';
 import {createPortal} from 'react-dom';
 import {useDispatch, useSelect} from '@wordpress/data';
@@ -510,7 +510,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                     <Button
                                         icon={isExternalEmbedCopied ? CheckIcon : CopyIcon}
                                         variant="secondary"
-                                        ref={copyExternalEmbedRef as Ref<HTMLAnchorElement>}
+                                        ref={copyExternalEmbedRef}
                                     >
                                         {isExternalEmbedCopied ? __('Copied', 'give') : __('Copy Embed Code', 'give')}
                                     </Button>
@@ -741,7 +741,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                         <Button
                             icon={state.isCopied ? CheckIcon : CopyIcon}
                             variant="secondary"
-                            ref={copyShortcodeRef as Ref<HTMLAnchorElement>}
+                            ref={copyShortcodeRef}
                         >
                             {state.isCopied ? __('Copied', 'give') : __('Copy Shortcode', 'give')}
                         </Button>

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -5,7 +5,9 @@ import {useDispatch, useSelect} from '@wordpress/data';
 import {useCopyToClipboard} from '@wordpress/compose';
 import {store} from '@wordpress/core-data';
 import {__, sprintf} from '@wordpress/i18n';
-import {BaseControl, Button, ColorPalette, Popover, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
+import {Button, Popover, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
+import {PanelColorSettings} from '@wordpress/block-editor';
+import defaultColors from '@givewp/form-builder/settings/design/style-controls/color/defaultColors';
 import {external} from '@wordpress/icons';
 import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
@@ -502,19 +504,24 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                         })}
                                     />
 
-                                    <BaseControl
-                                        id="give-embed-modal-button-color"
-                                        label={__('Button color', 'give')}
-                                        help={__('The button is part of the other website, so it keeps this color until the snippet is updated. The form itself always uses its current design.', 'give')}
-                                    >
-                                        <ColorPalette
-                                            colors={[{name: __('Form color', 'give'), color: formPrimaryColor}]}
-                                            value={buttonColor}
-                                            onChange={(value) => setState((prevState) => ({...prevState, buttonColor: value ?? ''}))}
-                                            clearable={false}
-                                            __experimentalIsRenderedInSidebar
-                                        />
-                                    </BaseControl>
+                                    {/* Same control as the Design tab's Primary Color, so it looks and works the same. */}
+                                    <PanelColorSettings
+                                        className="give-embed-modal-color"
+                                        colorSettings={[
+                                            {
+                                                value: buttonColor,
+                                                onChange: (value: string) =>
+                                                    setState((prevState) => ({...prevState, buttonColor: value ?? ''})),
+                                                label: __('Button color', 'give'),
+                                                disableCustomColors: false,
+                                                colors: defaultColors,
+                                            },
+                                        ]}
+                                    />
+
+                                    <div className="give-embed-modal-helptext">
+                                        {__('The button is part of the other website, so it keeps this color until the snippet is updated. The form itself always uses its current design.', 'give')}
+                                    </div>
                                 </>
                             )}
 

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -1,7 +1,8 @@
-import {MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {MouseEventHandler, Ref, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import cx from 'classnames';
 import {createPortal} from 'react-dom';
 import {useDispatch, useSelect} from '@wordpress/data';
+import {useCopyToClipboard} from '@wordpress/compose';
 import {store} from '@wordpress/core-data';
 import {__, sprintf} from '@wordpress/i18n';
 import {Button, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
@@ -275,39 +276,6 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     }
 
     /**
-     * @since TBD
-     */
-    const writeToClipboard = async (text: string): Promise<boolean> => {
-        if (navigator.clipboard && window.isSecureContext) {
-            try {
-                await navigator.clipboard.writeText(text);
-                return true;
-            } catch (error) {
-                // Clipboard API can reject (permissions); fall through to the textarea fallback.
-            }
-        }
-
-        const textArea = document.createElement('textarea');
-
-        textArea.value = text;
-        textArea.setAttribute('readonly', '');
-        textArea.style.position = 'fixed';
-        textArea.style.top = '0';
-        textArea.style.left = '-9999px';
-        textArea.style.opacity = '0';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        try {
-            return document.execCommand('copy');
-        } catch (error) {
-            return false;
-        } finally {
-            textArea.remove();
-        }
-    };
-
-    /**
      * The snippet is pasted as HTML, so every interpolated attribute value is
      * encoded. A button label with a quote must not break the markup.
      *
@@ -322,33 +290,6 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
         return `${name}="${encoded}"`;
     };
-
-    /**
-     * Handle copying shortcode to clipboard
-     *
-     * @since TBD extracted writeToClipboard
-     */
-    const handleCopy = async () => {
-        if (!(await writeToClipboard(getShortcode()))) {
-            return;
-        }
-
-        setState(prevState => {
-            return {
-                ...prevState,
-                isCopied: true,
-            };
-        });
-
-        setTimeout(() => {
-            setState(prevState => {
-                return {
-                    ...prevState,
-                    isCopied: false,
-                };
-            });
-        }, 2000);
-    }
 
     /**
      * The snippet carries the selected display style and the translated
@@ -388,16 +329,20 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     };
 
     /**
+     * Both copy buttons go through the WordPress clipboard hook, which reads
+     * the text on click and only reports success once the copy actually landed.
+     *
      * @since TBD
      */
-    const handleCopyExternalEmbed = async () => {
-        if (!(await writeToClipboard(getExternalEmbedSnippet()))) {
-            return;
-        }
+    const copyShortcodeRef = useCopyToClipboard(getShortcode, () => {
+        setState((prevState) => ({...prevState, isCopied: true}));
+        setTimeout(() => setState((prevState) => ({...prevState, isCopied: false})), 2000);
+    });
 
+    const copyExternalEmbedRef = useCopyToClipboard(getExternalEmbedSnippet, () => {
         setIsExternalEmbedCopied(true);
         setTimeout(() => setIsExternalEmbedCopied(false), 2000);
-    };
+    });
 
     /**
      * Handle inserting form into existing post/page
@@ -565,7 +510,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                     <Button
                                         icon={isExternalEmbedCopied ? CheckIcon : CopyIcon}
                                         variant="secondary"
-                                        onClick={handleCopyExternalEmbed}
+                                        ref={copyExternalEmbedRef as Ref<HTMLAnchorElement>}
                                     >
                                         {isExternalEmbedCopied ? __('Copied', 'give') : __('Copy Embed Code', 'give')}
                                     </Button>
@@ -796,7 +741,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                         <Button
                             icon={state.isCopied ? CheckIcon : CopyIcon}
                             variant="secondary"
-                            onClick={handleCopy}
+                            ref={copyShortcodeRef as Ref<HTMLAnchorElement>}
                         >
                             {state.isCopied ? __('Copied', 'give') : __('Copy Shortcode', 'give')}
                         </Button>

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -301,6 +301,11 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     const getExternalEmbedSnippet = () => {
         const attributes = [attribute('form-id', formId)];
 
+        // The iframe title and modal label; the form's own title beats the generic default.
+        if (parsedSettings.formTitle) {
+            attributes.push(attribute('form-title', parsedSettings.formTitle));
+        }
+
         const colors = getEmbedColors();
         if (colors.primary) {
             attributes.push(attribute('primary-color', colors.primary));
@@ -500,6 +505,10 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                     {__('This form has "Confirmation Page Redirect" enabled in its settings, so donors will leave the site the form is embedded on after donating.', 'give')}
                                 </div>
                             )}
+
+                            <pre className="give-embed-modal-code" tabIndex={0} aria-label={__('Embed code', 'give')}>
+                                <code>{getExternalEmbedSnippet()}</code>
+                            </pre>
 
                             <div className="give-embed-modal-items give-embed-modal-copy">
                                 <div>

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -54,6 +54,8 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
         try {
             return JSON.parse(settings);
         } catch (error) {
+            console.error(error);
+
             return {};
         }
     })();
@@ -101,6 +103,8 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
             return containsRequiredLogin(JSON.parse(blockData));
         } catch (error) {
+            console.error(error);
+
             return false;
         }
     })();

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -5,7 +5,7 @@ import {useDispatch, useSelect} from '@wordpress/data';
 import {useCopyToClipboard} from '@wordpress/compose';
 import {store} from '@wordpress/core-data';
 import {__, sprintf} from '@wordpress/i18n';
-import {Button, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
+import {BaseControl, Button, ColorPalette, RadioControl, SelectControl, Spinner, TabPanel, TextControl} from '@wordpress/components';
 import {external} from '@wordpress/icons';
 import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
@@ -35,6 +35,7 @@ interface StateProps {
     selectedPost: string;
     selectedStyle: string;
     openFormButton: string;
+    buttonColor: string;
     isCopied: boolean;
     isInserting: boolean;
     insertPageNotSelected: boolean;
@@ -64,20 +65,18 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
     }, [settings]);
 
     /**
-     * The external embed script cannot read form settings, so the snippet
-     * carries the form's colors as attributes. Campaign colors win when the
-     * form inherits them, matching how the form itself resolves colors.
+     * The color the launcher button starts with: the form's own primary color,
+     * campaign inheritance included. The form inside the iframe resolves its
+     * colors itself; this only seeds the button on the host page, and the
+     * admin can change it before copying.
      *
      * @since TBD
      */
-    const getEmbedColors = (): {primary: string; secondary: string} => {
+    const formPrimaryColor = useMemo((): string => {
         const inherit = parsedSettings.inheritCampaignColors;
 
-        return {
-            primary: (inherit && campaignColors?.primaryColor) || parsedSettings.primaryColor || '',
-            secondary: (inherit && campaignColors?.secondaryColor) || parsedSettings.secondaryColor || '',
-        };
-    };
+        return (inherit && campaignColors?.primaryColor) || parsedSettings.primaryColor || '';
+    }, [parsedSettings, campaignColors]);
 
     /**
      * The confirmation page redirect sends donors to a page on this
@@ -126,6 +125,7 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
         selectedPost: '',
         selectedStyle: 'onpage',
         openFormButton: '',
+        buttonColor: '',
         isCopied: false,
         isInserting: false,
         insertPageNotSelected: false,
@@ -291,10 +291,12 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
         return `${name}="${encoded}"`;
     };
 
+    const buttonColor = state.buttonColor || formPrimaryColor;
+
     /**
-     * The snippet carries the selected display style and the translated
-     * donor-facing strings, since the standalone embed script has no access
-     * to WordPress translations.
+     * The snippet carries only per-embed choices: the form, its title for
+     * assistive tech, and the launcher's display style, label, and color.
+     * Translated default labels travel with the script itself.
      *
      * @since TBD
      */
@@ -306,20 +308,15 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
             attributes.push(attribute('form-title', parsedSettings.formTitle));
         }
 
-        const colors = getEmbedColors();
-        if (colors.primary) {
-            attributes.push(attribute('primary-color', colors.primary));
-        }
-        if (colors.secondary) {
-            attributes.push(attribute('secondary-color', colors.secondary));
-        }
-
         // Default labels travel with the script in the site's locale (see
-        // GetExternalEmbedScriptData); only an admin-chosen label is written out.
+        // GetExternalEmbedScriptData); only admin choices are written out.
         if (isButton) {
             attributes.push(attribute('display-style', state.selectedStyle));
             if (state.openFormButton) {
                 attributes.push(attribute('button-text', state.openFormButton));
+            }
+            if (buttonColor) {
+                attributes.push(attribute('primary-color', buttonColor));
             }
         }
 
@@ -481,17 +478,32 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                             />
 
                             {isButton && (
-                                <TextControl
-                                    placeholder={__('Donate', 'give')}
-                                    label={__('Button label', 'give')}
-                                    value={state.openFormButton}
-                                    onChange={value => setState(prevState => {
-                                        return {
-                                            ...prevState,
-                                            openFormButton: value,
-                                        };
-                                    })}
-                                />
+                                <>
+                                    <TextControl
+                                        placeholder={__('Donate', 'give')}
+                                        label={__('Button label', 'give')}
+                                        value={state.openFormButton}
+                                        onChange={value => setState(prevState => {
+                                            return {
+                                                ...prevState,
+                                                openFormButton: value,
+                                            };
+                                        })}
+                                    />
+
+                                    <BaseControl
+                                        id="give-embed-modal-button-color"
+                                        label={__('Button color', 'give')}
+                                        help={__('The button is part of the other website, so it keeps this color until the snippet is updated. The form itself always uses its current design.', 'give')}
+                                    >
+                                        <ColorPalette
+                                            colors={[{name: __('Form color', 'give'), color: formPrimaryColor}]}
+                                            value={buttonColor}
+                                            onChange={(value) => setState((prevState) => ({...prevState, buttonColor: value ?? ''}))}
+                                            clearable={false}
+                                        />
+                                    </BaseControl>
+                                </>
                             )}
 
                             {hasRequiredLogin && (

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
@@ -33,6 +33,13 @@
         }
     }
 
+    &-tabs {
+        .components-tab-panel__tabs {
+            border-bottom: solid 1px #e6e6e6;
+            padding: 0 var(--givewp-spacing-6);
+        }
+    }
+
     &-badge {
         font-size: 12px;
         line-height: 1.33;

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
@@ -9,8 +9,14 @@
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
     border: solid 1px #e6e6e6;
     font-size: 13px;
+    max-height: calc(100vh - 90px);
+    overflow-y: auto;
 
     &-header {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background-color: #fff;
         font-weight: 500;
         line-height: 1.4;
         color: #0e0e0e;

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
@@ -1,3 +1,14 @@
+/*
+ * Zero-size anchor at the viewport origin so popovers rendered into the
+ * panel's slot are positioned in viewport coordinates and stack with the panel.
+ */
+.give-embed-modal-popovers {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 99999999999999;
+}
+
 .give-embed-modal {
     width: 474px;
     position: fixed;

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
@@ -19,9 +19,17 @@
     border-radius: 5px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
     border: solid 1px #e6e6e6;
-    font-size: 13px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--givewp-neutral-700);
     max-height: calc(100vh - 90px);
     overflow-y: auto;
+
+    /* WordPress control help defaults to 12px light grey, too faint in a side panel. */
+    .components-base-control__help {
+        font-size: 13px;
+        color: var(--givewp-neutral-600);
+    }
 
     &-header {
         position: sticky;
@@ -101,7 +109,9 @@
     }
 
     &-helptext {
-        font-size: 12px;
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--givewp-neutral-600);
         margin-bottom: var(--givewp-spacing-3);
     }
 
@@ -112,7 +122,8 @@
         border: 1px solid var(--givewp-grey-100);
         border-radius: 4px;
         background: var(--givewp-grey-25);
-        font-size: 12px;
+        color: var(--givewp-neutral-700);
+        font-size: 13px;
         line-height: 1.5;
         white-space: pre-wrap;
         word-break: break-all;
@@ -121,7 +132,7 @@
 
     &-select-error {
         margin-bottom: 0;
-        font-size: 12px;
+        font-size: 13px;
         color: var(--givewp-red-500);
 
         &:first-letter {

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/styles.scss
@@ -95,6 +95,19 @@
     }
 
 
+    &-code {
+        margin: 0 0 var(--givewp-spacing-3);
+        padding: var(--givewp-spacing-3);
+        border: 1px solid var(--givewp-grey-100);
+        border-radius: 4px;
+        background: var(--givewp-grey-25);
+        font-size: 12px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-all;
+        user-select: all;
+    }
+
     &-select-error {
         margin-bottom: 0;
         font-size: 12px;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/defaultColors.ts
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/defaultColors.ts
@@ -1,0 +1,22 @@
+/**
+ * The palette offered wherever the builder asks for a form color: the Design
+ * tab's primary and secondary colors and the external embed's button color.
+ *
+ * @since 4.3.0 Update the value of the default colors Primary color to improve accessibility color contrast.
+ * @since TBD Shared with the external embed button color.
+ */
+const defaultColors = [
+    {name: 'Black', slug: 'black', color: '#000000'},
+    {name: 'Dark Blue', slug: 'dark-blue', color: '#1E1AE2'},
+    {name: 'Give Primary Default', slug: 'give-primary-default', color: '#2d802f'},
+    {name: 'Red', slug: 'red', color: '#BD3D36'},
+    {name: 'Orange', slug: 'orange', color: '#EB712E'},
+    {name: 'Gray', slug: 'gray', color: '#5F7385'},
+    {name: 'Light Blue', slug: 'light-blue', color: '#4492DD'},
+    {name: 'Light Green', slug: 'light-green', color: '#63CC8A'},
+    {name: 'Purple', slug: 'purple', color: '#9058D8'},
+    {name: 'Teal', slug: 'teal', color: '#2BBAB1'},
+    {name: 'Yellow', slug: 'yellow', color: '#F1BB40'},
+];
+
+export default defaultColors;

--- a/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/settings/design/style-controls/color/index.tsx
@@ -4,8 +4,10 @@ import useDonationFormPubSub from '@givewp/forms/app/utilities/useDonationFormPu
 import {PanelColorSettings} from '@wordpress/block-editor';
 import {PanelBody} from '@wordpress/components';
 import ColorInheritanceToggle from '@givewp/form-builder/settings/design/style-controls/color-inheritance-toggle';
+import defaultColors from './defaultColors';
 
 /**
+ * @since TBD Move the default palette to defaultColors.ts so the embed panel can share it.
  * @since 4.3.0 Update the value of the default colors Primary color to improve accessibility color contrast.
  */
 export default function Color({dispatch}) {
@@ -15,19 +17,6 @@ export default function Color({dispatch}) {
 
     const {publishColors} = useDonationFormPubSub();
 
-    const defaultColors = [
-        {name: 'Black', slug: 'black', color: '#000000'},
-        {name: 'Dark Blue', slug: 'dark-blue', color: '#1E1AE2'},
-        {name: 'Give Primary Default', slug: 'give-primary-default', color: '#2d802f'},
-        {name: 'Red', slug: 'red', color: '#BD3D36'},
-        {name: 'Orange', slug: 'orange', color: '#EB712E'},
-        {name: 'Gray', slug: 'gray', color: '#5F7385'},
-        {name: 'Light Blue', slug: 'light-blue', color: '#4492DD'},
-        {name: 'Light Green', slug: 'light-green', color: '#63CC8A'},
-        {name: 'Purple', slug: 'purple', color: '#9058D8'},
-        {name: 'Teal', slug: 'teal', color: '#2BBAB1'},
-        {name: 'Yellow', slug: 'yellow', color: '#F1BB40'},
-    ];
 
     return (
         <PanelBody title={__('Color', 'give')}>

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -25,6 +25,7 @@ class FormBuilderViewModelTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the compared array
      * @since 3.9.0 Add support to intlTelInputSettings key in the compared array
      * @since 3.7.0 Add support to isExcerptEnabled key in the compared array
      * @since 3.2.0 Add support to nameTitlePrefixes key in the compared array
@@ -45,6 +46,8 @@ class FormBuilderViewModelTest extends TestCase
                 'formId' => $formId,
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
                 'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
+                'homeUrl' => home_url(),
+                'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . 'build/externalFormEmbed.js',
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => $mockForm->blocks->toJson(),
                 'settings' => $mockForm->settings->toJson(),

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -4,6 +4,7 @@ namespace Give\Tests\Unit\VieModels;
 
 use Exception;
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
+use Give\DonationForms\Routes\ExternalEmbedScriptRoute;
 use Give\DonationForms\Models\DonationForm;
 use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationMetaKeys;
@@ -47,7 +48,7 @@ class FormBuilderViewModelTest extends TestCase
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
                 'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
                 'homeUrl' => home_url(),
-                'externalEmbedScriptUrl' => GIVE_PLUGIN_URL . 'build/externalFormEmbed.js',
+                'externalEmbedScriptUrl' => ExternalEmbedScriptRoute::url(),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => $mockForm->blocks->toJson(),
                 'settings' => $mockForm->settings->toJson(),

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -26,7 +26,7 @@ class FormBuilderViewModelTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @since TBD Add homeUrl and externalEmbedScriptUrl keys to the compared array
+     * @since TBD Add externalEmbedScriptUrl key to the compared array
      * @since 3.9.0 Add support to intlTelInputSettings key in the compared array
      * @since 3.7.0 Add support to isExcerptEnabled key in the compared array
      * @since 3.2.0 Add support to nameTitlePrefixes key in the compared array
@@ -47,7 +47,6 @@ class FormBuilderViewModelTest extends TestCase
                 'formId' => $formId,
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
                 'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
-                'homeUrl' => home_url(),
                 'externalEmbedScriptUrl' => (new GenerateExternalEmbedScriptUrl())(),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => $mockForm->blocks->toJson(),

--- a/tests/Unit/ViewModels/FormBuilderViewModelTest.php
+++ b/tests/Unit/ViewModels/FormBuilderViewModelTest.php
@@ -4,7 +4,7 @@ namespace Give\Tests\Unit\VieModels;
 
 use Exception;
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
-use Give\DonationForms\Routes\ExternalEmbedScriptRoute;
+use Give\DonationForms\Actions\GenerateExternalEmbedScriptUrl;
 use Give\DonationForms\Models\DonationForm;
 use Give\Donations\Models\Donation;
 use Give\Donations\ValueObjects\DonationMetaKeys;
@@ -48,7 +48,7 @@ class FormBuilderViewModelTest extends TestCase
                 'resourceURL' => rest_url(FormBuilderRestRouteConfig::NAMESPACE . '/form/' . $formId),
                 'previewURL' => (new GenerateDonationFormPreviewRouteUrl())($formId),
                 'homeUrl' => home_url(),
-                'externalEmbedScriptUrl' => ExternalEmbedScriptRoute::url(),
+                'externalEmbedScriptUrl' => (new GenerateExternalEmbedScriptUrl())(),
                 'nonce' => wp_create_nonce('wp_rest'),
                 'blockData' => $mockForm->blocks->toJson(),
                 'settings' => $mockForm->settings->toJson(),


### PR DESCRIPTION
## Description

Stacked on #8311.

Adds an **External website** tab to the form builder's existing Embed Form modal: display style, button label, and button color controls, the generated snippet shown in a read-only code block, and a one-click copy. Warns when the form contains a required login block (login inside embedded forms is unreliable in some browsers) or has Confirmation Page Redirect enabled.

The snippet carries only per-embed choices: `form-id`, `form-title` (the form's own title, used for the iframe title and modal label), `display-style`, a `button-text` when the admin typed one, and `primary-color` for the launcher button. The color field is seeded with the form's resolved primary color (campaign inheritance included) and labeled as living on the other website, since the launcher renders before any WordPress response and cannot follow later design changes; the form inside the iframe always uses its current design. There is no `secondary-color`, nothing in the embed read it. The script URL comes from `GenerateExternalEmbedScriptUrl` (#8311), the site location is derived from it on the client, and the translated default labels travel with the script, so there is no `wp-url` and no per-language text in the snippet.

```html
<script src="https://example.org/give/embed/donation-form/script.js" defer></script>
<givewp-donation-form form-id="42" form-title="Spring Appeal" primary-color="#0b72d9" display-style="modal"></givewp-donation-form>
```

Localizes configuration only — home URL and embed script URL, no donor data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: SOFT-4294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for embedding donation forms on external websites.
  - Added a tabbed interface with a ready-to-copy `<givewp-donation-form>` snippet.
  - Embed snippets include form settings, translated text, display options, campaign colors, and modal controls.
  - Added warnings when donor login or confirmation-page redirects may affect embedded forms.

- **Improvements**
  - Improved clipboard copying with success feedback after the snippet is copied.
  - Made the embed window scrollable with a sticky header for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

