### PR TITLE
Fix: cover raw offsite return URLs in the secure gateway route signature

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,8 @@
 {
     "plugins": ["."],
     "port": 8888,
-    "testsEnvironment": false
+    "testsEnvironment": false,
+    "config": {
+        "GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY": true
+    }
 }

--- a/docs/architecture/payment-gateways.md
+++ b/docs/architecture/payment-gateways.md
@@ -168,7 +168,9 @@ The signature covers the args you pass to `generateSecureGatewayRouteUrl()`, so 
 trust the `$queryParams` it declared — the ids it reads to decide which record to act on, and the
 return URLs it redirects to. Editing or dropping one invalidates the signature. Anything the
 processor appends to the return URL on the way back was never signed and is ignored, so read those
-as untrusted input and validate them like any other processor claim.
+as untrusted input and validate them like any other processor claim. Args may be passed raw or
+rawurlencoded: they are normalized to what the route will receive, signed, and written to the URL
+encoded, so a return URL carrying its own query string survives the round trip either way.
 
 ## Structure
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,7 @@ slow test with a worse failure message.
 
 **One spec file per screen**, named for the screen, holding everything that screen is covered for:
 `campaigns.spec.ts`, `donation-forms.spec.ts`, `donor-dashboard.spec.ts`, `form-builder.spec.ts`,
-`reports.spec.ts`, `tools-logs.spec.ts`, `tools-migrations.spec.ts`.
+`legacy-donation-forms.spec.ts`, `reports.spec.ts`, `tools-logs.spec.ts`, `tools-migrations.spec.ts`.
 
 A v3 donation form is two screens, not one: the form builder that edits it in wp-admin and the
 form itself on the front end. They share a subject and nothing else - different apps, different
@@ -63,7 +63,10 @@ rather than depending on what a site already has. `utils/form.ts` reads and writ
 `givewp/v3/form/<id>` - the same route the builder saves through - which is how a donor-facing spec
 sets up the variation it needs without driving the builder to get there. `utils/donation-form.ts`
 holds the embed iframe locator and the steps every donating spec repeats. `utils/rest.ts` records the REST calls a page makes and
-asserts it reached the route it owns with nothing failing. Assert on that traffic rather than on
+asserts it reached the route it owns with nothing failing. `utils/legacy-form.ts` creates a v2 form
+and enables a gateway for it through `utils/wp-cli.ts`, because neither has a REST route: a v2 form
+is a post with protected meta, and GiveWP's settings are one option. WP-CLI runs in the wp-env this
+checkout started, so those fixtures assume `WP_BASE_URL` points at it. Assert on that traffic rather than on
 rendered records: a wrong route, a missing nonce, or a response shape the client no longer unwraps
 all produce a page that builds and mounts cleanly and then shows nothing.
 
@@ -73,6 +76,12 @@ Every spec that completes a donation pays with Test Donation (`manual`), the onl
 finish one without an account somewhere else. It is enabled on a fresh install, so CI has it. A
 developer site that has turned it off skips those tests rather than failing them - the message says
 so. Turn it back on under Give > Settings > Payment Gateways to run them locally.
+
+The offsite path is different: the donor leaves the site and comes back to a signed gateway route,
+and no gateway that ships enabled does that. `legacy-donation-forms.spec.ts` pays with Test Gateway
+(Offsite), whose "offsite" page is the return route itself. It only registers when
+`GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY` is defined, which `.wp-env.json` does for the environment the
+suite runs against and nothing else should.
 
 ### CI
 

