### PR TITLE
chore: drop the Tweak change type from the contributor conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,9 @@ These are the two things that get missed most often:
   there is no autodiscovery, and a provider missing from it loads nothing and reports no error. See
   [docs/architecture/bootstrapping.md](docs/architecture/bootstrapping.md).
 - PRs target the `develop` branch, never `master`.
-- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Tweak:`, `Fix:`,
-  `Security:` — the same set the changelogger uses.
+- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, or
+  `Security:`. Use the same type for the changelog entry. Small copy or behavior adjustments
+  are enhancements, not a separate type.
 - No leftover debug code (`var_dump()`, `error_log()`, `console.log()`), and `debug.log` should
   stay empty while testing a change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,8 @@ These are the two things that get missed most often:
   there is no autodiscovery, and a provider missing from it loads nothing and reports no error. See
   [docs/architecture/bootstrapping.md](docs/architecture/bootstrapping.md).
 - PRs target the `develop` branch, never `master`.
-- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, `Docs:`, or
-  `Chore:`. Use the same type for the changelog entry. Small copy or behavior adjustments
-  are enhancements, not a separate type. A PR that only adds or changes tests is prefixed
-  `Tests:` and needs no changelog entry.
+- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, `Docs:`, `Tests:` or
+  `Chore:`. Use the same type for the changelog entry. A PR that does not add or change production code needs no changelog entry.
 - No leftover debug code (`var_dump()`, `error_log()`, `console.log()`), and `debug.log` should
   stay empty while testing a change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ These are the two things that get missed most often:
   there is no autodiscovery, and a provider missing from it loads nothing and reports no error. See
   [docs/architecture/bootstrapping.md](docs/architecture/bootstrapping.md).
 - PRs target the `develop` branch, never `master`.
-- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, or
+- PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, `Docs:`, or
   `Chore:`. Use the same type for the changelog entry. Small copy or behavior adjustments
   are enhancements, not a separate type. A PR that only adds or changes tests is prefixed
   `Tests:` and needs no changelog entry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ These are the two things that get missed most often:
   [docs/architecture/bootstrapping.md](docs/architecture/bootstrapping.md).
 - PRs target the `develop` branch, never `master`.
 - PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, or
-  `Security:`. Use the same type for the changelog entry. Small copy or behavior adjustments
+  `Chore:`. Use the same type for the changelog entry. Small copy or behavior adjustments
   are enhancements, not a separate type. A PR that only adds or changes tests is prefixed
   `Tests:` and needs no changelog entry.
 - No leftover debug code (`var_dump()`, `error_log()`, `console.log()`), and `debug.log` should

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ These are the two things that get missed most often:
 - PRs target the `develop` branch, never `master`.
 - PR titles are prefixed with the change type: `Feature:`, `Enhancement:`, `Fix:`, or
   `Security:`. Use the same type for the changelog entry. Small copy or behavior adjustments
-  are enhancements, not a separate type.
+  are enhancements, not a separate type. A PR that only adds or changes tests is prefixed
+  `Tests:` and needs no changelog entry.
 - No leftover debug code (`var_dump()`, `error_log()`, `console.log()`), and `debug.log` should
   stay empty while testing a change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ See [tests/README.md](tests/README.md) for environment setup and how to filter t
    * You've added a changelog entry with `composer run changelog:add` — this drops a YAML file into `./changelog` that gets compiled into `readme.txt` at release time. Commit it with your PR.
    * There's no leftover debug code (`var_dump()`, `console.log()`) and `/wp-content/debug.log` stays empty while testing your changes.
 3. [Submit the pull request](https://help.github.com/articles/creating-a-pull-request) to the `develop` branch, referencing the related issue if there is one.
-4. Prefix the PR title with the type of change, e.g. `Feature: add donation form export`, `Fix: prevent duplicate receipts`, or `Tweak: improve settings copy`.
+4. Prefix the PR title with the type of change, e.g. `Feature: add donation form export`, `Fix: prevent duplicate receipts`, or `Enhancement: improve settings copy`.
 
 We review all pull requests and will make suggestions and changes if necessary.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ See [tests/README.md](tests/README.md) for environment setup and how to filter t
    * You've added a changelog entry with `composer run changelog:add` — this drops a YAML file into `./changelog` that gets compiled into `readme.txt` at release time. Commit it with your PR.
    * There's no leftover debug code (`var_dump()`, `console.log()`) and `/wp-content/debug.log` stays empty while testing your changes.
 3. [Submit the pull request](https://help.github.com/articles/creating-a-pull-request) to the `develop` branch, referencing the related issue if there is one.
-4. Prefix the PR title with the type of change, e.g. `Feature: add donation form export`, `Fix: prevent duplicate receipts`, or `Enhancement: improve settings copy`.
+4. Prefix the PR title with the type of change, e.g. `Feature: add donation form export`, `Fix: prevent duplicate receipts`, or `Enhancement: improve settings copy`. Use `Tests:` for a PR that only touches tests.
 
 We review all pull requests and will make suggestions and changes if necessary.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ See [tests/README.md](tests/README.md) for environment setup and how to filter t
    * All PHPUnit tests pass (`composer test`).
    * Your code follows PSR-12 and the `.eslintrc`/`.editorconfig` rulesets.
    * New or changed code has `@since TBD` docblock tags.
-   * You've added a changelog entry with `composer run changelog:add` — this drops a YAML file into `./changelog` that gets compiled into `readme.txt` at release time. Commit it with your PR.
+   * You've added a changelog entry with `composer run changelog:add` — this drops a YAML file into `./changelog` that gets compiled into `readme.txt` at release time. Commit it with your PR. PRs prefixed with `Tests:` that only add or change tests do not need a changelog entry.
    * There's no leftover debug code (`var_dump()`, `console.log()`) and `/wp-content/debug.log` stays empty while testing your changes.
 3. [Submit the pull request](https://help.github.com/articles/creating-a-pull-request) to the `develop` branch, referencing the related issue if there is one.
 4. Prefix the PR title with the type of change, e.g. `Feature: add donation form export`, `Fix: prevent duplicate receipts`, or `Enhancement: improve settings copy`. Use `Tests:` for a PR that only touches tests.


### PR DESCRIPTION
## Summary

Updated AGENTS.md and CONTRIBUTING.md about PR title conventions

The `tweak` changelogger type stays registered in package.json so existing unreleased changelog entries and the compiled history keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791143289&installation_model_id=426813&pr_number=8318&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8318&signature=a0bac7a454b0f9d090ca2de95692414d9ab0402c144300b1c017dfa906eb23b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated pull-request guidance to recognize `Tests:` as a valid change-type prefix.
  - Clarified that small copy or behavior adjustments should not be classified as enhancements.
  - Test-only pull requests are exempt from changelog-entry requirements; entries remain required for production-code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->