### PR TITLE
Fix: use explicit nullable types for PHP 8.4 compatibility

### DIFF
--- a/changelog/fix-php84-implicit-nullable.yaml
+++ b/changelog/fix-php84-implicit-nullable.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: fix
+entry: Fixed PHP 8.4+ deprecation notices for implicitly nullable parameter types by adding explicit nullable type hints across src/.
+timestamp: 2026-09-06T12:00:00.000Z

--- a/src/API/REST/V3/Routes/Donations/Exceptions/DonationValidationException.php
+++ b/src/API/REST/V3/Routes/Donations/Exceptions/DonationValidationException.php
@@ -27,7 +27,7 @@ class DonationValidationException extends Exception
      * @param int $statusCode
      * @param Exception|null $previous
      */
-    public function __construct(string $message, string $errorCode, int $statusCode = 400, Exception $previous = null)
+    public function __construct(string $message, string $errorCode, int $statusCode = 400, ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
         $this->errorCode = $errorCode;

--- a/src/API/REST/V3/Routes/Subscriptions/Exceptions/SubscriptionValidationException.php
+++ b/src/API/REST/V3/Routes/Subscriptions/Exceptions/SubscriptionValidationException.php
@@ -27,7 +27,7 @@ class SubscriptionValidationException extends Exception
      * @param int $statusCode
      * @param Exception|null $previous
      */
-    public function __construct(string $message, string $errorCode, int $statusCode = 400, Exception $previous = null)
+    public function __construct(string $message, string $errorCode, int $statusCode = 400, ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
         $this->errorCode = $errorCode;

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -878,7 +878,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return void
      */
-    public function resolving($abstract, Closure $callback = null)
+    public function resolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -899,7 +899,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return void
      */
-    public function afterResolving($abstract, Closure $callback = null)
+    public function afterResolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);

--- a/src/DonationForms/Exceptions/DonationFormFieldErrorsException.php
+++ b/src/DonationForms/Exceptions/DonationFormFieldErrorsException.php
@@ -19,7 +19,7 @@ class DonationFormFieldErrorsException extends \Exception implements LoggableExc
     /**
      * @since 3.0.0
      */
-    public function __construct(WP_Error $error, Throwable $previous = null)
+    public function __construct(WP_Error $error, ?Throwable $previous = null)
     {
         parent::__construct('Form field validation error', 0, $previous);
         $this->error = $error;

--- a/src/DonationForms/Exceptions/DonationFormForbidden.php
+++ b/src/DonationForms/Exceptions/DonationFormForbidden.php
@@ -10,7 +10,7 @@ use Throwable;
  */
 class DonationFormForbidden extends Exception
 {
-    public function __construct($message = 'Forbidden', $code = 403, Throwable $previous = null)
+    public function __construct($message = 'Forbidden', $code = 403, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/DonationForms/Routes/DonateRouteSignature.php
+++ b/src/DonationForms/Routes/DonateRouteSignature.php
@@ -19,7 +19,7 @@ class DonateRouteSignature
     /**
      * @since 3.0.0
      */
-    public function __construct(string $name, string $expiration = null)
+    public function __construct(string $name, ?string $expiration = null)
     {
         $this->expiration = $expiration ?: $this->createExpirationTimestamp();
         $this->signature = $this->generateSignatureString($name, $this->expiration);

--- a/src/DonationForms/Rules/ArrayRule.php
+++ b/src/DonationForms/Rules/ArrayRule.php
@@ -29,7 +29,7 @@ class ArrayRule implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/AuthenticationRule.php
+++ b/src/DonationForms/Rules/AuthenticationRule.php
@@ -18,7 +18,7 @@ class AuthenticationRule implements ValidationRule
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/BillingAddressCityRule.php
+++ b/src/DonationForms/Rules/BillingAddressCityRule.php
@@ -21,7 +21,7 @@ class BillingAddressCityRule implements ValidationRule
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/BillingAddressStateRule.php
+++ b/src/DonationForms/Rules/BillingAddressStateRule.php
@@ -20,7 +20,7 @@ class BillingAddressStateRule implements ValidationRule
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/BillingAddressZipRule.php
+++ b/src/DonationForms/Rules/BillingAddressZipRule.php
@@ -21,7 +21,7 @@ class BillingAddressZipRule implements ValidationRule
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/CurrencyRule.php
+++ b/src/DonationForms/Rules/CurrencyRule.php
@@ -27,7 +27,7 @@ class CurrencyRule implements ValidationRule
     /**
      * @since 4.10.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/DonationTypeRule.php
+++ b/src/DonationForms/Rules/DonationTypeRule.php
@@ -21,7 +21,7 @@ class DonationTypeRule implements ValidationRule, ValidatesOnFrontEnd, Sanitizer
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/GatewayRule.php
+++ b/src/DonationForms/Rules/GatewayRule.php
@@ -20,7 +20,7 @@ class GatewayRule implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/HoneyPotRule.php
+++ b/src/DonationForms/Rules/HoneyPotRule.php
@@ -23,7 +23,7 @@ class HoneyPotRule implements ValidationRule
     /**
      * @since 3.16.2
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/PhoneIntlInputRule.php
+++ b/src/DonationForms/Rules/PhoneIntlInputRule.php
@@ -22,7 +22,7 @@ class PhoneIntlInputRule implements ValidationRule
     /**
      * @since 3.9.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/Size.php
+++ b/src/DonationForms/Rules/Size.php
@@ -52,7 +52,7 @@ class Size implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         if (!is_numeric($options)) {
             Config::throwInvalidArgumentException('Size validation rule requires a numeric value');

--- a/src/DonationForms/Rules/SubscriptionFrequencyRule.php
+++ b/src/DonationForms/Rules/SubscriptionFrequencyRule.php
@@ -20,7 +20,7 @@ class SubscriptionFrequencyRule implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/SubscriptionInstallmentsRule.php
+++ b/src/DonationForms/Rules/SubscriptionInstallmentsRule.php
@@ -20,7 +20,7 @@ class SubscriptionInstallmentsRule implements ValidationRule, ValidatesOnFrontEn
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonationForms/Rules/SubscriptionPeriodRule.php
+++ b/src/DonationForms/Rules/SubscriptionPeriodRule.php
@@ -22,7 +22,7 @@ class SubscriptionPeriodRule implements ValidationRule, ValidatesOnFrontEnd, San
     /**
      * @since 3.0.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/DonorDashboards/Exceptions/DuplicateTabException.php
+++ b/src/DonorDashboards/Exceptions/DuplicateTabException.php
@@ -21,7 +21,7 @@ class DuplicateTabException extends Exception implements LoggableException
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($code = 0, Exception $previous = null)
+    public function __construct($code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             __('A tab can only be added once. Make sure there are not id conflicts.', 'give'),

--- a/src/DonorDashboards/Exceptions/MissingTabException.php
+++ b/src/DonorDashboards/Exceptions/MissingTabException.php
@@ -22,7 +22,7 @@ class MissingTabException extends Exception implements LoggableException
      * @param int            $code
      * @param Exception|null $previous
      */
-    public function __construct($tabId, $code = 0, Exception $previous = null)
+    public function __construct($tabId, $code = 0, ?Exception $previous = null)
     {
         $message = __('No tab exists with the ID: ', 'give') . $tabId;
 

--- a/src/Donors/Exceptions/FailedDonorUpdateException.php
+++ b/src/Donors/Exceptions/FailedDonorUpdateException.php
@@ -11,7 +11,7 @@ class FailedDonorUpdateException extends Exception
 {
     protected $donor;
 
-    public function __construct( Donor $donor = null, $code = 0, $previous = null ) {
+    public function __construct( ?Donor $donor = null, $code = 0, $previous = null ) {
         parent::__construct('Failed updating the donor', $code, $previous);
         $this->donor = $donor;
     }

--- a/src/Donors/Exceptions/FailedDonorUserCreationException.php
+++ b/src/Donors/Exceptions/FailedDonorUserCreationException.php
@@ -14,7 +14,7 @@ class FailedDonorUserCreationException extends Exception
 {
     protected $donor;
 
-    public function __construct( Donor $donor = null, $code = 0, $previous = null ) {
+    public function __construct( ?Donor $donor = null, $code = 0, $previous = null ) {
         parent::__construct('Failed creating a user for the donor.', $code, $previous);
         $this->donor = $donor;
     }

--- a/src/Framework/Blocks/BlockCollection.php
+++ b/src/Framework/Blocks/BlockCollection.php
@@ -117,7 +117,7 @@ class BlockCollection implements Arrayable
      *
      * @return BlockModel|BlockCollection|null
      */
-    private function findByNameRecursive(string $blockName, int $blockIndex = 0, string $return = 'self', BlockCollection $blockCollection = null, int &$count = 0)
+    private function findByNameRecursive(string $blockName, int $blockIndex = 0, string $return = 'self', ?BlockCollection $blockCollection = null, int &$count = 0)
     {
         if (!$blockCollection) {
             $blockCollection = $this;

--- a/src/Framework/Blocks/BlockModel.php
+++ b/src/Framework/Blocks/BlockModel.php
@@ -39,7 +39,7 @@ class BlockModel implements Arrayable
      */
     public function __construct(
         string $name,
-        string $clientId = null,
+        ?string $clientId = null,
         bool   $isValid = true,
         array  $attributes = [],
                $innerBlocks = null

--- a/src/Framework/Blocks/Exceptions/ReferenceBlockNotFoundException.php
+++ b/src/Framework/Blocks/Exceptions/ReferenceBlockNotFoundException.php
@@ -10,7 +10,7 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class ReferenceBlockNotFoundException extends Exception
 {
-    public function __construct($name, $code = 0, Exception $previous = null)
+    public function __construct($name, $code = 0, ?Exception $previous = null)
     {
         $message = "Reference block with the name \"$name\" not found - cannot insert new block.";
         parent::__construct($message, $code, $previous);

--- a/src/Framework/Database/Exceptions/DatabaseQueryException.php
+++ b/src/Framework/Database/Exceptions/DatabaseQueryException.php
@@ -35,7 +35,7 @@ class DatabaseQueryException extends Exception
         array $queryErrors,
         string $message = 'Database Query',
         $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         $this->query = $query;
         $this->queryErrors = $queryErrors;

--- a/src/Framework/FieldsAPI/Concerns/InsertNode.php
+++ b/src/Framework/FieldsAPI/Concerns/InsertNode.php
@@ -122,7 +122,7 @@ trait InsertNode
      *
      * @throws NameCollisionException
      */
-    protected function insert(Node $node, int $index = null)
+    protected function insert(Node $node, ?int $index = null)
     {
         $this->checkNameCollisionDeep($node);
 

--- a/src/Framework/FieldsAPI/Exceptions/EmptyNameException.php
+++ b/src/Framework/FieldsAPI/Exceptions/EmptyNameException.php
@@ -9,7 +9,7 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class EmptyNameException extends Exception
 {
-    public function __construct($code = 0, Exception $previous = null)
+    public function __construct($code = 0, ?Exception $previous = null)
     {
         $message = "Node name can not be empty";
         parent::__construct($message, $code, $previous);

--- a/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
+++ b/src/Framework/FieldsAPI/Exceptions/NameCollisionException.php
@@ -29,7 +29,7 @@ class NameCollisionException extends Exception
         Node $existingNode,
         Node $incomingNode,
         int $code = 0,
-        Exception $previous = null
+        ?Exception $previous = null
     )
     {
         $this->nodeNameCollision = $name;

--- a/src/Framework/FieldsAPI/Exceptions/ReferenceNodeNotFoundException.php
+++ b/src/Framework/FieldsAPI/Exceptions/ReferenceNodeNotFoundException.php
@@ -9,7 +9,7 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class ReferenceNodeNotFoundException extends Exception
 {
-    public function __construct($name, $code = 0, Exception $previous = null)
+    public function __construct($name, $code = 0, ?Exception $previous = null)
     {
         $message = "Reference node with the name \"$name\" not found - cannot insert new node.";
         parent::__construct($message, $code, $previous);

--- a/src/Framework/ListTable/Exceptions/ColumnIdCollisionException.php
+++ b/src/Framework/ListTable/Exceptions/ColumnIdCollisionException.php
@@ -9,7 +9,7 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class ColumnIdCollisionException extends Exception
 {
-    public function __construct($id, $code = 0, Exception $previous = null)
+    public function __construct($id, $code = 0, ?Exception $previous = null)
     {
         $message = "Column with id \"$id\" already exist";
         parent::__construct($message, $code, $previous);

--- a/src/Framework/ListTable/Exceptions/ReferenceColumnNotFoundException.php
+++ b/src/Framework/ListTable/Exceptions/ReferenceColumnNotFoundException.php
@@ -9,7 +9,7 @@ use Give\Framework\Exceptions\Primitives\Exception;
  */
 class ReferenceColumnNotFoundException extends Exception
 {
-    public function __construct($id, $code = 0, Exception $previous = null)
+    public function __construct($id, $code = 0, ?Exception $previous = null)
     {
         $message = "Reference column with the id \"$id\" not found.";
         parent::__construct($message, $code, $previous);

--- a/src/Framework/Models/EagerLoader.php
+++ b/src/Framework/Models/EagerLoader.php
@@ -62,7 +62,7 @@ class EagerLoader
      * @param string $foreignKey
      * @param string|null $foreignAttribute
      */
-    public function __construct(string $modelClass, string $eagerLoadedModelClass, string $relationshipKey, string $foreignKey, string $foreignAttribute = null)
+    public function __construct(string $modelClass, string $eagerLoadedModelClass, string $relationshipKey, string $foreignKey, ?string $foreignAttribute = null)
     {
         if (!is_subclass_of($modelClass, Model::class)) {
             throw new InvalidArgumentException("$modelClass must be an instance of " . Model::class);

--- a/src/Framework/PaymentGateways/Commands/PaymentCommand.php
+++ b/src/Framework/PaymentGateways/Commands/PaymentCommand.php
@@ -26,7 +26,7 @@ abstract class PaymentCommand implements GatewayCommand
      *
      * @return static
      */
-    public static function make(string $gatewayTransactionId = null): PaymentCommand
+    public static function make(?string $gatewayTransactionId = null): PaymentCommand
     {
         return new static($gatewayTransactionId);
     }
@@ -37,7 +37,7 @@ abstract class PaymentCommand implements GatewayCommand
      *
      * @param string|null $gatewayTransactionId
      */
-    final public function __construct(string $gatewayTransactionId = null)
+    final public function __construct(?string $gatewayTransactionId = null)
     {
         $this->gatewayTransactionId = $gatewayTransactionId;
     }

--- a/src/Framework/PaymentGateways/Commands/SubscriptionProcessing.php
+++ b/src/Framework/PaymentGateways/Commands/SubscriptionProcessing.php
@@ -25,7 +25,7 @@ class SubscriptionProcessing implements GatewayCommand
      */
     public function __construct(
         string $gatewaySubscriptionId,
-        string $gatewayTransactionId = null
+        ?string $gatewayTransactionId = null
     ) {
         $this->gatewayTransactionId = $gatewayTransactionId;
         $this->gatewaySubscriptionId = $gatewaySubscriptionId;

--- a/src/Framework/PaymentGateways/PaymentGatewayRegister.php
+++ b/src/Framework/PaymentGateways/PaymentGatewayRegister.php
@@ -24,7 +24,7 @@ class PaymentGatewayRegister extends PaymentGatewaysIterator
      * @since 2.30.0 added $supportedFormVersion param to filter gateways by supported form version
      * @since 2.18.0
      */
-    public function getPaymentGateways(int $supportedFormVersion = null): array
+    public function getPaymentGateways(?int $supportedFormVersion = null): array
     {
         if (!$supportedFormVersion) {
             return $this->gateways;

--- a/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
+++ b/src/Framework/PaymentGateways/Traits/HandleHttpResponses.php
@@ -54,7 +54,7 @@ trait HandleHttpResponses
         Exception $exception,
         string $message,
         string $type = DonationFormErrorTypes::UNKNOWN,
-        WP_Error $errors = null
+        ?WP_Error $errors = null
     ) {
         if ($exception instanceof PaymentGatewayException) {
             $message = $exception->getMessage();

--- a/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
+++ b/src/Framework/Receipts/Actions/GenerateConfirmationPageReceipt.php
@@ -337,7 +337,7 @@ class GenerateConfirmationPageReceipt
      * @since 4.16.8 Apply legacy tags before donor-supplied V3 tag values.
      * @since 3.0.0
      */
-    protected function getHeading(DonationReceipt $receipt, DonationForm $donationForm = null): string
+    protected function getHeading(DonationReceipt $receipt, ?DonationForm $donationForm = null): string
     {
         if (!$donationForm) {
             $content = __("Hey {first_name}, thanks for your donation!", 'give');
@@ -355,7 +355,7 @@ class GenerateConfirmationPageReceipt
      * @since 4.16.8 Apply legacy tags before donor-supplied V3 tag values.
      * @since 3.0.0
      */
-    protected function getDescription(DonationReceipt $receipt, DonationForm $donationForm = null): string
+    protected function getDescription(DonationReceipt $receipt, ?DonationForm $donationForm = null): string
     {
         if (!$donationForm) {
             $content = __(

--- a/src/Framework/Routes/RouteListener.php
+++ b/src/Framework/Routes/RouteListener.php
@@ -22,7 +22,7 @@ class RouteListener
     /**
      * @since 3.0.0
      */
-    public function isValid(array $request, callable $validation = null): bool
+    public function isValid(array $request, ?callable $validation = null): bool
     {
         $eventValid = isset($request['givewp-event']) && $request['givewp-event'] === $this->event;
         $listenerValid = isset($request['givewp-listener']) && $request['givewp-listener'] === $this->listener;

--- a/src/Framework/ValidationRules/Rules/AllowedTypes.php
+++ b/src/Framework/ValidationRules/Rules/AllowedTypes.php
@@ -42,7 +42,7 @@ class AllowedTypes implements ValidationRule
      *
      * @since 2.24.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         $types = explode(',', $options);
 

--- a/src/Framework/ValidationRules/Rules/File.php
+++ b/src/Framework/ValidationRules/Rules/File.php
@@ -107,7 +107,7 @@ class File implements ValidationRule, ValidatesOnFrontEnd
     /**
      * @since 2.32.0
      */
-    public static function fromString(string $options = null): ValidationRule
+    public static function fromString(?string $options = null): ValidationRule
     {
         return new self();
     }

--- a/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/BECSGateway.php
@@ -27,7 +27,7 @@ class BECSGateway extends PaymentGateway
     /**
      * @param SubscriptionModule|null $subscriptionModule
      */
-    public function __construct(SubscriptionModule $subscriptionModule = null)
+    public function __construct(?SubscriptionModule $subscriptionModule = null)
     {
         parent::__construct($subscriptionModule);
 

--- a/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/CreditCardGateway.php
@@ -22,7 +22,7 @@ class CreditCardGateway extends PaymentGateway
     /** @var array */
     protected $errorMessages = [];
 
-    public function __construct(SubscriptionModule $subscriptionModule = null)
+    public function __construct(?SubscriptionModule $subscriptionModule = null)
     {
         parent::__construct($subscriptionModule);
 

--- a/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
+++ b/src/PaymentGateways/Gateways/Stripe/SEPAGateway.php
@@ -27,7 +27,7 @@ class SEPAGateway extends PaymentGateway
     /**
      * @param SubscriptionModule|null $subscriptionModule
      */
-    public function __construct(SubscriptionModule $subscriptionModule = null)
+    public function __construct(?SubscriptionModule $subscriptionModule = null)
     {
         parent::__construct($subscriptionModule);
 

--- a/src/Subscriptions/Actions/GenerateNextRenewalForSubscription.php
+++ b/src/Subscriptions/Actions/GenerateNextRenewalForSubscription.php
@@ -22,7 +22,7 @@ class GenerateNextRenewalForSubscription
     public function __invoke(
         SubscriptionPeriod $period,
         int $frequency,
-        DateTimeInterface $baseDate = null
+        ?DateTimeInterface $baseDate = null
     ): DateTimeInterface {
         if ( $frequency < 1 ) {
             throw new InvalidArgumentException('Frequency must be greater than 0');


### PR DESCRIPTION
## Summary

Fixes #8315

On PHP 8.4+, implicitly nullable parameter types (`Type $param = null`) trigger `E_DEPRECATED` notices. This changes all method signatures in `src/` to use the explicit nullable form (`?Type $param = null`).

All changes are signature-only — no behavior change. Safe on PHP 7.1+.

### Files changed

- 47 files in `src/` (50 parameter signatures updated)
- Added changelog entry

### Before

```php
public function resolving($abstract, Closure $callback = null)
```

### After

```php
public function resolving($abstract, ?Closure $callback = null)
```

## Testing

- [x] Run on PHP 8.4+ and confirm no deprecation notices in `debug.log`
- [x] Run `composer test` to verify no regressions

## Checklist

- [x] Changelog entry added
- [ ] `@since TBD` docblocks on changed methods (may add if required)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/impress-org/codesmith/givewp/pr/8322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791299521&installation_model_id=426813&pr_number=8322&repository=impress-org%2Fgivewp&return_to=https%3A%2F%2Fgithub.com%2Fimpress-org%2Fgivewp%2Fpull%2F8322&signature=fa1ca4710a599ee04d59d70676304dd9f6324aca2df985c24eb0e3fa5ddd6171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved PHP 8.4+ deprecation notices related to implicitly nullable parameter types.
  - Updated donation, subscription, payment, validation, routing, dashboard, and framework components to explicitly support optional `null` values.
  - Preserved existing fallback behavior and application functionality while improving compatibility with newer PHP versions.

- **Documentation**
  - Added a changelog entry describing the PHP 8.4 compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->