### PR TITLE
Enhancement: sign donors in inside externally embedded forms without cookies

### DIFF
--- a/changelog/enhancement-sign-in-inside-external-embeds.yaml
+++ b/changelog/enhancement-sign-in-inside-external-embeds.yaml
@@ -1,4 +1,0 @@
-significance: minor
-type: enhancement
-entry: Donors can sign in inside a donation form embedded on another website; the login no longer depends on cookies the browser blocks in cross-site iframes.
-timestamp: 2026-09-04T00:00:00.000Z

--- a/changelog/enhancement-sign-in-inside-external-embeds.yaml
+++ b/changelog/enhancement-sign-in-inside-external-embeds.yaml
@@ -1,0 +1,4 @@
+significance: minor
+type: enhancement
+entry: Donors can sign in inside a donation form embedded on another website; the login no longer depends on cookies the browser blocks in cross-site iframes.
+timestamp: 2026-09-04T00:00:00.000Z

--- a/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
+++ b/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Give\DonationForms\Actions;
+
+/**
+ * Signs the donor in for a donate or validate request from a signed auth
+ * token instead of the login cookie.
+ *
+ * A donation form embedded on another website cannot rely on cookies: the
+ * browser drops WordPress auth cookies set from a cross-site iframe response.
+ * The authentication route therefore also returns the auth cookie value, which
+ * WordPress already signs, expires, and backs with a session token. The form
+ * sends it back with the donation and the route validates it the same way core
+ * validates the cookie.
+ *
+ * This runs from the two form routes rather than on determine_current_user so
+ * it works even when another plugin resolves the current user before this
+ * plugin has loaded, and so the token is never accepted anywhere else.
+ *
+ * @since TBD
+ */
+class AuthenticateFormRequestWithToken
+{
+    const TOKEN_KEY = 'authToken';
+
+    /**
+     * @since TBD
+     */
+    public function __invoke(array $request): void
+    {
+        if (is_user_logged_in()) {
+            return;
+        }
+
+        $token = $request[self::TOKEN_KEY] ?? '';
+
+        if (!is_string($token) || $token === '') {
+            return;
+        }
+
+        $userId = wp_validate_auth_cookie($token, 'logged_in');
+
+        if ($userId) {
+            wp_set_current_user($userId);
+        }
+    }
+}

--- a/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
+++ b/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
@@ -46,6 +46,17 @@ class AuthenticateFormRequestWithToken
             return;
         }
 