--- a/src/Framework/PaymentGateways/PaymentGateway.php
+++ b/src/Framework/PaymentGateways/PaymentGateway.php
@@ -355,6 +355,7 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
     /**
      * Generate secure gateway route url
      *
+     * @since TBD put the signed values on the URL encoded, so a raw value with an ampersand round-trips
      * @since 4.16.8 cover $args with the signature
      * @since 2.19.5 replace nonce with hash and expiration
      * @since 2.19.4 replace RouteSignature args with unique donationId
@@ -362,20 +363,14 @@ abstract class PaymentGateway implements PaymentGatewayInterface,
      */
     public function generateSecureGatewayRouteUrl(string $gatewayMethod, int $donationId, array $args = []): string
     {
-        $args = array_diff_key($args, array_flip(GatewayRouteData::ROUTE_PARAMS));
+        $args = RouteSignature::normalizeArgs(array_diff_key($args, array_flip(GatewayRouteData::ROUTE_PARAMS)));
 
-        $signature = new RouteSignature(
-            static::id(),
-            $gatewayMethod,
-            $donationId,
-            null,
-            RouteSignature::normalizeArgs($args)
-        );
+        $signature = new RouteSignature(static::id(), $gatewayMethod, $donationId, null, $args);
 
         return (new GenerateGatewayRouteUrl())(
             static::id(),
             $gatewayMethod,
-            array_merge($args, [
+            array_merge(RouteSignature::encodeArgs($args), [
                 'give-route-signature' => $signature->toHash(),
                 'give-route-signature-id' => $donationId,
                 'give-route-signature-expiration' => $signature->expiration,

--- a/src/Framework/PaymentGateways/Routes/RouteSignature.php
+++ b/src/Framework/PaymentGateways/Routes/RouteSignature.php
@@ -112,12 +112,37 @@ class RouteSignature
      *
      * Only URL generation runs this; values arriving on a request have been through the real thing.
      *
+     * @since TBD normalize nested values too, as PHP decodes and give_clean() cleans at every depth
      * @since 4.16.8
      */
     public static function normalizeArgs(array $args): array
     {
         return array_map(static function ($value) {
+            if (is_array($value)) {
+                return self::normalizeArgs($value);
+            }
+
             return is_string($value) ? give_clean(urldecode($value)) : $value;
+        }, $args);
+    }
+
+    /**
+     * Encodes normalized args for the URL. add_query_arg() writes values as given, so a raw value
+     * holding an ampersand — a legacy form's success URL under plain permalinks — is split into
+     * separate parameters on the way back and the signed value never round-trips. Encoding what was
+     * signed means PHP's single decode hands the route exactly that value, however the gateway
+     * shaped it.
+     *
+     * @since TBD
+     */
+    public static function encodeArgs(array $args): array
+    {
+        return array_map(static function ($value) {
+            if (is_array($value)) {
+                return self::encodeArgs($value);
+            }
+
+            return is_string($value) ? rawurlencode($value) : $value;
         }, $args);
     }
 

--- a/src/PaymentGateways/Gateways/ServiceProvider.php
+++ b/src/PaymentGateways/Gateways/ServiceProvider.php
@@ -58,6 +58,7 @@ class ServiceProvider implements ServiceProviderInterface
     }
 
     /**
+     * @since TBD register TestOffsiteGateway when GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY is set
      * @since 3.0.0
      *
      * @throws Exception
@@ -66,8 +67,11 @@ class ServiceProvider implements ServiceProviderInterface
     private function registerGateways()
     {
         add_action('givewp_register_payment_gateway', static function (PaymentGatewayRegister $registrar) {
-            // Enable as needed for testing but do not push to production
-            // $registrar->registerGateway(TestOffsiteGateway::class);
+            // Not for production: it completes donations without charging anyone. The e2e suite turns it
+            // on through .wp-env.json to walk an offsite redirect end to end.
+            if (defined('GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY') && GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY) {
+                $registrar->registerGateway(TestOffsiteGateway::class);
+            }
 
             $registrar->registerGateway(StripePaymentElementGateway::class);
 

--- a/tests/Feature/Gateways/SecureRouteArgsTest.php
+++ b/tests/Feature/Gateways/SecureRouteArgsTest.php
@@ -116,17 +116,36 @@ class SecureRouteArgsTest extends TestCase
     }
 
     /**
+     * A legacy form hands the gateway its success URL raw, and under plain permalinks that URL holds an
+     * ampersand. Written to the route URL as-is it would split into two parameters on the way back,
+     * leaving the route a truncated return URL and a signature it can never match.
+     *
+     * @since TBD
+     */
+    public function testARawReturnUrlWithAnAmpersandRoundTrips()
+    {
+        $donation = Donation::factory()->create(['status' => DonationStatus::PENDING()]);
+        $successUrl = home_url('/?page_id=5&payment-confirmation=test-gateway-offsite');
+
+        $request = $this->returnRequestFor($donation, $successUrl);
+
+        $this->assertSame($successUrl, $request['givewp-return-url']);
+        $this->assertArrayNotHasKey('payment-confirmation', $request);
+        $this->assertTrue($this->signatureFor($request)->isValid($request['give-route-signature']));
+    }
+
+    /**
      * Runs the gateway's real createPayment() and turns the URL it redirects to back into a request.
      *
-     * The successUrl is shaped like production hands it over: rawurlencoded by
+     * The default successUrl is shaped like a v3 form hands it over: rawurlencoded by
      * AddRedirectUrlsToGatewayData, carrying the confirmation page's own query args. parse_str
      * urldecodes the way PHP does for $_GET, and give_clean is what GatewayRoute applies — so the
      * value comes back decoded, not as it was signed.
      */
-    private function returnRequestFor(Donation $donation): array
+    private function returnRequestFor(Donation $donation, string $successUrl = null): array
     {
         $command = (new TestOffsiteGateway())->createPayment($donation, [
-            'successUrl' => rawurlencode(
+            'successUrl' => $successUrl ?? rawurlencode(
                 home_url('/donation-confirmation/?givewp-event=donation-completed&givewp-receipt-id=3e714ece57ed9590ece70ac2c296b6d0')
             ),
         ]);

--- a/tests/Feature/Gateways/SecureRouteArgsTest.php
+++ b/tests/Feature/Gateways/SecureRouteArgsTest.php
@@ -142,7 +142,7 @@ class SecureRouteArgsTest extends TestCase
      * urldecodes the way PHP does for $_GET, and give_clean is what GatewayRoute applies — so the
      * value comes back decoded, not as it was signed.
      */
-    private function returnRequestFor(Donation $donation, string $successUrl = null): array
+    private function returnRequestFor(Donation $donation, ?string $successUrl = null): array
     {
         $command = (new TestOffsiteGateway())->createPayment($donation, [
             'successUrl' => $successUrl ?? rawurlencode(

--- a/tests/Feature/Gateways/TestOffsiteGatewayLegacyFormTest.php
+++ b/tests/Feature/Gateways/TestOffsiteGatewayLegacyFormTest.php
@@ -56,7 +56,9 @@ class TestOffsiteGatewayLegacyFormTest extends TestCase
 
         give_update_option('gateways', [TestOffsiteGateway::id() => 1]);
 
-        // Plain permalinks, which the test site uses, give the success page a query string of its own.
+        // The ampersand this covers exists only under plain permalinks, where the success page is ?page_id=N.
+        update_option('permalink_structure', '');
+
         give_update_option('success_page', wp_insert_post([
             'post_type' => 'page',
             'post_status' => 'publish',

--- a/tests/Feature/Gateways/TestOffsiteGatewayLegacyFormTest.php
+++ b/tests/Feature/Gateways/TestOffsiteGatewayLegacyFormTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Give\Tests\Feature\Gateways;
+
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\LegacyPaymentGateways\Adapters\LegacyPaymentGatewayRegisterAdapter;
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+use Give\Framework\PaymentGateways\Routes\GatewayRoute;
+use Give\PaymentGateways\Gateways\TestOffsiteGateway\TestOffsiteGateway;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\InterruptsRedirects;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WPDieException;
+
+/**
+ * A legacy (v2) form donation paid through an offsite gateway, driven the way the browser drives it:
+ * the form posts to give_process_donation_form(), the gateway redirects the donor offsite with a signed
+ * return URL, and the processor sends the donor back to that URL, where GatewayRoute validates the
+ * signature and completes the donation.
+ *
+ * TestOffsiteGateway is the in-core offsite gateway, so it stands in for the real ones. The legacy adapter
+ * hands it the success URL raw, and under plain permalinks that URL carries a query string of its own, so
+ * this is the shape of return URL that Razorpay and PayPal Standard produce on legacy forms.
+ *
+ * @since TBD
+ */
+class TestOffsiteGatewayLegacyFormTest extends TestCase
+{
+    use RefreshDatabase;
+    use InterruptsRedirects;
+
+    /**
+     * @since TBD
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // The test case turns wp_die() into WPDieException, but only for the default handler. Once an earlier
+        // test has defined DOING_AJAX, wp_die() picks the ajax handler instead, which prints and exits.
+        add_filter('wp_die_ajax_handler', [$this, 'get_wp_die_handler']);
+        add_filter('wp_die_json_handler', [$this, 'get_wp_die_handler']);
+
+        /** @var PaymentGatewayRegister $registrar */
+        $registrar = give(PaymentGatewayRegister::class);
+
+        if ( ! $registrar->hasPaymentGateway(TestOffsiteGateway::id())) {
+            $registrar->registerGateway(TestOffsiteGateway::class);
+        }
+
+        // Boot connects the legacy adapter to the gateways registered by then; this one was not among them.
+        give(LegacyPaymentGatewayRegisterAdapter::class)->connectGatewayToLegacyPaymentGatewayAdapter(
+            TestOffsiteGateway::class
+        );
+
+        give_update_option('gateways', [TestOffsiteGateway::id() => 1]);
+
+        // Plain permalinks, which the test site uses, give the success page a query string of its own.
+        give_update_option('success_page', wp_insert_post([
+            'post_type' => 'page',
+            'post_status' => 'publish',
+            'post_title' => 'Donation Confirmation',
+        ]));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function tearDown(): void
+    {
+        $_POST = [];
+        $_GET = [];
+
+        give_clear_errors();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testALegacyFormDonationCompletesWhenTheDonorReturnsFromTheGateway()
+    {
+        $offsiteUrl = $this->donateThroughLegacyForm($this->createLegacyForm());
+
+        parse_str(parse_url($offsiteUrl, PHP_URL_QUERY), $_GET);
+
+        $donation = Donation::find((int)$_GET['givewp-donation-id']);
+
+        $this->assertTrue($donation->status->isPending());
+
+        $receiptUrl = $this->captureRedirect(static function () {
+            (new GatewayRoute())();
+        });
+
+        $this->assertSame(
+            add_query_arg(['payment-confirmation' => TestOffsiteGateway::id()], give_get_success_page_url()),
+            $receiptUrl
+        );
+        $this->assertStringContainsString('&payment-confirmation=', $receiptUrl);
+        $this->assertTrue(Donation::find($donation->id)->status->isComplete());
+    }
+
+    /**
+     * The same signed return URL, repointed at somebody else's pending donation, is refused before the
+     * route method can complete it.
+     *
+     * @since TBD
+     */
+    public function testAReturnRepointedAtAnotherDonationIsRefused()
+    {
+        $offsiteUrl = $this->donateThroughLegacyForm($this->createLegacyForm());
+
+        $theirs = Donation::factory()->create(['status' => DonationStatus::PENDING()]);
+
+        parse_str(parse_url($offsiteUrl, PHP_URL_QUERY), $_GET);
+        $_GET['givewp-donation-id'] = $theirs->id;
+
+        try {
+            (new GatewayRoute())();
+            $this->fail('The route accepted a return whose donation id had been edited.');
+        } catch (WPDieException $exception) {
+            $this->assertStringContainsString('Forbidden', $exception->getMessage());
+        }
+
+        $this->assertTrue(Donation::find($theirs->id)->status->isPending());
+    }
+
+    /**
+     * Posts the legacy form the way the browser does and returns the URL the gateway sends the donor to.
+     */
+    private function donateThroughLegacyForm(int $formId): string
+    {
+        $_POST = [
+            'give-form-id' => $formId,
+            'give-form-hash' => wp_create_nonce("give_donation_form_nonce_{$formId}"),
+            'give-form-title' => 'Legacy form',
+            'give-form-id-prefix' => "{$formId}-1",
+            'give-current-url' => home_url("/?post_type=give_forms&p={$formId}"),
+            'give-form-minimum' => '1.00',
+            'give-form-maximum' => '999999.99',
+            'give-amount' => '10.00',
+            'give-price-id' => '0',
+            'give-gateway' => TestOffsiteGateway::id(),
+            'payment-mode' => TestOffsiteGateway::id(),
+            'give_first' => 'Ada',
+            'give_last' => 'Lovelace',
+            'give_email' => 'ada@example.test',
+            'give_action' => 'purchase',
+        ];
+
+        $offsiteUrl = $this->captureRedirect(static function () {
+            give_process_donation_form();
+        });
+
+        $this->assertSame([], give_get_errors() ?: [], 'The legacy form did not accept the donation.');
+        $this->assertStringContainsString('give-listener=give-gateway', $offsiteUrl);
+
+        return $offsiteUrl;
+    }
+
+    private function createLegacyForm(): int
+    {
+        $formId = wp_insert_post([
+            'post_type' => 'give_forms',
+            'post_status' => 'publish',
+            'post_title' => 'Legacy form',
+        ]);
+
+        give_update_meta($formId, '_give_price_option', 'set');
+        give_update_meta($formId, '_give_set_price', '10.00');
+
+        return $formId;
+    }
+}

--- a/tests/Feature/Gateways/TestOffsiteGatewayV3FormTest.php
+++ b/tests/Feature/Gateways/TestOffsiteGatewayV3FormTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Give\Tests\Feature\Gateways;
+
+use Give\DonationForms\Listeners\AddRedirectUrlsToGatewayData;
+use Give\Donations\Models\Donation;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\PaymentGateways\Commands\RedirectOffsite;
+use Give\Framework\PaymentGateways\PaymentGatewayRegister;
+use Give\Framework\PaymentGateways\Routes\GatewayRoute;
+use Give\PaymentGateways\Gateways\TestOffsiteGateway\TestOffsiteGateway;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\InterruptsRedirects;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WPDieException;
+
+/**
+ * A v3 form donation paid through an offsite gateway, from the point the gateway takes over.
+ *
+ * A v3 form hands the gateway its success URL rawurlencoded (AddRedirectUrlsToGatewayData), and that URL
+ * carries the confirmation receipt's own query string. The gateway signs it into the offsite return URL,
+ * and coming back lands on GatewayRoute, which rebuilds the signature and completes the donation. The
+ * ampersand in that success URL is what the signature has to survive, and it is the v3 counterpart of the
+ * raw URL TestOffsiteGatewayLegacyFormTest drives through the legacy processor.
+ *
+ * This drives the gateway and the return route directly rather than the whole donate route: the return is
+ * the same GatewayRoute for every form version, and the piece that differs by version is only the shape of
+ * the success URL, which this builds the way the v3 listener does.
+ *
+ * @since TBD
+ */
+class TestOffsiteGatewayV3FormTest extends TestCase
+{
+    use RefreshDatabase;
+    use InterruptsRedirects;
+
+    /**
+     * @since TBD
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // The test case turns wp_die() into WPDieException, but only for the default handler. Once an earlier
+        // test has defined DOING_AJAX, wp_die() picks the ajax handler instead, which prints and exits.
+        add_filter('wp_die_ajax_handler', [$this, 'get_wp_die_handler']);
+        add_filter('wp_die_json_handler', [$this, 'get_wp_die_handler']);
+
+        /** @var PaymentGatewayRegister $registrar */
+        $registrar = give(PaymentGatewayRegister::class);
+
+        if ( ! $registrar->hasPaymentGateway(TestOffsiteGateway::id())) {
+            $registrar->registerGateway(TestOffsiteGateway::class);
+        }
+    }
+
+    /**
+     * @since TBD
+     */
+    public function tearDown(): void
+    {
+        $_GET = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testAV3FormDonationCompletesWhenTheDonorReturnsFromTheGateway()
+    {
+        $donation = Donation::factory()->create([
+            'status' => DonationStatus::PENDING(),
+            'gatewayId' => TestOffsiteGateway::id(),
+        ]);
+
+        parse_str(parse_url($this->offsiteUrlFor($donation), PHP_URL_QUERY), $_GET);
+
+        $receiptUrl = $this->captureRedirect(static function () {
+            (new GatewayRoute())();
+        });
+
+        parse_str(parse_url($receiptUrl, PHP_URL_QUERY), $receiptArgs);
+
+        $this->assertSame('donation-completed', $receiptArgs['givewp-event']);
+        $this->assertSame($donation->purchaseKey, $receiptArgs['givewp-receipt-id']);
+        $this->assertTrue(Donation::find($donation->id)->status->isComplete());
+    }
+
+    /**
+     * The same signed return URL, repointed at somebody else's pending donation, is refused before the
+     * route method can complete it.
+     *
+     * @since TBD
+     */
+    public function testAReturnRepointedAtAnotherDonationIsRefused()
+    {
+        $mine = Donation::factory()->create([
+            'status' => DonationStatus::PENDING(),
+            'gatewayId' => TestOffsiteGateway::id(),
+        ]);
+        $theirs = Donation::factory()->create(['status' => DonationStatus::PENDING()]);
+
+        parse_str(parse_url($this->offsiteUrlFor($mine), PHP_URL_QUERY), $_GET);
+        $_GET['givewp-donation-id'] = $theirs->id;
+
+        try {
+            (new GatewayRoute())();
+            $this->fail('The route accepted a return whose donation id had been edited.');
+        } catch (WPDieException $exception) {
+            $this->assertStringContainsString('Forbidden', $exception->getMessage());
+        }
+
+        $this->assertTrue(Donation::find($theirs->id)->status->isPending());
+    }
+
+    /**
+     * Runs the gateway's real createPayment() with the gateway data a v3 form hands it, and returns the URL
+     * it redirects the donor to.
+     *
+     * AddRedirectUrlsToGatewayData is what a v3 form runs to build successUrl and cancelUrl, so calling it
+     * here gives the rawurlencoded, receipt-bound URL the gateway actually receives rather than a
+     * hand-made stand-in.
+     */
+    private function offsiteUrlFor(Donation $donation): string
+    {
+        // The v3 listener registers a filter that adds successUrl and cancelUrl to the gateway data.
+        (new AddRedirectUrlsToGatewayData())($this->formDataFor($donation), $donation);
+
+        $gatewayData = apply_filters(
+            'givewp_create_payment_gateway_data_' . TestOffsiteGateway::id(),
+            [],
+            $donation
+        );
+
+        $command = (new TestOffsiteGateway())->createPayment($donation, $gatewayData);
+
+        $this->assertInstanceOf(RedirectOffsite::class, $command);
+
+        return $command->redirectUrl;
+    }
+
+    /**
+     * The v3 form data the redirect-url listener reads, with the confirmation-page redirect turned off so
+     * the success URL is the in-iframe receipt - the case that carries a query string of its own.
+     */
+    private function formDataFor(Donation $donation)
+    {
+        $formData = $this->getMockBuilder('Give\DonationForms\DataTransferObjects\DonateControllerData')
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSuccessUrl', 'getCancelUrl'])
+            ->getMock();
+
+        $formData->method('getSuccessUrl')->willReturn(
+            home_url('/donation-confirmation/?givewp-event=donation-completed&givewp-receipt-id=' . $donation->purchaseKey)
+        );
+        $formData->method('getCancelUrl')->willReturn(home_url('/donate/'));
+
+        return $formData;
+    }
+}

--- a/tests/TestTraits/InterruptsRedirects.php
+++ b/tests/TestTraits/InterruptsRedirects.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Give\Tests\TestTraits;
+
+use Error;
+
+/**
+ * Runs code up to the redirect it issues and hands back where it was going.
+ *
+ * wp_redirect() is followed by exit, so the only seam is the wp_redirect filter. What it throws must
+ * not be an Exception: the legacy adapter, the donate route and GatewayRoute all catch Exception on
+ * the way out and would turn it into an error response.
+ *
+ * @since TBD
+ */
+trait InterruptsRedirects
+{
+    /**
+     * @since TBD
+     */
+    protected function captureRedirect(callable $callback): string
+    {
+        $interrupt = static function (string $location) {
+            throw new class($location) extends Error {
+                public $location;
+
+                public function __construct(string $location)
+                {
+                    parent::__construct("Redirect to $location");
+                    $this->location = $location;
+                }
+            };
+        };
+
+        add_filter('wp_redirect', $interrupt);
+        $bufferLevel = ob_get_level();
+
+        try {
+            $callback();
+        } catch (Error $error) {
+            if (property_exists($error, 'location')) {
+                return $error->location;
+            }
+
+            throw $error;
+        } finally {
+            remove_filter('wp_redirect', $interrupt);
+
+            // The legacy processor opens a buffer around the gateway call that the interrupt skips closing.
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+        }
+
+        $this->fail('Expected a redirect.');
+    }
+}

--- a/tests/e2e/donation-forms.spec.ts
+++ b/tests/e2e/donation-forms.spec.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '@wordpress/e2e-test-utils-playwright';
 import {createCampaignWithForm} from './utils/campaign';
 import {editForm, section} from './utils/form';
+import {captureOffsiteRedirect, enableTestOffsiteGateway, signedReturnUrl} from './utils/offsite-gateway';
 import {
     DONOR,
     donationForm,
@@ -362,6 +363,49 @@ test.describe('V3 donation forms', () => {
                 'href',
                 new RegExp(`p=${formId}`)
             );
+        });
+    });
+    /*
+     * An offsite gateway takes the donor away and brings them back on a signed return URL. The form's
+     * half of that is a redirect out of the iframe, and the return URL it signs is the receipt route on
+     * the page the form was embedded on, query string and all. See legacy-donation-forms.spec.ts for the
+     * v2 form's version of the same trip.
+     */
+    test.describe('paying through an offsite gateway', () => {
+        let formId: number;
+
+        test.beforeAll(async ({requestUtils}) => {
+            enableTestOffsiteGateway(3);
+            ({formId} = await createCampaignWithForm(requestUtils));
+        });
+
+        test('takes the donation out to the gateway and back to the receipt', async ({page}) => {
+            await page.goto(`/?post_type=give_forms&p=${formId}`);
+
+            const form = donationForm(page);
+
+            await waitForForm(form);
+            await form.getByRole('button', {name: 'Donate now'}).click();
+
+            await fillDonorDetails(form);
+            await form.getByRole('button', {name: 'Continue'}).click();
+
+            await form.getByRole('radio', {name: 'Donate with Test Gateway (Offsite)'}).check();
+
+            const offsiteUrl = await captureOffsiteRedirect(page, async () => {
+                await form.getByRole('button', {name: 'Donate now'}).click();
+            });
+
+            const returnUrl = signedReturnUrl(offsiteUrl);
+
+            expect(returnUrl).toContain('givewp-event=donation-completed');
+            expect(returnUrl).toContain('givewp-receipt-id=');
+
+            // Back from the processor, in the donor's own window.
+            await page.goto(offsiteUrl);
+
+            await expect(page).toHaveURL(/givewp-event=donation-completed/);
+            await expectReceipt(donationForm(page), '$10.00');
         });
     });
 });

--- a/tests/e2e/legacy-donation-forms.spec.ts
+++ b/tests/e2e/legacy-donation-forms.spec.ts
@@ -1,0 +1,77 @@
+import {expect, test} from '@wordpress/e2e-test-utils-playwright';
+import {createLegacyForm} from './utils/legacy-form';
+import {
+    captureOffsiteRedirect,
+    enableTestOffsiteGateway,
+    signedReturnUrl,
+    TEST_OFFSITE_GATEWAY,
+} from './utils/offsite-gateway';
+
+/**
+ * A legacy (v2) donation form on the front end, paid through an offsite gateway.
+ *
+ * The form posts to the legacy processor, the gateway redirects the donor away with a signed return
+ * URL, and coming back lands on GatewayRoute, which checks the signature before completing the
+ * donation. Every gateway that leaves the site rides this path on v2 forms, and none of it is
+ * reachable from PHPUnit: the return URL is assembled by the legacy adapter from the page the form
+ * was embedded on, so only a real embed produces the shape that broke.
+ *
+ * The legacy adapter hands the gateway that return URL raw, and it carries a query string of its own
+ * because an embedded form's receipt is the form's page plus `giveDonationAction=showReceipt`. That is
+ * the ampersand the signature has to survive.
+ */
+
+// Donors are not logged in, and a logged-in admin's session would prefill and attach the donation.
+test.use({storageState: {cookies: [], origins: []}});
+
+test.describe('Legacy donation forms', () => {
+    let formId: number;
+
+    test.beforeAll(() => {
+        enableTestOffsiteGateway(2);
+        ({formId} = createLegacyForm());
+    });
+
+    test('takes an offsite donation out to the gateway and back to the receipt', async ({page}) => {
+        await page.goto(`/?post_type=give_forms&p=${formId}`);
+
+        const form = page.frameLocator('iframe[name="give-embed-form"]');
+
+        await form.locator('.give-section.introduction .advance-btn').click();
+        await form.locator('.give-section.choose-amount .advance-btn').click();
+
+        await form.locator('#give-first').fill('Ada');
+        await form.locator('#give-last').fill('Lovelace');
+        await form.locator('#give-email').fill('ada@example.test');
+
+        // The radio itself is hidden behind its styled label, and picking a gateway reloads its fields.
+        await form.getByText('Donate with Test Gateway (Offsite)').click();
+        await expect(form.locator('input[name="give-gateway"]')).toHaveValue(TEST_OFFSITE_GATEWAY);
+
+        const offsiteUrl = await captureOffsiteRedirect(page, async () => {
+            await form.locator('#give-purchase-button').click();
+        });
+
+        /*
+         * Read whole off the route URL rather than in the pieces an unencoded ampersand would have left
+         * behind. Without it the route sees a return URL cut off at the first argument and refuses the
+         * signature, which is the failure this covers.
+         */
+        const returnUrl = signedReturnUrl(offsiteUrl);
+
+        expect(returnUrl).toContain('giveDonationAction=showReceipt');
+        expect(returnUrl).toContain(`payment-confirmation=${TEST_OFFSITE_GATEWAY}`);
+
+        // Back from the processor, in the donor's own window rather than in the form's iframe.
+        await page.goto(offsiteUrl);
+
+        // The receipt for an embedded form is the page the form was on, showing the form's iframe again.
+        await expect(page).toHaveURL(new RegExp(`payment-confirmation=${TEST_OFFSITE_GATEWAY}`));
+
+        const receipt = page.frameLocator('iframe[name="give-embed-form"]').locator('.give-receipt-wrap');
+
+        await expect(receipt).toBeVisible({timeout: 30_000});
+        await expect(receipt).toContainText('ada@example.test');
+        await expect(receipt).toContainText('Complete');
+    });
+});

--- a/tests/e2e/utils/legacy-form.ts
+++ b/tests/e2e/utils/legacy-form.ts
@@ -1,0 +1,40 @@
+import {wp} from './wp-cli';
+
+/**
+ * Fixtures for the legacy (v2) donation form, which has no REST route and cannot be created in
+ * wp-admin any more - the classic "Add New" screen redirects to campaigns.
+ */
+
+/**
+ * Creates a published v2 form on the multi-step (Sequoia) template with one set amount.
+ *
+ * The template matters: the multi-step form embeds in an iframe and builds its success URL from the
+ * page it is on, which is how a return URL ends up carrying a query string of its own.
+ */
+export function createLegacyForm(): {title: string; formId: number} {
+    const title = `E2E legacy form ${Date.now()}`;
+
+    const formId = Number(
+        wp(
+            'post',
+            'create',
+            '--post_type=give_forms',
+            '--post_status=publish',
+            `--post_title=${title}`,
+            `--meta_input=${JSON.stringify({
+                _give_form_template: 'sequoia',
+                _give_price_option: 'set',
+                _give_set_price: '10.00',
+                // Without this the donor fields are not rendered at all; the editor saves it as 'none' by default.
+                _give_show_register_form: 'none',
+            })}`,
+            '--porcelain'
+        )
+    );
+
+    if (!formId) {
+        throw new Error('WP-CLI did not return the id of the legacy form it was asked to create.');
+    }
+
+    return {title, formId};
+}

--- a/tests/e2e/utils/offsite-gateway.ts
+++ b/tests/e2e/utils/offsite-gateway.ts
@@ -1,0 +1,75 @@
+import {Page} from '@wordpress/e2e-test-utils-playwright';
+import {wp} from './wp-cli';
+
+/**
+ * The offsite donation path, which no gateway that ships enabled can walk.
+ *
+ * An offsite gateway takes the donor's whole browser window away to the processor and gets it back on
+ * a signed `give-listener=give-gateway` URL, and the site never sees the processor in between. Test
+ * Gateway (Offsite) stands in for the real ones because its "offsite" page is that return route
+ * itself, so the two halves of the trip are one URL.
+ */
+
+export const TEST_OFFSITE_GATEWAY = 'test-offsite-gateway';
+
+/**
+ * The return route, which is also where this gateway sends the donor instead of a processor.
+ */
+const OFFSITE_REDIRECT = /give-listener=give-gateway/;
+
+/**
+ * Enables Test Gateway (Offsite) for one form generation, leaving whatever else the site has enabled
+ * alone.
+ *
+ * The two generations read separate options, so a gateway enabled for v2 forms is invisible to v3
+ * forms and the other way round. Neither option has a REST route - GiveWP's settings are one option -
+ * so this goes through WP-CLI.
+ */
+export function enableTestOffsiteGateway(formVersion: 2 | 3): void {
+    const option = formVersion === 2 ? 'gateways' : 'gateways_v3';
+    const gateways = JSON.parse(wp('option', 'pluck', 'give_settings', option, '--format=json') || '{}');
+
+    gateways[TEST_OFFSITE_GATEWAY] = 1;
+
+    wp('option', 'patch', 'update', 'give_settings', option, JSON.stringify(gateways), '--format=json');
+}
+
+/**
+ * Submits the form and returns the URL the gateway redirected the donor to, without letting the site
+ * load it.
+ *
+ * Aborting it is what makes this an offsite trip rather than a same-site hop. A real processor is
+ * somewhere else, so the site cannot answer its own return route while the donor is away, and on a v2
+ * form it matters twice: the form lives in an iframe, and a return route loaded inside that iframe
+ * still looks like form processing to `Helpers\Form\Utils::isProcessingForm()`, which rewrites the
+ * redirect to the plain success page. Coming back through `page.goto()` instead is the arrival a
+ * returning donor makes.
+ */
+export async function captureOffsiteRedirect(page: Page, submit: () => Promise<void>): Promise<string> {
+    await page.route(OFFSITE_REDIRECT, (route) => route.abort());
+
+    try {
+        const [request] = await Promise.all([page.waitForRequest(OFFSITE_REDIRECT, {timeout: 30_000}), submit()]);
+
+        return request.url();
+    } finally {
+        await page.unroute(OFFSITE_REDIRECT);
+    }
+}
+
+/**
+ * The return URL the gateway signed, which is where the donor lands when they come back.
+ *
+ * It is a URL inside a URL, and the reason these specs exist: it carries a query string of its own, so
+ * writing it onto the route URL unencoded would split it into separate parameters that the route reads
+ * back as a truncated return URL and a signature it can never match.
+ */
+export function signedReturnUrl(offsiteUrl: string): string {
+    const returnUrl = new URL(offsiteUrl).searchParams.get('givewp-return-url');
+
+    if (!returnUrl) {
+        throw new Error(`The gateway redirect carried no return URL to come back to: ${offsiteUrl}`);
+    }
+
+    return returnUrl;
+}

--- a/tests/e2e/utils/wp-cli.ts
+++ b/tests/e2e/utils/wp-cli.ts
@@ -1,0 +1,21 @@
+import {execFileSync} from 'child_process';
+
+/**
+ * Runs a WP-CLI command in the wp-env site this checkout started and returns its last line of output.
+ *
+ * Some fixtures have no REST route: a legacy (v2) donation form is a post with protected meta, and
+ * GiveWP's settings are one option nobody exposes. WP-CLI is what wp-env offers for those, and it
+ * talks to the environment `npm run env:start` created here - not to whatever `WP_BASE_URL` points
+ * at. A run against a different site has to set that site up by hand.
+ */
+export function wp(...args: string[]): string {
+    const output = execFileSync('npx', ['wp-env', 'run', 'cli', 'wp', ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    // wp-env wraps the command in status lines of its own; the command's result is the last line that is not one.
+    const lines = output.split('\n').filter((line) => line.trim() && !/^[✔✖ℹ]/.test(line.trim()));
+
+    return lines.pop()?.trim() ?? '';
+}


### PR DESCRIPTION
## Problem

QA found v2 donation forms failing with upcoming give-razorpay 3.0.0 on the release candidate. `fix/sign-secure-route-query-args` started signing the gateway route's own query args, but wrote them onto the URL as given. `add_query_arg` does no encoding, and a legacy (v2) form hands the gateway its success and cancel URLs **raw**. Under plain permalinks that URL carries a query string of its own, so its ampersand split it into separate parameters on the way back. The route rebuilt the signature from a truncated return URL and refused it with a 403.

This broke every offsite gateway on v2 forms. give-razorpay 3.0.0 passes both its success and cancel URLs through `generateSecureGatewayRouteUrl()`; PayPal Standard has the same exposure.

## Fix

`generateSecureGatewayRouteUrl()` now normalizes the args once, signs them, and writes them onto the URL **rawurlencoded**. PHP's single decode then hands the route exactly the signed value, whether the gateway passed it raw or pre-encoded. Route methods receive the same decoded values as before. `RouteSignature` gains `encodeArgs()` and a recursive `normalizeArgs()`.

## Tests

Application-layer coverage for both form versions, using the in-core `TestOffsiteGateway` as the subject:

- **PHPUnit** — `TestOffsiteGatewayLegacyFormTest` drives the real v2 flow (posts to `give_process_donation_form()`, follows the offsite redirect, runs `GatewayRoute` on the return); `TestOffsiteGatewayV3FormTest` drives the v3 shape (builds gateway data through `AddRedirectUrlsToGatewayData`, calls `createPayment`, runs the return route). Each also asserts a return repointed at another donation is refused. Both reproduce the 403 without the fix.
- **Playwright** — `legacy-donation-forms.spec.ts` and a new block in `donation-forms.spec.ts` walk the offsite redirect in a browser for v2 and v3.
- `TestOffsiteGateway` registers only when `GIVEWP_ENABLE_TEST_OFFSITE_GATEWAY` is defined, which `.wp-env.json` sets for the e2e environment. `docs/testing.md` documents this.

## Verification

- Gateway PHPUnit suite: 723 pass (4 pre-existing unrelated incompletes).
- Secure-route + offsite classes: 25 tests, stable across repeated runs.
- Both e2e specs pass against wp-env, including the new v2 and v3 offsite tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790972103&installation_model_id=426813&pr_number=8317&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8317&signature=74268bb07a4555a36ee792d1f4db79460aa015336d34132ac7e8d7c67dfc2a30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved payment gateway return URLs to safely preserve embedded query parameters, including ampersands.
  - Added validation to prevent tampered return URLs from redirecting to or modifying another donation.
  - Normalized and encoded route data consistently for reliable signed URL round trips.

- **Testing**
  - Added coverage for offsite payments using both current and legacy donation forms.
  - Added optional test-gateway support for local and end-to-end testing.

- **Documentation**
  - Updated payment gateway and testing guidance for secure return URLs and offsite payment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->