+        /*
+         * Core extends the expiry by an hour for POST requests, which is meant
+         * for a form that sat open in a browser. This token is a short-lived
+         * credential, so its own expiry is the limit.
+         */
+        $parts = wp_parse_auth_cookie($token, self::SCHEME);
+
+        if (!$parts || (int)$parts['expiration'] < time()) {
+            return;
+        }
+
         $userId = wp_validate_auth_cookie($token, self::SCHEME);
 
         if ($userId) {

--- a/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
+++ b/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
@@ -8,10 +8,11 @@ namespace Give\DonationForms\Actions;
  *
  * A donation form embedded on another website cannot rely on cookies: the
  * browser drops WordPress auth cookies set from a cross-site iframe response.
- * The authentication route therefore also returns the auth cookie value, which
- * WordPress already signs, expires, and backs with a session token. The form
- * sends it back with the donation and the route validates it the same way core
- * validates the cookie.
+ * The authentication route therefore also returns a token built with the same
+ * core functions as the auth cookie, which WordPress signs, expires, and backs
+ * with a session token, under a plugin-specific scheme. The form sends it back
+ * with the donation and the route validates it the same way core validates
+ * the cookie.
  *
  * This runs from the two form routes rather than on determine_current_user so
  * it works even when another plugin resolves the current user before this
@@ -22,6 +23,13 @@ namespace Give\DonationForms\Actions;
 class AuthenticateFormRequestWithToken
 {
     const TOKEN_KEY = 'authToken';
+
+    /**
+     * A plugin-specific salt scheme. WordPress derives the salt from the scheme
+     * name, so the token verifies only here and is never a valid login cookie
+     * if it leaks.
+     */
+    const SCHEME = 'givewp_embedded_form';
 
     /**
      * @since TBD
@@ -38,7 +46,7 @@ class AuthenticateFormRequestWithToken
             return;
         }
 
-        $userId = wp_validate_auth_cookie($token, 'logged_in');
+        $userId = wp_validate_auth_cookie($token, self::SCHEME);
 
         if ($userId) {
             wp_set_current_user($userId);

--- a/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
+++ b/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
@@ -22,14 +22,22 @@ namespace Give\DonationForms\Actions;
  */
 class AuthenticateFormRequestWithToken
 {
-    const TOKEN_KEY = 'authToken';
+    /**
+     * The request key the form sends the token under. The authentication
+     * route returns it under the same key.
+     *
+     * @since TBD
+     */
+    public const TOKEN_KEY = 'authToken';
 
     /**
      * A plugin-specific salt scheme. WordPress derives the salt from the scheme
      * name, so the token verifies only here and is never a valid login cookie
      * if it leaks.
+     *
+     * @since TBD
      */
-    const SCHEME = 'givewp_embedded_form';
+    public const SCHEME = 'givewp_embedded_form';
 
     /**
      * @since TBD

--- a/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
+++ b/src/DonationForms/Actions/AuthenticateFormRequestWithToken.php
@@ -59,7 +59,7 @@ class AuthenticateFormRequestWithToken
          * for a form that sat open in a browser. This token is a short-lived
          * credential, so its own expiry is the limit.
          */
-        $parts = wp_parse_auth_cookie($token, self::SCHEME);
+        $parts = wp_parse_auth_cookie($token);
 
         if (!$parts || (int)$parts['expiration'] < time()) {
             return;

--- a/src/DonationForms/Routes/AuthenticationRoute.php
+++ b/src/DonationForms/Routes/AuthenticationRoute.php
@@ -40,15 +40,16 @@ class AuthenticationRoute
     }
 
     /**
-     * The token is the logged_in auth cookie value: signed by core, session
-     * backed, and revoked with the session. It carries the login where the
-     * cookie cannot, which is inside a cross-site iframe.
+     * The token is built like an auth cookie: signed by core, session backed,
+     * and revoked with the session. It carries the login where the cookie
+     * cannot, which is inside a cross-site iframe. Its own salt scheme means
+     * it is not usable as a login cookie.
      *
      * @since TBD
      */
     protected function generateAuthToken(WP_User $user): string
     {
-        return wp_generate_auth_cookie($user->ID, time() + HOUR_IN_SECONDS, 'logged_in');
+        return wp_generate_auth_cookie($user->ID, time() + HOUR_IN_SECONDS, AuthenticateFormRequestWithToken::SCHEME);
     }
 
     /**

--- a/src/DonationForms/Routes/AuthenticationRoute.php
+++ b/src/DonationForms/Routes/AuthenticationRoute.php
@@ -2,6 +2,7 @@
 
 namespace Give\DonationForms\Routes;
 
+use Give\DonationForms\Actions\AuthenticateFormRequestWithToken;
 use Give\DonationForms\DataTransferObjects\AuthenticationData;
 use Give\DonationForms\DataTransferObjects\DonateRouteData;
 use Give\DonationForms\DataTransferObjects\UserData;
@@ -16,6 +17,7 @@ class AuthenticationRoute
     use HandleHttpResponses;
 
     /**
+     * @since TBD Return an auth token so embedded forms can authenticate without cookies.
      * @since 3.0.0
      *
      * @return void
@@ -28,9 +30,25 @@ class AuthenticationRoute
 
         $user = $this->authenticate(AuthenticationData::fromRequest($request));
 
-        wp_send_json_success(UserData::fromUser($user));
+        wp_send_json_success(
+            get_object_vars(UserData::fromUser($user)) + [
+                AuthenticateFormRequestWithToken::TOKEN_KEY => $this->generateAuthToken($user),
+            ]
+        );
 
         exit;
+    }
+
+    /**
+     * The token is the logged_in auth cookie value: signed by core, session
+     * backed, and revoked with the session. It carries the login where the
+     * cookie cannot, which is inside a cross-site iframe.
+     *
+     * @since TBD
+     */
+    protected function generateAuthToken(WP_User $user): string
+    {
+        return wp_generate_auth_cookie($user->ID, time() + HOUR_IN_SECONDS, 'logged_in');
     }
 
     /**

--- a/src/DonationForms/Routes/DonateRoute.php
+++ b/src/DonationForms/Routes/DonateRoute.php
@@ -2,8 +2,8 @@
 
 namespace Give\DonationForms\Routes;
 
-
 use Exception;
+use Give\DonationForms\Actions\AuthenticateFormRequestWithToken;
 use Give\DonationForms\Controllers\DonateController;
 use Give\DonationForms\DataTransferObjects\DonateControllerData;
 use Give\DonationForms\DataTransferObjects\DonateFormRouteData;
@@ -39,6 +39,7 @@ class DonateRoute
     }
 
     /**
+     * @since TBD Sign the donor in from the auth token when the login cookie is unavailable.
      * @since 3.0.0
      *
      * @return void
@@ -50,6 +51,8 @@ class DonateRoute
 
         // validate signature
         $routeData->validateSignature();
+
+        (new AuthenticateFormRequestWithToken())($request);
 
         // create DTO from POST request
         $formData = DonateFormRouteData::fromRequest($request);

--- a/src/DonationForms/Routes/ValidationRoute.php
+++ b/src/DonationForms/Routes/ValidationRoute.php
@@ -2,8 +2,8 @@
 
 namespace Give\DonationForms\Routes;
 
-
 use Exception;
+use Give\DonationForms\Actions\AuthenticateFormRequestWithToken;
 use Give\DonationForms\DataTransferObjects\DonateRouteData;
 use Give\DonationForms\DataTransferObjects\ValidationRouteData;
 use Give\DonationForms\Exceptions\DonationFormFieldErrorsException;
@@ -21,6 +21,7 @@ class ValidationRoute
     use HandleHttpResponses;
 
     /**
+     * @since TBD Sign the donor in from the auth token when the login cookie is unavailable.
      * @since 3.22.0 added additional catch statements for forbidden and unknown errors
      * @since 3.0.0
      */
@@ -31,6 +32,8 @@ class ValidationRoute
 
         // validate signature
         $routeData->validateSignature();
+
+        (new AuthenticateFormRequestWithToken())($request);
 
         // create DTO from POST request
         $formData = ValidationRouteData::fromRequest($request);

--- a/src/DonationForms/resources/app/utilities/authToken.ts
+++ b/src/DonationForms/resources/app/utilities/authToken.ts
@@ -1,0 +1,21 @@
+/**
+ * The auth token the authentication route returns after a successful login.
+ *
+ * Inside a cross-site iframe the browser drops the WordPress login cookie, so
+ * this token is what keeps the donor signed in for the validate and donate
+ * requests. It is request transport, not form data: keeping it out of the form
+ * values keeps it out of the client-side validation schema, which rejects keys
+ * it does not know.
+ *
+ * It lives on window.givewp.form because the login template and the form app
+ * ship in separate bundles, so module state would not be shared between them.
+ *
+ * @since TBD
+ */
+export function setAuthToken(token: string): void {
+    window.givewp.form.authToken = token ?? '';
+}
+
+export function getAuthToken(): string {
+    return window.givewp?.form?.authToken ?? '';
+}

--- a/src/DonationForms/resources/app/utilities/authToken.ts
+++ b/src/DonationForms/resources/app/utilities/authToken.ts
@@ -16,6 +16,9 @@ export function setAuthToken(token: string): void {
     window.givewp.form.authToken = token ?? '';
 }
 
+/**
+ * @since TBD
+ */
 export function getAuthToken(): string {
     return window.givewp?.form?.authToken ?? '';
 }

--- a/src/DonationForms/resources/app/utilities/handleFormSubmitRequest.ts
+++ b/src/DonationForms/resources/app/utilities/handleFormSubmitRequest.ts
@@ -13,8 +13,10 @@ import handleRedirect from '@givewp/forms/app/utilities/handleFormRedirect';
 import getCurrentFormUrlData from '@givewp/forms/app/utilities/getCurrentFormUrlData';
 import postFormData from '@givewp/forms/app/utilities/postFormData';
 import convertValuesToFormData from '@givewp/forms/app/utilities/convertValuesToFormData';
+import {getAuthToken} from '@givewp/forms/app/utilities/authToken';
 
 /**
+ * @since TBD Send the auth token so embedded forms stay signed in without cookies
  * @since 3.22.0 Add locale support
  */
 export default async function handleSubmitRequest(
@@ -42,6 +44,7 @@ export default async function handleSubmitRequest(
             isEmbed,
             embedId,
             locale,
+            authToken: getAuthToken(),
         };
 
         const formData = convertValuesToFormData(formValues);

--- a/src/DonationForms/resources/app/utilities/handleValidationRequest.ts
+++ b/src/DonationForms/resources/app/utilities/handleValidationRequest.ts
@@ -6,8 +6,10 @@ import {__} from '@wordpress/i18n';
 import {FieldValues, UseFormSetError} from 'react-hook-form';
 import postFormData from '@givewp/forms/app/utilities/postFormData';
 import convertValuesToFormData from '@givewp/forms/app/utilities/convertValuesToFormData';
+import {getAuthToken} from '@givewp/forms/app/utilities/authToken';
 
 /**
+ * @since TBD Send the auth token so embedded forms stay signed in without cookies
  * @since 3.0.0
  */
 export default async function handleValidationRequest(
@@ -26,7 +28,7 @@ export default async function handleValidationRequest(
     }
 
     try {
-        const formData = convertValuesToFormData(values);
+        const formData = convertValuesToFormData({...values, authToken: getAuthToken()});
 
         const {response} = await postFormData(validateUrl, formData);
 

--- a/src/DonationForms/resources/registrars/index.ts
+++ b/src/DonationForms/resources/registrars/index.ts
@@ -16,6 +16,7 @@ declare global {
             gateways: GatewayRegistrar;
             form: {
                 templates: typeof defaultFormTemplates;
+                authToken?: string;
                 hooks: {
                     useFormContext: typeof useFormContext;
                     useWatch: typeof useWatch;

--- a/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
+++ b/src/DonationForms/resources/registrars/templates/groups/Authentication.tsx
@@ -6,6 +6,7 @@ import getWindowData from '@givewp/forms/app/utilities/getWindowData';
 import postData from '@givewp/forms/app/utilities/postData';
 import getCurrentFormUrlData from '@givewp/forms/app/utilities/getCurrentFormUrlData';
 import navigateTop from '@givewp/forms/app/utilities/navigateTop';
+import {setAuthToken} from '@givewp/forms/app/utilities/authToken';
 import FieldError from '../layouts/FieldError';
 import styles from '../styles.module.scss';
 
@@ -157,6 +158,14 @@ const LoginForm = ({children, success, lostPasswordUrl, nodeName}) => {
             setValue('firstName', firstName || responseData.firstName);
             setValue('lastName', lastName || responseData.lastName);
             setValue('email', email || responseData.email);
+
+            /*
+             * Inside a cross-site iframe the browser drops the login cookie, so the
+             * server also returns a signed token that rides along with every
+             * validate and donate request instead.
+             */
+            setAuthToken(responseData.authToken);
+
             success();
         } else {
             setErrorMessage(

--- a/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
+++ b/src/FormBuilder/resources/js/form-builder/src/components/EmbedForm/index.tsx
@@ -13,7 +13,6 @@ import getWindowData from '@givewp/form-builder/common/getWindowData';
 import {CheckIcon} from '@givewp/form-builder/components/icons';
 import {CopyIcon, ExitIcon} from '@givewp/components/AdminUI/Icons';
 import {Interweave} from 'interweave';
-import type {BlockInstance} from '@wordpress/blocks';
 import type {FormSettings} from '@givewp/form-builder/types/formSettings';
 
 import './styles.scss';
@@ -53,7 +52,7 @@ interface StateProps {
  */
 export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
 
-    const {formId, externalEmbedScriptUrl, blockData, settings, campaignColors} = getWindowData();
+    const {formId, externalEmbedScriptUrl, settings, campaignColors} = getWindowData();
     const [isExternalEmbedCopied, setIsExternalEmbedCopied] = useState<boolean>(false);
 
     const parsedSettings = useMemo((): Partial<FormSettings> => {
@@ -88,30 +87,6 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
      * @since TBD
      */
     const hasConfirmationRedirect = !!parsedSettings.enableReceiptConfirmationPage;
-
-    /**
-     * Login inside a cross-origin embed is unreliable in some browsers, so
-     * warn when this form requires it. Based on the saved block data.
-     *
-     * @since TBD
-     */
-    const hasRequiredLogin = useMemo((): boolean => {
-        try {
-            const containsRequiredLogin = (blocks: BlockInstance[]): boolean =>
-                Array.isArray(blocks) &&
-                blocks.some(
-                    (block) =>
-                        (block?.name === 'givewp/login' && block?.attributes?.required) ||
-                        containsRequiredLogin(block?.innerBlocks)
-                );
-
-            return containsRequiredLogin(JSON.parse(blockData));
-        } catch (error) {
-            console.error(error);
-
-            return false;
-        }
-    }, [blockData]);
 
     const newPostNameRef = useRef<HTMLInputElement>(null);
     const openFormBtnRef = useRef<HTMLInputElement>(null);
@@ -523,12 +498,6 @@ export default function EmbedFormModal({handleClose}: EmbedFormModalProps) {
                                         {__('The button is part of the other website, so it keeps this color until the snippet is updated. The form itself always uses its current design.', 'give')}
                                     </div>
                                 </>
-                            )}
-
-                            {hasRequiredLogin && (
-                                <div className="give-embed-modal-helptext">
-                                    {__('This form requires donor login, which is unreliable inside embedded forms in some browsers (like Safari). Consider making login optional for external embedding.', 'give')}
-                                </div>
                             )}
 
                             {hasConfirmationRedirect && (

--- a/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
+++ b/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Give\Tests\Unit\DonationForms\Actions;
+
+use Give\DonationForms\Actions\AuthenticateFormRequestWithToken;
+use Give\Tests\TestCase;
+use Give\Tests\TestTraits\RefreshDatabase;
+use WP_Session_Tokens;
+
+/**
+ * @since TBD
+ */
+class AuthenticateFormRequestWithTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function tearDown(): void
+    {
+        wp_set_current_user(0);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testValidTokenSignsTheDonorIn(): void
+    {
+        $userId = $this->factory()->user->create();
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($this->tokenFor($userId)));
+
+        $this->assertSame($userId, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLoggedInUserIsKept(): void
+    {
+        $userId = $this->factory()->user->create();
+        $otherUserId = $this->factory()->user->create();
+        wp_set_current_user($userId);
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($this->tokenFor($otherUserId)));
+
+        $this->assertSame($userId, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testMissingTokenLeavesTheRequestAnonymous(): void
+    {
+        (new AuthenticateFormRequestWithToken())(['formId' => 1]);
+        $this->assertSame(0, get_current_user_id());
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith(''));
+        $this->assertSame(0, get_current_user_id());
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith(['array']));
+        $this->assertSame(0, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testExpiredTokenIsRejected(): void
+    {
+        $userId = $this->factory()->user->create();
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($this->tokenFor($userId, -HOUR_IN_SECONDS)));
+
+        $this->assertSame(0, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testTamperedTokenIsRejected(): void
+    {
+        $userId = $this->factory()->user->create();
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith(substr_replace($this->tokenFor($userId), 'x', -1)));
+        $this->assertSame(0, get_current_user_id());
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith('not-a-token'));
+        $this->assertSame(0, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testRevokedSessionIsRejected(): void
+    {
+        $userId = $this->factory()->user->create();
+        $token = $this->tokenFor($userId);
+        WP_Session_Tokens::get_instance($userId)->destroy_all();
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($token));
+
+        $this->assertSame(0, get_current_user_id());
+    }
+
+    private function tokenFor(int $userId, int $ttl = HOUR_IN_SECONDS): string
+    {
+        return wp_generate_auth_cookie($userId, time() + $ttl, 'logged_in');
+    }
+
+    /**
+     * @param mixed $token
+     */
+    private function requestWith($token): array
+    {
+        return ['formId' => 1, AuthenticateFormRequestWithToken::TOKEN_KEY => $token];
+    }
+}

--- a/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
+++ b/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
@@ -91,6 +91,32 @@ class AuthenticateFormRequestWithTokenTest extends TestCase
     /**
      * @since TBD
      */
+    public function testTokenIsNotAValidLoginCookie(): void
+    {
+        $userId = $this->factory()->user->create();
+        $token = $this->tokenFor($userId);
+
+        $this->assertFalse(wp_validate_auth_cookie($token, 'logged_in'));
+        $this->assertFalse(wp_validate_auth_cookie($token, 'auth'));
+        $this->assertFalse(wp_validate_auth_cookie($token, 'secure_auth'));
+    }
+
+    /**
+     * @since TBD
+     */
+    public function testLoginCookieIsNotAValidToken(): void
+    {
+        $userId = $this->factory()->user->create();
+        $cookie = wp_generate_auth_cookie($userId, time() + HOUR_IN_SECONDS, 'logged_in');
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($cookie));
+
+        $this->assertSame(0, get_current_user_id());
+    }
+
+    /**
+     * @since TBD
+     */
     public function testRevokedSessionIsRejected(): void
     {
         $userId = $this->factory()->user->create();
@@ -104,7 +130,7 @@ class AuthenticateFormRequestWithTokenTest extends TestCase
 
     private function tokenFor(int $userId, int $ttl = HOUR_IN_SECONDS): string
     {
-        return wp_generate_auth_cookie($userId, time() + $ttl, 'logged_in');
+        return wp_generate_auth_cookie($userId, time() + $ttl, AuthenticateFormRequestWithToken::SCHEME);
     }
 
     /**

--- a/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
+++ b/tests/Unit/DonationForms/Actions/AuthenticateFormRequestWithTokenTest.php
@@ -14,9 +14,27 @@ class AuthenticateFormRequestWithTokenTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @var string|null
+     */
+    private $requestMethod;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestMethod = $_SERVER['REQUEST_METHOD'] ?? null;
+    }
+
     public function tearDown(): void
     {
         wp_set_current_user(0);
+
+        if ($this->requestMethod === null) {
+            unset($_SERVER['REQUEST_METHOD']);
+        } else {
+            $_SERVER['REQUEST_METHOD'] = $this->requestMethod;
+        }
 
         parent::tearDown();
     }
@@ -69,7 +87,10 @@ class AuthenticateFormRequestWithTokenTest extends TestCase
     {
         $userId = $this->factory()->user->create();
 
-        (new AuthenticateFormRequestWithToken())($this->requestWith($this->tokenFor($userId, -HOUR_IN_SECONDS)));
+        // Core grants POST requests an extra hour; a token expired by minutes must still fail.
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        (new AuthenticateFormRequestWithToken())($this->requestWith($this->tokenFor($userId, -5 * MINUTE_IN_SECONDS)));
 
         $this->assertSame(0, get_current_user_id());
     }

--- a/tests/e2e/external-embeds.spec.ts
+++ b/tests/e2e/external-embeds.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@wordpress/e2e-test-utils-playwright';
 import {createCampaignWithForm} from './utils/campaign';
+import {editForm, section} from './utils/form';
 import {
     donationForm,
     expectReceipt,
@@ -118,6 +119,43 @@ test.describe('External donation form embeds', () => {
         await waitForForm(form);
 
         await form.getByRole('button', {name: 'Donate now'}).click();
+
+        await fillDonorDetails(form);
+        await form.getByRole('button', {name: 'Continue'}).click();
+
+        await payWithTestGateway(form);
+        await form.getByRole('button', {name: 'Donate now'}).click();
+
+        await expectReceipt(form, '$10.00');
+    });
+
+    test('signs the donor in and completes a donation on a form that requires login', async ({page, requestUtils}) => {
+        /*
+         * The browser drops WordPress login cookies set from a cross-site iframe, so this only
+         * passes if the auth token the login route returns is accepted on validate and donate.
+         */
+        const {formId: loginFormId} = await createCampaignWithForm(requestUtils);
+        await editForm(requestUtils, loginFormId, (form) => {
+            section(form, "Who's Giving Today?").innerBlocks.unshift({
+                name: 'givewp/login',
+                attributes: {required: true, loginRedirect: false},
+                innerBlocks: [],
+            });
+        });
+        await page.route(`${EXTERNAL_PAGE}*`, (route) =>
+            route.fulfill({contentType: 'text/html', body: externalPageHtml(loginFormId)})
+        );
+
+        await page.goto(EXTERNAL_PAGE);
+
+        const form = donationForm(page);
+        await waitForForm(form);
+        await form.getByRole('button', {name: 'Donate now'}).click();
+
+        await form.locator('input[name="login"]').fill(process.env.WP_USERNAME ?? 'admin');
+        await form.locator('input[name="password"]').fill(process.env.WP_PASSWORD ?? 'password');
+        await form.getByRole('button', {name: 'Log In'}).click();
+        await expect(form.locator('input[name="login"]')).toBeHidden();
 
         await fillDonorDetails(form);
         await form.getByRole('button', {name: 'Continue'}).click();


### PR DESCRIPTION
## Description

Stacked on #8312.

A form embedded on another website runs in a cross-site iframe, where every current browser drops the WordPress login cookie set by the authentication route (Chrome and Firefox under Lax-by-default, Safari under ITP). Verified in Chromium against wp-env: the login route returned 200 with five `Set-Cookie` headers and the browser stored none. The login appeared to succeed, then a required login block failed server validation with `Login required.` on a field the form had already hidden, so the donor was stuck on step one with no error.

### What changes

- **`AuthenticationRoute`** also returns an `authToken` built with `wp_generate_auth_cookie` under a plugin-specific salt scheme. WordPress signs it, expires it, and backs it with a `WP_Session_Tokens` session, so "log out everywhere" and password changes revoke it. Because the scheme is not `logged_in` or `auth`, the token is not a usable browser cookie if it leaks, and a real login cookie is not a usable token. No new crypto.
- **`AuthenticateFormRequestWithToken`** validates that token with `wp_validate_auth_cookie` and calls `wp_set_current_user`. It runs from the `donate` and `validate` routes only, so the token is never a site-wide credential. It is invoked from the routes rather than on `determine_current_user` because other plugins can resolve the current user before this plugin loads, which was observed locally.
- **Client** keeps the token on `window.givewp.form` (the login template and the form app are separate bundles) and the request builders append it to validate and donate requests. It stays out of form values because the client-side Joi schema rejects unknown keys and blocks submit silently.
- **Form builder** drops the "login is unreliable inside embeds" warning.

Same-origin embeds are unchanged: the cookie is present, so the token path is skipped.

## Testing

- PHPUnit: valid token signs in, logged-in user kept, missing/array token ignored, expired token rejected, tampered token rejected, revoked session rejected, token not valid as any login cookie, login cookie not valid as a token.
- E2E (`external-embeds.spec.ts`): a form with a required login block, embedded cross-origin, signs in with the wp-env admin and completes a donation through to the receipt.
- Manual: required-login embed signs in and donates in Safari.
- Full PHPUnit suite green locally. Same-origin donation form E2E green apart from the offsite Test Gateway case, which is not enabled on my local site and fails before any changed code runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: SOFT-4293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure authentication tokens for embedded donation forms.
  * Embedded forms preserve donor authentication across validation and submission.
  * Successful sign-in stores the authentication token automatically.
  * Added internal and external embed options with customizable snippets and settings.

* **Bug Fixes**
  * Improved external-embed donation flows requiring login.
  * Improved embed-code copying reliability and success feedback.

* **Changes**
  * Removed the external-embed warning about required donor login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->